### PR TITLE
feat(#462): oxlintでDDDレイヤ境界を機械的にガード

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -444,6 +444,228 @@
         "unicorn/no-abusive-eslint-disable": "off",
         "typescript/prefer-ts-expect-error": "off"
       }
+    },
+    {
+      "files": ["src/contexts/saved-tabs/domain/**/*.{ts,tsx}"],
+      "rules": {
+        "eslint/no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "react",
+                "message": "domain 層は React に依存できません"
+              },
+              {
+                "name": "react-dom",
+                "message": "domain 層は React DOM に依存できません"
+              }
+            ],
+            "patterns": [
+              {
+                "regex": "^@/components(/|$)",
+                "message": "domain 層は UI コンポーネントに依存できません"
+              },
+              {
+                "regex": "^@/features/[^/]+/components(/|$)",
+                "message": "domain 層は feature の UI コンポーネントに依存できません"
+              },
+              {
+                "regex": "^@/contexts/[^/]+/application(/|$)",
+                "message": "domain 層は application 層に依存できません"
+              },
+              {
+                "regex": "^@/contexts/[^/]+/infrastructure(/|$)",
+                "message": "domain 層は infrastructure 層に依存できません"
+              },
+              {
+                "regex": "^@/contexts/[^/]+/presentation(/|$)",
+                "message": "domain 層は presentation 層に依存できません"
+              }
+            ]
+          }
+        ],
+        "eslint/no-restricted-globals": [
+          "error",
+          {
+            "name": "chrome",
+            "message": "domain 層は chrome.* を直接利用できません（adapter / port 経由）"
+          },
+          {
+            "name": "localStorage",
+            "message": "domain 層は localStorage を直接利用できません"
+          },
+          {
+            "name": "sessionStorage",
+            "message": "domain 層は sessionStorage を直接利用できません"
+          },
+          {
+            "name": "document",
+            "message": "domain 層は document に依存できません"
+          },
+          {
+            "name": "window",
+            "message": "domain 層は window に依存できません"
+          }
+        ],
+        "eslint/no-restricted-properties": [
+          "error",
+          {
+            "object": "chrome",
+            "property": "tabs",
+            "message": "domain 層は chrome.tabs を直接利用できません"
+          },
+          {
+            "object": "chrome",
+            "property": "storage",
+            "message": "domain 層は chrome.storage を直接利用できません"
+          },
+          {
+            "object": "chrome",
+            "property": "contextMenus",
+            "message": "domain 層は chrome.contextMenus を直接利用できません"
+          },
+          {
+            "object": "chrome",
+            "property": "alarms",
+            "message": "domain 層は chrome.alarms を直接利用できません"
+          },
+          {
+            "object": "chrome",
+            "property": "notifications",
+            "message": "domain 層は chrome.notifications を直接利用できません"
+          },
+          {
+            "object": "chrome",
+            "property": "runtime",
+            "message": "domain 層は chrome.runtime を直接利用できません"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["src/contexts/saved-tabs/application/**/*.{ts,tsx}"],
+      "rules": {
+        "eslint/no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "react",
+                "message": "application 層は React に依存できません"
+              },
+              {
+                "name": "react-dom",
+                "message": "application 層は React DOM に依存できません"
+              }
+            ],
+            "patterns": [
+              {
+                "regex": "^@/components(/|$)",
+                "message": "application 層は UI コンポーネントに依存できません"
+              },
+              {
+                "regex": "^@/features/[^/]+/components(/|$)",
+                "message": "application 層は feature の UI コンポーネントに依存できません"
+              },
+              {
+                "regex": "^@/contexts/[^/]+/presentation(/|$)",
+                "message": "application 層は presentation 層に依存できません"
+              }
+            ]
+          }
+        ],
+        "eslint/no-restricted-properties": [
+          "error",
+          {
+            "object": "chrome",
+            "property": "tabs",
+            "message": "application 層は chrome.tabs を直接利用できません（BrowserTabPort 経由）"
+          },
+          {
+            "object": "chrome",
+            "property": "storage",
+            "message": "application 層は chrome.storage を直接利用できません（Repository 経由）"
+          },
+          {
+            "object": "chrome",
+            "property": "contextMenus",
+            "message": "application 層は chrome.contextMenus を直接利用できません"
+          },
+          {
+            "object": "chrome",
+            "property": "alarms",
+            "message": "application 層は chrome.alarms を直接利用できません"
+          },
+          {
+            "object": "chrome",
+            "property": "notifications",
+            "message": "application 層は chrome.notifications を直接利用できません（NotificationPort 経由）"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["src/contexts/saved-tabs/infrastructure/**/*.{ts,tsx}"],
+      "rules": {
+        "eslint/no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "react",
+                "message": "infrastructure 層は React に依存できません"
+              },
+              {
+                "name": "react-dom",
+                "message": "infrastructure 層は React DOM に依存できません"
+              }
+            ],
+            "patterns": [
+              {
+                "regex": "^@/components(/|$)",
+                "message": "infrastructure 層は UI コンポーネントに依存できません"
+              },
+              {
+                "regex": "^@/features/[^/]+/components(/|$)",
+                "message": "infrastructure 層は feature の UI コンポーネントに依存できません"
+              },
+              {
+                "regex": "^@/contexts/[^/]+/presentation(/|$)",
+                "message": "infrastructure 層は presentation 層に依存できません"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": ["src/contexts/saved-tabs/presentation/**/*.{ts,tsx}"],
+      "rules": {
+        "eslint/no-restricted-properties": [
+          "error",
+          {
+            "object": "chrome",
+            "property": "storage",
+            "message": "presentation 層は chrome.storage を直接利用できません（Repository 経由）"
+          },
+          {
+            "object": "chrome",
+            "property": "tabs",
+            "message": "presentation 層は chrome.tabs を直接利用できません（BrowserTabPort 経由）"
+          },
+          {
+            "object": "chrome",
+            "property": "contextMenus",
+            "message": "presentation 層は chrome.contextMenus を直接利用できません"
+          },
+          {
+            "object": "chrome",
+            "property": "alarms",
+            "message": "presentation 層は chrome.alarms を直接利用できません"
+          }
+        ]
+      }
     }
   ]
 }

--- a/docs/architecture/ddd.md
+++ b/docs/architecture/ddd.md
@@ -109,6 +109,16 @@ src/contexts/saved-tabs/
 | infrastructure | presentation への依存 / domain interface を通さない直接アクセス                                                                                    |
 | presentation   | `chrome.storage.local` / `chrome.*` API の直接利用 / ドメインルールの埋め込み                                                                      |
 
+## oxlint による機械的ガード
+
+上記の禁止ルールは `.oxlintrc.json` の `overrides` で機械的にチェックされます。`bun run lint` を実行すると、`src/contexts/saved-tabs/{domain,application,infrastructure,presentation}/**` 配下で禁止された import / global 参照 / プロパティアクセスを即座に検出します。
+
+- `eslint/no-restricted-imports` — layer を越えた依存（`@/components/*` / `@/features/**/components/**` / `@/contexts/**/application/**` など）をブロック
+- `eslint/no-restricted-globals` — domain 層での `chrome` / `localStorage` / `sessionStorage` / `document` / `window` 利用をブロック
+- `eslint/no-restricted-properties` — `chrome.tabs` / `chrome.storage` / `chrome.contextMenus` / `chrome.alarms` / `chrome.notifications` / `chrome.runtime` の直叩きを layer 別にブロック
+
+false positive が出たら `// oxlint-disable-next-line` ではなく、ルール側（許可リストや `allowImportNames`）で解決することを優先してください。Issue #462 がガード設定の source of truth です。
+
 ## composition ルール
 
 - Repository / port の実装インスタンスは `app/composition/` などの composition 層で生成し、context の外側（entrypoint や hook）から use-case へ注入します。
@@ -131,4 +141,5 @@ src/contexts/saved-tabs/
 
 - #454: DDD 構成へ段階移行するための全体設計と実装計画
 - #455: contexts/saved-tabs の DDD ディレクトリを追加する（最初の PR）
+- #462: oxlint で DDD レイヤ境界を機械的にガードする
 - #380: feature UI の直接 chrome API 利用を wrapper/service に寄せる（DDD 移行と並行で進める）


### PR DESCRIPTION
## 変更内容

Issue #462 に基づき、`.oxlintrc.json` の `overrides` に `src/contexts/saved-tabs/{domain,application,infrastructure,presentation}/**` 向けの DDD レイヤ境界ガードを追加しました。

### 追加したルール
- `eslint/no-restricted-imports`: layer を越えた依存をブロック
  - domain → React, @/components, @/features/**/components/**, 他の layer
  - application / infrastructure → React, @/components, presentation
  - 共通: `react`, `react-dom`
- `eslint/no-restricted-globals`: domain 層での `chrome` / `localStorage` / `sessionStorage` / `document` / `window` をブロック
- `eslint/no-restricted-properties`: `chrome.tabs` / `chrome.storage` / `chrome.contextMenus` / `chrome.alarms` / `chrome.notifications` / `chrome.runtime` の直叩きを layer 別にブロック

### ドキュメント
- `docs/architecture/ddd.md` に「oxlint による機械的ガード」セクションを追加
- 関連 Issue に #462 を追記

## 検証

- `bun run lint`: 既存コード 0 warnings / 0 errors
- `bun run compile`: 通過
- `bun run test`: 170 files / 1408 tests 通過
- 4 layer 分の違反サンプルファイルを `src/contexts/saved-tabs/{domain,application,infrastructure,presentation}/__violation_sample.ts` に一時的に作成し、検出動作を確認
  - domain: react, chrome, localStorage, sessionStorage, document, window, chrome.tabs, chrome.storage, @/components, @/features, @/contexts/{application,infrastructure,presentation} すべてを検出
  - application: react, @/components, @/features, @/contexts/presentation, chrome.tabs, chrome.storage を検出
  - infrastructure: react, @/components, @/contexts/presentation を検出
  - presentation: chrome.storage, chrome.tabs を検出
  - 確認後 4 ファイルとも削除

## 受け入れ条件

- [x] `.oxlintrc.json` に 4 layer 分の `overrides` が追加されている
- [x] domain 層から react / chrome / localStorage / document を import または利用すると lint エラー
- [x] application 層から react または chrome.* を直接利用すると lint エラー
- [x] infrastructure 層から react または presentation を import すると lint エラー
- [x] presentation 層から chrome.storage.local などを直接利用すると lint エラー
- [x] 既存テストおよび既存 lint 設定が回帰していない
- [x] `bun run lint` が通る
- [x] サンプル違反ファイルで 4 layer すべての検出を確認
- [x] `docs/architecture/ddd.md` にガードの旨を明記

## 関連Issue

- #454: DDD構成へ段階移行するための全体設計と実装計画
- #455: contexts/saved-tabs の DDD ディレクトリを追加する
- #462: oxlintでDDDレイヤ境界を機械的にガードする
- Closes #462