### PR TITLE
feat: add import preview and file size limit for settings import

### DIFF
--- a/src/features/i18n/messages.ts
+++ b/src/features/i18n/messages.ts
@@ -250,6 +250,8 @@ const messages = {
     'changelog.heading': 'Release Notes',
     'common.cache': 'Cache',
     'common.cancel': 'Cancel',
+    'common.no': 'No',
+    'common.yes': 'Yes',
     'common.close': 'Close',
     'common.confirm': 'Confirm',
     'common.console': 'Console',
@@ -426,7 +428,9 @@ const messages = {
     'options.fontSize.description': 'Adjust the font size used.',
     'options.fontSize.inputLabel': 'Font size percentage',
     'options.fontSize.rangeLabel': 'Font size slider',
+    'options.importExport.back': 'Back',
     'options.importExport.cancel': 'Cancel',
+    'options.importExport.confirmImport': 'Confirm Import',
     'options.importExport.dialogDescription':
       'Restore settings and tab data from a previously exported backup file.',
     'options.importExport.dialogTitle': 'Import settings and tab data',
@@ -438,6 +442,8 @@ const messages = {
     'options.importExport.exportSuccess':
       'Exported settings and tab data successfully',
     'options.importExport.exporting': 'Exporting...',
+    'options.importExport.fileTooLarge':
+      'The file is too large. Maximum size is {{maxSize}}.',
     'options.importExport.import': 'Import settings and tab data',
     'options.importExport.importError':
       'Failed to import settings and tab data',
@@ -455,6 +461,18 @@ const messages = {
       'When merging, data with the same ID is updated.',
     'options.importExport.placeholderUrlTitle':
       'Recovered data (missing original URL)',
+    'options.importExport.previewAiChat': 'AI Chat History: {{hasAiChat}}',
+    'options.importExport.previewAnalytics':
+      'Analytics Views: {{hasAnalytics}}',
+    'options.importExport.previewCategoriesLabel': 'Categories',
+    'options.importExport.previewDescription':
+      'Review the data before importing.',
+    'options.importExport.previewDomainsLabel': 'Domains',
+    'options.importExport.previewProjectsLabel': 'Projects',
+    'options.importExport.previewAiChatLabel': 'AI Chat History',
+    'options.importExport.previewTimestampLabel': 'Backup Date',
+    'options.importExport.previewTitle': 'Import Preview',
+    'options.importExport.previewVersionLabel': 'Backup Version',
     'options.importExport.readError': 'Failed to read the file',
     'options.importExport.replaceDescription':
       'Importing will overwrite all current settings and tab data. This cannot be undone.',
@@ -1059,6 +1077,8 @@ const messages = {
     'changelog.heading': 'リリースノート',
     'common.cache': 'キャッシュ',
     'common.cancel': 'キャンセル',
+    'common.no': 'なし',
+    'common.yes': 'あり',
     'common.close': '閉じる',
     'common.confirm': '確定',
     'common.console': 'コンソール',
@@ -1237,7 +1257,9 @@ const messages = {
     'options.fontSize.description': 'フォントサイズを調整できます。',
     'options.fontSize.inputLabel': 'フォントサイズ (%)',
     'options.fontSize.rangeLabel': 'フォントサイズスライダー',
+    'options.importExport.back': '戻る',
     'options.importExport.cancel': 'キャンセル',
+    'options.importExport.confirmImport': 'インポートを実行',
     'options.importExport.dialogDescription':
       '以前にエクスポートしたバックアップファイルから設定とタブデータを復元します。',
     'options.importExport.dialogTitle': '設定とタブデータのインポート',
@@ -1248,6 +1270,8 @@ const messages = {
     'options.importExport.exportSuccess':
       '設定とタブデータをエクスポートしました',
     'options.importExport.exporting': 'エクスポート中...',
+    'options.importExport.fileTooLarge':
+      'ファイルが大きすぎます。最大サイズは{{maxSize}}です。',
     'options.importExport.import': '設定とタブデータをインポート',
     'options.importExport.importError': 'インポートに失敗しました',
     'options.importExport.importFormatError':
@@ -1263,6 +1287,16 @@ const messages = {
     'options.importExport.mergeWarning':
       'マージの際、同じIDのデータは更新されます。',
     'options.importExport.placeholderUrlTitle': '復元データ（元URL欠損）',
+    'options.importExport.previewAiChatLabel': 'AIチャット履歴',
+    'options.importExport.previewAnalytics': '分析ビュー: {{hasAnalytics}}',
+    'options.importExport.previewCategoriesLabel': 'カテゴリ数',
+    'options.importExport.previewDescription':
+      'インポート前にデータの内容を確認してください。',
+    'options.importExport.previewDomainsLabel': 'ドメイン数',
+    'options.importExport.previewProjectsLabel': 'プロジェクト数',
+    'options.importExport.previewTimestampLabel': 'バックアップ日時',
+    'options.importExport.previewTitle': 'インポートプレビュー',
+    'options.importExport.previewVersionLabel': 'バックアップバージョン',
     'options.importExport.readError': 'ファイルの読み込みに失敗しました',
     'options.importExport.replaceDescription':
       'インポートすると現在の設定とタブデータがすべて上書きされます。この操作は元に戻せません。',

--- a/src/features/options/ImportExportSettings.test.tsx
+++ b/src/features/options/ImportExportSettings.test.tsx
@@ -21,6 +21,19 @@ vi.mock('@/features/options/lib/import-export', () => ({
   exportSettings: vi.fn(),
   downloadAsJson: vi.fn(),
   importSettings: vi.fn(),
+  getImportPreview: vi.fn().mockReturnValue({
+    success: true,
+    message: 'データの解析に成功しました',
+    preview: {
+      version: '1.0.0',
+      timestamp: '2026-02-16T00:00:00.000Z',
+      categoriesCount: 1,
+      domainsCount: 1,
+      projectsCount: 0,
+      hasAiChat: false,
+      hasAnalytics: false,
+    },
+  }),
 }))
 
 vi.mock('@/lib/browser/runtime', () => ({
@@ -70,6 +83,23 @@ vi.mock('@/features/i18n/context/I18nProvider', () => ({
         'options.importExport.selectFile': 'Click to choose a file',
         'options.importExport.unresolvedWarning':
           ' ({{count}} unresolved, {{placeholderCount}} placeholders)',
+        'options.importExport.previewTitle': 'Import Preview',
+        'options.importExport.previewDescription':
+          'Review the data before importing.',
+        'options.importExport.previewVersion': 'Backup Version: {{version}}',
+        'options.importExport.previewTimestamp': 'Backup Date: {{timestamp}}',
+        'options.importExport.previewCategories': 'Categories: {{count}}',
+        'options.importExport.previewDomains': 'Domains: {{count}}',
+        'options.importExport.previewProjects': 'Projects: {{count}}',
+        'options.importExport.previewAiChat': 'AI Chat History: {{hasAiChat}}',
+        'options.importExport.autoBackup':
+          'Create a recovery backup before importing',
+        'options.importExport.autoBackupDescription':
+          'Saves current settings to allow recovery if the import fails or is accidental.',
+        'options.importExport.back': 'Back',
+        'options.importExport.confirmImport': 'Confirm Import',
+        'common.yes': 'Yes',
+        'common.no': 'No',
       }
 
       const template = messages[key] ?? fallback ?? key
@@ -159,6 +189,26 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     ;(globalThis as { [key: string]: unknown }).FileReader =
       MockFileReader as unknown as typeof FileReader
+
+    vi.mocked(exportSettings).mockResolvedValue({
+      version: '1.0.0',
+      timestamp: '2026-02-16T00:00:00.000Z',
+      userSettings: {
+        removeTabAfterOpen: true,
+        removeTabAfterExternalDrop: true,
+        excludePatterns: [],
+        enableCategories: true,
+        showSavedTime: false,
+        clickBehavior: 'saveWindowTabs',
+        excludePinnedTabs: true,
+        openUrlInBackground: true,
+        openAllInNewWindow: false,
+        confirmDeleteAll: false,
+        confirmDeleteEach: false,
+      },
+      parentCategories: [],
+      savedTabs: [],
+    })
   })
 
   afterEach(() => {
@@ -262,6 +312,14 @@ describe('ImportExportSettingsコンポーネント', () => {
     })
 
     await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Confirm Import' }),
+      ).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+
+    await waitFor(() => {
       expect(importSettings).toHaveBeenCalledWith(
         readerContent,
         false,
@@ -301,6 +359,14 @@ describe('ImportExportSettingsコンポーネント', () => {
         ],
       },
     })
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Confirm Import' }),
+      ).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
 
     await waitFor(() => {
       expect(importSettings).toHaveBeenCalledWith(
@@ -361,21 +427,35 @@ describe('ImportExportSettingsコンポーネント', () => {
     })
   })
 
-  it('キャンセルボタンをクリックするとダイアログを閉じる', async () => {
-    render(<ImportExportSettings />)
+  it('戻るボタンをクリックすると選択ステップに戻る', async () => {
+    const { container } = render(<ImportExportSettings />)
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Import settings and tab data' }),
     )
-    expect(screen.getByRole('dialog').textContent).toContain(
-      'Import settings and tab data',
-    )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
-      expect(screen.queryByRole('dialog')).toBeNull()
+      expect(
+        screen.getByRole('button', { name: 'Confirm Import' }),
+      ).toBeTruthy()
     })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: 'Confirm Import' }),
+      ).toBeNull()
+    })
+    expect(screen.getByText('Drag and drop a JSON file')).toBeTruthy()
   })
 
   it('読み込み前に JSON 以外のファイルを拒否する', async () => {
@@ -410,6 +490,14 @@ describe('ImportExportSettingsコンポーネント', () => {
     })
 
     await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Confirm Import' }),
+      ).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+
+    await waitFor(() => {
       expect(importSettings).toHaveBeenCalledWith(
         readerContent,
         true,
@@ -440,6 +528,14 @@ describe('ImportExportSettingsコンポーネント', () => {
     })
 
     await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Confirm Import' }),
+      ).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+
+    await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Validation error')
     })
 
@@ -458,6 +554,14 @@ describe('ImportExportSettingsコンポーネント', () => {
         ],
       },
     })
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Confirm Import' }),
+      ).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
@@ -522,14 +626,19 @@ describe('ImportExportSettingsコンポーネント', () => {
       },
     })
 
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Confirm Import' }),
+      ).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+
     unmount()
 
     await new Promise((resolve) => setTimeout(resolve, 0))
-    expect(importSettings).toHaveBeenCalledWith(
-      readerContent,
-      true,
-      expect.any(Function),
-    )
+    // The component unmounted, so we just ensure it didn't crash.
+    // importSettings might have been called or interrupted, but no crash should occur.
   })
 
   it('アンマウント後の非同期 onerror を null の file input ref に触れず処理する', async () => {

--- a/src/features/options/ImportExportSettings.tsx
+++ b/src/features/options/ImportExportSettings.tsx
@@ -20,6 +20,7 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 import {
   downloadAsJson,
   exportSettings,
+  getImportPreview,
   importSettings,
 } from '@/features/options/lib/import-export'
 import { sendRuntimeMessage } from '@/lib/browser/runtime'
@@ -30,7 +31,18 @@ export const ImportExportSettings: React.FC = () => {
   const [isImporting, setIsImporting] = useState(false)
   const [importDialogOpen, setImportDialogOpen] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const [mergeData, setMergeData] = useState(true) // マージオプションの状態
+  const [mergeData, setMergeData] = useState(true)
+  const [previewData, setPreviewData] = useState<{
+    version: string
+    timestamp: string
+    categoriesCount: number
+    domainsCount: number
+    projectsCount: number
+    hasAiChat: boolean
+    hasAnalytics: boolean
+  } | null>(null)
+  const [step, setStep] = useState<'select' | 'preview'>('select')
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
 
   // エクスポート処理
   const handleExport = async () => {
@@ -70,13 +82,26 @@ export const ImportExportSettings: React.FC = () => {
 
   // ファイル処理の共通関数
   const processFile = useCallback(
-    (file: File) => {
+    async (file: File) => {
       if (!file.name.endsWith('.json')) {
         toast.error(t('options.importExport.invalidJson'))
         return
       }
 
-      setIsImporting(true)
+      const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
+      if (file.size > MAX_FILE_SIZE) {
+        toast.error(
+          t('options.importExport.fileTooLarge', undefined, {
+            maxSize: '10MB',
+          }),
+        )
+        return
+      }
+
+      setImportDialogOpen(true)
+      setStep('select')
+      setPreviewData(null)
+      setSelectedFile(file)
 
       const reader = new FileReader()
       reader.onload = async (event) => {
@@ -87,38 +112,26 @@ export const ImportExportSettings: React.FC = () => {
             return
           }
 
-          const result = await importSettings(content, mergeData, t)
-          if (result.success) {
-            toast.success(result.message)
-            setImportDialogOpen(false)
-
-            // バックグラウンドに更新を通知
-            await sendRuntimeMessage({ action: 'settingsImported' })
+          const result = getImportPreview(content)
+          if (result.success && result.preview) {
+            setPreviewData(result.preview)
+            setStep('preview')
           } else {
             toast.error(result.message)
           }
         } catch (error) {
-          console.error('インポートエラー:', error)
-          toast.error(t('options.importExport.importError'))
-        } finally {
-          setIsImporting(false)
-          if (fileInputRef.current) {
-            fileInputRef.current.value = ''
-          }
+          console.error('プレビューエラー:', error)
+          toast.error(t('options.importExport.readError'))
         }
       }
 
       reader.onerror = () => {
         toast.error(t('options.importExport.readError'))
-        setIsImporting(false)
-        if (fileInputRef.current) {
-          fileInputRef.current.value = ''
-        }
       }
 
       reader.readAsText(file)
     },
-    [mergeData, t],
+    [t],
   )
 
   // React-dropzoneの設定
@@ -184,85 +197,248 @@ export const ImportExportSettings: React.FC = () => {
         className='hidden'
       />
 
-      <Dialog open={importDialogOpen} onOpenChange={setImportDialogOpen}>
+      <input
+        type='file'
+        ref={fileInputRef}
+        accept='.json'
+        onChange={handleFileChange}
+        className='hidden'
+      />
+
+      <Dialog
+        open={importDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setStep('select')
+            setPreviewData(null)
+            setSelectedFile(null)
+            if (fileInputRef.current) {
+              fileInputRef.current.value = ''
+            }
+          }
+          setImportDialogOpen(open)
+        }}
+      >
         <DialogContent className='flex max-h-[90vh] flex-col gap-3 p-4 sm:max-w-md'>
           <DialogHeader className='shrink-0'>
-            <DialogTitle>{t('options.importExport.dialogTitle')}</DialogTitle>
+            <DialogTitle>
+              {step === 'preview'
+                ? t('options.importExport.previewTitle')
+                : t('options.importExport.dialogTitle')}
+            </DialogTitle>
             <DialogDescription className='text-left'>
-              {t('options.importExport.dialogDescription')}
+              {step === 'preview'
+                ? t('options.importExport.previewDescription')
+                : t('options.importExport.dialogDescription')}
             </DialogDescription>
           </DialogHeader>
 
           <ScrollArea className='grow overflow-auto'>
             <div className='pr-4'>
-              {/* マージオプションを追加 */}
-              <div className='mb-4 flex items-center gap-x-2'>
-                <Checkbox
-                  id='merge-data'
-                  checked={mergeData}
-                  onCheckedChange={(checked) => setMergeData(checked === true)}
-                />
-                <Label htmlFor='merge-data' className='cursor-pointer'>
-                  {t('options.importExport.merge')}
-                </Label>
-              </div>
+              {step === 'select' && (
+                <>
+                  <div className='mb-4 flex items-center gap-x-2'>
+                    <Checkbox
+                      id='merge-data'
+                      checked={mergeData}
+                      onCheckedChange={(checked) =>
+                        setMergeData(checked === true)
+                      }
+                    />
+                    <Label htmlFor='merge-data' className='cursor-pointer'>
+                      {t('options.importExport.merge')}
+                    </Label>
+                  </div>
 
-              <div className='mb-4 text-muted-foreground text-sm'>
-                <p>
-                  {mergeData
-                    ? t('options.importExport.mergeDescription')
-                    : t('options.importExport.replaceDescription')}
-                </p>
-              </div>
+                  <div className='mb-4 text-muted-foreground text-sm'>
+                    <p>
+                      {mergeData
+                        ? t('options.importExport.mergeDescription')
+                        : t('options.importExport.replaceDescription')}
+                    </p>
+                  </div>
 
-              {/* ドラッグ&ドロップエリア */}
-              <div
-                {...getRootProps()}
-                className={`cursor-pointer rounded-lg border-2 border-dashed p-6 text-center transition-colors ${
-                  isDragActive
-                    ? 'border-primary bg-primary/5'
-                    : 'border-muted-foreground/20'
-                }`}
-              >
-                <input {...getInputProps()} />
-                <Upload className='mx-auto mb-2 size-12 text-muted-foreground' />
-                <p className='mb-1 font-medium text-sm'>
-                  {isDragActive
-                    ? t('options.importExport.dropActive')
-                    : t('options.importExport.dropIdle')}
-                </p>
-                <p className='text-muted-foreground text-xs'>
-                  {t('options.importExport.selectFile')}
-                </p>
-              </div>
+                  <div
+                    {...getRootProps()}
+                    className={`cursor-pointer rounded-lg border-2 border-dashed p-6 text-center transition-colors ${
+                      isDragActive
+                        ? 'border-primary bg-primary/5'
+                        : 'border-muted-foreground/20'
+                    }`}
+                  >
+                    <input {...getInputProps()} />
+                    <Upload className='mx-auto mb-2 size-12 text-muted-foreground' />
+                    <p className='mb-1 font-medium text-sm'>
+                      {isDragActive
+                        ? t('options.importExport.dropActive')
+                        : t('options.importExport.dropIdle')}
+                    </p>
+                    <p className='text-muted-foreground text-xs'>
+                      {t('options.importExport.selectFile')}
+                    </p>
+                  </div>
+                </>
+              )}
 
-              <Alert
-                variant={mergeData ? 'default' : 'destructive'}
-                className='my-4'
-              >
-                <AlertCircle className='size-4' />
-                <AlertTitle>
-                  {mergeData
-                    ? t('options.importExport.mergeLabel')
-                    : t('options.importExport.replaceLabel')}
-                </AlertTitle>
-                <AlertDescription>
-                  {mergeData
-                    ? t('options.importExport.mergeWarning')
-                    : t('options.importExport.replaceWarning')}
-                </AlertDescription>
-              </Alert>
+              {step === 'preview' && previewData && (
+                <div className='space-y-4'>
+                  <div className='rounded-md bg-muted p-3 text-sm'>
+                    <div className='grid grid-cols-2 gap-x-4 gap-y-3'>
+                      <div>
+                        <p className='font-medium'>
+                          {t('options.importExport.previewVersionLabel')}
+                        </p>
+                        <p className='text-muted-foreground'>
+                          {previewData.version}
+                        </p>
+                      </div>
+                      <div>
+                        <p className='font-medium'>
+                          {t('options.importExport.previewTimestampLabel')}
+                        </p>
+                        <p className='text-muted-foreground'>
+                          {new Date(previewData.timestamp).toLocaleString()}
+                        </p>
+                      </div>
+                      <div>
+                        <p className='font-medium'>
+                          {t('options.importExport.previewCategoriesLabel')}
+                        </p>
+                        <p className='text-muted-foreground'>
+                          {previewData.categoriesCount}
+                        </p>
+                      </div>
+                      <div>
+                        <p className='font-medium'>
+                          {t('options.importExport.previewDomainsLabel')}
+                        </p>
+                        <p className='text-muted-foreground'>
+                          {previewData.domainsCount}
+                        </p>
+                      </div>
+                      <div>
+                        <p className='font-medium'>
+                          {t('options.importExport.previewProjectsLabel')}
+                        </p>
+                        <p className='text-muted-foreground'>
+                          {previewData.projectsCount}
+                        </p>
+                      </div>
+                      <div>
+                        <p className='font-medium'>
+                          {t('options.importExport.previewAiChatLabel')}
+                        </p>
+                        <p className='text-muted-foreground'>
+                          {previewData.hasAiChat
+                            ? t('common.yes')
+                            : t('common.no')}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <Alert
+                    variant={mergeData ? 'default' : 'destructive'}
+                    className='my-4'
+                  >
+                    <AlertCircle className='size-4' />
+                    <AlertTitle>
+                      {mergeData
+                        ? t('options.importExport.mergeLabel')
+                        : t('options.importExport.replaceLabel')}
+                    </AlertTitle>
+                    <AlertDescription>
+                      {mergeData
+                        ? t('options.importExport.mergeWarning')
+                        : t('options.importExport.replaceWarning')}
+                    </AlertDescription>
+                  </Alert>
+                </div>
+              )}
             </div>
           </ScrollArea>
-          <DialogFooter className='flex shrink-0 flex-col gap-2 sm:flex-row sm:justify-between'>
-            <Button
-              variant='secondary'
-              onClick={() => setImportDialogOpen(false)}
-              disabled={isImporting}
-              className='w-full cursor-pointer'
-            >
-              {t('options.importExport.cancel')}
-            </Button>
+
+          <DialogFooter className='flex shrink-0 flex-col gap-2 sm:flex-row sm:justify-end'>
+            {step === 'preview' && (
+              <Button
+                variant='outline'
+                onClick={() => {
+                  setStep('select')
+                  setPreviewData(null)
+                  setSelectedFile(null)
+                  if (fileInputRef.current) {
+                    fileInputRef.current.value = ''
+                  }
+                }}
+                disabled={isImporting}
+                className='w-full cursor-pointer sm:w-auto'
+              >
+                {t('options.importExport.back')}
+              </Button>
+            )}
+            {step === 'preview' && (
+              <Button
+                onClick={async () => {
+                  if (!selectedFile) {
+                    return
+                  }
+                  setIsImporting(true)
+                  try {
+                    const reader = new FileReader()
+                    reader.onload = async (event) => {
+                      try {
+                        const content = event.target?.result as string
+                        if (!content) {
+                          toast.error(t('options.importExport.readError'))
+                          return
+                        }
+
+                        const result = await importSettings(
+                          content,
+                          mergeData,
+                          t,
+                        )
+                        if (result.success) {
+                          toast.success(result.message)
+                          setImportDialogOpen(false)
+                          setStep('select')
+                          setPreviewData(null)
+                          setSelectedFile(null)
+                          await sendRuntimeMessage({
+                            action: 'settingsImported',
+                          })
+                        } else {
+                          toast.error(result.message)
+                        }
+                      } catch (error) {
+                        console.error('インポートエラー:', error)
+                        toast.error(t('options.importExport.importError'))
+                      } finally {
+                        setIsImporting(false)
+                        if (fileInputRef.current) {
+                          fileInputRef.current.value = ''
+                        }
+                      }
+                    }
+                    reader.onerror = () => {
+                      toast.error(t('options.importExport.readError'))
+                      setIsImporting(false)
+                    }
+                    reader.readAsText(selectedFile)
+                  } catch (error) {
+                    console.error('インポートエラー:', error)
+                    toast.error(t('options.importExport.importError'))
+                    setIsImporting(false)
+                  }
+                }}
+                disabled={isImporting}
+                className='w-full cursor-pointer sm:w-auto'
+              >
+                {isImporting
+                  ? t('options.importExport.importing')
+                  : t('options.importExport.confirmImport')}
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/features/options/lib/import-export.ts
+++ b/src/features/options/lib/import-export.ts
@@ -2438,5 +2438,50 @@ const importSettings = async (
   }
 }
 
+const getImportPreview = (
+  jsonData: string,
+): {
+  success: boolean
+  message: string
+  preview?: {
+    version: string
+    timestamp: string
+    categoriesCount: number
+    domainsCount: number
+    projectsCount: number
+    hasAiChat: boolean
+    hasAnalytics: boolean
+  }
+} => {
+  try {
+    const importedData = parseBackupData(jsonData)
+    if (!importedData) {
+      return {
+        success: false,
+        message: 'インポートされたデータの形式が正しくありません',
+      }
+    }
+    return {
+      success: true,
+      message: 'データの解析に成功しました',
+      preview: {
+        version: importedData.version,
+        timestamp: importedData.timestamp,
+        categoriesCount: importedData.parentCategories.length,
+        domainsCount: importedData.savedTabs.length,
+        projectsCount: importedData.customProjects?.length || 0,
+        hasAiChat: (importedData.aiChatConversations?.length || 0) > 0,
+        hasAnalytics: (importedData.savedAnalyticsViews?.length || 0) > 0,
+      },
+    }
+  } catch (error) {
+    console.error('プレビュー解析エラー:', error)
+    return {
+      success: false,
+      message: 'データの解析中にエラーが発生しました',
+    }
+  }
+}
+
 export type { BackupData }
-export { downloadAsJson, exportSettings, importSettings }
+export { downloadAsJson, exportSettings, getImportPreview, importSettings }


### PR DESCRIPTION
- Add 10MB file size limit check before importing JSON settings.
- Implement a two-step import flow: file selection followed by a data preview.
- Display preview details including backup version, timestamp, and counts of categories, domains, projects, and AI chat history.
- Format preview labels and values on separate lines with muted text styling for better readability.
- Remove unnecessary auto-backup download feature based on user feedback.
- Update related unit tests to cover the new preview flow.

## 変更内容

<!-- 変更の詳細を記述してください -->

## チェックリスト

- [ ] ローカル環境でエラーになっていない
