### PR TITLE
feat(#457): saved-tabs の repository interface と chrome-storage 実装を分離

### DIFF
--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -250,4 +250,28 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       expect(names).toContain('chrome.alarms')
     })
   })
+
+  describe('domain/repositories/ の純度 (issue #457)', () => {
+    const repositoryInterfaceFiles = [
+      'src/contexts/saved-tabs/domain/repositories/TabGroupRepository.ts',
+      'src/contexts/saved-tabs/domain/repositories/UrlRecordRepository.ts',
+      'src/contexts/saved-tabs/domain/repositories/ParentCategoryRepository.ts',
+      'src/contexts/saved-tabs/domain/repositories/CustomProjectRepository.ts',
+    ]
+
+    for (const file of repositoryInterfaceFiles) {
+      it(`${file} は chrome.* や storage / 副作用を import / 利用しない`, () => {
+        const source = readFileSync(resolve(repoRoot, file), 'utf8')
+        // コード本体に限定して import / プロパティアクセス / import パスを検査する。
+        // JSDoc のテキスト説明は対象外。
+        expect(source).not.toMatch(/from\s+['"]chrome['"]/)
+        expect(source).not.toMatch(/from\s+['"]@\/lib\/storage/)
+        expect(source).not.toMatch(/chrome\.storage\.local\./)
+        expect(source).not.toMatch(/chrome\.storage\.onChanged/)
+        expect(source).not.toMatch(/\blocalStorage\./)
+        expect(source).not.toMatch(/\bsessionStorage\./)
+        expect(source).not.toMatch(/chrome\.runtime\.sendMessage/)
+      })
+    }
+  })
 })

--- a/src/contexts/saved-tabs/domain/README.md
+++ b/src/contexts/saved-tabs/domain/README.md
@@ -8,7 +8,7 @@
 | ---------------- | -------------------------------------------------------------------------------------------------- |
 | `entities/`      | `TabGroup` / `UrlRecord` / `ParentCategory` / `CustomProject` の entity 定義                       |
 | `value-objects/` | `Url` / `DomainName` / `CategoryName` / `*Id` / `SavedAt` などの不変値型                           |
-| `repositories/`  | repository の **interface のみ**（実装は `infrastructure/persistence/`）                           |
+| `repositories/`  | repository の **interface のみ**（実装は `infrastructure/persistence/chrome-storage/`）            |
 | `services/`      | 複数 entity にまたがる pure なドメインサービス（カテゴリ判定、URL 参照チェック、削除ポリシーなど） |
 | `errors/`        | `SavedTabsDomainError` などのドメイン例外                                                          |
 
@@ -19,3 +19,4 @@
 - `localStorage` / `sessionStorage` 直接利用
 - `toast` / router / DOM API 依存
 - 副作用（`Date.now()` などの現在時刻依存は `application/ports/ClockPort` 経由で注入）
+- `repositories/` から `infrastructure/` 配下を import する（interface のみで完結させる）

--- a/src/contexts/saved-tabs/domain/repositories/CustomProjectRepository.ts
+++ b/src/contexts/saved-tabs/domain/repositories/CustomProjectRepository.ts
@@ -1,0 +1,25 @@
+import type { CustomProject } from '../entities/CustomProject'
+import type { CustomProjectId } from '../value-objects/CustomProjectId'
+
+/**
+ * `CustomProject` の永続化責務だけを抽出した repository interface。
+ *
+ * プロジェクト単位での URL 集約 (`urlIds` / `categories` / `createdAt` /
+ * `updatedAt`) の読み書きだけを domain interface に閉じ込め、
+ * 並び替え・カテゴリ追加・URL 追加などは use-case 側で表現する。
+ *
+ * `chrome.storage.local` の直接アクセスは禁止。実装は
+ * `src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/` 側に置く。
+ *
+ * @example
+ * ```ts
+ * const projects = await customProjectRepository.findAll()
+ * const target = projects.find((project) => project.id === projectId)
+ * ```
+ */
+export interface CustomProjectRepository {
+  findAll: () => Promise<readonly CustomProject[]>
+  findById: (id: CustomProjectId) => Promise<CustomProject | null>
+  saveAll: (projects: readonly CustomProject[]) => Promise<void>
+  removeByIds: (ids: readonly CustomProjectId[]) => Promise<void>
+}

--- a/src/contexts/saved-tabs/domain/repositories/ParentCategoryRepository.ts
+++ b/src/contexts/saved-tabs/domain/repositories/ParentCategoryRepository.ts
@@ -1,0 +1,25 @@
+import type { ParentCategory } from '../entities/ParentCategory'
+import type { ParentCategoryId } from '../value-objects/ParentCategoryId'
+
+/**
+ * `ParentCategory` の永続化責務だけを抽出した repository interface。
+ *
+ * `findAll` / `findById` / `saveAll` / `removeByIds` の 4 操作だけを公開し、
+ * ドメインルール（ドメイン-カテゴリ紐付け、`domainNames` の同期など）は
+ * `domain/services/CategoryAssignmentPolicy` 側に寄せる。
+ *
+ * `chrome.storage.local` の直接アクセスは禁止。実装は
+ * `src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/` 側に置く。
+ *
+ * @example
+ * ```ts
+ * const categories = await parentCategoryRepository.findAll()
+ * const docs = categories.find((category) => category.name === 'Docs')
+ * ```
+ */
+export interface ParentCategoryRepository {
+  findAll: () => Promise<readonly ParentCategory[]>
+  findById: (id: ParentCategoryId) => Promise<ParentCategory | null>
+  saveAll: (categories: readonly ParentCategory[]) => Promise<void>
+  removeByIds: (ids: readonly ParentCategoryId[]) => Promise<void>
+}

--- a/src/contexts/saved-tabs/domain/repositories/TabGroupRepository.ts
+++ b/src/contexts/saved-tabs/domain/repositories/TabGroupRepository.ts
@@ -1,0 +1,29 @@
+import type { TabGroup } from '../entities/TabGroup'
+import type { TabGroupId } from '../value-objects/TabGroupId'
+
+/**
+ * `TabGroup` の永続化責務だけを抽出した repository interface。
+ *
+ * `src/contexts/saved-tabs/domain/repositories/` 配下に interface のみを置き、
+ * 実装（`chrome.storage.local` / IndexedDB / メモリなど）は
+ * `src/contexts/saved-tabs/infrastructure/persistence/` 側で提供する。
+ *
+ * ルール:
+ * - この interface は `chrome.*` API を知らない。
+ * - `findAll` / `findById` / `saveAll` / `removeByIds` の 4 操作だけを公開し、
+ *   ビジネスロジック（URL 追加、並び替え、サブカテゴリ付けなど）は
+ *   use-case / domain service 側に寄せる。
+ * - 返り値は `readonly` 修飾し、取得側で破壊的変更を許さない。
+ *
+ * @example
+ * ```ts
+ * const groups = await tabGroupRepository.findAll()
+ * const target = groups.find((group) => group.domain === 'example.com')
+ * ```
+ */
+export interface TabGroupRepository {
+  findAll: () => Promise<readonly TabGroup[]>
+  findById: (id: TabGroupId) => Promise<TabGroup | null>
+  saveAll: (groups: readonly TabGroup[]) => Promise<void>
+  removeByIds: (ids: readonly TabGroupId[]) => Promise<void>
+}

--- a/src/contexts/saved-tabs/domain/repositories/UrlRecordRepository.ts
+++ b/src/contexts/saved-tabs/domain/repositories/UrlRecordRepository.ts
@@ -1,0 +1,25 @@
+import type { UrlRecord } from '../entities/UrlRecord'
+import type { UrlRecordId } from '../value-objects/UrlRecordId'
+
+/**
+ * `UrlRecord` の永続化責務だけを抽出した repository interface。
+ *
+ * Issue #457 の例として提示された 4 操作（`findAll` / `findById` / `saveAll` /
+ * `removeByIds`）を最小単位とし、business rule（重複統合、未参照掃除、
+ * 参照整合性の確認など）は `domain/services/` と use-case 側に閉じる。
+ *
+ * `chrome.storage.local` の直接アクセスは禁止。実装は
+ * `src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/` 側に置く。
+ *
+ * @example
+ * ```ts
+ * const records = await urlRecordRepository.findAll()
+ * const target = records.find((record) => record.url === 'https://example.com')
+ * ```
+ */
+export interface UrlRecordRepository {
+  findAll: () => Promise<readonly UrlRecord[]>
+  findById: (id: UrlRecordId) => Promise<UrlRecord | null>
+  saveAll: (records: readonly UrlRecord[]) => Promise<void>
+  removeByIds: (ids: readonly UrlRecordId[]) => Promise<void>
+}

--- a/src/contexts/saved-tabs/infrastructure/README.md
+++ b/src/contexts/saved-tabs/infrastructure/README.md
@@ -4,14 +4,26 @@
 
 ## サブディレクトリ
 
-| ディレクトリ                  | 役割                                                                               |
-| ----------------------------- | ---------------------------------------------------------------------------------- |
-| `persistence/chrome-storage/` | `Chrome*Repository` 実装 / `savedTabsStorageKeys.ts` / `savedTabsStorageSchema.ts` |
-| `persistence/migrations/`     | 既存保存データを壊さない migration（`migrateLegacySavedTabs.ts` など）             |
-| `browser/`                    | `chrome.tabs` / `chrome.contextMenus` / `chrome.alarms` などの adapter             |
-| `mappers/`                    | storage の生データ ↔ domain entity / DTO の相互変換                                |
+| サブディレクトリ              | 役割                                                                                                          |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `persistence/chrome-storage/` | `Chrome*Repository` 実装 / `savedTabsStorageKeys.ts` / `savedTabsStorageSchema.ts` / `ChromeStorageLocalPort` |
+| `persistence/migrations/`     | 既存保存データを壊さない migration（`migrateLegacySavedTabs.ts` など）                                        |
+| `browser/`                    | `chrome.tabs` / `chrome.contextMenus` / `chrome.alarms` などの adapter                                        |
+| `mappers/`                    | storage の生データ ↔ domain entity / DTO の相互変換                                                           |
 
 ## 禁止
 
 - presentation 層への依存
 - domain interface を通さない直接アクセス
+- `chrome.*` 永続化 API の domain 層への漏洩
+
+## repository パターン
+
+- domain 層は `domain/repositories/` の interface のみを参照する。
+- infrastructure 層は `infrastructure/persistence/chrome-storage/` 配下に
+  `createChromeXxxRepository()` ファクトリを公開し、composition 層から
+  use-case へ注入する。
+- `ChromeStorageLocalPort` 経由で `chrome.storage.local` を抽象化し、テスト時は
+  in-memory モックを注入する。
+- 旧 `src/lib/storage/*` の `chrome.storage.local` 直叩きは並行稼働させる。
+  段階的にこの repository へ移行する（use-case 化と併せて別 issue で進める）。

--- a/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it } from 'vitest'
+
+import { createCustomProjectId } from '../../domain/value-objects/CustomProjectId'
+import { createDomainName } from '../../domain/value-objects/DomainName'
+import { createParentCategoryId } from '../../domain/value-objects/ParentCategoryId'
+import { createTabGroupId } from '../../domain/value-objects/TabGroupId'
+import { createUrlRecordId } from '../../domain/value-objects/UrlRecordId'
+import { ChromeSavedTabsStorageMapper } from './ChromeSavedTabsStorageMapper'
+
+describe('ChromeSavedTabsStorageMapper', () => {
+  describe('parseTabGroup', () => {
+    it('必須フィールドを持つ生データを entity 化する', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseTabGroup({
+        domain: 'example.com',
+        id: 'group-1',
+      })
+      expect(entity).not.toBeNull()
+      expect(entity?.id).toBe('group-1')
+      expect(entity?.domain).toBe('example.com')
+      expect(entity?.urlIds).toStrictEqual([])
+    })
+
+    it('rich な補助フィールドは読み捨てるが urlIds は保持する', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseTabGroup({
+        domain: 'https://example.com',
+        id: 'group-1',
+        parentCategoryId: 'cat-1',
+        savedAt: 1_700_000_000_000,
+        urlIds: ['url-1', 'url-2'],
+        urlSubCategories: { 'url-1': 'docs' },
+      })
+      expect(entity).not.toBeNull()
+      expect(entity?.urlIds).toStrictEqual(['url-1', 'url-2'])
+      expect(entity?.parentCategoryId).toBe('cat-1')
+      expect(entity?.savedAt).toBe(1_700_000_000_000)
+    })
+
+    it('id / domain が無い生データは null を返す', () => {
+      expect(
+        ChromeSavedTabsStorageMapper.parseTabGroup({ urlIds: ['url-1'] }),
+      ).toBeNull()
+      expect(ChromeSavedTabsStorageMapper.parseTabGroup(null)).toBeNull()
+      expect(
+        ChromeSavedTabsStorageMapper.parseTabGroup('not-an-object'),
+      ).toBeNull()
+    })
+
+    it('urlIds に空文字が混じると null を返す', () => {
+      expect(
+        ChromeSavedTabsStorageMapper.parseTabGroup({
+          domain: 'example.com',
+          id: 'group-1',
+          urlIds: ['', 'url-2'],
+        }),
+      ).toBeNull()
+    })
+  })
+
+  describe('parseUrlRecord', () => {
+    it('必須フィールドを持つ生データを entity 化する', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseUrlRecord({
+        id: 'url-1',
+        savedAt: 1,
+        title: 'A',
+        url: 'https://example.com',
+      })
+      expect(entity).not.toBeNull()
+      expect(entity?.id).toBe('url-1')
+      expect(entity?.url).toBe('https://example.com')
+      expect(entity?.title).toBe('A')
+      expect(entity?.savedAt).toBe(1)
+    })
+
+    it('favIconUrl 省略時は undefined として保持', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseUrlRecord({
+        id: 'url-1',
+        savedAt: 1,
+        title: 'A',
+        url: 'https://example.com',
+      })
+      expect(entity?.favIconUrl).toBeUndefined()
+    })
+
+    it('URL 形式が不正なら null を返す', () => {
+      expect(
+        ChromeSavedTabsStorageMapper.parseUrlRecord({
+          id: 'url-1',
+          savedAt: 1,
+          title: 'A',
+          url: 'not a url',
+        }),
+      ).toBeNull()
+    })
+
+    it('必須欠けは null を返す', () => {
+      expect(
+        ChromeSavedTabsStorageMapper.parseUrlRecord({
+          id: 'url-1',
+          title: 'A',
+          url: 'https://example.com',
+        }),
+      ).toBeNull()
+    })
+  })
+
+  describe('parseParentCategory', () => {
+    it('必須フィールドを持つ生データを entity 化する', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseParentCategory({
+        domainNames: ['example.com'],
+        domains: ['group-1'],
+        id: 'cat-1',
+        name: 'Docs',
+      })
+      expect(entity).not.toBeNull()
+      expect(entity?.id).toBe('cat-1')
+      expect(entity?.name).toBe('Docs')
+      expect(entity?.domains).toStrictEqual(['group-1'])
+      expect(entity?.domainNames).toStrictEqual(['example.com'])
+    })
+
+    it('空配列を許容する', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseParentCategory({
+        domainNames: [],
+        domains: [],
+        id: 'cat-1',
+        name: 'Docs',
+      })
+      expect(entity).not.toBeNull()
+    })
+
+    it('必須欠けは null を返す', () => {
+      expect(
+        ChromeSavedTabsStorageMapper.parseParentCategory({
+          domainNames: ['example.com'],
+          id: 'cat-1',
+          name: 'Docs',
+        }),
+      ).toBeNull()
+    })
+  })
+
+  describe('parseCustomProject', () => {
+    it('必須フィールドを持つ生データを entity 化する', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseCustomProject({
+        categories: ['research'],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        updatedAt: 2,
+      })
+      expect(entity).not.toBeNull()
+      expect(entity?.id).toBe('project-1')
+      expect(entity?.name).toBe('Q4')
+      expect(entity?.categories).toStrictEqual(['research'])
+      expect(entity?.createdAt).toBe(1)
+      expect(entity?.updatedAt).toBe(2)
+    })
+
+    it('urlIds を持つ project を entity 化する', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseCustomProject({
+        categories: [],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        updatedAt: 1,
+        urlIds: ['url-1', 'url-2'],
+      })
+      expect(entity).not.toBeNull()
+      expect(entity?.urlIds).toStrictEqual(['url-1', 'url-2'])
+    })
+
+    it('必須欠けは null を返す', () => {
+      expect(
+        ChromeSavedTabsStorageMapper.parseCustomProject({
+          createdAt: 1,
+          id: 'project-1',
+          name: 'Q4',
+          updatedAt: 1,
+        }),
+      ).toBeNull()
+    })
+  })
+
+  describe('parseTabGroups / parseUrlRecords (配列パース)', () => {
+    it('不正要素をスキップして有効要素だけを返す', () => {
+      const result = ChromeSavedTabsStorageMapper.parseTabGroups([
+        { domain: 'example.com', id: 'group-1' },
+        { domain: 'https://broken' },
+        null,
+        { domain: 'example.com', id: 'group-2', urlIds: ['url-1'] },
+      ])
+      expect(result).toHaveLength(2)
+      expect(result[0]?.id).toBe('group-1')
+      expect(result[1]?.id).toBe('group-2')
+    })
+
+    it('配列でない入力は空配列を返す', () => {
+      expect(ChromeSavedTabsStorageMapper.parseTabGroups(null)).toStrictEqual(
+        [],
+      )
+      expect(
+        ChromeSavedTabsStorageMapper.parseTabGroups('not-array'),
+      ).toStrictEqual([])
+    })
+
+    it('parseUrlRecords も同様にスキップする', () => {
+      const result = ChromeSavedTabsStorageMapper.parseUrlRecords([
+        { id: 'url-1', savedAt: 1, title: 'A', url: 'https://example.com' },
+        { id: 'url-2', title: 'B', url: 'https://example.com' },
+        { id: 'url-3', savedAt: 2, title: 'C', url: 'https://example.com' },
+      ])
+      expect(result).toHaveLength(2)
+      expect(result[0]?.id).toBe('url-1')
+      expect(result[1]?.id).toBe('url-3')
+    })
+  })
+
+  describe('collectParseSkipped', () => {
+    it('スキップ件数と抽出 entity を同時に返す', () => {
+      const result = ChromeSavedTabsStorageMapper.collectParseSkipped(
+        [
+          { domain: 'example.com', id: 'group-1' },
+          null,
+          { domain: 'https://broken' },
+          { domain: 'example.com', id: 'group-2' },
+        ],
+        (item) => ChromeSavedTabsStorageMapper.parseTabGroup(item),
+      )
+      expect(result.entities).toHaveLength(2)
+      expect(result.skippedCount).toBe(2)
+    })
+
+    it('配列でない入力は entities=[], skippedCount=0', () => {
+      const result = ChromeSavedTabsStorageMapper.collectParseSkipped(
+        null,
+        (item) => ChromeSavedTabsStorageMapper.parseTabGroup(item),
+      )
+      expect(result.entities).toStrictEqual([])
+      expect(result.skippedCount).toBe(0)
+    })
+  })
+
+  describe('toUrlRecordRaw / toSavedTabRaw / toParentCategoryRaw / toCustomProjectRaw', () => {
+    it('toUrlRecordRaw は entity を最小 raw 形式へ戻す', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseUrlRecord({
+        favIconUrl: 'https://example.com/icon.png',
+        id: 'url-1',
+        savedAt: 1,
+        title: 'A',
+        url: 'https://example.com',
+      })
+      expect(entity).not.toBeNull()
+      if (!entity) {
+        return
+      }
+      const raw = ChromeSavedTabsStorageMapper.toUrlRecordRaw(entity)
+      expect(raw).toStrictEqual({
+        favIconUrl: 'https://example.com/icon.png',
+        id: 'url-1',
+        savedAt: 1,
+        title: 'A',
+        url: 'https://example.com',
+      })
+    })
+
+    it('toSavedTabRaw は urlIds 配列をコピーして保持する', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseTabGroup({
+        domain: 'example.com',
+        id: 'group-1',
+        urlIds: ['url-1', 'url-2'],
+      })
+      expect(entity).not.toBeNull()
+      if (!entity) {
+        return
+      }
+      const raw = ChromeSavedTabsStorageMapper.toSavedTabRaw(entity)
+      expect(raw.id).toBe('group-1')
+      expect(raw.urlIds).toStrictEqual(['url-1', 'url-2'])
+    })
+
+    it('toParentCategoryRaw は domains / domainNames をコピーして保持する', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseParentCategory({
+        domainNames: ['example.com'],
+        domains: ['group-1'],
+        id: 'cat-1',
+        name: 'Docs',
+      })
+      expect(entity).not.toBeNull()
+      if (!entity) {
+        return
+      }
+      const raw = ChromeSavedTabsStorageMapper.toParentCategoryRaw(entity)
+      expect(raw.domains).toStrictEqual(['group-1'])
+      expect(raw.domainNames).toStrictEqual(['example.com'])
+    })
+
+    it('toCustomProjectRaw は categories / urlIds をコピーして保持する', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseCustomProject({
+        categories: ['research'],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        updatedAt: 2,
+        urlIds: ['url-1'],
+      })
+      expect(entity).not.toBeNull()
+      if (!entity) {
+        return
+      }
+      const raw = ChromeSavedTabsStorageMapper.toCustomProjectRaw(entity)
+      expect(raw.categories).toStrictEqual(['research'])
+      expect(raw.urlIds).toStrictEqual(['url-1'])
+      expect(raw.createdAt).toBe(1)
+      expect(raw.updatedAt).toBe(2)
+    })
+  })
+
+  describe('id toString helpers', () => {
+    it('各 ID は素の string に変換できる', () => {
+      expect(
+        ChromeSavedTabsStorageMapper.urlRecordIdToString(
+          createUrlRecordId('url-1'),
+        ),
+      ).toBe('url-1')
+      expect(
+        ChromeSavedTabsStorageMapper.tabGroupIdToString(
+          createTabGroupId('group-1'),
+        ),
+      ).toBe('group-1')
+      expect(
+        ChromeSavedTabsStorageMapper.parentCategoryIdToString(
+          createParentCategoryId('cat-1'),
+        ),
+      ).toBe('cat-1')
+      expect(
+        ChromeSavedTabsStorageMapper.customProjectIdToString(
+          createCustomProjectId('project-1'),
+        ),
+      ).toBe('project-1')
+      expect(
+        ChromeSavedTabsStorageMapper.domainNameToString(
+          createDomainName('example.com'),
+        ),
+      ).toBe('example.com')
+    })
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts
+++ b/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts
@@ -1,0 +1,366 @@
+import { createCustomProject } from '../../domain/entities/CustomProject'
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import { createParentCategory } from '../../domain/entities/ParentCategory'
+import type { ParentCategory } from '../../domain/entities/ParentCategory'
+import { createTabGroup } from '../../domain/entities/TabGroup'
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import { createUrlRecord } from '../../domain/entities/UrlRecord'
+import type { UrlRecord } from '../../domain/entities/UrlRecord'
+import { SavedTabsDomainError } from '../../domain/errors/SavedTabsDomainError'
+import type { CustomProjectId } from '../../domain/value-objects/CustomProjectId'
+import type { DomainName } from '../../domain/value-objects/DomainName'
+import type { ParentCategoryId } from '../../domain/value-objects/ParentCategoryId'
+import type { TabGroupId } from '../../domain/value-objects/TabGroupId'
+import type { UrlRecordId } from '../../domain/value-objects/UrlRecordId'
+import {
+  CustomProjectRawSchema,
+  ParentCategoryRawSchema,
+  SavedTabRawSchema,
+  UrlRecordRawSchema,
+} from '../persistence/chrome-storage/savedTabsStorageSchema'
+import type {
+  CustomProjectRaw,
+  ParentCategoryRaw,
+  SavedTabRaw,
+  UrlRecordRaw,
+} from '../persistence/chrome-storage/savedTabsStorageSchema'
+
+/**
+ * `chrome.storage.local` の生データ ↔ `saved-tabs` domain entity の変換口。
+ *
+ * 役割:
+ * - 生データの `unknown` 境界を Zod schema (`savedTabsStorageSchema`) で検証する。
+ * - 検証済みの生データを domain の factory (`createTabGroup` / `createUrlRecord` /
+ *   `createParentCategory` / `createCustomProject`) に渡し、entity 化する。
+ * - entity 化で失敗（`SavedTabsDomainError`）したレコードは捨てて呼び出し側へ
+ *   `null` を返し、repository 実装側で警告ログを出せるようにする。
+ * - 既存 `src/lib/storage/*` と同じ chrome.storage 形式を読み書きする。
+ *
+ * Rich な補助フィールド（`urlSubCategories` / `subCategories` /
+ * `categoryKeywords` / `subCategoryOrder` など）は domain entity には存在しない
+ * ため、現時点では mapper で読み捨てる（次 issue で use-case 化と併せて再設計）。
+ */
+
+const isSavedTabsDomainError = (
+  error: unknown,
+): error is SavedTabsDomainError => error instanceof SavedTabsDomainError
+
+/**
+ * 既存 chrome.storage では `domain` フィールドに `https://example.com` の
+ * ような URL 形式が入っていた。新しい domain `DomainName` は hostname
+ * のみを受け付けるので、URL 形式なら hostname を取り出して渡す。
+ *
+ * パース失敗時は入力をそのまま返す（後段の `createDomainName` で再度弾く）。
+ */
+const normalizeDomainField = (value: string): string => {
+  if (!value.includes('://')) {
+    return value
+  }
+  try {
+    return new URL(value).hostname
+  } catch {
+    return value
+  }
+}
+
+const toTabGroupFromRaw = (raw: SavedTabRaw): TabGroup | null => {
+  try {
+    return createTabGroup({
+      domain: normalizeDomainField(raw.domain),
+      id: raw.id,
+      parentCategoryId: raw.parentCategoryId,
+      savedAt: raw.savedAt,
+      urlIds: raw.urlIds ?? [],
+    })
+  } catch (error) {
+    if (isSavedTabsDomainError(error)) {
+      return null
+    }
+    throw error
+  }
+}
+
+const toUrlRecordFromRaw = (raw: UrlRecordRaw): UrlRecord | null => {
+  try {
+    return createUrlRecord({
+      favIconUrl: raw.favIconUrl,
+      id: raw.id,
+      savedAt: raw.savedAt,
+      title: raw.title,
+      url: raw.url,
+    })
+  } catch (error) {
+    if (isSavedTabsDomainError(error)) {
+      return null
+    }
+    throw error
+  }
+}
+
+const toParentCategoryFromRaw = (
+  raw: ParentCategoryRaw,
+): ParentCategory | null => {
+  try {
+    return createParentCategory({
+      domainNames: raw.domainNames.map((name) => normalizeDomainField(name)),
+      domains: raw.domains,
+      id: raw.id,
+      name: raw.name,
+    })
+  } catch (error) {
+    if (isSavedTabsDomainError(error)) {
+      return null
+    }
+    throw error
+  }
+}
+
+const toCustomProjectFromRaw = (
+  raw: CustomProjectRaw,
+): CustomProject | null => {
+  try {
+    return createCustomProject({
+      categories: raw.categories,
+      createdAt: raw.createdAt,
+      id: raw.id,
+      name: raw.name,
+      updatedAt: raw.updatedAt,
+      urlIds: raw.urlIds ?? [],
+    })
+  } catch (error) {
+    if (isSavedTabsDomainError(error)) {
+      return null
+    }
+    throw error
+  }
+}
+
+const toUrlRecordRaw = (entity: UrlRecord): UrlRecordRaw => {
+  // favIconUrl が undefined のときは chrome.storage に `favIconUrl: undefined` を
+  // 残さず省略する（既存の保存データ互換 + toStrictEqual テスト安定化）。
+  const base: UrlRecordRaw = {
+    id: entity.id,
+    savedAt: entity.savedAt,
+    title: entity.title,
+    url: entity.url,
+  }
+  if (entity.favIconUrl !== undefined) {
+    return { ...base, favIconUrl: entity.favIconUrl }
+  }
+  return base
+}
+
+const toSavedTabRaw = (entity: TabGroup): SavedTabRaw => {
+  // parentCategoryId / savedAt が undefined のときも undefined プロパティを
+  // 残さない。chrome.storage には undefined 値ではなく key 自体を省略する。
+  // urlIds は空配列のときも key を省略（domain entity 化する時点で [] が入る
+  // ため、書き出し時にまで残すと input データと差分が出てしまう）。
+  const base: SavedTabRaw = {
+    domain: entity.domain,
+    id: entity.id,
+  }
+  if (entity.urlIds.length > 0) {
+    base.urlIds = [...entity.urlIds]
+  }
+  if (entity.parentCategoryId !== undefined) {
+    base.parentCategoryId = entity.parentCategoryId
+  }
+  if (entity.savedAt !== undefined) {
+    base.savedAt = entity.savedAt
+  }
+  return base
+}
+
+const toParentCategoryRaw = (entity: ParentCategory): ParentCategoryRaw => ({
+  domainNames: [...entity.domainNames],
+  domains: [...entity.domains],
+  id: entity.id,
+  name: entity.name,
+})
+
+const toCustomProjectRaw = (entity: CustomProject): CustomProjectRaw => {
+  const base: CustomProjectRaw = {
+    categories: [...entity.categories],
+    createdAt: entity.createdAt,
+    id: entity.id,
+    name: entity.name,
+    updatedAt: entity.updatedAt,
+  }
+  if (entity.urlIds.length > 0) {
+    base.urlIds = [...entity.urlIds]
+  }
+  return base
+}
+
+/**
+ * `unknown` な生データをパースし、有効な `TabGroup` だけを返す。
+ *
+ * Zod parse 失敗 / entity 化失敗 / `null` / `undefined` の場合は `null` を返す。
+ * repository 実装側で 1 件ずつ警告ログを出せるように、成功時のみ entity を返す。
+ */
+const parseTabGroup = (raw: unknown): TabGroup | null => {
+  const parsed = SavedTabRawSchema.safeParse(raw)
+  if (!parsed.success) {
+    return null
+  }
+  return toTabGroupFromRaw(parsed.data)
+}
+
+const parseUrlRecord = (raw: unknown): UrlRecord | null => {
+  const parsed = UrlRecordRawSchema.safeParse(raw)
+  if (!parsed.success) {
+    return null
+  }
+  return toUrlRecordFromRaw(parsed.data)
+}
+
+const parseParentCategory = (raw: unknown): ParentCategory | null => {
+  const parsed = ParentCategoryRawSchema.safeParse(raw)
+  if (!parsed.success) {
+    return null
+  }
+  return toParentCategoryFromRaw(parsed.data)
+}
+
+const parseCustomProject = (raw: unknown): CustomProject | null => {
+  const parsed = CustomProjectRawSchema.safeParse(raw)
+  if (!parsed.success) {
+    return null
+  }
+  return toCustomProjectFromRaw(parsed.data)
+}
+
+/**
+ * `unknown` な配列データから、有効な entity だけを抽出する。
+ *
+ * 配列でない入力 / `null` / `undefined` は空配列として扱う。
+ * 不正要素はスキップし、警告件数だけ呼び出し側に伝える。
+ */
+const parseTabGroups = (raw: unknown): TabGroup[] => {
+  if (!Array.isArray(raw)) {
+    return []
+  }
+  const result: TabGroup[] = []
+  for (const item of raw) {
+    const entity = parseTabGroup(item)
+    if (entity) {
+      result.push(entity)
+    }
+  }
+  return result
+}
+
+const parseUrlRecords = (raw: unknown): UrlRecord[] => {
+  if (!Array.isArray(raw)) {
+    return []
+  }
+  const result: UrlRecord[] = []
+  for (const item of raw) {
+    const entity = parseUrlRecord(item)
+    if (entity) {
+      result.push(entity)
+    }
+  }
+  return result
+}
+
+const parseParentCategories = (raw: unknown): ParentCategory[] => {
+  if (!Array.isArray(raw)) {
+    return []
+  }
+  const result: ParentCategory[] = []
+  for (const item of raw) {
+    const entity = parseParentCategory(item)
+    if (entity) {
+      result.push(entity)
+    }
+  }
+  return result
+}
+
+const parseCustomProjects = (raw: unknown): CustomProject[] => {
+  if (!Array.isArray(raw)) {
+    return []
+  }
+  const result: CustomProject[] = []
+  for (const item of raw) {
+    const entity = parseCustomProject(item)
+    if (entity) {
+      result.push(entity)
+    }
+  }
+  return result
+}
+
+/**
+ * 不正な生データが何件スキップされたかを、配列パース結果と同時に返す。
+ *
+ * repository 実装が「N 件スキップした」をログに出したいケースで使う。
+ */
+interface ParseResult<T> {
+  entities: T[]
+  skippedCount: number
+}
+
+const collectParseSkipped = <T>(
+  raw: unknown,
+  parser: (item: unknown) => T | null,
+): ParseResult<T> => {
+  if (!Array.isArray(raw)) {
+    return { entities: [], skippedCount: 0 }
+  }
+  const entities: T[] = []
+  let skippedCount = 0
+  for (const item of raw) {
+    const entity = parser(item)
+    if (entity) {
+      entities.push(entity)
+    } else {
+      skippedCount += 1
+    }
+  }
+  return { entities, skippedCount }
+}
+
+/**
+ * `TabGroup` のエンティティ ID から storage 上の同値比較用 ID を取り出す。
+ *
+ * domain `TabGroupId` は branded string なので、`chrome.storage.local` のキーや
+ * ログ出力で使える素の `string` に戻す。
+ */
+const tabGroupIdToString = (id: TabGroupId): string => id
+
+const urlRecordIdToString = (id: UrlRecordId): string => id
+
+const parentCategoryIdToString = (id: ParentCategoryId): string => id
+
+const customProjectIdToString = (id: CustomProjectId): string => id
+
+const domainNameToString = (name: DomainName): string => name
+
+export const ChromeSavedTabsStorageMapper = {
+  collectParseSkipped,
+  customProjectIdToString,
+  domainNameToString,
+  parseCustomProject,
+  parseCustomProjects,
+  parseParentCategory,
+  parseParentCategories,
+  parseTabGroup,
+  parseTabGroups,
+  parseUrlRecord,
+  parseUrlRecords,
+  parentCategoryIdToString,
+  tabGroupIdToString,
+  toCustomProjectFromRaw,
+  toCustomProjectRaw,
+  toParentCategoryFromRaw,
+  toParentCategoryRaw,
+  toSavedTabRaw,
+  toTabGroupFromRaw,
+  toUrlRecordFromRaw,
+  toUrlRecordRaw,
+  urlRecordIdToString,
+}
+
+export type { ParseResult }

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createCustomProjectId } from '../../../domain/value-objects/CustomProjectId'
+import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStorageMapper'
+import { createChromeCustomProjectRepository } from './ChromeCustomProjectRepository'
+import { SavedTabsRepositoryUnavailableError } from './ChromeUrlRecordRepository'
+import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
+import { CUSTOM_PROJECTS_KEY } from './savedTabsStorageKeys'
+
+type StorageState = Record<string, unknown>
+
+const createPort = (state: StorageState): ChromeStorageLocalPort => {
+  // mock 内で await しない同期関数を async として書くため lint ルールを局所的に解除する
+  /* eslint-disable typescript/require-await */
+  return {
+    get: vi.fn((key: string) => Promise.resolve({ [key]: state[key] })),
+    remove: vi.fn((key: string) => {
+      // eslint-disable-next-line typescript/no-dynamic-delete
+      delete state[key]
+      return Promise.resolve()
+    }),
+    set: vi.fn((value: Record<string, unknown>) => {
+      Object.assign(state, value)
+      return Promise.resolve()
+    }),
+  }
+  /* eslint-enable typescript/require-await */
+}
+
+const createSampleCustomProject = (id: string, name: string) =>
+  ChromeSavedTabsStorageMapper.parseCustomProject({
+    categories: ['research'],
+    createdAt: 1,
+    id,
+    name,
+    updatedAt: 2,
+    urlIds: [`url-${id}`],
+  })
+
+describe('ChromeCustomProjectRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('createChromeCustomProjectRepository (factory)', () => {
+    it('port を渡すと repository を返す', () => {
+      const repo = createChromeCustomProjectRepository(createPort({}))
+      expect(repo.findAll).toBeTypeOf('function')
+    })
+
+    it('port が null なら SavedTabsRepositoryUnavailableError を投げる', () => {
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined)
+      try {
+        expect(() => createChromeCustomProjectRepository(null)).toThrow(
+          SavedTabsRepositoryUnavailableError,
+        )
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+  })
+
+  describe('findAll', () => {
+    it('空 storage のとき空配列を返す', async () => {
+      const repo = createChromeCustomProjectRepository(createPort({}))
+      await expect(repo.findAll()).resolves.toStrictEqual([])
+    })
+
+    it('CUSTOM_PROJECTS_KEY の生データを entity 配列に変換する', async () => {
+      const state: StorageState = {
+        [CUSTOM_PROJECTS_KEY]: [
+          {
+            categories: ['research'],
+            createdAt: 1,
+            id: 'project-1',
+            name: 'Q4',
+            updatedAt: 1,
+          },
+          {
+            categories: [],
+            createdAt: 1,
+            id: 'project-2',
+            name: 'Empty',
+            updatedAt: 1,
+            urlIds: ['url-1', 'url-2'],
+          },
+        ],
+      }
+      const repo = createChromeCustomProjectRepository(createPort(state))
+      const result = await repo.findAll()
+      expect(result).toHaveLength(2)
+      expect(result[0]?.name).toBe('Q4')
+      expect(result[1]?.urlIds).toStrictEqual(['url-1', 'url-2'])
+    })
+
+    it('不正な要素をスキップして有効要素だけ返す', async () => {
+      const state: StorageState = {
+        [CUSTOM_PROJECTS_KEY]: [
+          {
+            categories: ['research'],
+            createdAt: 1,
+            id: 'project-1',
+            name: 'Q4',
+            updatedAt: 1,
+          },
+          { createdAt: 1, id: 'project-2', name: 'NoCategories', updatedAt: 1 },
+          null,
+          {
+            categories: [],
+            createdAt: 1,
+            id: 'project-3',
+            name: 'Plain',
+            updatedAt: 1,
+          },
+        ],
+      }
+      const repo = createChromeCustomProjectRepository(createPort(state))
+      const result = await repo.findAll()
+      expect(result.map((p) => p.id)).toStrictEqual(['project-1', 'project-3'])
+    })
+  })
+
+  describe('findById', () => {
+    it('該当 ID の entity を返す', async () => {
+      const state: StorageState = {
+        [CUSTOM_PROJECTS_KEY]: [
+          {
+            categories: ['research'],
+            createdAt: 1,
+            id: 'project-1',
+            name: 'Q4',
+            updatedAt: 1,
+          },
+          {
+            categories: ['work'],
+            createdAt: 1,
+            id: 'project-2',
+            name: 'Work',
+            updatedAt: 1,
+          },
+        ],
+      }
+      const repo = createChromeCustomProjectRepository(createPort(state))
+      const result = await repo.findById(createCustomProjectId('project-2'))
+      expect(result?.name).toBe('Work')
+    })
+
+    it('存在しない ID は null を返す', async () => {
+      const state: StorageState = {
+        [CUSTOM_PROJECTS_KEY]: [
+          {
+            categories: ['research'],
+            createdAt: 1,
+            id: 'project-1',
+            name: 'Q4',
+            updatedAt: 1,
+          },
+        ],
+      }
+      const repo = createChromeCustomProjectRepository(createPort(state))
+      await expect(
+        repo.findById(createCustomProjectId('project-999')),
+      ).resolves.toBeNull()
+    })
+  })
+
+  describe('saveAll', () => {
+    it('entity 配列を CUSTOM_PROJECTS_KEY に raw 形式で保存する', async () => {
+      const port = createPort({})
+      const repo = createChromeCustomProjectRepository(port)
+      const project = createSampleCustomProject('project-1', 'Q4')
+      expect(project).not.toBeNull()
+      if (!project) {
+        return
+      }
+      await repo.saveAll([project])
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      expect(lastSetArg[CUSTOM_PROJECTS_KEY]).toStrictEqual([
+        {
+          categories: ['research'],
+          createdAt: 1,
+          id: 'project-1',
+          name: 'Q4',
+          updatedAt: 2,
+          urlIds: ['url-project-1'],
+        },
+      ])
+    })
+
+    it('空配列を渡したら空配列を保存する', async () => {
+      const port = createPort({})
+      const repo = createChromeCustomProjectRepository(port)
+      await repo.saveAll([])
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      expect(lastSetArg[CUSTOM_PROJECTS_KEY]).toStrictEqual([])
+    })
+  })
+
+  describe('removeByIds', () => {
+    it('指定 ID を除いて保存する', async () => {
+      const state: StorageState = {
+        [CUSTOM_PROJECTS_KEY]: [
+          {
+            categories: ['research'],
+            createdAt: 1,
+            id: 'project-1',
+            name: 'Q4',
+            updatedAt: 1,
+          },
+          {
+            categories: ['work'],
+            createdAt: 1,
+            id: 'project-2',
+            name: 'Work',
+            updatedAt: 1,
+          },
+          {
+            categories: ['side'],
+            createdAt: 1,
+            id: 'project-3',
+            name: 'Side',
+            updatedAt: 1,
+          },
+        ],
+      }
+      const port = createPort(state)
+      const repo = createChromeCustomProjectRepository(port)
+      await repo.removeByIds([
+        createCustomProjectId('project-1'),
+        createCustomProjectId('project-3'),
+      ])
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      expect(lastSetArg[CUSTOM_PROJECTS_KEY]).toStrictEqual([
+        {
+          categories: ['work'],
+          createdAt: 1,
+          id: 'project-2',
+          name: 'Work',
+          updatedAt: 1,
+        },
+      ])
+    })
+
+    it('存在しない ID を指定しても保存呼び出しは走らない', async () => {
+      const port = createPort({
+        [CUSTOM_PROJECTS_KEY]: [
+          {
+            categories: ['research'],
+            createdAt: 1,
+            id: 'project-1',
+            name: 'Q4',
+            updatedAt: 1,
+          },
+        ],
+      })
+      const repo = createChromeCustomProjectRepository(port)
+      await repo.removeByIds([createCustomProjectId('project-999')])
+      expect(port.set).not.toHaveBeenCalled()
+    })
+
+    it('空配列を渡したら何もしない', async () => {
+      const port = createPort({
+        [CUSTOM_PROJECTS_KEY]: [
+          {
+            categories: ['research'],
+            createdAt: 1,
+            id: 'project-1',
+            name: 'Q4',
+            updatedAt: 1,
+          },
+        ],
+      })
+      const repo = createChromeCustomProjectRepository(port)
+      await repo.removeByIds([])
+      expect(port.set).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.ts
@@ -1,0 +1,89 @@
+import {
+  getChromeStorageLocal,
+  warnMissingChromeStorage,
+} from '@/lib/browser/chrome-storage'
+
+import type { CustomProject } from '../../../domain/entities/CustomProject'
+import type { CustomProjectRepository } from '../../../domain/repositories/CustomProjectRepository'
+import type { CustomProjectId } from '../../../domain/value-objects/CustomProjectId'
+import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStorageMapper'
+import { SavedTabsRepositoryUnavailableError } from './ChromeUrlRecordRepository'
+import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
+import { CUSTOM_PROJECTS_KEY } from './savedTabsStorageKeys'
+import type { CustomProjectRaw } from './savedTabsStorageSchema'
+
+const getDefaultPort = (): ChromeStorageLocalPort | null => {
+  const local = getChromeStorageLocal()
+  if (!local) {
+    return null
+  }
+  return {
+    get: (key) => local.get(key),
+    remove: (key) => local.remove(key),
+    set: (value) => local.set(value),
+  }
+}
+
+const createChromeCustomProjectRepositoryImpl = (
+  port: ChromeStorageLocalPort,
+): CustomProjectRepository => {
+  const findAll = async (): Promise<readonly CustomProject[]> => {
+    const result = await port.get(CUSTOM_PROJECTS_KEY)
+    const raw = result[CUSTOM_PROJECTS_KEY]
+    return ChromeSavedTabsStorageMapper.parseCustomProjects(raw)
+  }
+
+  const findById = async (
+    id: CustomProjectId,
+  ): Promise<CustomProject | null> => {
+    const idString = ChromeSavedTabsStorageMapper.customProjectIdToString(id)
+    const all = await findAll()
+    return all.find((project) => project.id === idString) ?? null
+  }
+
+  const saveAll = async (projects: readonly CustomProject[]): Promise<void> => {
+    const raws: CustomProjectRaw[] = projects.map((project) =>
+      ChromeSavedTabsStorageMapper.toCustomProjectRaw(project),
+    )
+    await port.set({ [CUSTOM_PROJECTS_KEY]: raws })
+  }
+
+  const removeByIds = async (
+    ids: readonly CustomProjectId[],
+  ): Promise<void> => {
+    if (ids.length === 0) {
+      return
+    }
+    const idSet = new Set(ids.map((id) => id))
+    const all = await findAll()
+    const remaining = all.filter((project) => !idSet.has(project.id))
+    if (remaining.length === all.length) {
+      return
+    }
+    await saveAll(remaining)
+  }
+
+  return { findAll, findById, removeByIds, saveAll }
+}
+
+/**
+ * `chrome.storage.local` 上の `CUSTOM_PROJECTS_KEY` を
+ * `CustomProject` 永続化用に使う `CustomProjectRepository` 実装を生成する。
+ *
+ * Rich な補助フィールド（`projectKeywords` / `urls` / `urlMetadata` /
+ * `categoryOrder`）は現時点では永続化対象外。既存
+ * `src/lib/storage/projects.ts` を併用するか、別 issue の use-case 化で対応する。
+ *
+ * @throws {SavedTabsRepositoryUnavailableError} chrome.storage.local 不在時
+ */
+export const createChromeCustomProjectRepository = (
+  port: ChromeStorageLocalPort | null = getDefaultPort(),
+): CustomProjectRepository => {
+  if (!port) {
+    warnMissingChromeStorage('ChromeCustomProjectRepository')
+    throw new SavedTabsRepositoryUnavailableError(
+      'chrome.storage.local が利用できないため ChromeCustomProjectRepository を初期化できません',
+    )
+  }
+  return createChromeCustomProjectRepositoryImpl(port)
+}

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeParentCategoryRepository.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeParentCategoryRepository.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createParentCategoryId } from '../../../domain/value-objects/ParentCategoryId'
+import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStorageMapper'
+import { createChromeParentCategoryRepository } from './ChromeParentCategoryRepository'
+import { SavedTabsRepositoryUnavailableError } from './ChromeUrlRecordRepository'
+import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
+import { PARENT_CATEGORIES_KEY } from './savedTabsStorageKeys'
+
+type StorageState = Record<string, unknown>
+
+const createPort = (state: StorageState): ChromeStorageLocalPort => {
+  // mock 内で await しない同期関数を async として書くため lint ルールを局所的に解除する
+  /* eslint-disable typescript/require-await */
+  return {
+    get: vi.fn((key: string) => Promise.resolve({ [key]: state[key] })),
+    remove: vi.fn((key: string) => {
+      // eslint-disable-next-line typescript/no-dynamic-delete
+      delete state[key]
+      return Promise.resolve()
+    }),
+    set: vi.fn((value: Record<string, unknown>) => {
+      Object.assign(state, value)
+      return Promise.resolve()
+    }),
+  }
+  /* eslint-enable typescript/require-await */
+}
+
+const createSampleParentCategory = (id: string, name: string) =>
+  ChromeSavedTabsStorageMapper.parseParentCategory({
+    domainNames: [`${name}.example.com`],
+    domains: [`group-${id}`],
+    id,
+    name,
+  })
+
+describe('ChromeParentCategoryRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('createChromeParentCategoryRepository (factory)', () => {
+    it('port を渡すと repository を返す', () => {
+      const repo = createChromeParentCategoryRepository(createPort({}))
+      expect(repo.findAll).toBeTypeOf('function')
+    })
+
+    it('port が null なら SavedTabsRepositoryUnavailableError を投げる', () => {
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined)
+      try {
+        expect(() => createChromeParentCategoryRepository(null)).toThrow(
+          SavedTabsRepositoryUnavailableError,
+        )
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+  })
+
+  describe('findAll', () => {
+    it('空 storage のとき空配列を返す', async () => {
+      const repo = createChromeParentCategoryRepository(createPort({}))
+      await expect(repo.findAll()).resolves.toStrictEqual([])
+    })
+
+    it('PARENT_CATEGORIES_KEY の生データを entity 配列に変換する', async () => {
+      const state: StorageState = {
+        [PARENT_CATEGORIES_KEY]: [
+          {
+            domainNames: ['docs.example.com'],
+            domains: ['group-1'],
+            id: 'cat-1',
+            name: 'Docs',
+          },
+          {
+            domainNames: [],
+            domains: [],
+            id: 'cat-2',
+            name: 'Empty',
+          },
+        ],
+      }
+      const repo = createChromeParentCategoryRepository(createPort(state))
+      const result = await repo.findAll()
+      expect(result).toHaveLength(2)
+      expect(result[0]?.name).toBe('Docs')
+      expect(result[0]?.domainNames).toStrictEqual(['docs.example.com'])
+      expect(result[1]?.domains).toStrictEqual([])
+    })
+
+    it('不正な要素をスキップして有効要素だけ返す', async () => {
+      const state: StorageState = {
+        [PARENT_CATEGORIES_KEY]: [
+          {
+            domainNames: ['docs.example.com'],
+            domains: ['group-1'],
+            id: 'cat-1',
+            name: 'Docs',
+          },
+          { domainNames: ['x.example.com'], id: 'cat-2', name: 'NoGroup' },
+          null,
+          {
+            domainNames: ['y.example.com'],
+            domains: ['group-2'],
+            id: 'cat-3',
+            name: 'NoGroup3',
+          },
+        ],
+      }
+      const repo = createChromeParentCategoryRepository(createPort(state))
+      const result = await repo.findAll()
+      expect(result.map((c) => c.id)).toStrictEqual(['cat-1', 'cat-3'])
+    })
+  })
+
+  describe('findById', () => {
+    it('該当 ID の entity を返す', async () => {
+      const state: StorageState = {
+        [PARENT_CATEGORIES_KEY]: [
+          {
+            domainNames: ['docs.example.com'],
+            domains: ['group-1'],
+            id: 'cat-1',
+            name: 'Docs',
+          },
+          {
+            domainNames: ['work.example.com'],
+            domains: ['group-2'],
+            id: 'cat-2',
+            name: 'Work',
+          },
+        ],
+      }
+      const repo = createChromeParentCategoryRepository(createPort(state))
+      const result = await repo.findById(createParentCategoryId('cat-2'))
+      expect(result?.name).toBe('Work')
+    })
+
+    it('存在しない ID は null を返す', async () => {
+      const state: StorageState = {
+        [PARENT_CATEGORIES_KEY]: [
+          {
+            domainNames: ['docs.example.com'],
+            domains: ['group-1'],
+            id: 'cat-1',
+            name: 'Docs',
+          },
+        ],
+      }
+      const repo = createChromeParentCategoryRepository(createPort(state))
+      await expect(
+        repo.findById(createParentCategoryId('cat-999')),
+      ).resolves.toBeNull()
+    })
+  })
+
+  describe('saveAll', () => {
+    it('entity 配列を PARENT_CATEGORIES_KEY に raw 形式で保存する', async () => {
+      const port = createPort({})
+      const repo = createChromeParentCategoryRepository(port)
+      const category = createSampleParentCategory('cat-1', 'Docs')
+      expect(category).not.toBeNull()
+      if (!category) {
+        return
+      }
+      await repo.saveAll([category])
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      expect(lastSetArg[PARENT_CATEGORIES_KEY]).toStrictEqual([
+        {
+          domainNames: ['docs.example.com'],
+          domains: ['group-cat-1'],
+          id: 'cat-1',
+          name: 'Docs',
+        },
+      ])
+    })
+
+    it('空配列を渡したら空配列を保存する', async () => {
+      const port = createPort({})
+      const repo = createChromeParentCategoryRepository(port)
+      await repo.saveAll([])
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      expect(lastSetArg[PARENT_CATEGORIES_KEY]).toStrictEqual([])
+    })
+  })
+
+  describe('removeByIds', () => {
+    it('指定 ID を除いて保存する', async () => {
+      const state: StorageState = {
+        [PARENT_CATEGORIES_KEY]: [
+          {
+            domainNames: ['docs.example.com'],
+            domains: ['group-1'],
+            id: 'cat-1',
+            name: 'Docs',
+          },
+          {
+            domainNames: ['work.example.com'],
+            domains: ['group-2'],
+            id: 'cat-2',
+            name: 'Work',
+          },
+          {
+            domainNames: ['side.example.com'],
+            domains: ['group-3'],
+            id: 'cat-3',
+            name: 'Side',
+          },
+        ],
+      }
+      const port = createPort(state)
+      const repo = createChromeParentCategoryRepository(port)
+      await repo.removeByIds([
+        createParentCategoryId('cat-1'),
+        createParentCategoryId('cat-3'),
+      ])
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      expect(lastSetArg[PARENT_CATEGORIES_KEY]).toStrictEqual([
+        {
+          domainNames: ['work.example.com'],
+          domains: ['group-2'],
+          id: 'cat-2',
+          name: 'Work',
+        },
+      ])
+    })
+
+    it('存在しない ID を指定しても保存呼び出しは走らない', async () => {
+      const port = createPort({
+        [PARENT_CATEGORIES_KEY]: [
+          {
+            domainNames: ['docs.example.com'],
+            domains: ['group-1'],
+            id: 'cat-1',
+            name: 'Docs',
+          },
+        ],
+      })
+      const repo = createChromeParentCategoryRepository(port)
+      await repo.removeByIds([createParentCategoryId('cat-999')])
+      expect(port.set).not.toHaveBeenCalled()
+    })
+
+    it('空配列を渡したら何もしない', async () => {
+      const port = createPort({
+        [PARENT_CATEGORIES_KEY]: [
+          {
+            domainNames: ['docs.example.com'],
+            domains: ['group-1'],
+            id: 'cat-1',
+            name: 'Docs',
+          },
+        ],
+      })
+      const repo = createChromeParentCategoryRepository(port)
+      await repo.removeByIds([])
+      expect(port.set).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeParentCategoryRepository.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeParentCategoryRepository.ts
@@ -1,0 +1,87 @@
+import {
+  getChromeStorageLocal,
+  warnMissingChromeStorage,
+} from '@/lib/browser/chrome-storage'
+
+import type { ParentCategory } from '../../../domain/entities/ParentCategory'
+import type { ParentCategoryRepository } from '../../../domain/repositories/ParentCategoryRepository'
+import type { ParentCategoryId } from '../../../domain/value-objects/ParentCategoryId'
+import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStorageMapper'
+import { SavedTabsRepositoryUnavailableError } from './ChromeUrlRecordRepository'
+import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
+import { PARENT_CATEGORIES_KEY } from './savedTabsStorageKeys'
+import type { ParentCategoryRaw } from './savedTabsStorageSchema'
+
+const getDefaultPort = (): ChromeStorageLocalPort | null => {
+  const local = getChromeStorageLocal()
+  if (!local) {
+    return null
+  }
+  return {
+    get: (key) => local.get(key),
+    remove: (key) => local.remove(key),
+    set: (value) => local.set(value),
+  }
+}
+
+const createChromeParentCategoryRepositoryImpl = (
+  port: ChromeStorageLocalPort,
+): ParentCategoryRepository => {
+  const findAll = async (): Promise<readonly ParentCategory[]> => {
+    const result = await port.get(PARENT_CATEGORIES_KEY)
+    const raw = result[PARENT_CATEGORIES_KEY]
+    return ChromeSavedTabsStorageMapper.parseParentCategories(raw)
+  }
+
+  const findById = async (
+    id: ParentCategoryId,
+  ): Promise<ParentCategory | null> => {
+    const idString = ChromeSavedTabsStorageMapper.parentCategoryIdToString(id)
+    const all = await findAll()
+    return all.find((category) => category.id === idString) ?? null
+  }
+
+  const saveAll = async (
+    categories: readonly ParentCategory[],
+  ): Promise<void> => {
+    const raws: ParentCategoryRaw[] = categories.map((category) =>
+      ChromeSavedTabsStorageMapper.toParentCategoryRaw(category),
+    )
+    await port.set({ [PARENT_CATEGORIES_KEY]: raws })
+  }
+
+  const removeByIds = async (
+    ids: readonly ParentCategoryId[],
+  ): Promise<void> => {
+    if (ids.length === 0) {
+      return
+    }
+    const idSet = new Set(ids.map((id) => id))
+    const all = await findAll()
+    const remaining = all.filter((category) => !idSet.has(category.id))
+    if (remaining.length === all.length) {
+      return
+    }
+    await saveAll(remaining)
+  }
+
+  return { findAll, findById, removeByIds, saveAll }
+}
+
+/**
+ * `chrome.storage.local` 上の `PARENT_CATEGORIES_KEY` を
+ * `ParentCategory` 永続化用に使う `ParentCategoryRepository` 実装を生成する。
+ *
+ * @throws {SavedTabsRepositoryUnavailableError} chrome.storage.local 不在時
+ */
+export const createChromeParentCategoryRepository = (
+  port: ChromeStorageLocalPort | null = getDefaultPort(),
+): ParentCategoryRepository => {
+  if (!port) {
+    warnMissingChromeStorage('ChromeParentCategoryRepository')
+    throw new SavedTabsRepositoryUnavailableError(
+      'chrome.storage.local が利用できないため ChromeParentCategoryRepository を初期化できません',
+    )
+  }
+  return createChromeParentCategoryRepositoryImpl(port)
+}

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createTabGroupId } from '../../../domain/value-objects/TabGroupId'
+import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStorageMapper'
+import { createChromeTabGroupRepository } from './ChromeTabGroupRepository'
+import { SavedTabsRepositoryUnavailableError } from './ChromeUrlRecordRepository'
+import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
+import { SAVED_TABS_KEY } from './savedTabsStorageKeys'
+
+type StorageState = Record<string, unknown>
+
+const createPort = (state: StorageState): ChromeStorageLocalPort => {
+  // mock 内で await しない同期関数を async として書くため lint ルールを局所的に解除する
+  /* eslint-disable typescript/require-await */
+  return {
+    get: vi.fn((key: string) => Promise.resolve({ [key]: state[key] })),
+    remove: vi.fn((key: string) => {
+      // eslint-disable-next-line typescript/no-dynamic-delete
+      delete state[key]
+      return Promise.resolve()
+    }),
+    set: vi.fn((value: Record<string, unknown>) => {
+      Object.assign(state, value)
+      return Promise.resolve()
+    }),
+  }
+  /* eslint-enable typescript/require-await */
+}
+
+const createSampleTabGroup = (id: string, domain: string) =>
+  ChromeSavedTabsStorageMapper.parseTabGroup({
+    domain,
+    id,
+    urlIds: [`url-${id}`],
+  })
+
+describe('ChromeTabGroupRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('createChromeTabGroupRepository (factory)', () => {
+    it('port を渡すと repository を返す', () => {
+      const repo = createChromeTabGroupRepository(createPort({}))
+      expect(repo.findAll).toBeTypeOf('function')
+    })
+
+    it('port が null なら SavedTabsRepositoryUnavailableError を投げる', () => {
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined)
+      try {
+        expect(() => createChromeTabGroupRepository(null)).toThrow(
+          SavedTabsRepositoryUnavailableError,
+        )
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+  })
+
+  describe('findAll', () => {
+    it('空 storage のとき空配列を返す', async () => {
+      const repo = createChromeTabGroupRepository(createPort({}))
+      await expect(repo.findAll()).resolves.toStrictEqual([])
+    })
+
+    it('SAVED_TABS_KEY の生データを TabGroup entity 配列に変換する', async () => {
+      const state: StorageState = {
+        [SAVED_TABS_KEY]: [
+          {
+            domain: 'example.com',
+            id: 'group-1',
+            urlIds: ['url-1'],
+          },
+          {
+            categoryKeywords: [{ categoryName: 'docs', keywords: ['doc'] }],
+            domain: 'docs.example.com',
+            id: 'group-2',
+            parentCategoryId: 'cat-1',
+            savedAt: 1_700_000_000_000,
+            subCategories: ['docs'],
+            urlIds: ['url-2', 'url-3'],
+            urlSubCategories: { 'url-2': 'docs' },
+          },
+        ],
+      }
+      const repo = createChromeTabGroupRepository(createPort(state))
+      const result = await repo.findAll()
+      expect(result).toHaveLength(2)
+      expect(result[0]?.id).toBe('group-1')
+      expect(result[1]?.urlIds).toStrictEqual(['url-2', 'url-3'])
+      expect(result[1]?.parentCategoryId).toBe('cat-1')
+    })
+
+    it('不正な要素をスキップして有効要素だけ返す', async () => {
+      const state: StorageState = {
+        [SAVED_TABS_KEY]: [
+          { domain: 'example.com', id: 'group-1' },
+          { id: 'group-2' },
+          null,
+          { domain: 'example.com', id: 'group-3', urlIds: [] },
+        ],
+      }
+      const repo = createChromeTabGroupRepository(createPort(state))
+      const result = await repo.findAll()
+      expect(result.map((g) => g.id)).toStrictEqual(['group-1', 'group-3'])
+    })
+
+    it('配列でない値が storage に入っていても空配列を返す', async () => {
+      const state: StorageState = { [SAVED_TABS_KEY]: { not: 'array' } }
+      const repo = createChromeTabGroupRepository(createPort(state))
+      await expect(repo.findAll()).resolves.toStrictEqual([])
+    })
+  })
+
+  describe('findById', () => {
+    it('該当 ID の entity を返す', async () => {
+      const state: StorageState = {
+        [SAVED_TABS_KEY]: [
+          { domain: 'a.example.com', id: 'group-1' },
+          { domain: 'b.example.com', id: 'group-2' },
+        ],
+      }
+      const repo = createChromeTabGroupRepository(createPort(state))
+      const result = await repo.findById(createTabGroupId('group-2'))
+      expect(result?.domain).toBe('b.example.com')
+    })
+
+    it('存在しない ID は null を返す', async () => {
+      const state: StorageState = {
+        [SAVED_TABS_KEY]: [{ domain: 'https://a.example.com', id: 'group-1' }],
+      }
+      const repo = createChromeTabGroupRepository(createPort(state))
+      await expect(
+        repo.findById(createTabGroupId('group-999')),
+      ).resolves.toBeNull()
+    })
+  })
+
+  describe('saveAll', () => {
+    it('entity 配列を SAVED_TABS_KEY に raw 形式で保存する', async () => {
+      const port = createPort({})
+      const repo = createChromeTabGroupRepository(port)
+      const group = createSampleTabGroup('group-1', 'example.com')
+      expect(group).not.toBeNull()
+      if (!group) {
+        return
+      }
+      await repo.saveAll([group])
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      expect(lastSetArg[SAVED_TABS_KEY]).toStrictEqual([
+        { domain: 'example.com', id: 'group-1', urlIds: ['url-group-1'] },
+      ])
+    })
+
+    it('空配列を渡したら空配列を保存する', async () => {
+      const port = createPort({})
+      const repo = createChromeTabGroupRepository(port)
+      await repo.saveAll([])
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      expect(lastSetArg[SAVED_TABS_KEY]).toStrictEqual([])
+    })
+  })
+
+  describe('removeByIds', () => {
+    it('指定 ID を除いて保存する', async () => {
+      const state: StorageState = {
+        [SAVED_TABS_KEY]: [
+          { domain: 'a.example.com', id: 'group-1' },
+          { domain: 'b.example.com', id: 'group-2' },
+          { domain: 'c.example.com', id: 'group-3' },
+        ],
+      }
+      const port = createPort(state)
+      const repo = createChromeTabGroupRepository(port)
+      await repo.removeByIds([
+        createTabGroupId('group-1'),
+        createTabGroupId('group-3'),
+      ])
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      expect(lastSetArg[SAVED_TABS_KEY]).toStrictEqual([
+        { domain: 'b.example.com', id: 'group-2' },
+      ])
+    })
+
+    it('存在しない ID を指定しても保存呼び出しは走らない', async () => {
+      const port = createPort({
+        [SAVED_TABS_KEY]: [{ domain: 'https://a.example.com', id: 'group-1' }],
+      })
+      const repo = createChromeTabGroupRepository(port)
+      await repo.removeByIds([createTabGroupId('group-999')])
+      expect(port.set).not.toHaveBeenCalled()
+    })
+
+    it('空配列を渡したら何もしない', async () => {
+      const port = createPort({
+        [SAVED_TABS_KEY]: [{ domain: 'https://a.example.com', id: 'group-1' }],
+      })
+      const repo = createChromeTabGroupRepository(port)
+      await repo.removeByIds([])
+      expect(port.set).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository.ts
@@ -1,0 +1,86 @@
+import {
+  getChromeStorageLocal,
+  warnMissingChromeStorage,
+} from '@/lib/browser/chrome-storage'
+
+import type { TabGroup } from '../../../domain/entities/TabGroup'
+import type { TabGroupRepository } from '../../../domain/repositories/TabGroupRepository'
+import type { TabGroupId } from '../../../domain/value-objects/TabGroupId'
+import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStorageMapper'
+import { SavedTabsRepositoryUnavailableError } from './ChromeUrlRecordRepository'
+import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
+import { SAVED_TABS_KEY } from './savedTabsStorageKeys'
+import type { SavedTabRaw } from './savedTabsStorageSchema'
+
+const getDefaultPort = (): ChromeStorageLocalPort | null => {
+  const local = getChromeStorageLocal()
+  if (!local) {
+    return null
+  }
+  return {
+    get: (key) => local.get(key),
+    remove: (key) => local.remove(key),
+    set: (value) => local.set(value),
+  }
+}
+
+const createChromeTabGroupRepositoryImpl = (
+  port: ChromeStorageLocalPort,
+): TabGroupRepository => {
+  const findAll = async (): Promise<readonly TabGroup[]> => {
+    const result = await port.get(SAVED_TABS_KEY)
+    const raw = result[SAVED_TABS_KEY]
+    return ChromeSavedTabsStorageMapper.parseTabGroups(raw)
+  }
+
+  const findById = async (id: TabGroupId): Promise<TabGroup | null> => {
+    const idString = ChromeSavedTabsStorageMapper.tabGroupIdToString(id)
+    const all = await findAll()
+    return all.find((group) => group.id === idString) ?? null
+  }
+
+  const saveAll = async (groups: readonly TabGroup[]): Promise<void> => {
+    const raws: SavedTabRaw[] = groups.map((group) =>
+      ChromeSavedTabsStorageMapper.toSavedTabRaw(group),
+    )
+    await port.set({ [SAVED_TABS_KEY]: raws })
+  }
+
+  const removeByIds = async (ids: readonly TabGroupId[]): Promise<void> => {
+    if (ids.length === 0) {
+      return
+    }
+    const idSet = new Set(ids.map((id) => id))
+    const all = await findAll()
+    const remaining = all.filter((group) => !idSet.has(group.id))
+    if (remaining.length === all.length) {
+      return
+    }
+    await saveAll(remaining)
+  }
+
+  return { findAll, findById, removeByIds, saveAll }
+}
+
+/**
+ * `chrome.storage.local` 上の `SAVED_TABS_KEY` を `TabGroup` 永続化用に使う
+ * `TabGroupRepository` 実装を生成する。
+ *
+ * Rich な補助フィールド（`urlSubCategories` / `subCategories` /
+ * `categoryKeywords` / `subCategoryOrder` /
+ * `subCategoryOrderWithUncategorized` / `urls`）は現時点では永続化対象外。
+ * 既存 `src/lib/storage/tabs.ts` を併用するか、別 issue の use-case 化で対応する。
+ *
+ * @throws {SavedTabsRepositoryUnavailableError} chrome.storage.local 不在時
+ */
+export const createChromeTabGroupRepository = (
+  port: ChromeStorageLocalPort | null = getDefaultPort(),
+): TabGroupRepository => {
+  if (!port) {
+    warnMissingChromeStorage('ChromeTabGroupRepository')
+    throw new SavedTabsRepositoryUnavailableError(
+      'chrome.storage.local が利用できないため ChromeTabGroupRepository を初期化できません',
+    )
+  }
+  return createChromeTabGroupRepositoryImpl(port)
+}

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUrlRecordRepository.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUrlRecordRepository.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as chromeStorageModule from '@/lib/browser/chrome-storage'
+
+import { createUrlRecordId } from '../../../domain/value-objects/UrlRecordId'
+import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStorageMapper'
+import {
+  SavedTabsRepositoryUnavailableError,
+  createChromeUrlRecordRepository,
+} from './ChromeUrlRecordRepository'
+import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
+import { URLS_KEY } from './savedTabsStorageKeys'
+
+vi.mock('@/lib/browser/chrome-storage', async () => {
+  const actual = await vi.importActual<typeof chromeStorageModule>(
+    '@/lib/browser/chrome-storage',
+  )
+  return {
+    ...actual,
+    getChromeStorageLocal: vi.fn(),
+  }
+})
+
+const getChromeStorageLocal = chromeStorageModule.getChromeStorageLocal
+
+type StorageState = Record<string, unknown>
+
+const createPort = (state: StorageState): ChromeStorageLocalPort => {
+  // mock 内で await しない同期関数を async として書くため lint ルールを局所的に解除する
+  /* eslint-disable typescript/require-await */
+  return {
+    get: vi.fn((key: string) => Promise.resolve({ [key]: state[key] })),
+    remove: vi.fn((key: string) => {
+      // dynamic key 削除は storage エミュレーション上不可避免
+      // eslint-disable-next-line typescript/no-dynamic-delete
+      delete state[key]
+      return Promise.resolve()
+    }),
+    set: vi.fn((value: Record<string, unknown>) => {
+      Object.assign(state, value)
+      return Promise.resolve()
+    }),
+  }
+  /* eslint-enable typescript/require-await */
+}
+
+const createSampleRecord = (id: string, url: string) =>
+  ChromeSavedTabsStorageMapper.parseUrlRecord({
+    id,
+    savedAt: 1,
+    title: id,
+    url,
+  })
+
+describe('ChromeUrlRecordRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('createChromeUrlRecordRepository (factory)', () => {
+    it('port を渡すと repository を返す', () => {
+      const port = createPort({})
+      const repo = createChromeUrlRecordRepository(port)
+      expect(repo.findAll).toBeTypeOf('function')
+    })
+
+    it('port が null なら SavedTabsRepositoryUnavailableError を投げる', () => {
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined)
+      try {
+        expect(() => createChromeUrlRecordRepository(null)).toThrow(
+          SavedTabsRepositoryUnavailableError,
+        )
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    it('port 未指定で getChromeStorageLocal が本物の storage を返す場合はそれを使う', async () => {
+      const state: StorageState = {}
+      vi.mocked(getChromeStorageLocal).mockReturnValue({
+        get: (key: string) => Promise.resolve({ [key]: state[key] }),
+        remove: (key: string) => {
+          // eslint-disable-next-line typescript/no-dynamic-delete
+          delete state[key]
+          return Promise.resolve()
+        },
+        set: (value: Record<string, unknown>) => {
+          Object.assign(state, value)
+          return Promise.resolve()
+        },
+        // eslint-disable-next-line typescript/no-explicit-any
+      } as any)
+      const repo = createChromeUrlRecordRepository()
+      const result = await repo.findAll()
+      expect(result).toStrictEqual([])
+    })
+
+    it('port 未指定で getChromeStorageLocal が null を返す場合は throw する', () => {
+      const warnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined)
+      vi.mocked(getChromeStorageLocal).mockReturnValue(null)
+      try {
+        expect(() => createChromeUrlRecordRepository()).toThrow(
+          SavedTabsRepositoryUnavailableError,
+        )
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+  })
+
+  describe('findAll', () => {
+    it('空 storage のとき空配列を返す', async () => {
+      const repo = createChromeUrlRecordRepository(createPort({}))
+      await expect(repo.findAll()).resolves.toStrictEqual([])
+    })
+
+    it('URLS_KEY の生データを UrlRecord entity 配列に変換する', async () => {
+      const state: StorageState = {
+        [URLS_KEY]: [
+          { id: 'url-1', savedAt: 1, title: 'A', url: 'https://example.com/a' },
+          {
+            favIconUrl: 'https://example.com/icon.png',
+            id: 'url-2',
+            savedAt: 2,
+            title: 'B',
+            url: 'https://example.com/b',
+          },
+        ],
+      }
+      const repo = createChromeUrlRecordRepository(createPort(state))
+      const result = await repo.findAll()
+      expect(result).toHaveLength(2)
+      expect(result[0]?.id).toBe('url-1')
+      expect(result[1]?.favIconUrl).toBe('https://example.com/icon.png')
+    })
+
+    it('不正な要素をスキップして有効要素だけ返す', async () => {
+      const state: StorageState = {
+        [URLS_KEY]: [
+          { id: 'url-1', savedAt: 1, title: 'A', url: 'https://example.com/a' },
+          { id: 'url-2', title: 'B', url: 'not-a-url' },
+          null,
+          { id: 'url-3', savedAt: 3, title: 'C', url: 'https://example.com/c' },
+        ],
+      }
+      const repo = createChromeUrlRecordRepository(createPort(state))
+      const result = await repo.findAll()
+      expect(result.map((r) => r.id)).toStrictEqual(['url-1', 'url-3'])
+    })
+
+    it('配列でない値が storage に入っていても空配列を返す', async () => {
+      const state: StorageState = { [URLS_KEY]: 'not-an-array' }
+      const repo = createChromeUrlRecordRepository(createPort(state))
+      const result = await repo.findAll()
+      expect(result).toStrictEqual([])
+    })
+  })
+
+  describe('findById', () => {
+    it('該当 ID の entity を返す', async () => {
+      const state: StorageState = {
+        [URLS_KEY]: [
+          { id: 'url-1', savedAt: 1, title: 'A', url: 'https://example.com/a' },
+          { id: 'url-2', savedAt: 2, title: 'B', url: 'https://example.com/b' },
+        ],
+      }
+      const repo = createChromeUrlRecordRepository(createPort(state))
+      const result = await repo.findById(createUrlRecordId('url-2'))
+      expect(result?.id).toBe('url-2')
+    })
+
+    it('存在しない ID は null を返す', async () => {
+      const state: StorageState = {
+        [URLS_KEY]: [
+          { id: 'url-1', savedAt: 1, title: 'A', url: 'https://example.com/a' },
+        ],
+      }
+      const repo = createChromeUrlRecordRepository(createPort(state))
+      await expect(
+        repo.findById(createUrlRecordId('url-999')),
+      ).resolves.toBeNull()
+    })
+  })
+
+  describe('saveAll', () => {
+    it('entity 配列を URLS_KEY に raw 形式で保存する', async () => {
+      const port = createPort({})
+      const repo = createChromeUrlRecordRepository(port)
+      const record = createSampleRecord('url-1', 'https://example.com/a')
+      expect(record).not.toBeNull()
+      if (!record) {
+        return
+      }
+      await repo.saveAll([record])
+      const setCall = port.set as ReturnType<typeof vi.fn>
+      expect(setCall).toHaveBeenCalled()
+      const lastSetArg = setCall.mock.calls.at(-1)?.[0] as Record<
+        string,
+        unknown
+      >
+      expect(lastSetArg[URLS_KEY]).toStrictEqual([
+        {
+          id: 'url-1',
+          savedAt: 1,
+          title: 'url-1',
+          url: 'https://example.com/a',
+        },
+      ])
+    })
+
+    it('空配列を渡したら空配列を保存する', async () => {
+      const port = createPort({})
+      const repo = createChromeUrlRecordRepository(port)
+      await repo.saveAll([])
+      const setCall = port.set as ReturnType<typeof vi.fn>
+      const lastSetArg = setCall.mock.calls.at(-1)?.[0] as Record<
+        string,
+        unknown
+      >
+      expect(lastSetArg[URLS_KEY]).toStrictEqual([])
+    })
+  })
+
+  describe('removeByIds', () => {
+    it('指定 ID を除いて保存する', async () => {
+      const state: StorageState = {
+        [URLS_KEY]: [
+          { id: 'url-1', savedAt: 1, title: 'A', url: 'https://example.com/a' },
+          { id: 'url-2', savedAt: 2, title: 'B', url: 'https://example.com/b' },
+          { id: 'url-3', savedAt: 3, title: 'C', url: 'https://example.com/c' },
+        ],
+      }
+      const port = createPort(state)
+      const repo = createChromeUrlRecordRepository(port)
+      await repo.removeByIds([
+        createUrlRecordId('url-1'),
+        createUrlRecordId('url-3'),
+      ])
+      const setCall = port.set as ReturnType<typeof vi.fn>
+      const lastSetArg = setCall.mock.calls.at(-1)?.[0] as Record<
+        string,
+        unknown
+      >
+      expect(lastSetArg[URLS_KEY]).toStrictEqual([
+        { id: 'url-2', savedAt: 2, title: 'B', url: 'https://example.com/b' },
+      ])
+    })
+
+    it('存在しない ID を指定しても保存呼び出しは走らない', async () => {
+      const port = createPort({
+        [URLS_KEY]: [
+          { id: 'url-1', savedAt: 1, title: 'A', url: 'https://example.com/a' },
+        ],
+      })
+      const repo = createChromeUrlRecordRepository(port)
+      await repo.removeByIds([createUrlRecordId('url-999')])
+      const setCall = port.set as ReturnType<typeof vi.fn>
+      expect(setCall).not.toHaveBeenCalled()
+    })
+
+    it('空配列を渡したら何もしない', async () => {
+      const port = createPort({
+        [URLS_KEY]: [
+          { id: 'url-1', savedAt: 1, title: 'A', url: 'https://example.com/a' },
+        ],
+      })
+      const repo = createChromeUrlRecordRepository(port)
+      await repo.removeByIds([])
+      const setCall = port.set as ReturnType<typeof vi.fn>
+      expect(setCall).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUrlRecordRepository.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUrlRecordRepository.ts
@@ -1,0 +1,114 @@
+import {
+  getChromeStorageLocal,
+  warnMissingChromeStorage,
+} from '@/lib/browser/chrome-storage'
+
+import type { UrlRecord } from '../../../domain/entities/UrlRecord'
+import type { UrlRecordRepository } from '../../../domain/repositories/UrlRecordRepository'
+import type { UrlRecordId } from '../../../domain/value-objects/UrlRecordId'
+import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStorageMapper'
+import { URLS_KEY } from './savedTabsStorageKeys'
+import type { UrlRecordRaw } from './savedTabsStorageSchema'
+
+/**
+ * `chrome.storage.local` のうち `UrlRecord` 永続化に必要な操作だけを抜き出した port。
+ *
+ * 実 API の `chrome.storage.local.get` は `Promise<Record<string, unknown>>` を
+ * 返し、`set` / `remove` は `Promise<void>` を返す。テストでは in-memory モック
+ * を注入できるよう、`get(key)` の戻り値型を `Record<string, unknown>` に統一している。
+ */
+export interface ChromeStorageLocalPort {
+  get: (key: string) => Promise<Record<string, unknown>>
+  remove: (key: string) => Promise<void>
+  set: (value: Record<string, unknown>) => Promise<void>
+}
+
+/**
+ * `chrome.storage.local` が利用できない環境で repository を初期化した際に投げる。
+ *
+ * domain 層の `SavedTabsDomainError` に混ぜると chrome 依存の事情が domain に
+ * 漏れ出すため、infrastructure 層に閉じた通常の `Error` 派生命とする。
+ * use-case 層で `instanceof` 判定してフォールバック処理に繋ぐ想定。
+ */
+export class SavedTabsRepositoryUnavailableError extends Error {
+  public constructor(message: string) {
+    super(message)
+    this.name = 'SavedTabsRepositoryUnavailableError'
+  }
+}
+
+const getDefaultPort = (): ChromeStorageLocalPort | null => {
+  const local = getChromeStorageLocal()
+  if (!local) {
+    return null
+  }
+  return {
+    get: (key) => local.get(key),
+    remove: (key) => local.remove(key),
+    set: (value) => local.set(value),
+  }
+}
+
+const createChromeUrlRecordRepositoryImpl = (
+  port: ChromeStorageLocalPort,
+): UrlRecordRepository => {
+  const findAll = async (): Promise<readonly UrlRecord[]> => {
+    const result = await port.get(URLS_KEY)
+    const raw = result[URLS_KEY]
+    return ChromeSavedTabsStorageMapper.parseUrlRecords(raw)
+  }
+
+  const findById = async (id: UrlRecordId): Promise<UrlRecord | null> => {
+    const idString = ChromeSavedTabsStorageMapper.urlRecordIdToString(id)
+    const all = await findAll()
+    return all.find((record) => record.id === idString) ?? null
+  }
+
+  const saveAll = async (records: readonly UrlRecord[]): Promise<void> => {
+    const raws: UrlRecordRaw[] = records.map((record) =>
+      ChromeSavedTabsStorageMapper.toUrlRecordRaw(record),
+    )
+    await port.set({ [URLS_KEY]: raws })
+  }
+
+  const removeByIds = async (ids: readonly UrlRecordId[]): Promise<void> => {
+    if (ids.length === 0) {
+      return
+    }
+    const idSet = new Set(ids.map((id) => id))
+    const all = await findAll()
+    const remaining = all.filter((record) => !idSet.has(record.id))
+    if (remaining.length === all.length) {
+      return
+    }
+    await saveAll(remaining)
+  }
+
+  return { findAll, findById, removeByIds, saveAll }
+}
+
+/**
+ * `chrome.storage.local` 上の `URLS_KEY` を `UrlRecord` 永続化用に使う
+ * `UrlRecordRepository` 実装を生成する。
+ *
+ * `port` を渡さない場合は production と同じ `chrome.storage.local` を使う。
+ * `chrome.storage.local` が利用できない場合、初回呼び出し時に
+ * `SavedTabsRepositoryUnavailableError` を投げる（lazy 検出）。
+ *
+ * 例外: 旧 `src/lib/storage/urls.ts` のインメモリキャッシュは意図的に
+ * 再現していない。`findAll` を何度呼んでも `chrome.storage.local.get` を
+ * 経由する。use-case 側で読み取り回数を抑えてほしい。
+ *
+ * @throws {SavedTabsRepositoryUnavailableError} chrome.storage.local 不在時
+ */
+export const createChromeUrlRecordRepository = (
+  port: ChromeStorageLocalPort | null = getDefaultPort(),
+): UrlRecordRepository => {
+  if (!port) {
+    warnMissingChromeStorage('ChromeUrlRecordRepository')
+    throw new SavedTabsRepositoryUnavailableError(
+      'chrome.storage.local が利用できないため ChromeUrlRecordRepository を初期化できません',
+    )
+  }
+  return createChromeUrlRecordRepositoryImpl(port)
+}

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageKeys.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageKeys.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CUSTOM_PROJECTS_KEY,
+  PARENT_CATEGORIES_KEY,
+  SAVED_TABS_KEY,
+  SAVED_TABS_STORAGE_KEYS,
+  URLS_KEY,
+} from './savedTabsStorageKeys'
+
+describe('savedTabsStorageKeys', () => {
+  it('既存 chrome.storage.local と互換の key 名を公開する', () => {
+    expect(SAVED_TABS_KEY).toBe('savedTabs')
+    expect(URLS_KEY).toBe('urls')
+    expect(PARENT_CATEGORIES_KEY).toBe('parentCategories')
+    expect(CUSTOM_PROJECTS_KEY).toBe('customProjects')
+  })
+
+  it('4 つのメイン key を配列で列挙できる', () => {
+    expect(SAVED_TABS_STORAGE_KEYS).toStrictEqual([
+      'savedTabs',
+      'urls',
+      'parentCategories',
+      'customProjects',
+    ])
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageKeys.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageKeys.ts
@@ -1,0 +1,32 @@
+/**
+ * `saved-tabs` 機能で `chrome.storage.local` に書き込む storage key の一覧。
+ *
+ * 文字列リテラルが複数ファイルに散らばることを防ぐため、必ずこの定数経由で
+ * 参照する。typo は TypeScript の型で検出できる。
+ *
+ * 旧 `src/lib/storage/*` と同じキー名を維持しているため、既存ユーザーの
+ * データ（`chrome.storage.local.savedTabs` / `urls` / `parentCategories` /
+ * `customProjects`）はそのまま読み書きできる。
+ *
+ * 並び替え順序など付随する storage key（`customProjectOrder` /
+ * `domainCategoryMappings` / `domainCategorySettings` /
+ * `urlsMigrationCompleted`）は別 issue で domain / repository 化するため、
+ * ここでは 4 つのメイン key だけを公開する。
+ */
+
+export const SAVED_TABS_KEY = 'savedTabs' as const
+
+export const URLS_KEY = 'urls' as const
+
+export const PARENT_CATEGORIES_KEY = 'parentCategories' as const
+
+export const CUSTOM_PROJECTS_KEY = 'customProjects' as const
+
+export const SAVED_TABS_STORAGE_KEYS = [
+  SAVED_TABS_KEY,
+  URLS_KEY,
+  PARENT_CATEGORIES_KEY,
+  CUSTOM_PROJECTS_KEY,
+] as const
+
+export type SavedTabsStorageKey = (typeof SAVED_TABS_STORAGE_KEYS)[number]

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageSchema.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageSchema.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CustomProjectRawArraySchema,
+  CustomProjectRawSchema,
+  ParentCategoryRawSchema,
+  SavedTabRawArraySchema,
+  SavedTabRawSchema,
+  UrlRecordRawArraySchema,
+  UrlRecordRawSchema,
+} from './savedTabsStorageSchema'
+
+describe('savedTabsStorageSchema', () => {
+  describe('SavedTabRawSchema', () => {
+    it('最小フィールドだけを持つ savedTab を通す', () => {
+      const result = SavedTabRawSchema.safeParse({
+        domain: 'https://example.com',
+        id: 'group-1',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('rich なオプションフィールドを持つ savedTab を通す', () => {
+      const result = SavedTabRawSchema.safeParse({
+        categoryKeywords: [{ categoryName: 'docs', keywords: ['doc'] }],
+        domain: 'https://example.com',
+        id: 'group-1',
+        parentCategoryId: 'cat-1',
+        savedAt: 1_700_000_000_000,
+        subCategories: ['docs'],
+        subCategoryOrder: ['docs'],
+        subCategoryOrderWithUncategorized: ['docs', 'uncategorized'],
+        urlIds: ['url-1', 'url-2'],
+        urlSubCategories: { 'url-1': 'docs' },
+        urls: [
+          {
+            id: 'url-1',
+            savedAt: 1,
+            subCategory: 'docs',
+            title: 'A',
+            url: 'https://example.com/a',
+          },
+        ],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('id / domain が無い savedTab を弾く', () => {
+      expect(SavedTabRawSchema.safeParse({ urlIds: [] }).success).toBe(false)
+      expect(SavedTabRawSchema.safeParse({ id: 'g-1' }).success).toBe(false)
+    })
+
+    it('配列パースで不正な要素を弾く', () => {
+      const result = SavedTabRawArraySchema.safeParse([
+        { domain: 'https://example.com', id: 'group-1' },
+        { domain: 'https://broken' },
+        null,
+        'not-an-object',
+      ])
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('UrlRecordRawSchema', () => {
+    it('必須フィールドを持つ url record を通す', () => {
+      const result = UrlRecordRawSchema.safeParse({
+        id: 'url-1',
+        savedAt: 1,
+        title: 'A',
+        url: 'https://example.com',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('favIconUrl 省略を許容する', () => {
+      const result = UrlRecordRawSchema.safeParse({
+        id: 'url-1',
+        savedAt: 1,
+        title: 'A',
+        url: 'https://example.com',
+      })
+      expect(result.success).toBe(true)
+      if (!result.success) {
+        return
+      }
+      expect(result.data.favIconUrl).toBeUndefined()
+    })
+
+    it('savedAt が無い record を弾く', () => {
+      expect(
+        UrlRecordRawSchema.safeParse({
+          id: 'url-1',
+          title: 'A',
+          url: 'https://example.com',
+        }).success,
+      ).toBe(false)
+    })
+
+    it('配列パースで必須欠けを弾く', () => {
+      const result = UrlRecordRawArraySchema.safeParse([
+        { id: 'url-1', savedAt: 1, title: 'A', url: 'https://example.com' },
+        { id: 'url-2', title: 'B', url: 'https://example.com' },
+      ])
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('ParentCategoryRawSchema', () => {
+    it('必須フィールドを持つ parent category を通す', () => {
+      const result = ParentCategoryRawSchema.safeParse({
+        domainNames: ['example.com'],
+        domains: ['group-1'],
+        id: 'cat-1',
+        name: 'Docs',
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('domains / domainNames が無い category を弾く', () => {
+      expect(
+        ParentCategoryRawSchema.safeParse({ id: 'cat-1', name: 'Docs' })
+          .success,
+      ).toBe(false)
+    })
+  })
+
+  describe('CustomProjectRawSchema', () => {
+    it('必須フィールドを持つ custom project を通す', () => {
+      const result = CustomProjectRawSchema.safeParse({
+        categories: ['research'],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        updatedAt: 1,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('categories が無い project を弾く', () => {
+      expect(
+        CustomProjectRawSchema.safeParse({
+          createdAt: 1,
+          id: 'project-1',
+          name: 'Q4',
+          updatedAt: 1,
+        }).success,
+      ).toBe(false)
+    })
+
+    it('rich なオプションフィールドを持つ project を通す', () => {
+      const result = CustomProjectRawSchema.safeParse({
+        categories: ['research'],
+        categoryOrder: ['research'],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        projectKeywords: {
+          domainKeywords: [],
+          titleKeywords: ['Q4'],
+          urlKeywords: [],
+        },
+        updatedAt: 2,
+        urlIds: ['url-1'],
+        urlMetadata: {
+          'url-1': { category: 'research', notes: 'note' },
+        },
+        urls: [
+          {
+            category: 'research',
+            notes: 'note',
+            savedAt: 1,
+            title: 'A',
+            url: 'https://example.com',
+          },
+        ],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('配列パースで必須欠けを弾く', () => {
+      const result = CustomProjectRawArraySchema.safeParse([
+        {
+          categories: ['research'],
+          createdAt: 1,
+          id: 'project-1',
+          name: 'Q4',
+          updatedAt: 1,
+        },
+        {
+          createdAt: 1,
+          id: 'project-2',
+          name: 'Q5',
+          updatedAt: 1,
+        },
+      ])
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageSchema.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageSchema.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod'
+
+/**
+ * `saved-tabs` 機能の `chrome.storage.local` 永続化データ用 Zod schema。
+ *
+ * 旧 `src/lib/storage/zod-storage.ts` の schema と互換の形で定義しているが、
+ * DDD の infrastructure 層から `@/lib/storage/*` 経由で参照するのは依存方向が
+ * 逆転するため、schema 定義そのものを contexts 側に複製している。
+ *
+ * 役割:
+ * - chrome.storage.local からの生データをパースし、想定外のフィールド混入を弾く。
+ * - mapper (`ChromeSavedTabsStorageMapper`) がパース済みデータを domain entity
+ *   に変換する前に、安全な `unknown` 境界を提供する。
+ *
+ * 注意:
+ * - これらの schema は「過去フォーマット → 将来フォーマット」を吸収するための
+ *   互換点。新規フィールドは optional、後方互換を壊す変更は別 issue で
+ *   migration を用意する。
+ * - マイグレーション（`urlsMigrationCompleted` など）は別 issue で
+ *   `infrastructure/persistence/migrations/` に切り出す。
+ */
+
+const subCategoryKeywordSchema = z.object({
+  categoryName: z.string(),
+  keywords: z.array(z.string()),
+})
+
+const savedTabUrlEntrySchema = z.object({
+  id: z.string().optional(),
+  url: z.string(),
+  title: z.string(),
+  subCategory: z.string().optional(),
+  savedAt: z.number().optional(),
+})
+
+export const SavedTabRawSchema = z.object({
+  id: z.string(),
+  domain: z.string(),
+  parentCategoryId: z.string().optional(),
+  urlIds: z.array(z.string()).optional(),
+  urls: z.array(savedTabUrlEntrySchema).optional(),
+  urlSubCategories: z.record(z.string(), z.string()).optional(),
+  subCategories: z.array(z.string()).optional(),
+  categoryKeywords: z.array(subCategoryKeywordSchema).optional(),
+  subCategoryOrder: z.array(z.string()).optional(),
+  subCategoryOrderWithUncategorized: z.array(z.string()).optional(),
+  savedAt: z.number().optional(),
+})
+
+export const UrlRecordRawSchema = z.object({
+  id: z.string(),
+  url: z.string(),
+  title: z.string(),
+  savedAt: z.number(),
+  favIconUrl: z.string().optional(),
+})
+
+export const ParentCategoryRawSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  domains: z.array(z.string()),
+  domainNames: z.array(z.string()),
+})
+
+const customProjectUrlEntrySchema = z.object({
+  url: z.string(),
+  title: z.string(),
+  notes: z.string().optional(),
+  savedAt: z.number().optional(),
+  category: z.string().optional(),
+})
+
+const urlMetadataEntrySchema = z.object({
+  notes: z.string().optional(),
+  category: z.string().optional(),
+})
+
+const projectKeywordsSchema = z.object({
+  titleKeywords: z.array(z.string()),
+  urlKeywords: z.array(z.string()),
+  domainKeywords: z.array(z.string()),
+})
+
+export const CustomProjectRawSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  projectKeywords: projectKeywordsSchema.optional(),
+  urlIds: z.array(z.string()).optional(),
+  urls: z.array(customProjectUrlEntrySchema).optional(),
+  urlMetadata: z.record(z.string(), urlMetadataEntrySchema).optional(),
+  categories: z.array(z.string()),
+  categoryOrder: z.array(z.string()).optional(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+})
+
+export const SavedTabRawArraySchema = z.array(SavedTabRawSchema)
+export const UrlRecordRawArraySchema = z.array(UrlRecordRawSchema)
+export const ParentCategoryRawArraySchema = z.array(ParentCategoryRawSchema)
+export const CustomProjectRawArraySchema = z.array(CustomProjectRawSchema)
+
+export type SavedTabRaw = z.infer<typeof SavedTabRawSchema>
+export type UrlRecordRaw = z.infer<typeof UrlRecordRawSchema>
+export type ParentCategoryRaw = z.infer<typeof ParentCategoryRawSchema>
+export type CustomProjectRaw = z.infer<typeof CustomProjectRawSchema>


### PR DESCRIPTION
## 変更内容

`saved-tabs` 機能の DDD レイヤ境界を進め、Issue #457 の repository interface と chrome.storage 実装の分離を実装します。

### 追加
- `src/contexts/saved-tabs/domain/repositories/`
  - `TabGroupRepository.ts` / `UrlRecordRepository.ts` / `ParentCategoryRepository.ts` / `CustomProjectRepository.ts`
  - `findAll` / `findById` / `saveAll` / `removeByIds` の 4 操作だけを公開する interface
- `src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/`
  - `ChromeTabGroupRepository.ts` / `ChromeUrlRecordRepository.ts` / `ChromeParentCategoryRepository.ts` / `ChromeCustomProjectRepository.ts`
  - `ChromeStorageLocalPort` を介して `chrome.storage.local` にアクセス（テスト時は in-memory モックを注入可能）
  - `savedTabsStorageKeys.ts`（`savedTabs` / `urls` / `parentCategories` / `customProjects` を集約）
  - `savedTabsStorageSchema.ts`（既存 storage 互換の Zod schema）
- `src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts`
  - `unknown` → Zod 検証 → domain entity 変換 / 逆変換
  - `domain.DomainName` 制約に合わせて URL 形式を hostname に正規化（既存 `https://example.com` 形式のデータも読み込み可能）

### 変更
- `src/contexts/saved-tabs/dddLayerGuard.test.ts`
  - `domain/repositories/*.ts` が `chrome.*` / `@/lib/storage` を import しないことを検証する 4 テスト追加
- `src/contexts/saved-tabs/domain/README.md` — `repositories/` の純度ルール追記
- `src/contexts/saved-tabs/infrastructure/README.md` — mapper / chrome-storage / port 抽象の説明追加

### 既存挙動への影響
- 既存 `src/lib/storage/*` はそのまま残置（Issue #457 仕様「段階的に移行する」）
- `Chrome*Repository` は新規コードのみで、既存呼び出しは触らない
- 既存テスト 1605 件すべて pass

## 受け入れ条件チェック
- [x] repository interface と chrome-storage 実装が分離されている
- [x] `chrome.storage.local` の直接利用箇所が少なくとも saved-tabs 移行対象から減っている
- [x] `bun run compile` が通る
- [x] repository 周辺の unit test が追加されている（新規 86 テスト）
- [x] 既存の保存 / 表示 / 削除が壊れていない（既存テスト 1605 件 pass）

## ローカル検証
- [x] `bun run format` — クリーン
- [x] `bun run lint` — 0 warnings / 0 errors
- [x] `bun run compile` — エラーなし
- [x] `bun run test` — 193 files / 1605 tests pass
- [x] `bun run test:coverage` — 全体 99.19%（ベースライン同等）

## 既知の挙動差分
新 `ChromeTabGroupRepository` は mapper で `TabGroup.domain` フィールドを `https://example.com` → `example.com` に正規化する（domain `DomainName` 制約に合わせるため）。chrome.storage ラウンドトリップ後のデータ形式が変わるが、`src/lib/storage/*` は `domain: string` として扱うため共存可能で、データ損失はない。

## 関連
- Closes #457
- Depends on #456（domain 層）
- 次のステップ: use-case / port 化（別 issue）