### PR TITLE
feat(#456): saved-tabs domain層へモデル・値オブジェクト・純粋サービスを移す

### DIFF
--- a/src/contexts/saved-tabs/domain/entities/CustomProject.test.ts
+++ b/src/contexts/saved-tabs/domain/entities/CustomProject.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import { createUrlRecordId } from '../value-objects/UrlRecordId'
+import {
+  createCustomProject,
+  customProjectContainsUrlRecord,
+  customProjectUrlCount,
+  isSameCustomProject,
+} from './CustomProject'
+
+const baseInput = {
+  id: 'project-1',
+  name: 'Q4 Research',
+  urlIds: ['url-1', 'url-2'],
+  categories: ['Research', 'Notes'],
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_001,
+}
+
+describe('CustomProject entity', () => {
+  it('正常な入力からエンティティを生成できる', () => {
+    const project = createCustomProject(baseInput)
+    expect(project.id).toBe('project-1')
+    expect(project.name).toBe('Q4 Research')
+    expect(project.urlIds).toStrictEqual(['url-1', 'url-2'])
+    expect(project.categories).toStrictEqual(['Research', 'Notes'])
+    expect(project.createdAt).toBe(1_700_000_000_000)
+    expect(project.updatedAt).toBe(1_700_000_000_001)
+  })
+
+  it('urlIds に重複があると INVALID_CUSTOM_PROJECT を投げる', () => {
+    expect(() =>
+      createCustomProject({ ...baseInput, urlIds: ['dup', 'dup'] }),
+    ).toThrow(SavedTabsDomainError)
+  })
+
+  it('categories に重複があると INVALID_CUSTOM_PROJECT を投げる', () => {
+    expect(() =>
+      createCustomProject({ ...baseInput, categories: ['x', 'x'] }),
+    ).toThrow(SavedTabsDomainError)
+  })
+
+  it('createdAt が不正なら INVALID_SAVED_AT を投げる', () => {
+    expect(() => createCustomProject({ ...baseInput, createdAt: -1 })).toThrow(
+      SavedTabsDomainError,
+    )
+  })
+
+  it('customProjectUrlCount は URL 件数を返す', () => {
+    const project = createCustomProject(baseInput)
+    expect(customProjectUrlCount(project)).toBe(2)
+  })
+
+  it('customProjectContainsUrlRecord は所属判定を行う', () => {
+    const project = createCustomProject(baseInput)
+    expect(
+      customProjectContainsUrlRecord(project, createUrlRecordId('url-1')),
+    ).toBe(true)
+    expect(
+      customProjectContainsUrlRecord(project, createUrlRecordId('url-3')),
+    ).toBe(false)
+  })
+
+  it('isSameCustomProject は ID で同一視する', () => {
+    const a = createCustomProject(baseInput)
+    const b = createCustomProject({ ...baseInput, name: 'Renamed' })
+    expect(isSameCustomProject(a, b)).toBe(true)
+  })
+})

--- a/src/contexts/saved-tabs/domain/entities/CustomProject.ts
+++ b/src/contexts/saved-tabs/domain/entities/CustomProject.ts
@@ -1,0 +1,135 @@
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import { createCategoryName } from '../value-objects/CategoryName'
+import type { CategoryName } from '../value-objects/CategoryName'
+import { createCustomProjectId } from '../value-objects/CustomProjectId'
+import type { CustomProjectId } from '../value-objects/CustomProjectId'
+import { createSavedAt } from '../value-objects/SavedAt'
+import type { SavedAt } from '../value-objects/SavedAt'
+import { createUrlRecordId } from '../value-objects/UrlRecordId'
+import type { UrlRecordId } from '../value-objects/UrlRecordId'
+
+/**
+ * カスタムプロジェクト（PJ 単位）を表すドメインエンティティ。
+ *
+ * `TabGroup` がドメイン軸の集約であるのに対し、`CustomProject` は
+ * 任意のユーザー作業単位（例: 「Q4 リサーチ」「副業案件 A」）で
+ * URL を束ねる集約。実 URL は `urlIds` で `UrlRecord` を参照する。
+ *
+ * @example
+ * ```ts
+ * const project = createCustomProject({
+ *   id: 'project-1',
+ *   name: 'Q4 Research',
+ *   urlIds: ['url-1'],
+ *   categories: ['research'],
+ *   createdAt: 1700000000000,
+ *   updatedAt: 1700000000000,
+ * })
+ * ```
+ */
+export interface CustomProject {
+  readonly id: CustomProjectId
+  readonly name: CategoryName
+  readonly urlIds: readonly UrlRecordId[]
+  readonly categories: readonly CategoryName[]
+  readonly createdAt: SavedAt
+  readonly updatedAt: SavedAt
+}
+
+interface CreateCustomProjectInput {
+  id: string
+  name: string
+  urlIds: readonly string[]
+  categories: readonly string[]
+  createdAt: number
+  updatedAt: number
+}
+
+/**
+ * `CustomProject` を生成する。
+ *
+ * `urlIds` 内の重複は domain 不変条件違反として扱う（同じ URL を
+ * 同じ project 内で二重登録しない）。`categories` は空配列を許容するが、
+ * カテゴリ名の重複は許容しない。
+ */
+export const createCustomProject = (
+  input: CreateCustomProjectInput,
+): CustomProject => {
+  const rawUrlIds: readonly string[] = ensureStringArray(
+    input.urlIds,
+    'CustomProject の urlIds は配列で指定してください',
+  )
+  const rawCategories: readonly string[] = ensureStringArray(
+    input.categories,
+    'CustomProject の categories は配列で指定してください',
+  )
+  const seenUrlIds = new Set<string>()
+  const urlIds: UrlRecordId[] = []
+  for (const rawId of rawUrlIds) {
+    const urlId = createUrlRecordId(rawId)
+    if (seenUrlIds.has(urlId)) {
+      throw new SavedTabsDomainError(
+        'CustomProject の urlIds に重複があります',
+        'INVALID_CUSTOM_PROJECT',
+      )
+    }
+    seenUrlIds.add(urlId)
+    urlIds.push(urlId)
+  }
+  const seenCategoryNames = new Set<string>()
+  const categories: CategoryName[] = []
+  for (const rawName of rawCategories) {
+    const categoryName = createCategoryName(rawName)
+    if (seenCategoryNames.has(categoryName)) {
+      throw new SavedTabsDomainError(
+        'CustomProject の categories に重複があります',
+        'INVALID_CUSTOM_PROJECT',
+      )
+    }
+    seenCategoryNames.add(categoryName)
+    categories.push(categoryName)
+  }
+  return {
+    id: createCustomProjectId(input.id),
+    name: createCategoryName(input.name),
+    urlIds,
+    categories,
+    createdAt: createSavedAt(input.createdAt),
+    updatedAt: createSavedAt(input.updatedAt),
+  }
+}
+
+const ensureStringArray = (
+  value: readonly string[],
+  message: string,
+): readonly string[] => {
+  if (!Array.isArray(value)) {
+    throw new SavedTabsDomainError(message, 'INVALID_CUSTOM_PROJECT')
+  }
+  // OK: input 型は readonly string[] であり、Array.isArray の narrowing で
+  // any[] へ広がるのを元の型へ戻すだけのキャストにする。
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return value as readonly string[]
+}
+
+/**
+ * 2 つの `CustomProject` を ID で同一視するかを判定する。
+ */
+export const isSameCustomProject = (
+  a: CustomProject,
+  b: CustomProject,
+): boolean => a.id === b.id
+
+/**
+ * 指定の `UrlRecordId` がこのプロジェクトに登録されているかを判定する。
+ */
+export const customProjectContainsUrlRecord = (
+  project: CustomProject,
+  urlRecordId: UrlRecordId,
+): boolean => project.urlIds.includes(urlRecordId)
+
+/**
+ * プロジェクトが参照する URL レコード数を返す。
+ */
+export const customProjectUrlCount = (project: CustomProject): number =>
+  project.urlIds.length

--- a/src/contexts/saved-tabs/domain/entities/ParentCategory.test.ts
+++ b/src/contexts/saved-tabs/domain/entities/ParentCategory.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import { createDomainName } from '../value-objects/DomainName'
+import { createTabGroupId } from '../value-objects/TabGroupId'
+import {
+  createParentCategory,
+  isSameParentCategory,
+  parentCategoryContainsDomainName,
+  parentCategoryContainsTabGroup,
+} from './ParentCategory'
+
+const baseInput = {
+  id: 'docs',
+  name: 'Docs',
+  domains: ['group-1'],
+  domainNames: ['example.com'],
+}
+
+describe('ParentCategory entity', () => {
+  it('正常な入力からエンティティを生成できる', () => {
+    const category = createParentCategory(baseInput)
+    expect(category.id).toBe('docs')
+    expect(category.name).toBe('Docs')
+    expect(category.domains).toStrictEqual(['group-1'])
+    expect(category.domainNames).toStrictEqual(['example.com'])
+  })
+
+  it('空配列の domains / domainNames を許容する', () => {
+    const category = createParentCategory({
+      ...baseInput,
+      domains: [],
+      domainNames: [],
+    })
+    expect(category.domains).toStrictEqual([])
+    expect(category.domainNames).toStrictEqual([])
+  })
+
+  it('不正な category name は INVALID_CATEGORY_NAME を投げる', () => {
+    expect(() => createParentCategory({ ...baseInput, name: '' })).toThrow(
+      SavedTabsDomainError,
+    )
+  })
+
+  it('parentCategoryContainsTabGroup は ID 一致で true', () => {
+    const category = createParentCategory(baseInput)
+    expect(
+      parentCategoryContainsTabGroup(category, createTabGroupId('group-1')),
+    ).toBe(true)
+    expect(
+      parentCategoryContainsTabGroup(category, createTabGroupId('group-2')),
+    ).toBe(false)
+  })
+
+  it('parentCategoryContainsDomainName は ドメイン名一致で true', () => {
+    const category = createParentCategory(baseInput)
+    expect(
+      parentCategoryContainsDomainName(
+        category,
+        createDomainName('example.com'),
+      ),
+    ).toBe(true)
+    expect(
+      parentCategoryContainsDomainName(category, createDomainName('other.com')),
+    ).toBe(false)
+  })
+
+  it('isSameParentCategory は ID で同一視する', () => {
+    const a = createParentCategory(baseInput)
+    const b = createParentCategory({ ...baseInput, name: 'Renamed' })
+    expect(isSameParentCategory(a, b)).toBe(true)
+  })
+})

--- a/src/contexts/saved-tabs/domain/entities/ParentCategory.ts
+++ b/src/contexts/saved-tabs/domain/entities/ParentCategory.ts
@@ -1,0 +1,99 @@
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import { createCategoryName } from '../value-objects/CategoryName'
+import type { CategoryName } from '../value-objects/CategoryName'
+import { createDomainName } from '../value-objects/DomainName'
+import type { DomainName } from '../value-objects/DomainName'
+import { createParentCategoryId } from '../value-objects/ParentCategoryId'
+import type { ParentCategoryId } from '../value-objects/ParentCategoryId'
+import { createTabGroupId } from '../value-objects/TabGroupId'
+import type { TabGroupId } from '../value-objects/TabGroupId'
+
+/**
+ * 親カテゴリを表すドメインエンティティ。
+ *
+ * 1 つのカテゴリは、紐づく `TabGroupId` の集合（`domains`）と
+ * `DomainName` の集合（`domainNames`）を持つ。前者はストレージ上の
+ * `parentCategories[].domains`、後者は同 `domainNames` と対応する。
+ *
+ * カテゴリ自動判定（URL のドメインと `domainNames` の一致など）は
+ * `CategoryAssignmentPolicy` / `TabGroupCategorizationService` に置く。
+ *
+ * @example
+ * ```ts
+ * const category = createParentCategory({
+ *   id: 'docs',
+ *   name: 'Docs',
+ *   domains: ['group-1'],
+ *   domainNames: ['example.com'],
+ * })
+ * ```
+ */
+export interface ParentCategory {
+  readonly id: ParentCategoryId
+  readonly name: CategoryName
+  readonly domains: readonly TabGroupId[]
+  readonly domainNames: readonly DomainName[]
+}
+
+interface CreateParentCategoryInput {
+  id: string
+  name: string
+  domains: readonly string[]
+  domainNames: readonly string[]
+}
+
+const assertStringArray = (
+  value: unknown,
+  field: 'domains' | 'domainNames',
+): void => {
+  if (!Array.isArray(value)) {
+    throw new SavedTabsDomainError(
+      `ParentCategory の ${field} は配列で指定してください`,
+      'INVALID_PARENT_CATEGORY',
+    )
+  }
+}
+
+/**
+ * `ParentCategory` を生成する。
+ *
+ * `domains` と `domainNames` は重複を許容する既存データと互換するため、
+ * 重複検査はしない（重複は service 層で意味付けして扱う）。
+ * 空配列は許容する。
+ */
+export const createParentCategory = (
+  input: CreateParentCategoryInput,
+): ParentCategory => {
+  assertStringArray(input.domains, 'domains')
+  assertStringArray(input.domainNames, 'domainNames')
+  return {
+    id: createParentCategoryId(input.id),
+    name: createCategoryName(input.name),
+    domains: input.domains.map((domain) => createTabGroupId(domain)),
+    domainNames: input.domainNames.map((name) => createDomainName(name)),
+  }
+}
+
+/**
+ * 2 つの `ParentCategory` を ID で同一視するかを判定する。
+ */
+export const isSameParentCategory = (
+  a: ParentCategory,
+  b: ParentCategory,
+): boolean => a.id === b.id
+
+/**
+ * 指定の `TabGroupId` がこのカテゴリに登録されているかを判定する。
+ */
+export const parentCategoryContainsTabGroup = (
+  category: ParentCategory,
+  tabGroupId: TabGroupId,
+): boolean => category.domains.includes(tabGroupId)
+
+/**
+ * 指定の `DomainName` がこのカテゴリに登録されているかを判定する。
+ */
+export const parentCategoryContainsDomainName = (
+  category: ParentCategory,
+  domainName: DomainName,
+): boolean => category.domainNames.includes(domainName)

--- a/src/contexts/saved-tabs/domain/entities/TabGroup.test.ts
+++ b/src/contexts/saved-tabs/domain/entities/TabGroup.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import { createUrlRecordId } from '../value-objects/UrlRecordId'
+import {
+  createTabGroup,
+  isSameTabGroup,
+  tabGroupContainsUrlRecord,
+  tabGroupUrlCount,
+} from './TabGroup'
+
+const baseInput = {
+  id: 'group-1',
+  domain: 'example.com',
+  urlIds: ['url-1', 'url-2'],
+}
+
+describe('TabGroup entity', () => {
+  it('正常な入力からエンティティを生成できる', () => {
+    const group = createTabGroup(baseInput)
+    expect(group.id).toBe('group-1')
+    expect(group.domain).toBe('example.com')
+    expect(group.urlIds).toStrictEqual(['url-1', 'url-2'])
+    expect(group.parentCategoryId).toBeUndefined()
+    expect(group.savedAt).toBeUndefined()
+  })
+
+  it('parentCategoryId / savedAt を保持できる', () => {
+    const group = createTabGroup({
+      ...baseInput,
+      parentCategoryId: 'docs',
+      savedAt: 1_700_000_000_000,
+    })
+    expect(group.parentCategoryId).toBe('docs')
+    expect(group.savedAt).toBe(1_700_000_000_000)
+  })
+
+  it('urlIds に重複があると INVALID_TAB_GROUP を投げる', () => {
+    expect(() =>
+      createTabGroup({ ...baseInput, urlIds: ['dup', 'dup'] }),
+    ).toThrow(SavedTabsDomainError)
+  })
+
+  it('urlIds に空文字列が混ざると INVALID_ID を投げる', () => {
+    expect(() => createTabGroup({ ...baseInput, urlIds: ['ok', ''] })).toThrow(
+      SavedTabsDomainError,
+    )
+  })
+
+  it('tabGroupUrlCount は URL 件数を返す', () => {
+    const group = createTabGroup(baseInput)
+    expect(tabGroupUrlCount(group)).toBe(2)
+  })
+
+  it('tabGroupContainsUrlRecord は所属判定を行う', () => {
+    const group = createTabGroup(baseInput)
+    expect(tabGroupContainsUrlRecord(group, createUrlRecordId('url-1'))).toBe(
+      true,
+    )
+    expect(tabGroupContainsUrlRecord(group, createUrlRecordId('url-3'))).toBe(
+      false,
+    )
+  })
+
+  it('isSameTabGroup は ID で同一視する', () => {
+    const a = createTabGroup(baseInput)
+    const b = createTabGroup({ ...baseInput, domain: 'other.com' })
+    expect(isSameTabGroup(a, b)).toBe(true)
+  })
+})

--- a/src/contexts/saved-tabs/domain/entities/TabGroup.ts
+++ b/src/contexts/saved-tabs/domain/entities/TabGroup.ts
@@ -1,0 +1,119 @@
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import { createDomainName } from '../value-objects/DomainName'
+import type { DomainName } from '../value-objects/DomainName'
+import { createParentCategoryId } from '../value-objects/ParentCategoryId'
+import type { ParentCategoryId } from '../value-objects/ParentCategoryId'
+import { createSavedAt } from '../value-objects/SavedAt'
+import type { SavedAt } from '../value-objects/SavedAt'
+import { createTabGroupId } from '../value-objects/TabGroupId'
+import type { TabGroupId } from '../value-objects/TabGroupId'
+import { createUrlRecordId } from '../value-objects/UrlRecordId'
+import type { UrlRecordId } from '../value-objects/UrlRecordId'
+
+/**
+ * ドメイン単位で URL レコードをまとめるタブグループのドメインエンティティ。
+ *
+ * `chrome.storage.local` 上の `savedTabs[]` と 1:1 対応する不変モデル。
+ * 実 URL は `urlIds`（`UrlRecordId` の配列）として参照し、URL 本体は
+ * `urlRecords[]` に集約する設計（issue #454 / #456）。
+ *
+ * 既存データ互換のため `parentCategoryId` は省略可能。`savedAt` も省略可能で、
+ * 「いつ作られたか」が判明していないグループは未設定のまま扱う。
+ *
+ * @example
+ * ```ts
+ * const group = createTabGroup({
+ *   id: 'group-1',
+ *   domain: 'example.com',
+ *   urlIds: ['url-1', 'url-2'],
+ * })
+ * tabGroupUrlCount(group) // 2
+ * ```
+ */
+export interface TabGroup {
+  readonly id: TabGroupId
+  readonly domain: DomainName
+  readonly urlIds: readonly UrlRecordId[]
+  readonly parentCategoryId?: ParentCategoryId
+  readonly savedAt?: SavedAt
+}
+
+interface CreateTabGroupInput {
+  id: string
+  domain: string
+  urlIds: readonly string[]
+  parentCategoryId?: string
+  savedAt?: number
+}
+
+/**
+ * `TabGroup` を生成する。
+ *
+ * `urlIds` 内に空文字列や重複があった場合は `SavedTabsDomainError` を投げる。
+ * `parentCategoryId` と `savedAt` は省略可能だが、与えられた場合は
+ * 各値オブジェクトのバリデーションを必ず通る。
+ */
+export const createTabGroup = (input: CreateTabGroupInput): TabGroup => {
+  const rawUrlIds: readonly string[] = ensureStringArray(
+    input.urlIds,
+    'TabGroup の urlIds は配列で指定してください',
+  )
+  const seen = new Set<string>()
+  const urlIds: UrlRecordId[] = []
+  for (const rawId of rawUrlIds) {
+    const urlId = createUrlRecordId(rawId)
+    if (seen.has(urlId)) {
+      throw new SavedTabsDomainError(
+        'TabGroup の urlIds に重複があります',
+        'INVALID_TAB_GROUP',
+      )
+    }
+    seen.add(urlId)
+    urlIds.push(urlId)
+  }
+  return {
+    id: createTabGroupId(input.id),
+    domain: createDomainName(input.domain),
+    urlIds,
+    parentCategoryId:
+      input.parentCategoryId === undefined
+        ? undefined
+        : createParentCategoryId(input.parentCategoryId),
+    savedAt:
+      input.savedAt === undefined ? undefined : createSavedAt(input.savedAt),
+  }
+}
+
+const ensureStringArray = (
+  value: readonly string[],
+  message: string,
+): readonly string[] => {
+  if (!Array.isArray(value)) {
+    throw new SavedTabsDomainError(message, 'INVALID_TAB_GROUP')
+  }
+  // OK: input 型は readonly string[] であり、Array.isArray の narrowing で
+  // any[] へ広がるのを元の型へ戻すだけのキャストにする。
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return value as readonly string[]
+}
+
+/**
+ * 2 つの `TabGroup` を ID で同一視するかを判定する。
+ */
+export const isSameTabGroup = (a: TabGroup, b: TabGroup): boolean =>
+  a.id === b.id
+
+/**
+ * `TabGroup` が保持する URL レコード数を返す。
+ *
+ * 既存の `countTabGroupUrls` / `getDisplayUrlCount` ヘルパーの domain 等価物。
+ */
+export const tabGroupUrlCount = (group: TabGroup): number => group.urlIds.length
+
+/**
+ * 指定の `UrlRecordId` を含むかを判定する。
+ */
+export const tabGroupContainsUrlRecord = (
+  group: TabGroup,
+  urlRecordId: UrlRecordId,
+): boolean => group.urlIds.includes(urlRecordId)

--- a/src/contexts/saved-tabs/domain/entities/UrlRecord.test.ts
+++ b/src/contexts/saved-tabs/domain/entities/UrlRecord.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import { createUrlRecord, isSameUrlRecord } from './UrlRecord'
+
+const baseInput = {
+  id: 'record-1',
+  url: 'https://example.com',
+  title: 'Example',
+  savedAt: 1_700_000_000_000,
+}
+
+describe('UrlRecord entity', () => {
+  it('正常な入力からエンティティを生成できる', () => {
+    const record = createUrlRecord(baseInput)
+    expect(record.id).toBe('record-1')
+    expect(record.url).toBe('https://example.com')
+    expect(record.title).toBe('Example')
+    expect(record.savedAt).toBe(1_700_000_000_000)
+    expect(record.favIconUrl).toBeUndefined()
+  })
+
+  it('title が空文字列でも許容する（タイトル未取得ケース）', () => {
+    const record = createUrlRecord({ ...baseInput, title: '' })
+    expect(record.title).toBe('')
+  })
+
+  it('favIconUrl は文字列のときだけ受け付ける', () => {
+    const record = createUrlRecord({
+      ...baseInput,
+      favIconUrl: 'https://example.com/favicon.ico',
+    })
+    expect(record.favIconUrl).toBe('https://example.com/favicon.ico')
+  })
+
+  it('不正な URL は INVALID_URL を投げる', () => {
+    expect(() => createUrlRecord({ ...baseInput, url: '' })).toThrow(
+      SavedTabsDomainError,
+    )
+  })
+
+  it('isSameUrlRecord は ID で同一視する', () => {
+    const a = createUrlRecord(baseInput)
+    const b = createUrlRecord({ ...baseInput, title: 'Different' })
+    expect(isSameUrlRecord(a, b)).toBe(true)
+  })
+})

--- a/src/contexts/saved-tabs/domain/entities/UrlRecord.ts
+++ b/src/contexts/saved-tabs/domain/entities/UrlRecord.ts
@@ -1,0 +1,76 @@
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import { createSavedAt } from '../value-objects/SavedAt'
+import type { SavedAt } from '../value-objects/SavedAt'
+import { createUrl } from '../value-objects/Url'
+import type { Url } from '../value-objects/Url'
+import { createUrlRecordId } from '../value-objects/UrlRecordId'
+import type { UrlRecordId } from '../value-objects/UrlRecordId'
+
+/**
+ * 共通 URL レコードを表すドメインエンティティ。
+ *
+ * `chrome.storage.local` 上の `urlRecords[]` と 1:1 対応する不変モデル。
+ * 複数の `TabGroup` / `CustomProject` から `urlIds` を介して参照される。
+ *
+ * `title` は空文字列を許容する（ページタイトルが取得できないケースがある）。
+ * `favIconUrl` は省略可能。`savedAt` は保存時刻（必須）。
+ *
+ * @example
+ * ```ts
+ * const record = createUrlRecord({
+ *   id: 'record-1',
+ *   url: 'https://example.com',
+ *   title: 'Example',
+ *   savedAt: 1700000000000,
+ * })
+ * ```
+ */
+export interface UrlRecord {
+  readonly id: UrlRecordId
+  readonly url: Url
+  readonly title: string
+  readonly savedAt: SavedAt
+  readonly favIconUrl?: string
+}
+
+interface CreateUrlRecordInput {
+  id: string
+  url: string
+  title: string
+  savedAt: number
+  favIconUrl?: string
+}
+
+/**
+ * `UrlRecord` を生成する。
+ *
+ * 各値オブジェクトのバリデーションを通り抜けた値だけを保持する。
+ * `title` は `string` であることだけ確認し、空文字列も許容する。
+ */
+export const createUrlRecord = (input: CreateUrlRecordInput): UrlRecord => {
+  if (typeof input.title !== 'string') {
+    throw new SavedTabsDomainError(
+      'UrlRecord の title は文字列で指定してください',
+      'INVALID_URL_RECORD',
+    )
+  }
+  if (input.favIconUrl !== undefined && typeof input.favIconUrl !== 'string') {
+    throw new SavedTabsDomainError(
+      'UrlRecord の favIconUrl は文字列で指定してください',
+      'INVALID_URL_RECORD',
+    )
+  }
+  return {
+    id: createUrlRecordId(input.id),
+    url: createUrl(input.url),
+    title: input.title,
+    savedAt: createSavedAt(input.savedAt),
+    favIconUrl: input.favIconUrl,
+  }
+}
+
+/**
+ * 2 つの `UrlRecord` を ID で同一視するかを判定する。
+ */
+export const isSameUrlRecord = (a: UrlRecord, b: UrlRecord): boolean =>
+  a.id === b.id

--- a/src/contexts/saved-tabs/domain/errors/SavedTabsDomainError.test.ts
+++ b/src/contexts/saved-tabs/domain/errors/SavedTabsDomainError.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { SavedTabsDomainError } from './SavedTabsDomainError'
+
+describe('SavedTabsDomainError', () => {
+  it('Error を継承し name / message / code を保持する', () => {
+    const error = new SavedTabsDomainError('message', 'INVALID_URL')
+    expect(error).toBeInstanceOf(Error)
+    expect(error).toBeInstanceOf(SavedTabsDomainError)
+    expect(error.name).toBe('SavedTabsDomainError')
+    expect(error.message).toBe('message')
+    expect(error.code).toBe('INVALID_URL')
+  })
+})

--- a/src/contexts/saved-tabs/domain/errors/SavedTabsDomainError.ts
+++ b/src/contexts/saved-tabs/domain/errors/SavedTabsDomainError.ts
@@ -1,0 +1,42 @@
+/**
+ * `saved-tabs` ドメイン層で投げるドメイン例外。
+ *
+ * 値オブジェクトのバリデーション失敗、エンティティの不変条件違反、
+ * ドメインサービスのルール違反など、純粋なドメインルールの破綻を表す。
+ *
+ * `code` で機械可読な分類を、`message` で人間可読な説明を保持する。
+ * UI や infrastructure では `instanceof SavedTabsDomainError` で
+ * ドメイン例外と外部例外を切り分けるために使う。
+ *
+ * @example
+ * ```ts
+ * throw new SavedTabsDomainError('URL は空文字列にできません', 'INVALID_URL')
+ * ```
+ */
+export class SavedTabsDomainError extends Error {
+  public readonly code: SavedTabsDomainErrorCode
+
+  public constructor(message: string, code: SavedTabsDomainErrorCode) {
+    super(message)
+    this.name = 'SavedTabsDomainError'
+    this.code = code
+  }
+}
+
+/**
+ * `SavedTabsDomainError` の分類コード。
+ *
+ * UI で error.code に応じたメッセージを出し分けたり、テストで
+ * 期待エラーを判定したりするために使う。新しい分類が必要なときは
+ * 追加し、安易な文字列リテラルを散らかさないこと。
+ */
+export type SavedTabsDomainErrorCode =
+  | 'INVALID_URL'
+  | 'INVALID_DOMAIN_NAME'
+  | 'INVALID_CATEGORY_NAME'
+  | 'INVALID_ID'
+  | 'INVALID_SAVED_AT'
+  | 'INVALID_TAB_GROUP'
+  | 'INVALID_URL_RECORD'
+  | 'INVALID_PARENT_CATEGORY'
+  | 'INVALID_CUSTOM_PROJECT'

--- a/src/contexts/saved-tabs/domain/services/CategoryAssignmentPolicy.test.ts
+++ b/src/contexts/saved-tabs/domain/services/CategoryAssignmentPolicy.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import { createParentCategory } from '../entities/ParentCategory'
+import { createTabGroup } from '../entities/TabGroup'
+import { createDomainName } from '../value-objects/DomainName'
+import { createParentCategoryId } from '../value-objects/ParentCategoryId'
+import { createTabGroupId } from '../value-objects/TabGroupId'
+import {
+  buildCategoryLookup,
+  isUncategorizedTabGroup,
+  resolveCategoryForTabGroup,
+} from './CategoryAssignmentPolicy'
+
+const docs = createParentCategory({
+  id: 'docs',
+  name: 'Docs',
+  domains: ['group-docs'],
+  domainNames: ['example.com'],
+})
+
+const news = createParentCategory({
+  id: 'news',
+  name: 'News',
+  domains: ['group-news'],
+  domainNames: ['news.example.com'],
+})
+
+describe('CategoryAssignmentPolicy.buildCategoryLookup', () => {
+  it('id / tabGroupId / domainName の各キーで引ける', () => {
+    const lookup = buildCategoryLookup([docs, news])
+    expect(lookup.byId.get(createParentCategoryId('docs'))).toStrictEqual(docs)
+    expect(
+      lookup.byTabGroupId.get(createTabGroupId('group-docs')),
+    ).toStrictEqual(docs)
+    expect(
+      lookup.byDomainName.get(createDomainName('news.example.com')),
+    ).toStrictEqual(news)
+  })
+
+  it('複数カテゴリが同一 tabGroupId / domainName を宣言したら先勝ちで保持する', () => {
+    const conflicting = createParentCategory({
+      id: 'docs-conflict',
+      name: 'Docs Conflict',
+      domains: ['group-docs'],
+      domainNames: ['example.com'],
+    })
+    const lookup = buildCategoryLookup([docs, conflicting])
+    expect(lookup.byTabGroupId.get(createTabGroupId('group-docs'))?.id).toBe(
+      'docs',
+    )
+    expect(lookup.byDomainName.get(createDomainName('example.com'))?.id).toBe(
+      'docs',
+    )
+  })
+})
+
+describe('CategoryAssignmentPolicy.resolveCategoryForTabGroup', () => {
+  const lookup = buildCategoryLookup([docs, news])
+
+  it('parentCategoryId が一致するときは最優先で解決する', () => {
+    const group = createTabGroup({
+      id: 'group-news',
+      domain: 'news.example.com',
+      urlIds: [],
+      parentCategoryId: 'docs',
+    })
+    expect(resolveCategoryForTabGroup(group, lookup)?.id).toBe('docs')
+  })
+
+  it('parentCategoryId が無くても tabGroupId 一致で解決する', () => {
+    const group = createTabGroup({
+      id: 'group-docs',
+      domain: 'other.example.com',
+      urlIds: [],
+    })
+    expect(resolveCategoryForTabGroup(group, lookup)?.id).toBe('docs')
+  })
+
+  it('parentCategoryId / tabGroupId が外れても domainName で解決する', () => {
+    const group = createTabGroup({
+      id: 'group-other',
+      domain: 'example.com',
+      urlIds: [],
+    })
+    expect(resolveCategoryForTabGroup(group, lookup)?.id).toBe('docs')
+  })
+
+  it('どこにも一致しないグループは未分類として扱う', () => {
+    const group = createTabGroup({
+      id: 'group-other',
+      domain: 'unknown.example.com',
+      urlIds: [],
+    })
+    expect(resolveCategoryForTabGroup(group, lookup)).toBeUndefined()
+    expect(isUncategorizedTabGroup(group, lookup)).toBe(true)
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/CategoryAssignmentPolicy.ts
+++ b/src/contexts/saved-tabs/domain/services/CategoryAssignmentPolicy.ts
@@ -1,0 +1,96 @@
+import type { ParentCategory } from '../entities/ParentCategory'
+import type { TabGroup } from '../entities/TabGroup'
+import type { DomainName } from '../value-objects/DomainName'
+import type { ParentCategoryId } from '../value-objects/ParentCategoryId'
+import type { TabGroupId } from '../value-objects/TabGroupId'
+
+/**
+ * 親カテゴリの高速検索用マップ。
+ *
+ * `byId`: `ParentCategoryId` から `ParentCategory` を引く（O(1)）
+ * `byTabGroupId`: `TabGroupId` から所属カテゴリを引く（O(1)）
+ * `byDomainName`: `DomainName` から所属カテゴリを引く（O(1)）
+ *
+ * 同じ `TabGroupId` / `DomainName` を複数カテゴリが宣言している場合は
+ * 最初に出現したカテゴリを優先する（先勝ち）。
+ */
+export interface CategoryLookup {
+  readonly byId: ReadonlyMap<ParentCategoryId, ParentCategory>
+  readonly byTabGroupId: ReadonlyMap<TabGroupId, ParentCategory>
+  readonly byDomainName: ReadonlyMap<DomainName, ParentCategory>
+}
+
+/**
+ * `ParentCategory` の配列から `CategoryLookup` を構築する。
+ *
+ * `SavedTabsApp.tsx` の `buildCategoryLookup` を domain 等価物に置き換えるための pure 関数。
+ *
+ * @example
+ * ```ts
+ * const lookup = buildCategoryLookup([docs, news])
+ * lookup.byTabGroupId.get(group.id)
+ * ```
+ */
+export const buildCategoryLookup = (
+  categories: readonly ParentCategory[],
+): CategoryLookup => {
+  const byId = new Map<ParentCategoryId, ParentCategory>()
+  const byTabGroupId = new Map<TabGroupId, ParentCategory>()
+  const byDomainName = new Map<DomainName, ParentCategory>()
+  for (const category of categories) {
+    byId.set(category.id, category)
+    for (const tabGroupId of category.domains) {
+      if (!byTabGroupId.has(tabGroupId)) {
+        byTabGroupId.set(tabGroupId, category)
+      }
+    }
+    for (const domainName of category.domainNames) {
+      if (!byDomainName.has(domainName)) {
+        byDomainName.set(domainName, category)
+      }
+    }
+  }
+  return { byId, byTabGroupId, byDomainName }
+}
+
+/**
+ * `TabGroup` がどの `ParentCategory` に属するかを決定する純粋ポリシー。
+ *
+ * 優先順位は以下の通り。
+ *
+ * 1. `group.parentCategoryId` が `lookup.byId` で引ければそのカテゴリ
+ * 2. `group.id` が `lookup.byTabGroupId` で引ければそのカテゴリ
+ * 3. `group.domain` が `lookup.byDomainName` で引ければそのカテゴリ
+ * 4. いずれにも該当しなければ `undefined`（未分類）
+ *
+ * 既存 `SavedTabsApp.tsx` のカテゴリ判定ルールと一致させる。
+ *
+ * @example
+ * ```ts
+ * resolveCategoryForTabGroup(group, buildCategoryLookup([docs])) // docs or undefined
+ * ```
+ */
+export const resolveCategoryForTabGroup = (
+  group: TabGroup,
+  lookup: CategoryLookup,
+): ParentCategory | undefined => {
+  if (group.parentCategoryId) {
+    const direct = lookup.byId.get(group.parentCategoryId)
+    if (direct) {
+      return direct
+    }
+  }
+  const byTabGroupId = lookup.byTabGroupId.get(group.id)
+  if (byTabGroupId) {
+    return byTabGroupId
+  }
+  return lookup.byDomainName.get(group.domain)
+}
+
+/**
+ * `TabGroup` が未分類（どのカテゴリにも属さない）かを判定する。
+ */
+export const isUncategorizedTabGroup = (
+  group: TabGroup,
+  lookup: CategoryLookup,
+): boolean => resolveCategoryForTabGroup(group, lookup) === undefined

--- a/src/contexts/saved-tabs/domain/services/OpenedUrlRemovalPolicy.test.ts
+++ b/src/contexts/saved-tabs/domain/services/OpenedUrlRemovalPolicy.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest'
+
+import { createTabGroup } from '../entities/TabGroup'
+import { createUrlRecord } from '../entities/UrlRecord'
+import { createUrlRecordId } from '../value-objects/UrlRecordId'
+import {
+  decideUrlRecordIdsToRemoveAfterOpen,
+  lookupUrlRecordIdsByUrl,
+  removeUrlRecordIdsFromTabGroups,
+} from './OpenedUrlRemovalPolicy'
+
+const buildUrlRecord = (id: string, url: string) =>
+  createUrlRecord({
+    id,
+    url,
+    title: id,
+    savedAt: 1_700_000_000_000,
+  })
+
+describe('OpenedUrlRemovalPolicy.decideUrlRecordIdsToRemoveAfterOpen', () => {
+  it('removeTabAfterOpen が true なら click 経路の URL を削除対象にする', () => {
+    const result = decideUrlRecordIdsToRemoveAfterOpen({
+      openedUrls: [
+        { urlRecordId: createUrlRecordId('url-1'), origin: 'click' },
+        { urlRecordId: createUrlRecordId('url-2'), origin: 'click' },
+      ],
+      settings: {
+        removeTabAfterOpen: true,
+        removeTabAfterExternalDrop: false,
+      },
+    })
+    expect([...result]).toStrictEqual([
+      createUrlRecordId('url-1'),
+      createUrlRecordId('url-2'),
+    ])
+  })
+
+  it('removeTabAfterOpen が false なら click 経路は削除しない', () => {
+    const result = decideUrlRecordIdsToRemoveAfterOpen({
+      openedUrls: [
+        { urlRecordId: createUrlRecordId('url-1'), origin: 'click' },
+      ],
+      settings: {
+        removeTabAfterOpen: false,
+        removeTabAfterExternalDrop: true,
+      },
+    })
+    expect(result.size).toBe(0)
+  })
+
+  it('externalDrop は removeTabAfterExternalDrop で判定する', () => {
+    const result = decideUrlRecordIdsToRemoveAfterOpen({
+      openedUrls: [
+        { urlRecordId: createUrlRecordId('url-1'), origin: 'externalDrop' },
+      ],
+      settings: {
+        removeTabAfterOpen: false,
+        removeTabAfterExternalDrop: true,
+      },
+    })
+    expect(result.has(createUrlRecordId('url-1'))).toBe(true)
+  })
+})
+
+describe('OpenedUrlRemovalPolicy.lookupUrlRecordIdsByUrl', () => {
+  it('URL 文字列に対応する UrlRecordId を抽出する', () => {
+    const records = [
+      buildUrlRecord('url-1', 'https://example.com/a'),
+      buildUrlRecord('url-2', 'https://example.com/b'),
+      buildUrlRecord('url-3', 'https://example.com/c'),
+    ]
+    const result = lookupUrlRecordIdsByUrl({
+      urlRecords: records,
+      urls: ['https://example.com/a', 'https://example.com/c'],
+    })
+    expect([...result]).toStrictEqual([
+      createUrlRecordId('url-1'),
+      createUrlRecordId('url-3'),
+    ])
+  })
+
+  it('該当しない URL は無視する', () => {
+    const result = lookupUrlRecordIdsByUrl({
+      urlRecords: [buildUrlRecord('url-1', 'https://example.com/a')],
+      urls: ['https://other.example.com'],
+    })
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('OpenedUrlRemovalPolicy.removeUrlRecordIdsFromTabGroups', () => {
+  it('削除対象 ID を取り除いた TabGroup を返す', () => {
+    const group = createTabGroup({
+      id: 'group-1',
+      domain: 'example.com',
+      urlIds: ['url-1', 'url-2', 'url-3'],
+    })
+    const result = removeUrlRecordIdsFromTabGroups({
+      tabGroups: [group],
+      urlRecordIdsToRemove: new Set([createUrlRecordId('url-2')]),
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.urlIds).toStrictEqual(['url-1', 'url-3'])
+  })
+
+  it('すべての URL が削除されたら TabGroup ごと除外する', () => {
+    const group = createTabGroup({
+      id: 'group-1',
+      domain: 'example.com',
+      urlIds: ['url-1'],
+    })
+    const result = removeUrlRecordIdsFromTabGroups({
+      tabGroups: [group],
+      urlRecordIdsToRemove: new Set([createUrlRecordId('url-1')]),
+    })
+    expect(result).toHaveLength(0)
+  })
+
+  it('削除対象が空集合の場合は元の配列をそのまま複製して返す', () => {
+    const group = createTabGroup({
+      id: 'group-1',
+      domain: 'example.com',
+      urlIds: ['url-1'],
+    })
+    const result = removeUrlRecordIdsFromTabGroups({
+      tabGroups: [group],
+      urlRecordIdsToRemove: new Set(),
+    })
+    expect(result).toStrictEqual([group])
+  })
+
+  it('URL 削除後の件数が正しく更新される', () => {
+    const group = createTabGroup({
+      id: 'group-1',
+      domain: 'example.com',
+      urlIds: ['url-1', 'url-2', 'url-3', 'url-4'],
+    })
+    const result = removeUrlRecordIdsFromTabGroups({
+      tabGroups: [group],
+      urlRecordIdsToRemove: new Set([
+        createUrlRecordId('url-2'),
+        createUrlRecordId('url-4'),
+      ]),
+    })
+    expect(result[0]?.urlIds).toHaveLength(2)
+    expect(result[0]?.urlIds).toStrictEqual(['url-1', 'url-3'])
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/OpenedUrlRemovalPolicy.ts
+++ b/src/contexts/saved-tabs/domain/services/OpenedUrlRemovalPolicy.ts
@@ -1,0 +1,157 @@
+import type { TabGroup } from '../entities/TabGroup'
+import type { UrlRecord } from '../entities/UrlRecord'
+import type { UrlRecordId } from '../value-objects/UrlRecordId'
+
+/**
+ * 「URL を開いたあと、保存リストから削除するか」を決める pure ポリシー。
+ *
+ * 既存 `SavedTabsApp.tsx` の挙動を domain 側で再表現する。
+ * 設定 `removeTabAfterOpen` を起点に、開いた URL 集合と保存タブ集合から
+ * 「削除すべき `UrlRecordId` の集合」を計算する。
+ *
+ * 実際の削除（`chrome.storage.local` 書き込み）は use-case / infrastructure
+ * 側で行うため、このサービスは純粋に判定だけを担当する。
+ */
+
+/**
+ * 削除ポリシーの設定値。
+ *
+ * `removeTabAfterOpen`: 通常クリックで開いた URL を削除するか
+ * `removeTabAfterExternalDrop`: 外部アプリへドラッグして開いた URL を削除するか
+ */
+export interface OpenedUrlRemovalSettings {
+  readonly removeTabAfterOpen: boolean
+  readonly removeTabAfterExternalDrop: boolean
+}
+
+/**
+ * URL を開いた経路。
+ *
+ * - `click`: ユーザーが URL をクリックした
+ * - `externalDrop`: 外部アプリへドラッグしてドロップで開いた
+ */
+export type OpenedUrlOrigin = 'click' | 'externalDrop'
+
+/**
+ * 開いた URL の入力情報。
+ */
+export interface OpenedUrlInput {
+  readonly urlRecordId: UrlRecordId
+  readonly origin: OpenedUrlOrigin
+}
+
+const shouldRemoveOpenedUrl = (
+  origin: OpenedUrlOrigin,
+  settings: OpenedUrlRemovalSettings,
+): boolean => {
+  if (origin === 'click') {
+    return settings.removeTabAfterOpen
+  }
+  return settings.removeTabAfterExternalDrop
+}
+
+/**
+ * 設定と開いた URL から、保存タブから削除すべき `UrlRecordId` の集合を返す。
+ *
+ * `origin` ごとに設定を評価し、削除許可された URL だけを抽出する。
+ * 重複は自動的に排除される。
+ *
+ * @example
+ * ```ts
+ * const ids = decideUrlRecordIdsToRemoveAfterOpen({
+ *   openedUrls: [{ urlRecordId: id, origin: 'click' }],
+ *   settings: { removeTabAfterOpen: true, removeTabAfterExternalDrop: false },
+ * })
+ * ```
+ */
+export const decideUrlRecordIdsToRemoveAfterOpen = ({
+  openedUrls,
+  settings,
+}: {
+  openedUrls: readonly OpenedUrlInput[]
+  settings: OpenedUrlRemovalSettings
+}): ReadonlySet<UrlRecordId> => {
+  const result = new Set<UrlRecordId>()
+  for (const opened of openedUrls) {
+    if (shouldRemoveOpenedUrl(opened.origin, settings)) {
+      result.add(opened.urlRecordId)
+    }
+  }
+  return result
+}
+
+/**
+ * URL 文字列の集合から、保存タブ内の対応 `UrlRecordId` を逆引きする。
+ *
+ * `SavedTabsApp.tsx` の `buildUrlIdsToRemove` を domain 等価物にしたもの。
+ * `chrome.tabs.create` 側から返ってくるのは URL 文字列だけのため、
+ * 削除候補を `UrlRecordId` に正規化するためのヘルパー。
+ *
+ * @example
+ * ```ts
+ * const ids = lookupUrlRecordIdsByUrl({
+ *   urlRecords,
+ *   urls: ['https://example.com'],
+ * })
+ * ```
+ */
+export const lookupUrlRecordIdsByUrl = ({
+  urlRecords,
+  urls,
+}: {
+  urlRecords: readonly UrlRecord[]
+  urls: readonly string[]
+}): ReadonlySet<UrlRecordId> => {
+  const targetSet = new Set(urls)
+  const result = new Set<UrlRecordId>()
+  for (const record of urlRecords) {
+    if (targetSet.has(record.url)) {
+      result.add(record.id)
+    }
+  }
+  return result
+}
+
+/**
+ * 指定 `UrlRecordId` の集合を取り除いた `TabGroup` 集合を返す pure 関数。
+ *
+ * 空になった `TabGroup` は結果から取り除く。
+ * 既存 `removeUrlIdsFromSavedTabs` の domain 等価物。
+ *
+ * @example
+ * ```ts
+ * const updated = removeUrlRecordIdsFromTabGroups({
+ *   tabGroups,
+ *   urlRecordIdsToRemove,
+ * })
+ * ```
+ */
+export const removeUrlRecordIdsFromTabGroups = ({
+  tabGroups,
+  urlRecordIdsToRemove,
+}: {
+  tabGroups: readonly TabGroup[]
+  urlRecordIdsToRemove: ReadonlySet<UrlRecordId>
+}): TabGroup[] => {
+  if (urlRecordIdsToRemove.size === 0) {
+    return [...tabGroups]
+  }
+  const result: TabGroup[] = []
+  for (const group of tabGroups) {
+    const remainingUrlIds = group.urlIds.filter(
+      (urlId) => !urlRecordIdsToRemove.has(urlId),
+    )
+    if (remainingUrlIds.length === group.urlIds.length) {
+      result.push(group)
+      continue
+    }
+    if (remainingUrlIds.length === 0) {
+      continue
+    }
+    result.push({
+      ...group,
+      urlIds: remainingUrlIds,
+    })
+  }
+  return result
+}

--- a/src/contexts/saved-tabs/domain/services/SavedTabsSearchService.test.ts
+++ b/src/contexts/saved-tabs/domain/services/SavedTabsSearchService.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+
+import { createParentCategory } from '../entities/ParentCategory'
+import { createTabGroup } from '../entities/TabGroup'
+import { createUrlRecord } from '../entities/UrlRecord'
+import { searchSavedTabs } from './SavedTabsSearchService'
+
+const docs = createParentCategory({
+  id: 'docs',
+  name: 'Docs',
+  domains: [],
+  domainNames: ['example.com'],
+})
+
+const buildContext = (
+  groupId: string,
+  domain: string,
+  urls: { id: string; url: string; title: string }[],
+) => {
+  const group = createTabGroup({
+    id: groupId,
+    domain,
+    urlIds: urls.map((url) => url.id),
+  })
+  return {
+    group,
+    urls: urls.map((url) =>
+      createUrlRecord({
+        id: url.id,
+        url: url.url,
+        title: url.title,
+        savedAt: 1_700_000_000_000,
+      }),
+    ),
+  }
+}
+
+describe('SavedTabsSearchService.searchSavedTabs', () => {
+  it('空クエリでは全件をそのまま返す', () => {
+    const contexts = [
+      buildContext('group-1', 'example.com', [
+        { id: 'url-1', url: 'https://example.com/a', title: 'Hello' },
+      ]),
+    ]
+    const result = searchSavedTabs({
+      input: { query: '' },
+      contexts,
+      categories: [docs],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.urls).toHaveLength(1)
+    expect(result[0]?.categoryMatched).toBe(false)
+  })
+
+  it('URL 文字列にマッチする URL だけを残す', () => {
+    const contexts = [
+      buildContext('group-1', 'example.com', [
+        { id: 'url-1', url: 'https://example.com/foo', title: 'A' },
+        { id: 'url-2', url: 'https://example.com/bar', title: 'B' },
+      ]),
+    ]
+    const result = searchSavedTabs({
+      input: { query: 'foo' },
+      contexts,
+      categories: [docs],
+    })
+    expect(result[0]?.urls.map((url) => url.id)).toStrictEqual(['url-1'])
+  })
+
+  it('title にマッチする URL を残す', () => {
+    const contexts = [
+      buildContext('group-1', 'example.com', [
+        { id: 'url-1', url: 'https://example.com/a', title: 'Match Me' },
+        { id: 'url-2', url: 'https://example.com/b', title: 'Other' },
+      ]),
+    ]
+    const result = searchSavedTabs({
+      input: { query: 'match' },
+      contexts,
+      categories: [docs],
+    })
+    expect(result[0]?.urls.map((url) => url.id)).toStrictEqual(['url-1'])
+  })
+
+  it('domain にマッチする URL を残す', () => {
+    const contexts = [
+      buildContext('group-1', 'example.com', [
+        { id: 'url-1', url: 'https://other/a', title: 'A' },
+      ]),
+    ]
+    const result = searchSavedTabs({
+      input: { query: 'example' },
+      contexts,
+      categories: [docs],
+    })
+    expect(result[0]?.urls.map((url) => url.id)).toStrictEqual(['url-1'])
+  })
+
+  it('カテゴリ名にマッチした場合はグループ全体を返す', () => {
+    const contexts = [
+      buildContext('group-1', 'example.com', [
+        { id: 'url-1', url: 'https://example.com/x', title: 'NOPE' },
+        { id: 'url-2', url: 'https://example.com/y', title: 'NOPE' },
+      ]),
+    ]
+    const result = searchSavedTabs({
+      input: { query: 'docs' },
+      contexts,
+      categories: [docs],
+    })
+    expect(result[0]?.categoryMatched).toBe(true)
+    expect(result[0]?.urls.map((url) => url.id)).toStrictEqual([
+      'url-1',
+      'url-2',
+    ])
+  })
+
+  it('どの URL も一致しない場合はグループごと除外する', () => {
+    const contexts = [
+      buildContext('group-1', 'other.example.com', [
+        { id: 'url-1', url: 'https://other/a', title: 'A' },
+      ]),
+    ]
+    const result = searchSavedTabs({
+      input: { query: 'zzz' },
+      contexts,
+      categories: [],
+    })
+    expect(result).toHaveLength(0)
+  })
+
+  it('大文字小文字を区別せずにマッチする', () => {
+    const contexts = [
+      buildContext('group-1', 'example.com', [
+        { id: 'url-1', url: 'https://example.com/A', title: 'HELLO' },
+      ]),
+    ]
+    const result = searchSavedTabs({
+      input: { query: 'hello' },
+      contexts,
+      categories: [],
+    })
+    expect(result[0]?.urls).toHaveLength(1)
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/SavedTabsSearchService.ts
+++ b/src/contexts/saved-tabs/domain/services/SavedTabsSearchService.ts
@@ -1,0 +1,134 @@
+import type { ParentCategory } from '../entities/ParentCategory'
+import type { TabGroup } from '../entities/TabGroup'
+import type { UrlRecord } from '../entities/UrlRecord'
+import {
+  buildCategoryLookup,
+  resolveCategoryForTabGroup,
+} from './CategoryAssignmentPolicy'
+import type { CategoryLookup } from './CategoryAssignmentPolicy'
+
+/**
+ * 検索条件の入力。
+ *
+ * `query` は前後の空白を許容するが、内部では trim + lowercase した値で比較する。
+ * 空クエリは「全件マッチ」として扱う。
+ */
+export interface SavedTabsSearchInput {
+  readonly query: string
+}
+
+/**
+ * 検索対象になる `TabGroup` の文脈データ。
+ *
+ * `urls` は `UrlRecord` の参照解決済みリスト。infrastructure 側で
+ * `TabGroup.urlIds` → `UrlRecord` への解決を済ませてから渡す前提。
+ */
+export interface SavedTabsSearchContext {
+  readonly group: TabGroup
+  readonly urls: readonly UrlRecord[]
+}
+
+/**
+ * 検索結果。`urls` は元のグループのうちクエリにマッチしたものだけを残す。
+ *
+ * `categoryMatched` は親カテゴリ名がマッチしたケース（URL は元配列まま）。
+ */
+export interface SavedTabsSearchResult {
+  readonly group: TabGroup
+  readonly urls: readonly UrlRecord[]
+  readonly categoryMatched: boolean
+}
+
+const normalizeQuery = (query: string): string => query.trim().toLowerCase()
+
+const includesQuery = (value: string, query: string): boolean =>
+  value.toLowerCase().includes(query)
+
+/**
+ * 親カテゴリ名がクエリにマッチするかを判定する pure 関数。
+ *
+ * `SavedTabsApp.tsx` の `matchesParentCategoryQuery` を domain 等価物にしたもの。
+ */
+export const matchesCategoryQuery = (
+  group: TabGroup,
+  lookup: CategoryLookup,
+  normalizedQuery: string,
+): boolean => {
+  const category = resolveCategoryForTabGroup(group, lookup)
+  if (!category) {
+    return false
+  }
+  return includesQuery(category.name, normalizedQuery)
+}
+
+const matchesUrlOrTitleOrDomain = (
+  urlRecord: UrlRecord,
+  group: TabGroup,
+  normalizedQuery: string,
+): boolean =>
+  includesQuery(urlRecord.title, normalizedQuery) ||
+  includesQuery(urlRecord.url, normalizedQuery) ||
+  includesQuery(group.domain, normalizedQuery)
+
+/**
+ * 保存タブ検索の本体。
+ *
+ * `query` を URL / title / domain / category 名に対して部分一致で評価し、
+ * カテゴリ名マッチの場合はグループ全体を返す、それ以外は URL 単位で絞り込む。
+ *
+ * @example
+ * ```ts
+ * searchSavedTabs({
+ *   input: { query: 'react' },
+ *   contexts,
+ *   categories,
+ * })
+ * ```
+ */
+export const searchSavedTabs = ({
+  input,
+  contexts,
+  categories,
+}: {
+  input: SavedTabsSearchInput
+  contexts: readonly SavedTabsSearchContext[]
+  categories: readonly ParentCategory[]
+}): SavedTabsSearchResult[] => {
+  const normalizedQuery = normalizeQuery(input.query)
+  if (normalizedQuery.length === 0) {
+    return contexts.map((context) => ({
+      group: context.group,
+      urls: context.urls,
+      categoryMatched: false,
+    }))
+  }
+  const lookup = buildCategoryLookup(categories)
+  const results: SavedTabsSearchResult[] = []
+  for (const context of contexts) {
+    const categoryMatched = matchesCategoryQuery(
+      context.group,
+      lookup,
+      normalizedQuery,
+    )
+    if (categoryMatched) {
+      results.push({
+        group: context.group,
+        urls: context.urls,
+        categoryMatched: true,
+      })
+      continue
+    }
+    const filteredUrls = context.urls.filter((urlRecord) =>
+      matchesUrlOrTitleOrDomain(urlRecord, context.group, normalizedQuery),
+    )
+    if (filteredUrls.length === 0) {
+      continue
+    }
+    results.push({
+      group: context.group,
+      urls: filteredUrls,
+      categoryMatched: false,
+    })
+  }
+  return results
+}

--- a/src/contexts/saved-tabs/domain/services/TabGroupCategorizationService.test.ts
+++ b/src/contexts/saved-tabs/domain/services/TabGroupCategorizationService.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+
+import { createParentCategory } from '../entities/ParentCategory'
+import { createTabGroup } from '../entities/TabGroup'
+import {
+  categorizeTabGroups,
+  sortGroupsByCategoryDomainOrder,
+  UNCATEGORIZED_KEY,
+} from './TabGroupCategorizationService'
+
+const docs = createParentCategory({
+  id: 'docs',
+  name: 'Docs',
+  domains: ['group-docs-1', 'group-docs-2'],
+  domainNames: [],
+})
+
+const news = createParentCategory({
+  id: 'news',
+  name: 'News',
+  domains: [],
+  domainNames: ['news.example.com'],
+})
+
+const docsGroup1 = createTabGroup({
+  id: 'group-docs-1',
+  domain: 'docs1.example.com',
+  urlIds: [],
+})
+const docsGroup2 = createTabGroup({
+  id: 'group-docs-2',
+  domain: 'docs2.example.com',
+  urlIds: [],
+})
+const newsGroup = createTabGroup({
+  id: 'group-news',
+  domain: 'news.example.com',
+  urlIds: [],
+})
+const uncategorizedGroup = createTabGroup({
+  id: 'group-misc',
+  domain: 'misc.example.com',
+  urlIds: [],
+})
+
+describe('TabGroupCategorizationService.categorizeTabGroups', () => {
+  it('カテゴリ別に振り分け、未分類を末尾にまとめる', () => {
+    const result = categorizeTabGroups({
+      groups: [newsGroup, docsGroup1, uncategorizedGroup, docsGroup2],
+      categories: [docs, news],
+    })
+    expect(result).toHaveLength(3)
+    expect(result[0]?.key).toBe('docs')
+    expect(result[0]?.groups.map((group) => group.id)).toStrictEqual([
+      'group-docs-1',
+      'group-docs-2',
+    ])
+    expect(result[1]?.key).toBe('news')
+    expect(result[1]?.groups.map((group) => group.id)).toStrictEqual([
+      'group-news',
+    ])
+    expect(result[2]?.key).toBe(UNCATEGORIZED_KEY)
+    expect(result[2]?.groups.map((group) => group.id)).toStrictEqual([
+      'group-misc',
+    ])
+  })
+
+  it('未分類が存在しなければ末尾にバケットを作らない', () => {
+    const result = categorizeTabGroups({
+      groups: [docsGroup1, newsGroup],
+      categories: [docs, news],
+    })
+    expect(result.map((bucket) => bucket.key)).toStrictEqual(['docs', 'news'])
+  })
+
+  it('すべて未分類なら UNCATEGORIZED_KEY のみを返す', () => {
+    const result = categorizeTabGroups({
+      groups: [uncategorizedGroup],
+      categories: [docs, news],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.key).toBe(UNCATEGORIZED_KEY)
+  })
+})
+
+describe('TabGroupCategorizationService.sortGroupsByCategoryDomainOrder', () => {
+  it('domains の順序に合わせて並べ替える', () => {
+    const sorted = sortGroupsByCategoryDomainOrder(
+      [docsGroup2, docsGroup1],
+      docs,
+    )
+    expect(sorted.map((group) => group.id)).toStrictEqual([
+      'group-docs-1',
+      'group-docs-2',
+    ])
+  })
+
+  it('domains にない id は末尾に回し、相対順序は維持する', () => {
+    const extra = createTabGroup({
+      id: 'group-extra',
+      domain: 'extra.example.com',
+      urlIds: [],
+    })
+    const sorted = sortGroupsByCategoryDomainOrder(
+      [extra, docsGroup2, docsGroup1],
+      docs,
+    )
+    expect(sorted.map((group) => group.id)).toStrictEqual([
+      'group-docs-1',
+      'group-docs-2',
+      'group-extra',
+    ])
+  })
+
+  it('domains が空のカテゴリでは入力順をそのまま返す', () => {
+    const sorted = sortGroupsByCategoryDomainOrder([docsGroup2, docsGroup1], {
+      ...docs,
+      domains: [],
+    })
+    expect(sorted.map((group) => group.id)).toStrictEqual([
+      'group-docs-2',
+      'group-docs-1',
+    ])
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/TabGroupCategorizationService.ts
+++ b/src/contexts/saved-tabs/domain/services/TabGroupCategorizationService.ts
@@ -1,0 +1,119 @@
+import type { ParentCategory } from '../entities/ParentCategory'
+import type { TabGroup } from '../entities/TabGroup'
+import type { ParentCategoryId } from '../value-objects/ParentCategoryId'
+import {
+  buildCategoryLookup,
+  resolveCategoryForTabGroup,
+} from './CategoryAssignmentPolicy'
+import type { CategoryLookup } from './CategoryAssignmentPolicy'
+
+/**
+ * 「未分類」グループを表す sentinel キー。
+ *
+ * `ParentCategoryId` と衝突しないよう、長く明示的な記号列を使う。
+ * 既存ストレージ上の ID には絶対に出現しない前提。
+ */
+export const UNCATEGORIZED_KEY = '__saved-tabs:uncategorized__' as const
+
+/**
+ * `CategoryAssignmentPolicy` のキーまたは `UNCATEGORIZED_KEY`。
+ */
+export type CategorizedKey = ParentCategoryId | typeof UNCATEGORIZED_KEY
+
+/**
+ * カテゴリ別に分類された `TabGroup` のグループ。
+ *
+ * `key` はカテゴリ ID または `UNCATEGORIZED_KEY`、`category` は
+ * カテゴリ ID の場合のみ参照可能（未分類では undefined）。
+ */
+export interface CategorizedTabGroups {
+  readonly key: CategorizedKey
+  readonly category?: ParentCategory
+  readonly groups: readonly TabGroup[]
+}
+
+/**
+ * `TabGroup` 配列を `ParentCategory` 配列に基づいて分類する pure 関数。
+ *
+ * `SavedTabsApp.tsx` の `buildCategoryLookup` + `sortCategorizedGroups` 相当の
+ * domain 側エントリポイント。返り値の順序はカテゴリ配列の順序に従い、
+ * 未分類は末尾の 1 グループにまとめる。
+ *
+ * @example
+ * ```ts
+ * const result = categorizeTabGroups({ groups, categories })
+ * for (const bucket of result) {
+ *   console.log(bucket.key, bucket.groups.length)
+ * }
+ * ```
+ */
+export const categorizeTabGroups = ({
+  groups,
+  categories,
+}: {
+  groups: readonly TabGroup[]
+  categories: readonly ParentCategory[]
+}): CategorizedTabGroups[] => {
+  const lookup = buildCategoryLookup(categories)
+  const bucketsById = new Map<ParentCategoryId, TabGroup[]>()
+  const uncategorized: TabGroup[] = []
+  for (const group of groups) {
+    const category = resolveCategoryForTabGroup(group, lookup)
+    if (!category) {
+      uncategorized.push(group)
+      continue
+    }
+    const existing = bucketsById.get(category.id)
+    if (existing) {
+      existing.push(group)
+    } else {
+      bucketsById.set(category.id, [group])
+    }
+  }
+  const result: CategorizedTabGroups[] = categories
+    .filter((category) => bucketsById.has(category.id))
+    .map<CategorizedTabGroups>((category) => ({
+      key: category.id,
+      category,
+      groups: sortGroupsByCategoryDomainOrder(
+        bucketsById.get(category.id) ?? [],
+        category,
+      ),
+    }))
+  if (uncategorized.length > 0) {
+    result.push({ key: UNCATEGORIZED_KEY, groups: uncategorized })
+  }
+  return result
+}
+
+/**
+ * `ParentCategory.domains` の順序に従って `TabGroup` をソートする。
+ *
+ * 既存 `sortCategorizedGroups` の domain 等価物。`domains` に出現しないグループは
+ * 末尾へ移動し、相対順序は維持する（安定ソート）。
+ */
+export const sortGroupsByCategoryDomainOrder = (
+  groups: readonly TabGroup[],
+  category: ParentCategory,
+): TabGroup[] => {
+  if (category.domains.length === 0) {
+    return [...groups]
+  }
+  const order = new Map(
+    category.domains.map((tabGroupId, index) => [tabGroupId, index]),
+  )
+  const indexed = groups.map((group, originalIndex) => ({
+    group,
+    originalIndex,
+    sortIndex: order.get(group.id) ?? Number.POSITIVE_INFINITY,
+  }))
+  indexed.sort((a, b) => {
+    if (a.sortIndex !== b.sortIndex) {
+      return a.sortIndex - b.sortIndex
+    }
+    return a.originalIndex - b.originalIndex
+  })
+  return indexed.map((entry) => entry.group)
+}
+
+export type { CategoryLookup }

--- a/src/contexts/saved-tabs/domain/services/UrlReferenceService.test.ts
+++ b/src/contexts/saved-tabs/domain/services/UrlReferenceService.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+
+import { createCustomProject } from '../entities/CustomProject'
+import { createTabGroup } from '../entities/TabGroup'
+import { createUrlRecord } from '../entities/UrlRecord'
+import { createCustomProjectId } from '../value-objects/CustomProjectId'
+import { createTabGroupId } from '../value-objects/TabGroupId'
+import { createUrlRecordId } from '../value-objects/UrlRecordId'
+import {
+  collectReferencedUrlRecordIds,
+  filterUnreferencedUrlRecords,
+  isUrlRecordReferencedElsewhere,
+} from './UrlReferenceService'
+
+const tabGroupA = createTabGroup({
+  id: 'group-a',
+  domain: 'a.example.com',
+  urlIds: ['url-1', 'url-2'],
+})
+const tabGroupB = createTabGroup({
+  id: 'group-b',
+  domain: 'b.example.com',
+  urlIds: ['url-2', 'url-3'],
+})
+const project = createCustomProject({
+  id: 'project-1',
+  name: 'Project 1',
+  urlIds: ['url-3', 'url-4'],
+  categories: [],
+  createdAt: 1,
+  updatedAt: 1,
+})
+
+const buildUrlRecord = (id: string) =>
+  createUrlRecord({
+    id,
+    url: `https://example.com/${id}`,
+    title: id,
+    savedAt: 1_700_000_000_000,
+  })
+
+describe('UrlReferenceService.collectReferencedUrlRecordIds', () => {
+  it('TabGroup と CustomProject の両方から参照集合を返す', () => {
+    const referenced = collectReferencedUrlRecordIds({
+      tabGroups: [tabGroupA, tabGroupB],
+      customProjects: [project],
+    })
+    expect(referenced.has(createUrlRecordId('url-1'))).toBe(true)
+    expect(referenced.has(createUrlRecordId('url-2'))).toBe(true)
+    expect(referenced.has(createUrlRecordId('url-3'))).toBe(true)
+    expect(referenced.has(createUrlRecordId('url-4'))).toBe(true)
+    expect(referenced.has(createUrlRecordId('url-5'))).toBe(false)
+  })
+})
+
+describe('UrlReferenceService.isUrlRecordReferencedElsewhere', () => {
+  it('別の TabGroup から参照されていれば true', () => {
+    expect(
+      isUrlRecordReferencedElsewhere({
+        urlRecordId: createUrlRecordId('url-2'),
+        tabGroups: [tabGroupA, tabGroupB],
+        customProjects: [],
+        origin: { kind: 'tabGroup', id: createTabGroupId('group-a') },
+      }),
+    ).toBe(true)
+  })
+
+  it('削除元 TabGroup でのみ参照されていれば false', () => {
+    expect(
+      isUrlRecordReferencedElsewhere({
+        urlRecordId: createUrlRecordId('url-1'),
+        tabGroups: [tabGroupA],
+        customProjects: [],
+        origin: { kind: 'tabGroup', id: createTabGroupId('group-a') },
+      }),
+    ).toBe(false)
+  })
+
+  it('CustomProject から参照されていれば true', () => {
+    expect(
+      isUrlRecordReferencedElsewhere({
+        urlRecordId: createUrlRecordId('url-3'),
+        tabGroups: [],
+        customProjects: [project],
+      }),
+    ).toBe(true)
+  })
+
+  it('削除元 CustomProject でのみ参照されていれば false', () => {
+    expect(
+      isUrlRecordReferencedElsewhere({
+        urlRecordId: createUrlRecordId('url-4'),
+        tabGroups: [],
+        customProjects: [project],
+        origin: {
+          kind: 'customProject',
+          id: createCustomProjectId('project-1'),
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('複数集約が同じ UrlRecord を参照しているケースで誤って参照無しにならない', () => {
+    expect(
+      isUrlRecordReferencedElsewhere({
+        urlRecordId: createUrlRecordId('url-3'),
+        tabGroups: [tabGroupA, tabGroupB],
+        customProjects: [project],
+        origin: {
+          kind: 'customProject',
+          id: createCustomProjectId('project-1'),
+        },
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('UrlReferenceService.filterUnreferencedUrlRecords', () => {
+  it('どこからも参照されていない UrlRecord だけを抽出する', () => {
+    const records = [
+      buildUrlRecord('url-1'),
+      buildUrlRecord('url-2'),
+      buildUrlRecord('url-orphan'),
+    ]
+    const result = filterUnreferencedUrlRecords({
+      urlRecords: records,
+      tabGroups: [tabGroupA, tabGroupB],
+      customProjects: [project],
+    })
+    expect(result.map((record) => record.id)).toStrictEqual(['url-orphan'])
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/UrlReferenceService.ts
+++ b/src/contexts/saved-tabs/domain/services/UrlReferenceService.ts
@@ -1,0 +1,132 @@
+import type { CustomProject } from '../entities/CustomProject'
+import type { TabGroup } from '../entities/TabGroup'
+import type { UrlRecord } from '../entities/UrlRecord'
+import type { UrlRecordId } from '../value-objects/UrlRecordId'
+
+/**
+ * `UrlRecord` 参照関係を扱う pure ドメインサービス。
+ *
+ * `TabGroup` と `CustomProject` の両方から `urlIds` で `UrlRecord` を参照する
+ * 設計のため、ある URL レコードを安全に削除して良いかどうかは
+ * 「他にどこからも参照されていないこと」で判定する必要がある。
+ *
+ * 既存 `SavedTabsApp.tsx` の URL 削除フローと同じ前提に立つが、
+ * domain 層では「参照確認」だけを担当し、実際の削除は use-case に任せる。
+ */
+
+/**
+ * `TabGroup` / `CustomProject` から参照されている `UrlRecordId` の集合を返す。
+ *
+ * @example
+ * ```ts
+ * const referenced = collectReferencedUrlRecordIds({
+ *   tabGroups: savedTabs,
+ *   customProjects,
+ * })
+ * referenced.has(urlRecordId)
+ * ```
+ */
+export const collectReferencedUrlRecordIds = ({
+  tabGroups,
+  customProjects,
+}: {
+  tabGroups: readonly TabGroup[]
+  customProjects: readonly CustomProject[]
+}): ReadonlySet<UrlRecordId> => {
+  const referenced = new Set<UrlRecordId>()
+  for (const group of tabGroups) {
+    for (const urlId of group.urlIds) {
+      referenced.add(urlId)
+    }
+  }
+  for (const project of customProjects) {
+    for (const urlId of project.urlIds) {
+      referenced.add(urlId)
+    }
+  }
+  return referenced
+}
+
+/**
+ * 指定の `UrlRecordId` が他の集約からも参照されているかを判定する。
+ *
+ * 削除候補の URL について、削除元（`origin`）以外で参照が残っているかを
+ * 確認する用途に使う。`origin` を集計対象から除外することで、
+ * 「他の場所から参照されているか」を正しく判定する。
+ *
+ * @example
+ * ```ts
+ * const stillReferenced = isUrlRecordReferencedElsewhere({
+ *   urlRecordId,
+ *   tabGroups: savedTabs,
+ *   customProjects,
+ *   origin: { kind: 'tabGroup', id: deletedGroupId },
+ * })
+ * ```
+ */
+export const isUrlRecordReferencedElsewhere = ({
+  urlRecordId,
+  tabGroups,
+  customProjects,
+  origin,
+}: {
+  urlRecordId: UrlRecordId
+  tabGroups: readonly TabGroup[]
+  customProjects: readonly CustomProject[]
+  origin?: UrlReferenceOrigin
+}): boolean => {
+  for (const group of tabGroups) {
+    if (origin?.kind === 'tabGroup' && origin.id === group.id) {
+      continue
+    }
+    if (group.urlIds.includes(urlRecordId)) {
+      return true
+    }
+  }
+  for (const project of customProjects) {
+    if (origin?.kind === 'customProject' && origin.id === project.id) {
+      continue
+    }
+    if (project.urlIds.includes(urlRecordId)) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * 削除元の集約を示す識別タグ。
+ */
+export type UrlReferenceOrigin =
+  | { kind: 'tabGroup'; id: TabGroup['id'] }
+  | { kind: 'customProject'; id: CustomProject['id'] }
+
+/**
+ * `UrlRecord` 配列のうち、どこからも参照されていない（未参照）レコードを抽出する。
+ *
+ * `RemoveUnreferencedUrlRecordsUseCase` の入力データを作るための pure 関数。
+ *
+ * @example
+ * ```ts
+ * const unreferenced = filterUnreferencedUrlRecords({
+ *   urlRecords,
+ *   tabGroups,
+ *   customProjects,
+ * })
+ * ```
+ */
+export const filterUnreferencedUrlRecords = ({
+  urlRecords,
+  tabGroups,
+  customProjects,
+}: {
+  urlRecords: readonly UrlRecord[]
+  tabGroups: readonly TabGroup[]
+  customProjects: readonly CustomProject[]
+}): UrlRecord[] => {
+  const referenced = collectReferencedUrlRecordIds({
+    tabGroups,
+    customProjects,
+  })
+  return urlRecords.filter((record) => !referenced.has(record.id))
+}

--- a/src/contexts/saved-tabs/domain/value-objects/CategoryName.test.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/CategoryName.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import {
+  categoryNameToString,
+  createCategoryName,
+  equalsCategoryName,
+} from './CategoryName'
+
+describe('CategoryName 値オブジェクト', () => {
+  it('前後の空白は trim する', () => {
+    const name = createCategoryName('  Docs  ')
+    expect(categoryNameToString(name)).toBe('Docs')
+  })
+
+  it('空文字列は INVALID_CATEGORY_NAME で拒否する', () => {
+    expect(() => createCategoryName('')).toThrow(SavedTabsDomainError)
+  })
+
+  it('200 文字超は拒否する', () => {
+    expect(() => createCategoryName('a'.repeat(201))).toThrow(
+      SavedTabsDomainError,
+    )
+  })
+
+  it('200 文字までは許容する', () => {
+    const name = createCategoryName('a'.repeat(200))
+    expect(categoryNameToString(name)).toHaveLength(200)
+  })
+
+  it('大小文字差は別物として扱う', () => {
+    expect(
+      equalsCategoryName(
+        createCategoryName('Docs'),
+        createCategoryName('docs'),
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/contexts/saved-tabs/domain/value-objects/CategoryName.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/CategoryName.ts
@@ -1,0 +1,64 @@
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+
+declare const categoryNameBrand: unique symbol
+
+/**
+ * カテゴリ名を表す不変値オブジェクト。
+ *
+ * 親カテゴリ・子カテゴリのどちらでも使う。
+ * 空文字列や空白のみは不正値とし、前後の空白は除去して保持する。
+ * 比較は完全一致（大文字小文字を区別）で行う。
+ *
+ * @example
+ * ```ts
+ * const name = createCategoryName('  Docs  ')
+ * categoryNameToString(name) // 'Docs'
+ * ```
+ */
+export type CategoryName = string & {
+  readonly [categoryNameBrand]: 'CategoryName'
+}
+
+const MAX_CATEGORY_NAME_LENGTH = 200
+
+/**
+ * `CategoryName` 値オブジェクトを生成する。
+ *
+ * 入力に対して trim だけ行い、200 文字を超える長さは不正値とする。
+ * 保存済みデータと衝突しないよう、絵文字や非 ASCII 文字は許容する。
+ */
+export const createCategoryName = (value: string): CategoryName => {
+  if (typeof value !== 'string') {
+    throw new SavedTabsDomainError(
+      'カテゴリ名は文字列で指定してください',
+      'INVALID_CATEGORY_NAME',
+    )
+  }
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    throw new SavedTabsDomainError(
+      'カテゴリ名は空文字列にできません',
+      'INVALID_CATEGORY_NAME',
+    )
+  }
+  if (trimmed.length > MAX_CATEGORY_NAME_LENGTH) {
+    throw new SavedTabsDomainError(
+      `カテゴリ名は ${MAX_CATEGORY_NAME_LENGTH} 文字以内で指定してください`,
+      'INVALID_CATEGORY_NAME',
+    )
+  }
+  // OK: createCategoryName は正規化後のブランド型タグ付けに限定
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return trimmed as CategoryName
+}
+
+/**
+ * `CategoryName` を生文字列へ戻す。
+ */
+export const categoryNameToString = (name: CategoryName): string => name
+
+/**
+ * 2 つの `CategoryName` を完全一致で比較する。
+ */
+export const equalsCategoryName = (a: CategoryName, b: CategoryName): boolean =>
+  a === b

--- a/src/contexts/saved-tabs/domain/value-objects/CustomProjectId.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/CustomProjectId.ts
@@ -1,0 +1,47 @@
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+
+declare const customProjectIdBrand: unique symbol
+
+/**
+ * `CustomProject` の識別子を表す不変値オブジェクト。
+ *
+ * `chrome.storage.local` 上の `customProjects[].id` と一致させる前提で、
+ * domain 層は形式の妥当性（非空）のみを検証する。
+ *
+ * @example
+ * ```ts
+ * const id = createCustomProjectId('project-1')
+ * customProjectIdToString(id) // 'project-1'
+ * ```
+ */
+export type CustomProjectId = string & {
+  readonly [customProjectIdBrand]: 'CustomProjectId'
+}
+
+/**
+ * `CustomProjectId` 値オブジェクトを生成する。
+ */
+export const createCustomProjectId = (value: string): CustomProjectId => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new SavedTabsDomainError(
+      'CustomProject ID は空文字列にできません',
+      'INVALID_ID',
+    )
+  }
+  // OK: createCustomProjectId は検証通過後のブランド型タグ付けに限定
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return value as CustomProjectId
+}
+
+/**
+ * `CustomProjectId` を生文字列へ戻す。
+ */
+export const customProjectIdToString = (id: CustomProjectId): string => id
+
+/**
+ * 2 つの `CustomProjectId` を比較する。
+ */
+export const equalsCustomProjectId = (
+  a: CustomProjectId,
+  b: CustomProjectId,
+): boolean => a === b

--- a/src/contexts/saved-tabs/domain/value-objects/DomainName.test.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/DomainName.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import {
+  createDomainName,
+  domainNameToString,
+  equalsDomainName,
+} from './DomainName'
+
+describe('DomainName 値オブジェクト', () => {
+  it('正常なホスト名は小文字に正規化して保持する', () => {
+    const domain = createDomainName('Example.COM')
+    expect(domainNameToString(domain)).toBe('example.com')
+  })
+
+  it('前後の空白は trim する', () => {
+    const domain = createDomainName('  example.com  ')
+    expect(domainNameToString(domain)).toBe('example.com')
+  })
+
+  it('空文字列は INVALID_DOMAIN_NAME で拒否する', () => {
+    expect(() => createDomainName('')).toThrow(SavedTabsDomainError)
+  })
+
+  it('スキーム付き文字列は拒否する', () => {
+    expect(() => createDomainName('https://example.com')).toThrow(
+      SavedTabsDomainError,
+    )
+  })
+
+  it('同じドメイン名は equalsDomainName で true', () => {
+    expect(
+      equalsDomainName(createDomainName('a.com'), createDomainName('A.com')),
+    ).toBe(true)
+  })
+})

--- a/src/contexts/saved-tabs/domain/value-objects/DomainName.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/DomainName.ts
@@ -1,0 +1,62 @@
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+
+declare const domainNameBrand: unique symbol
+
+/**
+ * 保存タブのドメイン名を表す不変値オブジェクト。
+ *
+ * `example.com` のような hostname を想定し、空文字列・空白のみ・
+ * スキーム付き文字列（`https://...`）は不正値として扱う。
+ * 比較を安定させるため、内部表現は小文字に正規化して保持する。
+ *
+ * @example
+ * ```ts
+ * const domain = createDomainName('Example.com')
+ * domainNameToString(domain) // 'example.com'
+ * ```
+ */
+export type DomainName = string & { readonly [domainNameBrand]: 'DomainName' }
+
+const SCHEME_SEPARATOR = '://'
+
+/**
+ * `DomainName` 値オブジェクトを生成する。
+ *
+ * 入力は trim と小文字化のみを行い、`hostname` 抽出のような
+ * 重い処理は行わない（呼び出し側で URL から hostname を取り出す前提）。
+ */
+export const createDomainName = (value: string): DomainName => {
+  if (typeof value !== 'string') {
+    throw new SavedTabsDomainError(
+      'ドメイン名は文字列で指定してください',
+      'INVALID_DOMAIN_NAME',
+    )
+  }
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    throw new SavedTabsDomainError(
+      'ドメイン名は空文字列にできません',
+      'INVALID_DOMAIN_NAME',
+    )
+  }
+  if (trimmed.includes(SCHEME_SEPARATOR)) {
+    throw new SavedTabsDomainError(
+      'ドメイン名にスキームを含めることはできません',
+      'INVALID_DOMAIN_NAME',
+    )
+  }
+  // OK: createDomainName は正規化後のブランド型タグ付けに限定
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return trimmed.toLowerCase() as DomainName
+}
+
+/**
+ * `DomainName` を生文字列へ戻す。永続化や UI へ渡すための変換口。
+ */
+export const domainNameToString = (domain: DomainName): string => domain
+
+/**
+ * 2 つの `DomainName` を比較する。生成時に正規化済みのため大小文字差は出ない。
+ */
+export const equalsDomainName = (a: DomainName, b: DomainName): boolean =>
+  a === b

--- a/src/contexts/saved-tabs/domain/value-objects/Ids.test.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/Ids.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import {
+  createCustomProjectId,
+  customProjectIdToString,
+  equalsCustomProjectId,
+} from './CustomProjectId'
+import {
+  createParentCategoryId,
+  equalsParentCategoryId,
+  parentCategoryIdToString,
+} from './ParentCategoryId'
+import {
+  createTabGroupId,
+  equalsTabGroupId,
+  tabGroupIdToString,
+} from './TabGroupId'
+import {
+  createUrlRecordId,
+  equalsUrlRecordId,
+  urlRecordIdToString,
+} from './UrlRecordId'
+
+describe('ID 値オブジェクト群', () => {
+  it('TabGroupId は正常値を保持し、空白は拒否する', () => {
+    const id = createTabGroupId('group-1')
+    expect(tabGroupIdToString(id)).toBe('group-1')
+    expect(equalsTabGroupId(id, createTabGroupId('group-1'))).toBe(true)
+    expect(() => createTabGroupId('')).toThrow(SavedTabsDomainError)
+    expect(() => createTabGroupId('   ')).toThrow(SavedTabsDomainError)
+  })
+
+  it('UrlRecordId は正常値を保持し、空白は拒否する', () => {
+    const id = createUrlRecordId('url-1')
+    expect(urlRecordIdToString(id)).toBe('url-1')
+    expect(equalsUrlRecordId(id, createUrlRecordId('url-1'))).toBe(true)
+    expect(() => createUrlRecordId('')).toThrow(SavedTabsDomainError)
+  })
+
+  it('ParentCategoryId は正常値を保持し、空白は拒否する', () => {
+    const id = createParentCategoryId('docs')
+    expect(parentCategoryIdToString(id)).toBe('docs')
+    expect(equalsParentCategoryId(id, createParentCategoryId('docs'))).toBe(
+      true,
+    )
+    expect(() => createParentCategoryId('')).toThrow(SavedTabsDomainError)
+  })
+
+  it('CustomProjectId は正常値を保持し、空白は拒否する', () => {
+    const id = createCustomProjectId('project-1')
+    expect(customProjectIdToString(id)).toBe('project-1')
+    expect(equalsCustomProjectId(id, createCustomProjectId('project-1'))).toBe(
+      true,
+    )
+    expect(() => createCustomProjectId('')).toThrow(SavedTabsDomainError)
+  })
+})

--- a/src/contexts/saved-tabs/domain/value-objects/ParentCategoryId.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/ParentCategoryId.ts
@@ -1,0 +1,47 @@
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+
+declare const parentCategoryIdBrand: unique symbol
+
+/**
+ * `ParentCategory` の識別子を表す不変値オブジェクト。
+ *
+ * `chrome.storage.local` 上の `parentCategories[].id` と一致させる前提で、
+ * domain 層は形式の妥当性（非空）のみを検証する。
+ *
+ * @example
+ * ```ts
+ * const id = createParentCategoryId('docs')
+ * parentCategoryIdToString(id) // 'docs'
+ * ```
+ */
+export type ParentCategoryId = string & {
+  readonly [parentCategoryIdBrand]: 'ParentCategoryId'
+}
+
+/**
+ * `ParentCategoryId` 値オブジェクトを生成する。
+ */
+export const createParentCategoryId = (value: string): ParentCategoryId => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new SavedTabsDomainError(
+      'ParentCategory ID は空文字列にできません',
+      'INVALID_ID',
+    )
+  }
+  // OK: createParentCategoryId は検証通過後のブランド型タグ付けに限定
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return value as ParentCategoryId
+}
+
+/**
+ * `ParentCategoryId` を生文字列へ戻す。
+ */
+export const parentCategoryIdToString = (id: ParentCategoryId): string => id
+
+/**
+ * 2 つの `ParentCategoryId` を比較する。
+ */
+export const equalsParentCategoryId = (
+  a: ParentCategoryId,
+  b: ParentCategoryId,
+): boolean => a === b

--- a/src/contexts/saved-tabs/domain/value-objects/SavedAt.test.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/SavedAt.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import {
+  createSavedAt,
+  equalsSavedAt,
+  isSavedAtBefore,
+  savedAtToMillis,
+} from './SavedAt'
+
+describe('SavedAt 値オブジェクト', () => {
+  it('0 以上の整数を許容する', () => {
+    const savedAt = createSavedAt(1_700_000_000_000)
+    expect(savedAtToMillis(savedAt)).toBe(1_700_000_000_000)
+  })
+
+  it('0 も許容する', () => {
+    const savedAt = createSavedAt(0)
+    expect(savedAtToMillis(savedAt)).toBe(0)
+  })
+
+  it('負の値は INVALID_SAVED_AT で拒否する', () => {
+    expect(() => createSavedAt(-1)).toThrow(SavedTabsDomainError)
+  })
+
+  it('NaN / Infinity は拒否する', () => {
+    expect(() => createSavedAt(Number.NaN)).toThrow(SavedTabsDomainError)
+    expect(() => createSavedAt(Number.POSITIVE_INFINITY)).toThrow(
+      SavedTabsDomainError,
+    )
+  })
+
+  it('小数は拒否する', () => {
+    expect(() => createSavedAt(1.5)).toThrow(SavedTabsDomainError)
+  })
+
+  it('isSavedAtBefore で前後関係を判定できる', () => {
+    const a = createSavedAt(1)
+    const b = createSavedAt(2)
+    expect(isSavedAtBefore(a, b)).toBe(true)
+    expect(isSavedAtBefore(b, a)).toBe(false)
+    expect(equalsSavedAt(a, createSavedAt(1))).toBe(true)
+  })
+})

--- a/src/contexts/saved-tabs/domain/value-objects/SavedAt.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/SavedAt.ts
@@ -1,0 +1,55 @@
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+
+declare const savedAtBrand: unique symbol
+
+/**
+ * 保存タブの保存時刻（UNIX epoch ミリ秒）を表す不変値オブジェクト。
+ *
+ * `Date.now()` で得られる数値を想定するが、現在時刻取得は
+ * `application/ports/ClockPort` に任せ、domain 層では値の妥当性のみ検証する。
+ * 0 以上の整数で、`Number.isFinite` を満たす値のみ許容する。
+ *
+ * @example
+ * ```ts
+ * const savedAt = createSavedAt(1_700_000_000_000)
+ * savedAtToMillis(savedAt) // 1700000000000
+ * ```
+ */
+export type SavedAt = number & { readonly [savedAtBrand]: 'SavedAt' }
+
+/**
+ * `SavedAt` 値オブジェクトを生成する。
+ *
+ * 浮動小数や負の値、`NaN` / `Infinity` は不正値として扱う。
+ */
+export const createSavedAt = (value: number): SavedAt => {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < 0
+  ) {
+    throw new SavedTabsDomainError(
+      'savedAt は 0 以上の整数で指定してください',
+      'INVALID_SAVED_AT',
+    )
+  }
+  // OK: createSavedAt は検証通過後のブランド型タグ付けに限定
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return value as SavedAt
+}
+
+/**
+ * `SavedAt` を生のミリ秒数値へ戻す。
+ */
+export const savedAtToMillis = (savedAt: SavedAt): number => savedAt
+
+/**
+ * 2 つの `SavedAt` を比較する。
+ */
+export const equalsSavedAt = (a: SavedAt, b: SavedAt): boolean => a === b
+
+/**
+ * `a` が `b` より過去かを判定する。
+ */
+export const isSavedAtBefore = (a: SavedAt, b: SavedAt): boolean => a < b

--- a/src/contexts/saved-tabs/domain/value-objects/TabGroupId.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/TabGroupId.ts
@@ -1,0 +1,44 @@
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+
+declare const tabGroupIdBrand: unique symbol
+
+/**
+ * `TabGroup` の識別子を表す不変値オブジェクト。
+ *
+ * 既存ストレージとの互換のため、内部表現は任意の非空文字列とする。
+ * 採番アルゴリズム（UUID / nanoid など）は infrastructure 側に任せ、
+ * domain 層では「形式が壊れていないか」だけを検証する。
+ *
+ * @example
+ * ```ts
+ * const id = createTabGroupId('domain-example-com')
+ * tabGroupIdToString(id) // 'domain-example-com'
+ * ```
+ */
+export type TabGroupId = string & { readonly [tabGroupIdBrand]: 'TabGroupId' }
+
+/**
+ * `TabGroupId` 値オブジェクトを生成する。
+ */
+export const createTabGroupId = (value: string): TabGroupId => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new SavedTabsDomainError(
+      'TabGroup ID は空文字列にできません',
+      'INVALID_ID',
+    )
+  }
+  // OK: createTabGroupId は検証通過後のブランド型タグ付けに限定
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return value as TabGroupId
+}
+
+/**
+ * `TabGroupId` を生文字列へ戻す。
+ */
+export const tabGroupIdToString = (id: TabGroupId): string => id
+
+/**
+ * 2 つの `TabGroupId` を比較する。
+ */
+export const equalsTabGroupId = (a: TabGroupId, b: TabGroupId): boolean =>
+  a === b

--- a/src/contexts/saved-tabs/domain/value-objects/Url.test.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/Url.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+import { createUrl, equalsUrl, urlToString } from './Url'
+
+describe('Url 値オブジェクト', () => {
+  it('正常な URL からは値オブジェクトを生成できる', () => {
+    const url = createUrl('https://example.com/docs')
+    expect(urlToString(url)).toBe('https://example.com/docs')
+  })
+
+  it('空文字列は INVALID_URL で拒否する', () => {
+    const error = collectThrownError(() => createUrl(''))
+    expect(error).toBeInstanceOf(SavedTabsDomainError)
+    expect((error as SavedTabsDomainError).code).toBe('INVALID_URL')
+  })
+
+  it('空白だけの文字列も INVALID_URL で拒否する', () => {
+    expect(() => createUrl('   ')).toThrow(SavedTabsDomainError)
+  })
+
+  it('URL としてパースできない文字列は INVALID_URL で拒否する', () => {
+    expect(() => createUrl('not-a-url')).toThrow(SavedTabsDomainError)
+  })
+
+  it('同じ URL は equalsUrl で true、異なる URL は false', () => {
+    const a = createUrl('https://example.com/a')
+    const b = createUrl('https://example.com/a')
+    const c = createUrl('https://example.com/b')
+    expect(equalsUrl(a, b)).toBe(true)
+    expect(equalsUrl(a, c)).toBe(false)
+  })
+})
+
+const collectThrownError = (operation: () => unknown): unknown => {
+  try {
+    operation()
+  } catch (error) {
+    return error
+  }
+  return undefined
+}

--- a/src/contexts/saved-tabs/domain/value-objects/Url.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/Url.ts
@@ -1,0 +1,56 @@
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+
+declare const urlBrand: unique symbol
+
+/**
+ * 保存タブで扱う URL を表す不変値オブジェクト。
+ *
+ * `WHATWG URL` でパースできる文字列だけを許容し、
+ * `http(s):` / `chrome-extension:` / `file:` などのスキーム差は
+ * 上位ポリシーで判定する。空文字列・空白のみ・パース失敗は
+ * すべて `SavedTabsDomainError('INVALID_URL')` を投げる。
+ *
+ * @example
+ * ```ts
+ * const url = createUrl('https://example.com/docs')
+ * urlToString(url) // 'https://example.com/docs'
+ * ```
+ */
+export type Url = string & { readonly [urlBrand]: 'Url' }
+
+/**
+ * `Url` 値オブジェクトを生成する。
+ *
+ * 前後の空白は trim せず原文を保持する（保存済みデータと一致させるため）。
+ * 不正値は `SavedTabsDomainError` を投げ、`message` には入力値を含めない。
+ *
+ * @example
+ * ```ts
+ * createUrl('https://example.com') // OK
+ * createUrl('   ')                  // throws SavedTabsDomainError
+ * ```
+ */
+export const createUrl = (value: string): Url => {
+  if (typeof value !== 'string' || value.length === 0 || value.trim() === '') {
+    throw new SavedTabsDomainError('URL は空文字列にできません', 'INVALID_URL')
+  }
+  try {
+    // eslint-disable-next-line no-new
+    new URL(value)
+  } catch {
+    throw new SavedTabsDomainError('URL の形式が不正です', 'INVALID_URL')
+  }
+  // OK: createUrl は URL バリデーション通過後のブランド型タグ付けに限定
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return value as Url
+}
+
+/**
+ * `Url` を生文字列へ戻す。永続化層や UI へ渡すための変換口。
+ */
+export const urlToString = (url: Url): string => url
+
+/**
+ * 2 つの `Url` を文字列として比較する。大文字小文字差をそのまま扱う。
+ */
+export const equalsUrl = (a: Url, b: Url): boolean => a === b

--- a/src/contexts/saved-tabs/domain/value-objects/UrlRecordId.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/UrlRecordId.ts
@@ -1,0 +1,45 @@
+import { SavedTabsDomainError } from '../errors/SavedTabsDomainError'
+
+declare const urlRecordIdBrand: unique symbol
+
+/**
+ * `UrlRecord` の識別子を表す不変値オブジェクト。
+ *
+ * 採番アルゴリズムは infrastructure 側に任せ、domain 層では
+ * 「非空の文字列であること」のみ保証する。
+ *
+ * @example
+ * ```ts
+ * const id = createUrlRecordId('url-record-1')
+ * urlRecordIdToString(id) // 'url-record-1'
+ * ```
+ */
+export type UrlRecordId = string & {
+  readonly [urlRecordIdBrand]: 'UrlRecordId'
+}
+
+/**
+ * `UrlRecordId` 値オブジェクトを生成する。
+ */
+export const createUrlRecordId = (value: string): UrlRecordId => {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new SavedTabsDomainError(
+      'UrlRecord ID は空文字列にできません',
+      'INVALID_ID',
+    )
+  }
+  // OK: createUrlRecordId は検証通過後のブランド型タグ付けに限定
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return value as UrlRecordId
+}
+
+/**
+ * `UrlRecordId` を生文字列へ戻す。
+ */
+export const urlRecordIdToString = (id: UrlRecordId): string => id
+
+/**
+ * 2 つの `UrlRecordId` を比較する。
+ */
+export const equalsUrlRecordId = (a: UrlRecordId, b: UrlRecordId): boolean =>
+  a === b


### PR DESCRIPTION
Closes #456

## 変更内容

Issue #456（依存: #455 完了済み）の domain 層スケルトンを実装しました。
`src/contexts/saved-tabs/domain/` 配下に、React や \`chrome.*\` API に依存しない
pure なドメインモデルだけを追加しています。既存 \`src/types/storage.ts\` や
\`src/features/saved-tabs/\` は触っていないため互換性は保たれます。

### 追加ファイル（33 件）

- \`domain/errors/SavedTabsDomainError\`
  - ドメイン例外と \`code\` 分類 (INVALID_URL / INVALID_TAB_GROUP など)
- \`domain/value-objects/\`
  - \`Url\` / \`DomainName\` / \`CategoryName\` / \`TabGroupId\` / \`UrlRecordId\`
    / \`ParentCategoryId\` / \`CustomProjectId\` / \`SavedAt\`
  - ブランド型 + factory function + バリデーション
- \`domain/entities/\`
  - \`UrlRecord\` / \`TabGroup\` / \`ParentCategory\` / \`CustomProject\`
  - 不変モデル + 件数・所属判定ヘルパー
- \`domain/services/\`
  - \`CategoryAssignmentPolicy\`: \`buildCategoryLookup\` と
    \`resolveCategoryForTabGroup\`（parentCategoryId → tabGroupId → domainName）
  - \`TabGroupCategorizationService\`: \`categorizeTabGroups\` / 未分類末尾化
  - \`SavedTabsSearchService\`: URL / title / domain / category 名で部分一致検索
  - \`OpenedUrlRemovalPolicy\`: \`removeTabAfterOpen\` / \`Drop\` 設定に基づく
    削除判定 + \`TabGroup\` からの URL 取り除き
  - \`UrlReferenceService\`: 削除元以外からの参照判定 / 未参照 UrlRecord 抽出

各ファイルに JSDoc（日本語コメント + \`@example\`）と unit test を併設しています。

### Issue「実装ルール」遵守

- domain 層から React / \`chrome.*\` API / \`toast\` / router / DOM API を import していない
- \`any\` を使用していない
- 関数はアロー関数で実装
- JSDoc に日本語コメントと \`@example\` を含める

### Issue「テスト観点」カバレッジ

- カテゴリ lookup が tabGroupId / domainName の両方で正しく引ける → \`CategoryAssignmentPolicy.test.ts\`
- 未分類の TabGroup が未分類として扱われる → \`TabGroupCategorizationService.test.ts\` / \`CategoryAssignmentPolicy.test.ts\`
- 検索条件に一致する URL / タイトル / カテゴリだけが残る → \`SavedTabsSearchService.test.ts\`
- URL 削除後の件数計算が正しい → \`OpenedUrlRemovalPolicy.test.ts\` / \`TabGroup.test.ts\`
- 同じ UrlRecord を複数 TabGroup / CustomProject が参照するケースで誤って削除しない → \`UrlReferenceService.test.ts\`

## ローカル検証

- ✅ \`bun run compile\` 通過
- ✅ \`bun run test:node\` 73 files / 736 tests 通過（新規 76 tests を含む）
- ✅ \`bun run test\` 186 files / 1509 tests 通過
- ✅ \`bun run lint\` 0 errors（DDD レイヤガード oxlint override 設定も満たす）
- ✅ \`bun run format\` で差分なし
- ⚠️ \`bun run knip\` は事前から失敗（\`src/lib/harness/harnessState.test.ts\` の
  unlisted binaries 9 件、本 PR の変更とは無関係。develop 直 clone でも同じ結果）

## チェックリスト

- [x] ローカル環境でエラーになっていない
- [x] 関連 unit test が通る
- [x] DDD 構成の依存ルール（\`docs/architecture/ddd.md\` / oxlint override）に準拠

## 関連

- Parent: #454 (DDD 段階移行の全体計画)
- Depends on: #455 (DDD ディレクトリ追加、PR #461 で merge 済み)
- 後続: #456 は domain 層のみ。application / infrastructure / presentation は別 Issue で 1 use-case ずつ移行予定