### PR TITLE
feat(#460): DDDレイヤガードのoxlint設定を検証するリグレッションテストを追加

### DIFF
--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -1,0 +1,253 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+type RuleEntry = string | [string, ...unknown[]]
+
+interface OxlintOverride {
+  files?: string[]
+  rules?: Record<string, RuleEntry>
+}
+
+interface OxlintConfig {
+  overrides?: OxlintOverride[]
+}
+
+const contextsRoot = import.meta.dirname
+const repoRoot = resolve(contextsRoot, '..', '..', '..')
+const oxlintrcPath = resolve(repoRoot, '.oxlintrc.json')
+
+const loadOxlintConfig = (): OxlintConfig => {
+  const raw = readFileSync(oxlintrcPath, 'utf8')
+  return JSON.parse(raw) as OxlintConfig
+}
+
+const findOverride = (
+  config: OxlintConfig,
+  layer: string,
+): OxlintOverride | undefined => {
+  const pattern = `src/contexts/saved-tabs/${layer}/**`
+  return config.overrides?.find((entry) =>
+    entry.files?.some((file) => file.includes(pattern)),
+  )
+}
+
+const collectRulePatterns = (entry: RuleEntry | undefined): string[] => {
+  if (!entry) {
+    return []
+  }
+  if (typeof entry === 'string') {
+    return [entry]
+  }
+  const [, options] = entry
+  if (!options || typeof options !== 'object') {
+    return []
+  }
+  const optionsObj = options as Record<string, unknown>
+  const pathEntries = Array.isArray(optionsObj.paths) ? optionsObj.paths : []
+  const patternEntries = Array.isArray(optionsObj.patterns)
+    ? optionsObj.patterns
+    : []
+  const names: string[] = []
+  for (const value of [...pathEntries, ...patternEntries]) {
+    if (value && typeof value === 'object') {
+      const record = value as Record<string, unknown>
+      if (typeof record.name === 'string') {
+        names.push(record.name)
+      }
+      if (typeof record.regex === 'string') {
+        names.push(record.regex)
+      }
+    }
+  }
+  return names
+}
+
+const getRestrictedImportNames = (
+  override: OxlintOverride | undefined,
+): string[] => {
+  if (!override?.rules) {
+    return []
+  }
+  return collectRulePatterns(override.rules['eslint/no-restricted-imports'])
+}
+
+const getRestrictedGlobals = (
+  override: OxlintOverride | undefined,
+): string[] => {
+  if (!override?.rules) {
+    return []
+  }
+  const entry = override.rules['eslint/no-restricted-globals']
+  if (!entry || typeof entry === 'string') {
+    return []
+  }
+  const [, ...rest] = entry
+  return rest.flatMap((value) => {
+    if (!value || typeof value !== 'object') {
+      return []
+    }
+    const record = value as Record<string, unknown>
+    return typeof record.name === 'string' ? [record.name] : []
+  })
+}
+
+const getRestrictedProperties = (
+  override: OxlintOverride | undefined,
+): string[] => {
+  if (!override?.rules) {
+    return []
+  }
+  const entry = override.rules['eslint/no-restricted-properties']
+  if (!entry || typeof entry === 'string') {
+    return []
+  }
+  const [, ...rest] = entry
+  return rest.flatMap((value) => {
+    if (!value || typeof value !== 'object') {
+      return []
+    }
+    const record = value as Record<string, unknown>
+    if (
+      typeof record.object === 'string' &&
+      typeof record.property === 'string'
+    ) {
+      return [`${record.object}.${record.property}`]
+    }
+    return []
+  })
+}
+
+describe('src/contexts/saved-tabs DDD layer guard', () => {
+  const config = loadOxlintConfig()
+
+  it('.oxlintrc.json に overrides が定義されている', () => {
+    expect(Array.isArray(config.overrides)).toBe(true)
+    expect(config.overrides?.length ?? 0).toBeGreaterThan(0)
+  })
+
+  describe('domain 層', () => {
+    const override = findOverride(config, 'domain')
+
+    it('override が定義されている', () => {
+      expect(override).toBeDefined()
+    })
+
+    it('react / react-dom の import を禁止している', () => {
+      const names = getRestrictedImportNames(override)
+      expect(names).toContain('react')
+      expect(names).toContain('react-dom')
+    })
+
+    it('@/components / @/features/*/components / @/contexts/*/{application,infrastructure,presentation} への依存を禁止している', () => {
+      const names = getRestrictedImportNames(override)
+      expect(names.some((name) => name.includes('@/components'))).toBe(true)
+      expect(
+        names.some(
+          (name) =>
+            name.includes('@/features/') && name.includes('/components'),
+        ),
+      ).toBe(true)
+      expect(names.some((name) => name.includes('/application'))).toBe(true)
+      expect(names.some((name) => name.includes('/infrastructure'))).toBe(true)
+      expect(names.some((name) => name.includes('/presentation'))).toBe(true)
+    })
+
+    it('chrome / localStorage / sessionStorage / document / window の global 参照を禁止している', () => {
+      const names = getRestrictedGlobals(override)
+      expect(names).toContain('chrome')
+      expect(names).toContain('localStorage')
+      expect(names).toContain('sessionStorage')
+      expect(names).toContain('document')
+      expect(names).toContain('window')
+    })
+
+    it('chrome.tabs / chrome.storage / chrome.contextMenus / chrome.alarms / chrome.notifications / chrome.runtime の直叩きを禁止している', () => {
+      const names = getRestrictedProperties(override)
+      expect(names).toContain('chrome.tabs')
+      expect(names).toContain('chrome.storage')
+      expect(names).toContain('chrome.contextMenus')
+      expect(names).toContain('chrome.alarms')
+      expect(names).toContain('chrome.notifications')
+      expect(names).toContain('chrome.runtime')
+    })
+  })
+
+  describe('application 層', () => {
+    const override = findOverride(config, 'application')
+
+    it('override が定義されている', () => {
+      expect(override).toBeDefined()
+    })
+
+    it('react / react-dom の import を禁止している', () => {
+      const names = getRestrictedImportNames(override)
+      expect(names).toContain('react')
+      expect(names).toContain('react-dom')
+    })
+
+    it('@/components / @/features/*/components / @/contexts/*/presentation への依存を禁止している', () => {
+      const names = getRestrictedImportNames(override)
+      expect(names.some((name) => name.includes('@/components'))).toBe(true)
+      expect(
+        names.some(
+          (name) =>
+            name.includes('@/features/') && name.includes('/components'),
+        ),
+      ).toBe(true)
+      expect(names.some((name) => name.includes('/presentation'))).toBe(true)
+    })
+
+    it('chrome.tabs / chrome.storage / chrome.contextMenus / chrome.alarms / chrome.notifications の直叩きを禁止している', () => {
+      const names = getRestrictedProperties(override)
+      expect(names).toContain('chrome.tabs')
+      expect(names).toContain('chrome.storage')
+      expect(names).toContain('chrome.contextMenus')
+      expect(names).toContain('chrome.alarms')
+      expect(names).toContain('chrome.notifications')
+    })
+  })
+
+  describe('infrastructure 層', () => {
+    const override = findOverride(config, 'infrastructure')
+
+    it('override が定義されている', () => {
+      expect(override).toBeDefined()
+    })
+
+    it('react / react-dom の import を禁止している', () => {
+      const names = getRestrictedImportNames(override)
+      expect(names).toContain('react')
+      expect(names).toContain('react-dom')
+    })
+
+    it('@/components / @/features/*/components / @/contexts/*/presentation への依存を禁止している', () => {
+      const names = getRestrictedImportNames(override)
+      expect(names.some((name) => name.includes('@/components'))).toBe(true)
+      expect(
+        names.some(
+          (name) =>
+            name.includes('@/features/') && name.includes('/components'),
+        ),
+      ).toBe(true)
+      expect(names.some((name) => name.includes('/presentation'))).toBe(true)
+    })
+  })
+
+  describe('presentation 層', () => {
+    const override = findOverride(config, 'presentation')
+
+    it('override が定義されている', () => {
+      expect(override).toBeDefined()
+    })
+
+    it('chrome.storage / chrome.tabs / chrome.contextMenus / chrome.alarms の直叩きを禁止している', () => {
+      const names = getRestrictedProperties(override)
+      expect(names).toContain('chrome.storage')
+      expect(names).toContain('chrome.tabs')
+      expect(names).toContain('chrome.contextMenus')
+      expect(names).toContain('chrome.alarms')
+    })
+  })
+})

--- a/vitest.ci.config.ts
+++ b/vitest.ci.config.ts
@@ -87,6 +87,7 @@ export default defineConfig({
             'src/lib/**/*.test.ts',
             'src/utils/**/*.test.ts',
             'src/constants/**/*.test.ts',
+            'src/contexts/**/*.test.ts',
             'src/features/**/lib/**/*.test.ts',
             'src/features/i18n/lib/**/*.test.ts',
             'src/features/analytics/**/*.test.ts',


### PR DESCRIPTION
## 変更内容

- `src/contexts/saved-tabs/dddLayerGuard.test.ts` を追加
  - `#455` / `#462` で確立した saved-tabs の DDD レイヤ境界が、将来の `.oxlintrc.json` 変更で崩れないよう Vitest で構造を assert
  - 4 層 (domain / application / infrastructure / presentation) それぞれの override が存在し、禁止 import / global / property が設定されていることを確認
  - 違反サンプル (`react` を domain から削除 / presentation override を全削除) で fail することを確認済み
- `vitest.ci.config.ts` の node project include に `src/contexts/**/*.test.ts` を追加

## 関連 Issue

- #460 (この PR)
- 親: #454
- 先行: #455 (DDD スケルトン), #462 (oxlint ガード)

## 検証

- [x] `bun run compile` が通る
- [x] `bun run lint` が通る
- [x] `bun run test` 171 files / 1423 tests pass (新テスト 15 件追加)
- [x] `bun run test:coverage` 新ファイル 100%
- [x] `bun run knip` 新ファイル由来の指摘なし
- [x] ローカル環境でエラーになっていない

## 受け入れ条件 (Issue #460)

- [x] DDD構成のルールがドキュメント化されている (`docs/architecture/ddd.md`, `AGENTS.md`, `.apm/instructions/repository-guidelines.instructions.md`)
- [x] 依存方向違反を検知する仕組みが最低1つ追加されている (`#462` の oxlint guard + 本 PR のリグレッションテスト)
- [x] `bun run compile` が通る
- [x] 既存 lint/test が壊れていない
- [x] AI が Issue 本文を見て実装方針を判断できる粒度になっている