### PR TITLE
グローバルのドロップ状態を追跡する機能を追加し、ドラッグ開始時に内部ドロップフラグをリセットする処理を実装しました。

### DIFF
--- a/features/saved-tabs/components/ProjectUrlItem.tsx
+++ b/features/saved-tabs/components/ProjectUrlItem.tsx
@@ -16,6 +16,14 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import type { CustomProject, UserSettings } from '@/types/storage'
 
+// グローバルのドロップ状態を追跡（ウィンドウ内でのドロップか外部へのドロップかを判定するため）
+let isGlobalInternalDrop = false
+if (typeof window !== 'undefined') {
+  window.addEventListener('drop', () => {
+    isGlobalInternalDrop = true
+  })
+}
+
 interface ProjectUrlItemProps {
   item: NonNullable<CustomProject['urls']>[0]
   projectId: string
@@ -126,6 +134,7 @@ const ProjectUrlItemComponent = ({
   const handleDragStart = (e: React.DragEvent<HTMLElement>) => {
     isDraggingRef.current = true
     windowBlurredDuringDragRef.current = false
+    isGlobalInternalDrop = false
 
     e.dataTransfer.setData('text/plain', originalUrl)
     e.dataTransfer.setData('text/uri-list', originalUrl)
@@ -146,6 +155,7 @@ const ProjectUrlItemComponent = ({
   const handleDragEnd = (e: React.DragEvent<HTMLElement>) => {
     window.removeEventListener('blur', handleWindowBlur)
     const shouldHandleAsExternalDrop =
+      !isGlobalInternalDrop &&
       isDraggingRef.current &&
       (e.dataTransfer.dropEffect === 'copy' ||
         (windowBlurredDuringDragRef.current &&

--- a/features/saved-tabs/components/SortableUrlItem.tsx
+++ b/features/saved-tabs/components/SortableUrlItem.tsx
@@ -16,6 +16,14 @@ import { Button } from '@/components/ui/button'
 import type { SortableUrlItemProps } from '@/types/saved-tabs'
 import { TimeRemaining, formatDatetime } from '@/utils/datetime'
 
+// グローバルのドロップ状態を追跡（ウィンドウ内でのドロップか外部へのドロップかを判定するため）
+let isGlobalInternalDrop = false
+if (typeof window !== 'undefined') {
+  window.addEventListener('drop', () => {
+    isGlobalInternalDrop = true
+  })
+}
+
 // URL項目用のソータブルコンポーネント - 型定義を修正
 export const SortableUrlItem = ({
   url,
@@ -51,6 +59,7 @@ export const SortableUrlItem = ({
   const handleDragStart = (e: React.DragEvent<HTMLElement>, url: string) => {
     isDraggingRef.current = true
     windowBlurredDuringDragRef.current = false
+    isGlobalInternalDrop = false
     // URLをテキストとして設定
     e.dataTransfer.setData('text/plain', url)
     // URI-listとしても設定（多くのブラウザやアプリがこのフォーマットを認識）
@@ -95,6 +104,7 @@ export const SortableUrlItem = ({
     window.removeEventListener('blur', handleWindowBlur)
 
     const shouldHandleAsExternalDrop =
+      !isGlobalInternalDrop &&
       isDraggingRef.current &&
       (e.dataTransfer.dropEffect === 'copy' ||
         (windowBlurredDuringDragRef.current &&


### PR DESCRIPTION
## 変更内容
<!-- 変更の詳細を記述してください -->

## チェックリスト
- [ ] ローカル環境でエラーになっていない
