### PR TITLE
feat(#459): saved-tabs presentation 層を use-case 呼び出しベースで追加

### DIFF
--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -251,6 +251,96 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
     })
   })
 
+  describe('issue #459: presentation controller / view-model / page ファイルが追加されている', () => {
+    const expectedFiles = [
+      'src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.ts',
+      'src/contexts/saved-tabs/presentation/view-models/SavedTabsViewModel.ts',
+      'src/contexts/saved-tabs/presentation/view-models/TabGroupViewModel.ts',
+      'src/contexts/saved-tabs/presentation/view-models/CustomProjectViewModel.ts',
+      'src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx',
+      'src/contexts/saved-tabs/presentation/routes/SavedTabsRoute.tsx',
+    ]
+
+    for (const file of expectedFiles) {
+      it(`${file} が存在する`, () => {
+        const source = readFileSync(resolve(repoRoot, file), 'utf8')
+        expect(source.length).toBeGreaterThan(0)
+      })
+    }
+
+    it('SavedTabsPage は chrome.* / localStorage / sessionStorage を import / 利用しない', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx',
+        ),
+        'utf8',
+      )
+      expect(source).not.toMatch(/from\s+['"]chrome['"]/)
+      expect(source).not.toMatch(/chrome\.storage\.local\./)
+      expect(source).not.toMatch(/chrome\.tabs\./)
+      expect(source).not.toMatch(/\blocalStorage\./)
+      expect(source).not.toMatch(/\bsessionStorage\./)
+    })
+
+    it('useSavedTabsController は chrome.* / localStorage / sessionStorage を import / 利用しない', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.ts',
+        ),
+        'utf8',
+      )
+      expect(source).not.toMatch(/from\s+['"]chrome['"]/)
+      expect(source).not.toMatch(/chrome\.storage\.local\./)
+      expect(source).not.toMatch(/chrome\.tabs\./)
+      expect(source).not.toMatch(/\blocalStorage\./)
+      expect(source).not.toMatch(/\bsessionStorage\./)
+    })
+  })
+
+  describe('issue #459: infrastructure browser adapter / composition ファイルが追加されている', () => {
+    const expectedFiles = [
+      'src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter.ts',
+      'src/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter.ts',
+      'src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts',
+      'src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts',
+    ]
+
+    for (const file of expectedFiles) {
+      it(`${file} が存在する`, () => {
+        const source = readFileSync(resolve(repoRoot, file), 'utf8')
+        expect(source.length).toBeGreaterThan(0)
+      })
+    }
+
+    it('ChromeBrowserTabAdapter は application port 経由で chrome.tabs を呼ぶ', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('BrowserTabPort')
+      expect(source).not.toMatch(/from\s+['"]@\/components/)
+      expect(source).not.toMatch(/from\s+['"]@\/features\//)
+    })
+
+    it('SonnerNotificationAdapter は application port 経由で sonner を呼ぶ', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('NotificationPort')
+      expect(source).not.toMatch(/from\s+['"]@\/components/)
+      expect(source).not.toMatch(/from\s+['"]@\/features\//)
+    })
+  })
+
   describe('domain/repositories/ の純度 (issue #457)', () => {
     const repositoryInterfaceFiles = [
       'src/contexts/saved-tabs/domain/repositories/TabGroupRepository.ts',

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createChromeBrowserTabAdapter } from './ChromeBrowserTabAdapter'
+import type { ChromeApiLike, ChromeTabsLike } from './ChromeBrowserTabAdapter'
+
+const createMockTabs = (
+  impl?: ChromeTabsLike['create'],
+): ChromeTabsLike['create'] =>
+  impl ??
+  vi.fn((createProperties) =>
+    Promise.resolve({
+      url: createProperties.url,
+    }),
+  )
+
+const createMockApi = (tabs?: ChromeTabsLike): ChromeApiLike => ({
+  tabs: tabs ?? { create: createMockTabs() },
+})
+
+describe('createChromeBrowserTabAdapter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('chrome.tabs.create に委譲して url を返す', async () => {
+    const create = vi.fn((props) => Promise.resolve({ url: props.url }))
+    const adapter = createChromeBrowserTabAdapter({
+      getApi: () => createMockApi({ create }),
+    })
+    const result = await adapter.open({ url: 'https://example.com' })
+    expect(create).toHaveBeenCalledWith({
+      active: true,
+      url: 'https://example.com',
+    })
+    expect(result).toStrictEqual({ url: 'https://example.com' })
+  })
+
+  it('resolveActive が false を返すときは active: false で開く', async () => {
+    const create = vi.fn((props) => Promise.resolve({ url: props.url }))
+    const adapter = createChromeBrowserTabAdapter(
+      { getApi: () => createMockApi({ create }) },
+      { resolveActive: () => false },
+    )
+    await adapter.open({ url: 'https://example.com/page' })
+    expect(create).toHaveBeenCalledWith({
+      active: false,
+      url: 'https://example.com/page',
+    })
+  })
+
+  it('chrome.tabs.create の戻り url が undefined のとき入力 url を返す', async () => {
+    const create = vi.fn(() => Promise.resolve(undefined))
+    const adapter = createChromeBrowserTabAdapter({
+      getApi: () => createMockApi({ create }),
+    })
+    const result = await adapter.open({ url: 'https://example.com' })
+    expect(result).toStrictEqual({ url: 'https://example.com' })
+  })
+
+  it('chrome API がない環境では Error を投げる', async () => {
+    const adapter = createChromeBrowserTabAdapter({
+      getApi: () => undefined,
+    })
+    await expect(adapter.open({ url: 'https://example.com' })).rejects.toThrow(
+      'chrome.tabs.create is not available',
+    )
+  })
+
+  it('chrome.tabs.create が無い環境では Error を投げる', async () => {
+    const adapter = createChromeBrowserTabAdapter({
+      getApi: () => createMockApi({}),
+    })
+    await expect(adapter.open({ url: 'https://example.com' })).rejects.toThrow(
+      'chrome.tabs.create is not available',
+    )
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter.ts
@@ -1,0 +1,71 @@
+/**
+ * `chrome.tabs` 依存を `BrowserTabPort` interface に適合させる adapter。
+ *
+ * `presentation` 層は `chrome.tabs` を直接参照できないため、
+ * `composition` 層からこの adapter を `BrowserTabPort` として use-case へ注入する。
+ *
+ * `active` / `url` のみを port の最小 interface として公開し、それ以外の
+ * 拡張機能固有のフィールドは port 仕様変更まで持ち込まない。
+ *
+ * @example
+ * ```ts
+ * const port: BrowserTabPort = createChromeBrowserTabAdapter({
+ *   getApi: () => chrome,
+ * })
+ * await port.open({ url: 'https://example.com' })
+ * ```
+ */
+
+export interface ChromeBrowserTabAdapterDeps {
+  /**
+   * `chrome.tabs` を提供する chrome API 全体。テスト時は
+   * `chrome.tabs.create` を持つモックオブジェクトを渡す。
+   */
+  readonly getApi: () => ChromeApiLike | undefined
+}
+
+export interface ChromeApiLike {
+  readonly tabs?: ChromeTabsLike
+}
+
+export interface ChromeTabsLike {
+  readonly create?: (createProperties: {
+    readonly active?: boolean
+    readonly url: string
+  }) => Promise<{ readonly url?: string } | undefined> | undefined
+}
+
+interface ChromeBrowserTabAdapterOptions {
+  /**
+   * 新規タブをアクティブ（前面）にするかを port 利用側（open saved url use-case）が
+   * 決められるよう、`active` を返す関数を委譲できる。
+   * 未指定なら `active: true` で開く。
+   */
+  readonly resolveActive?: () => boolean
+}
+
+/**
+ * `chrome.tabs.create` を利用する `BrowserTabPort` 実装を生成する。
+ *
+ * `chrome` API が見つからない環境（テスト / SSR など）では
+ * 即座に `Error` を投げ、use-case 側で失敗を通知する。
+ * 「サイレントに何もしない」よりも、副作用が必要な操作は
+ * 失敗を可視化することが重要という DDD の方針に従う。
+ */
+export const createChromeBrowserTabAdapter = (
+  deps: ChromeBrowserTabAdapterDeps,
+  options: ChromeBrowserTabAdapterOptions = {},
+) => {
+  return {
+    open: async (input: { readonly url: string }) => {
+      const api = deps.getApi()
+      const tabs = api?.tabs
+      const active = options.resolveActive?.() ?? true
+      if (!tabs?.create) {
+        throw new Error('chrome.tabs.create is not available')
+      }
+      const result = await tabs.create({ active, url: input.url })
+      return { url: result?.url ?? input.url }
+    },
+  }
+}

--- a/src/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createSonnerNotificationAdapter } from './SonnerNotificationAdapter'
+import type { SonnerNotificationAdapterDeps } from './SonnerNotificationAdapter'
+
+interface ToastMock {
+  error: ReturnType<typeof vi.fn>
+  info: ReturnType<typeof vi.fn>
+  success: ReturnType<typeof vi.fn>
+}
+
+const createMockToast = (): ToastMock => {
+  return {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  }
+}
+
+describe('createSonnerNotificationAdapter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('info / success / error が対応する toast メソッドに委譲される', () => {
+    const mockToast = createMockToast()
+    const port = createSonnerNotificationAdapter({
+      toastOverride:
+        mockToast as SonnerNotificationAdapterDeps['toastOverride'],
+    })
+    port.info({ message: 'info message' })
+    port.success({ message: 'success message' })
+    port.error({ message: 'error message' })
+    expect(mockToast.info).toHaveBeenCalledWith('info message')
+    expect(mockToast.success).toHaveBeenCalledWith('success message')
+    expect(mockToast.error).toHaveBeenCalledWith('error message')
+  })
+
+  it('action を含む場合は sonner の action オプションに渡される', () => {
+    const mockToast = createMockToast()
+    const onClick = vi.fn()
+    const port = createSonnerNotificationAdapter({
+      toastOverride:
+        mockToast as SonnerNotificationAdapterDeps['toastOverride'],
+    })
+    port.info({ action: { label: 'Undo', onClick }, message: 'removed' })
+    const call = mockToast.info.mock.calls[0]
+    expect(call?.[0]).toBe('removed')
+    const action = call?.[1]?.action as
+      | { label: string; onClick: () => void }
+      | undefined
+    expect(action?.label).toBe('Undo')
+    action?.onClick()
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('action.onClick が失敗しても port 全体が throw しない', async () => {
+    const mockToast = createMockToast()
+    const errorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const port = createSonnerNotificationAdapter({
+      toastOverride:
+        mockToast as SonnerNotificationAdapterDeps['toastOverride'],
+    })
+    port.error({
+      action: {
+        label: 'retry',
+        onClick: () => {
+          throw new Error('boom')
+        },
+      },
+      message: 'failed',
+    })
+    const call = mockToast.error.mock.calls[0]
+    const action = call?.[1]?.action as
+      | { label: string; onClick: () => void }
+      | undefined
+    // action.onClick() は内部で throw を吸収するため同期呼び出しでも例外を投げない
+    expect(() => action?.onClick()).not.toThrow()
+    // microtask: 内部 Promise の catch が resolve するのを待つ
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(errorSpy).toHaveBeenCalled()
+        resolve()
+      }, 0)
+    })
+  })
+
+  it('action.onClick が reject する Promise を返しても port 全体が throw しない', async () => {
+    const mockToast = createMockToast()
+    const errorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const port = createSonnerNotificationAdapter({
+      toastOverride:
+        mockToast as SonnerNotificationAdapterDeps['toastOverride'],
+    })
+    port.info({
+      action: {
+        label: 'retry',
+        onClick: () => Promise.reject(new Error('async-boom')),
+      },
+      message: 'failed',
+    })
+    const call = mockToast.info.mock.calls[0]
+    const action = call?.[1]?.action as
+      | { label: string; onClick: () => void }
+      | undefined
+    expect(() => action?.onClick()).not.toThrow()
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(errorSpy).toHaveBeenCalled()
+        resolve()
+      }, 0)
+    })
+  })
+
+  it('toast が無い場合 error は console.error にフォールバックする', () => {
+    const errorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const port = createSonnerNotificationAdapter({
+      toastOverride: {
+        error: undefined,
+        info: undefined,
+        success: undefined,
+      } as unknown as SonnerNotificationAdapterDeps['toastOverride'],
+    })
+    port.error({ message: 'failed without toast' })
+    expect(errorSpy).toHaveBeenCalledWith('failed without toast')
+  })
+
+  it('toast が無い場合 info は console.warn にフォールバックする', () => {
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+    const port = createSonnerNotificationAdapter({
+      toastOverride: {
+        error: undefined,
+        info: undefined,
+        success: undefined,
+      } as unknown as SonnerNotificationAdapterDeps['toastOverride'],
+    })
+    port.info({ message: 'informational' })
+    expect(warnSpy).toHaveBeenCalledWith('informational')
+  })
+
+  it('deps を省略した場合は sonner の toast を使う', () => {
+    const port = createSonnerNotificationAdapter()
+    // toast が見つからない環境では console へフォールバックすることを許容しつつ、
+    // ここでは throw せず関数として呼び出せることを確認する。
+    expect(() => port.info({ message: 'no-deps' })).not.toThrow()
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter.ts
@@ -1,0 +1,94 @@
+import { toast } from 'sonner'
+
+import type {
+  NotificationMessage,
+  NotificationPort,
+} from '@/contexts/saved-tabs/application/ports/NotificationPort'
+
+/**
+ * `sonner` の `toast` を `NotificationPort` interface に適合させる adapter。
+ *
+ * `info` / `success` / `error` の 3 種を `toast.info` / `toast.success` /
+ * `toast.error` に対応付ける。`action` を含む場合は `action` ボタンを
+ * 通知に紐付ける。Undo 復元など、ポート利用者（use-case / controller）が
+ * 任意で渡せる構造を維持する。
+ *
+ * `sonner` が見つからない / toast が利用できない環境では
+ * `console.warn` にフォールバックする。port 仕様は「失敗を throw しない」
+ * 方針のため、UI 通知の失敗で use-case 全体が落ちないようにする。
+ */
+export interface SonnerNotificationAdapterDeps {
+  /**
+   * テストや差し替えで `toast` 自体をモックしたい場合に注入する。
+   * 未指定なら `sonner` から `toast` を直接 import したものを使う。
+   */
+  readonly toastOverride?: Pick<typeof toast, 'info' | 'success' | 'error'>
+}
+
+const resolveToast = (
+  override?: SonnerNotificationAdapterDeps['toastOverride'],
+) => override ?? toast
+
+const toSonnerAction = (
+  action: NotificationMessage['action'],
+): { label: string; onClick: () => void } | undefined => {
+  if (!action) {
+    return undefined
+  }
+  return {
+    label: action.label,
+    onClick: () => {
+      // port 仕様: 失敗時挙動は port 実装側の責務。void Promise を fire-and-forget。
+      // 同期 throw は `try / catch` で吸収し、reject / async throw は `.catch` で吸収する。
+      try {
+        const result = action.onClick()
+        if (result && typeof (result as Promise<unknown>).then === 'function') {
+          void (result as Promise<unknown>).catch((error: unknown) => {
+            console.error('NotificationPort action onClick で失敗:', error)
+          })
+        }
+      } catch (error) {
+        console.error('NotificationPort action onClick で失敗:', error)
+      }
+    },
+  }
+}
+
+const fallback = (level: 'info' | 'success' | 'error', message: string) => {
+  if (level === 'error') {
+    console.error(message)
+  } else {
+    console.warn(message)
+  }
+}
+
+/**
+ * `sonner.toast` を利用する `NotificationPort` 実装を生成する。
+ *
+ * `toast` が `undefined`（テストで意図的に取り除いたケースなど）の場合は
+ * `console.warn` / `console.error` にフォールバックする。
+ */
+export const createSonnerNotificationAdapter = (
+  deps: SonnerNotificationAdapterDeps = {},
+) => {
+  const notify =
+    (level: 'info' | 'success' | 'error') => (input: NotificationMessage) => {
+      const t = resolveToast(deps.toastOverride)
+      const action = toSonnerAction(input.action)
+      if (!t?.[level]) {
+        fallback(level, input.message)
+        return
+      }
+      if (action) {
+        t[level](input.message, { action })
+        return
+      }
+      t[level](input.message)
+    }
+  const port: NotificationPort = {
+    error: notify('error'),
+    info: notify('info'),
+    success: notify('success'),
+  }
+  return port
+}

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts
@@ -1,0 +1,71 @@
+import { createDeleteTabGroupUseCase } from '../../application/use-cases/DeleteTabGroupUseCase'
+import type { DeleteTabGroupUseCase } from '../../application/use-cases/DeleteTabGroupUseCase'
+import { createOpenSavedUrlUseCase } from '../../application/use-cases/OpenSavedUrlUseCase'
+import type { OpenSavedUrlUseCase } from '../../application/use-cases/OpenSavedUrlUseCase'
+import { createRemoveUnreferencedUrlRecordsUseCase } from '../../application/use-cases/RemoveUnreferencedUrlRecordsUseCase'
+import type { RemoveUnreferencedUrlRecordsUseCase } from '../../application/use-cases/RemoveUnreferencedUrlRecordsUseCase'
+import { createRestoreOpenedUrlsSnapshotUseCase } from '../../application/use-cases/RestoreOpenedUrlsSnapshotUseCase'
+import type { RestoreOpenedUrlsSnapshotUseCase } from '../../application/use-cases/RestoreOpenedUrlsSnapshotUseCase'
+import { createSyncCategoryAssignmentsUseCase } from '../../application/use-cases/SyncCategoryAssignmentsUseCase'
+import type { SyncCategoryAssignmentsUseCase } from '../../application/use-cases/SyncCategoryAssignmentsUseCase'
+import type { SavedTabsUseCasesDeps } from './createSavedTabsUseCasesDeps'
+
+/**
+ * presentation 層（controller hook / page）へ公開する SavedTabs の
+ * 主要 use-case バンドル。
+ *
+ * 各 use-case は repository 実装と port 実装を
+ * `createSavedTabsUseCasesDeps()` から受け取り、純関数として保持する。
+ * React 側はこのバンドルから個別 use-case を取り出して呼び出す。
+ */
+export interface SavedTabsUseCases {
+  readonly openSavedUrl: OpenSavedUrlUseCase
+  readonly deleteTabGroup: DeleteTabGroupUseCase
+  readonly restoreOpenedUrlsSnapshot: RestoreOpenedUrlsSnapshotUseCase
+  readonly syncCategoryAssignments: SyncCategoryAssignmentsUseCase
+  readonly removeUnreferencedUrlRecords: RemoveUnreferencedUrlRecordsUseCase
+}
+
+/**
+ * `SavedTabsUseCasesDeps` から `SavedTabsUseCases` を組み立てる composition 関数。
+ *
+ * `application` 層は React / chrome.* に依存しない pure な use-case なので、
+ * ここで関数バインドを行い、controller hook 側では「関数を受け取って呼ぶ」だけに閉じる。
+ *
+ * @example
+ * ```ts
+ * const deps = createSavedTabsUseCasesDeps()
+ * const useCases = createSavedTabsUseCases(deps)
+ * await useCases.openSavedUrl({ urlRecordId, origin: 'click', settings })
+ * ```
+ */
+export const createSavedTabsUseCases = (
+  deps: SavedTabsUseCasesDeps,
+): SavedTabsUseCases => ({
+  deleteTabGroup: createDeleteTabGroupUseCase({
+    customProjectRepository: deps.customProjectRepository,
+    tabGroupRepository: deps.tabGroupRepository,
+    urlRecordRepository: deps.urlRecordRepository,
+  }),
+  openSavedUrl: createOpenSavedUrlUseCase({
+    browserTabPort: deps.browserTabPort,
+    customProjectRepository: deps.customProjectRepository,
+    tabGroupRepository: deps.tabGroupRepository,
+    urlRecordRepository: deps.urlRecordRepository,
+  }),
+  removeUnreferencedUrlRecords: createRemoveUnreferencedUrlRecordsUseCase({
+    customProjectRepository: deps.customProjectRepository,
+    tabGroupRepository: deps.tabGroupRepository,
+    urlRecordRepository: deps.urlRecordRepository,
+  }),
+  restoreOpenedUrlsSnapshot: createRestoreOpenedUrlsSnapshotUseCase({
+    customProjectRepository: deps.customProjectRepository,
+    parentCategoryRepository: deps.parentCategoryRepository,
+    tabGroupRepository: deps.tabGroupRepository,
+    urlRecordRepository: deps.urlRecordRepository,
+  }),
+  syncCategoryAssignments: createSyncCategoryAssignmentsUseCase({
+    parentCategoryRepository: deps.parentCategoryRepository,
+    tabGroupRepository: deps.tabGroupRepository,
+  }),
+})

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
@@ -1,0 +1,85 @@
+import {
+  getChromeStorageLocal,
+  warnMissingChromeStorage,
+} from '@/lib/browser/chrome-storage'
+
+import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { NotificationPort } from '../../application/ports/NotificationPort'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import { createChromeBrowserTabAdapter } from '../browser/ChromeBrowserTabAdapter'
+import { createSonnerNotificationAdapter } from '../browser/SonnerNotificationAdapter'
+import { createChromeCustomProjectRepository } from '../persistence/chrome-storage/ChromeCustomProjectRepository'
+import { createChromeParentCategoryRepository } from '../persistence/chrome-storage/ChromeParentCategoryRepository'
+import { createChromeTabGroupRepository } from '../persistence/chrome-storage/ChromeTabGroupRepository'
+import { createChromeUrlRecordRepository } from '../persistence/chrome-storage/ChromeUrlRecordRepository'
+
+/**
+ * presentation / composition 層が repository と port を「テスト可能な形」で
+ * 受け取るための依存バンドル。
+ *
+ * use-case ファクトリ (`create*UseCase`) へ直接このオブジェクトを分割して渡す。
+ * ポートを `null` 許容にしないことで、未注入の依存で use-case が
+ * 動作してしまう事故を防ぐ。
+ */
+export interface SavedTabsUseCasesDeps {
+  readonly tabGroupRepository: TabGroupRepository
+  readonly urlRecordRepository: UrlRecordRepository
+  readonly customProjectRepository: CustomProjectRepository
+  readonly parentCategoryRepository: ParentCategoryRepository
+  readonly browserTabPort: BrowserTabPort
+  readonly notificationPort: NotificationPort
+}
+
+interface ChromeLike {
+  readonly tabs?: {
+    readonly create?: (createProperties: {
+      readonly active?: boolean
+      readonly url: string
+    }) => Promise<{ readonly url?: string } | undefined> | undefined
+  }
+}
+
+const getChromeApi = (): ChromeLike | undefined =>
+  (globalThis as typeof globalThis & { chrome?: ChromeLike }).chrome
+
+/**
+ * chrome 実環境向けに SavedTabsUseCasesDeps を構築する。
+ *
+ * `chrome.storage.local` が無い環境（テストで `chrome` を未注入）では
+ * `SavedTabsRepositoryUnavailableError` が repository factory から投げられる。
+ * presentation 層はそれを呼び出し元（`SavedTabsPage`）でハンドルし、
+ * loading 状態を `error` へ遷移させる。
+ *
+ * @example
+ * ```tsx
+ * const deps = createSavedTabsUseCasesDeps()
+ * const controller = useSavedTabsController({ deps })
+ * ```
+ */
+export const createSavedTabsUseCasesDeps = (): SavedTabsUseCasesDeps => {
+  const local = getChromeStorageLocal()
+  if (!local) {
+    warnMissingChromeStorage('createSavedTabsUseCasesDeps')
+  }
+  const port = local
+    ? {
+        get: (key: string) => local.get(key),
+        remove: (key: string) => local.remove(key),
+        set: (value: Record<string, unknown>) => local.set(value),
+      }
+    : null
+
+  return {
+    browserTabPort: createChromeBrowserTabAdapter({
+      getApi: () => getChromeApi(),
+    }),
+    customProjectRepository: createChromeCustomProjectRepository(port),
+    notificationPort: createSonnerNotificationAdapter(),
+    parentCategoryRepository: createChromeParentCategoryRepository(port),
+    tabGroupRepository: createChromeTabGroupRepository(port),
+    urlRecordRepository: createChromeUrlRecordRepository(port),
+  }
+}

--- a/src/contexts/saved-tabs/presentation/controllers/SavedTabsUseCasesContext.tsx
+++ b/src/contexts/saved-tabs/presentation/controllers/SavedTabsUseCasesContext.tsx
@@ -1,0 +1,55 @@
+import { createContext, useContext } from 'react'
+
+import { createSavedTabsUseCases } from '../../infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCases } from '../../infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCasesDeps } from '../../infrastructure/composition/createSavedTabsUseCasesDeps'
+
+/**
+ * `SavedTabsPage` 配下に use-case ハンドルと deps を配布する Context。
+ *
+ * presentation 層のコンポーネントが追加で use-case を呼びたい場合、
+ * `useSavedTabsUseCases()` から取り出して直接呼ぶ。
+ * 「components から use-case を直接呼ぶ」設計は濫用禁止のため、controller hook
+ * 側の拡張（`useDomainModeController` / `useCustomModeController`）を優先する。
+ */
+export interface SavedTabsUseCasesContextValue {
+  readonly deps: SavedTabsUseCasesDeps
+  readonly useCases: SavedTabsUseCases
+}
+
+const SavedTabsUseCasesContext =
+  createContext<SavedTabsUseCasesContextValue | null>(null)
+
+/**
+ * `SavedTabsUseCasesContext` の Provider。
+ */
+export const SavedTabsUseCasesProvider = ({
+  value,
+  children,
+}: {
+  value: SavedTabsUseCasesContextValue
+  children: React.ReactNode
+}) => (
+  <SavedTabsUseCasesContext.Provider value={value}>
+    {children}
+  </SavedTabsUseCasesContext.Provider>
+)
+
+/**
+ * `SavedTabsUseCasesContext` の値を取り出す。Provider 外で呼ぶと `null`。
+ */
+export const useSavedTabsUseCases = (): SavedTabsUseCasesContextValue | null =>
+  useContext(SavedTabsUseCasesContext)
+
+/**
+ * 渡された `deps` から `SavedTabsUseCasesContextValue` を組み立てる。
+ *
+ * chrome 依存を初期化しないため、SSR / Storybook / テストでも安全に呼べる。
+ * 実機環境では `createSavedTabsUseCasesContextValue`（chrome 側）を使う。
+ */
+export const createSavedTabsUseCasesContextValueFromDeps = (
+  deps: SavedTabsUseCasesDeps,
+): SavedTabsUseCasesContextValue => ({
+  deps,
+  useCases: createSavedTabsUseCases(deps),
+})

--- a/src/contexts/saved-tabs/presentation/controllers/createSavedTabsUseCasesContextValue.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/createSavedTabsUseCasesContextValue.ts
@@ -1,0 +1,21 @@
+import { createSavedTabsUseCases } from '../../infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCases } from '../../infrastructure/composition/createSavedTabsUseCases'
+import { createSavedTabsUseCasesDeps } from '../../infrastructure/composition/createSavedTabsUseCasesDeps'
+import type { SavedTabsUseCasesDeps } from '../../infrastructure/composition/createSavedTabsUseCasesDeps'
+import type { SavedTabsUseCasesContextValue } from './SavedTabsUseCasesContext'
+
+/**
+ * chrome 実環境向けに SavedTabsUseCasesContextValue を構築する。
+ *
+ * `createSavedTabsUseCasesDeps()` が chrome.* / repository factory を経由して
+ * 永続化層を立ち上げるため、SSR / Storybook / テストなど chrome 不在環境では
+ * 代わりに `createSavedTabsUseCasesContextValueFromDeps` を使う。
+ */
+export const createSavedTabsUseCasesContextValue =
+  (): SavedTabsUseCasesContextValue => {
+    const deps = createSavedTabsUseCasesDeps()
+    const useCases: SavedTabsUseCases = createSavedTabsUseCases(deps)
+    return { deps, useCases }
+  }
+
+export type { SavedTabsUseCases, SavedTabsUseCasesDeps }

--- a/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.test.ts
@@ -1,0 +1,728 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { NotificationPort } from '../../application/ports/NotificationPort'
+import { createCustomProject } from '../../domain/entities/CustomProject'
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import { createTabGroup } from '../../domain/entities/TabGroup'
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import { createUrlRecord } from '../../domain/entities/UrlRecord'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import { createSavedTabsUseCases } from '../../infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCasesDeps } from '../../infrastructure/composition/createSavedTabsUseCasesDeps'
+import { useSavedTabsController } from './useSavedTabsController'
+
+const createSampleTabGroup = (id: string, domain: string): TabGroup =>
+  createTabGroup({
+    domain,
+    id,
+    urlIds: [`url-${id}`],
+  })
+
+const createSampleCustomProject = (id: string, name: string): CustomProject =>
+  createCustomProject({
+    categories: [],
+    createdAt: 1,
+    id,
+    name,
+    updatedAt: 1,
+    urlIds: [],
+  })
+
+interface InMemoryState {
+  tabGroups: TabGroup[]
+  customProjects: CustomProject[]
+}
+
+const createInMemoryRepositories = (initial: Partial<InMemoryState> = {}) => {
+  const state: InMemoryState = {
+    customProjects: [...(initial.customProjects ?? [])],
+    tabGroups: [...(initial.tabGroups ?? [])],
+  }
+  const tabGroupRepository: TabGroupRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => state.tabGroups.map((group) => ({ ...group })),
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      state.tabGroups.find((group) => group.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids)
+      state.tabGroups = state.tabGroups.filter((group) => !idSet.has(group.id))
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (groups) => {
+      state.tabGroups = groups.map((group) => ({ ...group }))
+    },
+  }
+  const customProjectRepository: CustomProjectRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () =>
+      state.customProjects.map((project) => ({ ...project })),
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      state.customProjects.find((project) => project.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids)
+      state.customProjects = state.customProjects.filter(
+        (project) => !idSet.has(project.id),
+      )
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (projects) => {
+      state.customProjects = projects.map((project) => ({ ...project }))
+    },
+  }
+  return { customProjectRepository, state, tabGroupRepository }
+}
+
+const createEmptyDeps = (
+  initialUrlRecords: ReturnType<typeof createUrlRecord>[] = [],
+): {
+  deps: SavedTabsUseCasesDeps
+  openSpy: ReturnType<typeof vi.fn>
+  notifySpy: ReturnType<typeof vi.fn>
+  urlRecords: ReturnType<typeof createUrlRecord>[]
+} => {
+  const urlRecords: ReturnType<typeof createUrlRecord>[] = [
+    ...initialUrlRecords,
+  ]
+  const urlRecordRepository: UrlRecordRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => urlRecords.map((record) => ({ ...record })),
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      urlRecords.find((record) => record.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids)
+      for (let i = urlRecords.length - 1; i >= 0; i--) {
+        if (idSet.has(urlRecords[i]?.id ?? '')) {
+          urlRecords.splice(i, 1)
+        }
+      }
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (records) => {
+      urlRecords.splice(
+        0,
+        urlRecords.length,
+        ...records.map((record) => ({ ...record })),
+      )
+    },
+  }
+  const parentCategoryRepository: ParentCategoryRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    findById: async () => null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async () => undefined,
+  }
+  const openSpy = vi.fn((input: { url: string }) =>
+    Promise.resolve({ url: input.url }),
+  )
+  const browserTabPort: BrowserTabPort = { open: openSpy }
+  const notifySpy = vi.fn()
+  const notificationPort: NotificationPort = {
+    error: notifySpy,
+    info: notifySpy,
+    success: notifySpy,
+  }
+  return {
+    deps: {
+      browserTabPort,
+      customProjectRepository:
+        createInMemoryRepositories().customProjectRepository,
+      notificationPort,
+      parentCategoryRepository,
+      tabGroupRepository: createInMemoryRepositories().tabGroupRepository,
+      urlRecordRepository,
+    },
+    notifySpy,
+    openSpy,
+    urlRecords,
+  }
+}
+
+const renderController = (input: {
+  deps: SavedTabsUseCasesDeps
+  initialTabGroups?: readonly TabGroup[]
+  initialCustomProjects?: readonly CustomProject[]
+  useCases?: ReturnType<typeof createSavedTabsUseCases>
+}) => {
+  const useCases = input.useCases ?? createSavedTabsUseCases(input.deps)
+  return renderHook(() =>
+    useSavedTabsController({
+      deps: input.deps,
+      initialCustomProjects: input.initialCustomProjects,
+      initialTabGroups: input.initialTabGroups,
+      useCases,
+    }),
+  )
+}
+
+describe('useSavedTabsController', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('initialTabGroups / initialCustomProjects を渡すと view-model へ反映する', () => {
+    const { deps } = createEmptyDeps()
+    const groups = [createSampleTabGroup('g1', 'example.com')]
+    const projects = [createSampleCustomProject('p1', 'Reading')]
+    const { result } = renderController({
+      deps,
+      initialCustomProjects: projects,
+      initialTabGroups: groups,
+    })
+    expect(result.current.viewModel.loading).toBe(false)
+    expect(result.current.viewModel.tabGroups).toHaveLength(1)
+    expect(result.current.viewModel.customProjects).toHaveLength(1)
+    expect(result.current.viewModel.hasContent).toBe(true)
+  })
+
+  it('initial が無ければ refresh で view-model を構築する', async () => {
+    const { deps } = createEmptyDeps()
+    const groups = [createSampleTabGroup('g1', 'example.com')]
+    const projects = [createSampleCustomProject('p1', 'Reading')]
+    const inMemory = createInMemoryRepositories({
+      customProjects: projects,
+      tabGroups: groups,
+    })
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    expect(result.current.viewModel.loading).toBe(false)
+    expect(result.current.viewModel.tabGroups).toHaveLength(1)
+    expect(result.current.viewModel.customProjects).toHaveLength(1)
+  })
+
+  it('openSavedUrl は use-case を呼び、refresh で最新を反映する', async () => {
+    const urlRecord = createUrlRecord({
+      id: 'url-g1',
+      savedAt: 1,
+      title: 'example article',
+      url: 'https://example.com/article',
+    })
+    const { deps, openSpy } = createEmptyDeps([urlRecord])
+    const group = createSampleTabGroup('g1', 'example.com')
+    const inMemory = createInMemoryRepositories({ tabGroups: [group] })
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    await act(async () => {
+      await result.current.openSavedUrl({
+        origin: 'click',
+        settings: {
+          removeTabAfterExternalDrop: false,
+          removeTabAfterOpen: false,
+        },
+        urlRecordId: 'url-g1',
+      })
+    })
+    expect(openSpy).toHaveBeenCalledWith({ url: 'https://example.com/article' })
+  })
+
+  it('use-case 失敗時は error をセットし再 throw する', async () => {
+    const { deps } = createEmptyDeps()
+    const group = createSampleTabGroup('g1', 'example.com')
+    const inMemory = createInMemoryRepositories({ tabGroups: [group] })
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    // urlRecordRepository は空のため openSavedUrl は 'URL_RECORD_NOT_FOUND' で失敗する
+    await act(async () => {
+      await expect(
+        result.current.openSavedUrl({
+          origin: 'click',
+          settings: {
+            removeTabAfterExternalDrop: false,
+            removeTabAfterOpen: false,
+          },
+          urlRecordId: 'url-missing',
+        }),
+      ).rejects.toThrow(/.*/)
+    })
+    expect(result.current.viewModel.error).not.toBeNull()
+  })
+
+  it('deleteTabGroup は use-case を呼んで repository から消す', async () => {
+    const { deps } = createEmptyDeps()
+    const group = createSampleTabGroup('g1', 'example.com')
+    const inMemory = createInMemoryRepositories({ tabGroups: [group] })
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    await act(async () => {
+      await result.current.deleteTabGroup({ tabGroupId: 'g1' })
+    })
+    expect(result.current.viewModel.tabGroups).toHaveLength(0)
+  })
+
+  it('restoreOpenedUrlsSnapshot は snapshot を受け取って use-case を呼ぶ', async () => {
+    const { deps } = createEmptyDeps()
+    const group = createSampleTabGroup('g1', 'example.com')
+    const inMemory = createInMemoryRepositories({ tabGroups: [] })
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    let summary: {
+      restoredTabGroupCount: number
+      restoredUrlRecordCount: number
+    } = {
+      restoredTabGroupCount: -1,
+      restoredUrlRecordCount: -1,
+    }
+    await act(async () => {
+      summary = await result.current.restoreOpenedUrlsSnapshot({
+        snapshot: { savedTabs: [group] },
+      })
+    })
+    expect(summary.restoredTabGroupCount).toBe(1)
+    expect(summary.restoredUrlRecordCount).toBe(0)
+  })
+
+  it('restoreOpenedUrlsSnapshot は parentCategories / urlRecords を含む snapshot をそのまま use-case へ流す', async () => {
+    const { deps } = createEmptyDeps()
+    const inMemory = createInMemoryRepositories({ tabGroups: [] })
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    let summary = { restoredTabGroupCount: -1, restoredUrlRecordCount: -1 }
+    await act(async () => {
+      summary = await result.current.restoreOpenedUrlsSnapshot({
+        snapshot: {
+          parentCategories: [
+            {
+              domainNames: ['example.com'],
+              domains: ['group-1'],
+              id: 'cat-1',
+              name: 'Docs',
+            },
+          ],
+          savedTabs: [createSampleTabGroup('g1', 'example.com')],
+          urlRecords: [
+            {
+              id: 'url-1',
+              savedAt: 1,
+              title: 'example',
+              url: 'https://example.com',
+            },
+          ],
+        },
+      })
+    })
+    expect(summary.restoredTabGroupCount).toBe(1)
+    expect(summary.restoredUrlRecordCount).toBe(1)
+  })
+
+  it('restoreOpenedUrlsSnapshot の use-case 失敗時は error をセットし再 throw する', async () => {
+    const { deps } = createEmptyDeps()
+    const inMemory = createInMemoryRepositories({ tabGroups: [] })
+    const failingParentCategoryRepository: ParentCategoryRepository = {
+      // eslint-disable-next-line typescript/require-await
+      findAll: async () => [],
+      // eslint-disable-next-line typescript/require-await
+      findById: async () => null,
+      // eslint-disable-next-line typescript/require-await
+      removeByIds: async () => undefined,
+      // eslint-disable-next-line typescript/require-await
+      saveAll: async () => {
+        throw new Error('restore-broken')
+      },
+    }
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      parentCategoryRepository: failingParentCategoryRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    await act(async () => {
+      await expect(
+        result.current.restoreOpenedUrlsSnapshot({
+          snapshot: {
+            parentCategories: [
+              {
+                domainNames: [],
+                domains: [],
+                id: 'cat-1',
+                name: 'Docs',
+              },
+            ],
+          },
+        }),
+      ).rejects.toThrow(/.*/)
+    })
+    expect(result.current.viewModel.error).not.toBeNull()
+  })
+
+  it('deleteTabGroup の snapshot に parentCategories が含まれるケースを吸収する', async () => {
+    const { deps } = createEmptyDeps()
+    const inMemory = createInMemoryRepositories({ tabGroups: [] })
+    const baseUseCases = createSavedTabsUseCases({
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    })
+    // parentCategories 付きの snapshot を返すモックへ差し替える
+    const useCases = {
+      ...baseUseCases,
+      deleteTabGroup: (() =>
+        Promise.resolve({
+          removedTabGroupId: 'g1' as never,
+          removedUrlRecordIds: [],
+          snapshot: {
+            customProjects: undefined,
+            parentCategories: [
+              {
+                domainNames: ['example.com'],
+                domains: [],
+                id: 'cat-1' as never,
+                name: 'Docs' as never,
+              },
+            ],
+            savedTabs: [createSampleTabGroup('g1', 'example.com')],
+            urlRecords: [],
+          },
+        }) as never) as never,
+    }
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderController({
+      deps: overrideDeps,
+      useCases,
+    })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    await act(async () => {
+      const dto = await result.current.deleteTabGroup({ tabGroupId: 'g1' })
+      expect(dto.removedTabGroupId).toBe('g1')
+    })
+  })
+
+  it('deleteTabGroup の use-case 失敗時は error をセットし再 throw する', async () => {
+    const { deps } = createEmptyDeps()
+    const inMemory = createInMemoryRepositories({ tabGroups: [] })
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    await act(async () => {
+      await expect(
+        result.current.deleteTabGroup({ tabGroupId: 'not-found' }),
+      ).rejects.toThrow(/.*/)
+    })
+    expect(result.current.viewModel.error).not.toBeNull()
+  })
+
+  it('syncCategoryAssignments の use-case 失敗時は error をセットし再 throw する', async () => {
+    const { deps } = createEmptyDeps()
+    const inMemory = createInMemoryRepositories({ tabGroups: [] })
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    // parentCategoryRepository は空配列を返すので、存在しない parentCategoryId
+    // を指定すると SavedTabsDomainError が投げられる
+    await act(async () => {
+      await expect(
+        result.current.syncCategoryAssignments({
+          command: {
+            domain: 'example.com',
+            parentCategoryId: 'missing-cat',
+          },
+        }),
+      ).rejects.toThrow(/.*/)
+    })
+    expect(result.current.viewModel.error).not.toBeNull()
+  })
+
+  it('removeUnreferencedUrlRecords の use-case 失敗時は error をセットし再 throw する', async () => {
+    const failingUrlRecordRepository: UrlRecordRepository = {
+      // eslint-disable-next-line typescript/require-await
+      findAll: async () => {
+        throw new Error('storage broken')
+      },
+      // eslint-disable-next-line typescript/require-await
+      findById: async () => null,
+      // eslint-disable-next-line typescript/require-await
+      removeByIds: async () => undefined,
+      // eslint-disable-next-line typescript/require-await
+      saveAll: async () => undefined,
+    }
+    const { deps } = createEmptyDeps()
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      urlRecordRepository: failingUrlRecordRepository,
+    }
+    const { result } = renderController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    await act(async () => {
+      await expect(
+        result.current.removeUnreferencedUrlRecords(),
+      ).rejects.toThrow(/.*/)
+    })
+    expect(result.current.viewModel.error).not.toBeNull()
+  })
+
+  it('openSavedUrl の use-case 成功時に snapshot に parentCategories / urlRecords が含まれていれば controller に保持する', async () => {
+    const urlRecord = createUrlRecord({
+      id: 'url-g1',
+      savedAt: 1,
+      title: 'example article',
+      url: 'https://example.com/article',
+    })
+    const { deps } = createEmptyDeps([urlRecord])
+    const inMemory = createInMemoryRepositories({
+      tabGroups: [createSampleTabGroup('g1', 'example.com')],
+    })
+    const baseUseCases = createSavedTabsUseCases({
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    })
+    // parentCategories 付き snapshot を返すモックへ差し替える
+    const useCases = {
+      ...baseUseCases,
+      openSavedUrl: (() =>
+        Promise.resolve({
+          openedUrl: 'https://example.com/article',
+          removedUrlRecord: null,
+          removedUrlRecordId: null,
+          snapshot: {
+            customProjects: undefined,
+            parentCategories: [
+              {
+                domainNames: ['example.com'],
+                domains: [],
+                id: 'cat-1' as never,
+                name: 'Docs' as never,
+              },
+            ],
+            savedTabs: undefined,
+            urlRecords: [
+              {
+                id: 'url-g1' as never,
+                savedAt: 1 as never,
+                title: 'example article',
+                url: 'https://example.com/article' as never,
+              },
+            ],
+          },
+        }) as never) as never,
+    }
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderController({
+      deps: overrideDeps,
+      useCases,
+    })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    await act(async () => {
+      const dto = await result.current.openSavedUrl({
+        origin: 'click',
+        settings: {
+          removeTabAfterExternalDrop: false,
+          removeTabAfterOpen: false,
+        },
+        urlRecordId: 'url-g1',
+      })
+      expect(dto.openedUrl).toBe('https://example.com/article')
+    })
+  })
+
+  it('deleteTabGroup の snapshot に urlRecords が含まれるケースを吸収する', async () => {
+    const { deps } = createEmptyDeps()
+    const inMemory = createInMemoryRepositories({ tabGroups: [] })
+    const baseUseCases = createSavedTabsUseCases({
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    })
+    const useCases = {
+      ...baseUseCases,
+      deleteTabGroup: (() =>
+        Promise.resolve({
+          removedTabGroupId: 'g1' as never,
+          removedUrlRecordIds: ['url-1' as never],
+          snapshot: {
+            customProjects: undefined,
+            parentCategories: undefined,
+            savedTabs: [createSampleTabGroup('g1', 'example.com')],
+            urlRecords: [
+              {
+                id: 'url-1' as never,
+                savedAt: 1 as never,
+                title: 'example',
+                url: 'https://example.com' as never,
+              },
+            ],
+          },
+        }) as never) as never,
+    }
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderController({
+      deps: overrideDeps,
+      useCases,
+    })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    await act(async () => {
+      const dto = await result.current.deleteTabGroup({ tabGroupId: 'g1' })
+      expect(dto.removedUrlRecordIds).toHaveLength(1)
+    })
+  })
+
+  it('refresh の repository 取得失敗時は error をセットする', async () => {
+    const failingTabGroupRepository: TabGroupRepository = {
+      // eslint-disable-next-line typescript/require-await
+      findAll: async () => {
+        throw new Error('storage broken')
+      },
+      // eslint-disable-next-line typescript/require-await
+      findById: async () => null,
+      // eslint-disable-next-line typescript/require-await
+      removeByIds: async () => undefined,
+      // eslint-disable-next-line typescript/require-await
+      saveAll: async () => undefined,
+    }
+    const { deps } = createEmptyDeps()
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      tabGroupRepository: failingTabGroupRepository,
+    }
+    const { result } = renderController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    expect(result.current.viewModel.error).not.toBeNull()
+    expect(result.current.viewModel.loading).toBe(false)
+  })
+
+  it('removeUnreferencedUrlRecords は use-case の removedCount を返す', async () => {
+    const { deps } = createEmptyDeps()
+    const { result } = renderController({ deps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    let removed = 0
+    await act(async () => {
+      removed = (await result.current.removeUnreferencedUrlRecords())
+        .removedCount
+    })
+    expect(removed).toBe(0)
+  })
+
+  it('syncCategoryAssignments の戻り値を view-model へ集計する', async () => {
+    const { deps } = createEmptyDeps()
+    const { result } = renderController({ deps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    let summary: {
+      assignedTabGroupCount: number
+      updatedCategoryCount: number
+      unassignedTabGroupCount: number
+    } = {
+      assignedTabGroupCount: -1,
+      unassignedTabGroupCount: -1,
+      updatedCategoryCount: -1,
+    }
+    await act(async () => {
+      summary = await result.current.syncCategoryAssignments({})
+    })
+    expect(summary.assignedTabGroupCount).toBe(0)
+    expect(summary.unassignedTabGroupCount).toBe(0)
+    expect(summary.updatedCategoryCount).toBe(0)
+  })
+
+  it('createSavedTabsUseCases が use-case を組み立てる', () => {
+    const { deps } = createEmptyDeps()
+    const inMemory = createInMemoryRepositories()
+    const useCases = createSavedTabsUseCases({
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    })
+    expect(useCases.openSavedUrl).toBeTypeOf('function')
+    expect(useCases.deleteTabGroup).toBeTypeOf('function')
+    expect(useCases.restoreOpenedUrlsSnapshot).toBeTypeOf('function')
+    expect(useCases.syncCategoryAssignments).toBeTypeOf('function')
+    expect(useCases.removeUnreferencedUrlRecords).toBeTypeOf('function')
+  })
+})

--- a/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.ts
@@ -1,0 +1,441 @@
+import { useCallback, useMemo, useRef, useState } from 'react'
+
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import type { DomainName } from '../../domain/value-objects/DomainName'
+import type { ParentCategoryId } from '../../domain/value-objects/ParentCategoryId'
+import type { SavedAt } from '../../domain/value-objects/SavedAt'
+import type { TabGroupId } from '../../domain/value-objects/TabGroupId'
+import type { Url } from '../../domain/value-objects/Url'
+import type { UrlRecordId } from '../../domain/value-objects/UrlRecordId'
+import type { SavedTabsUseCases } from '../../infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCasesDeps } from '../../infrastructure/composition/createSavedTabsUseCasesDeps'
+import type { CustomProjectViewModel } from '../view-models/CustomProjectViewModel'
+import { toCustomProjectViewModel } from '../view-models/CustomProjectViewModel'
+import type { SavedTabsViewModel } from '../view-models/SavedTabsViewModel'
+import {
+  createSavedTabsViewModel,
+  createEmptySavedTabsViewModel,
+} from '../view-models/SavedTabsViewModel'
+import type { TabGroupViewModel } from '../view-models/TabGroupViewModel'
+import { toTabGroupViewModel } from '../view-models/TabGroupViewModel'
+
+/**
+ * `useSavedTabsController` が UI に公開する入力。
+ *
+ * - `useCases` があれば application use-case 経由で操作する。
+ * - テストや SSR 用に `initialTabGroups` / `initialCustomProjects` を渡せる。
+ *   省略時は use-case / repository の readAll を初回マウント時に行う。
+ */
+export interface UseSavedTabsControllerInput {
+  readonly deps: SavedTabsUseCasesDeps
+  readonly useCases: SavedTabsUseCases
+  readonly initialTabGroups?: readonly TabGroup[]
+  readonly initialCustomProjects?: readonly CustomProject[]
+}
+
+/**
+ * `useSavedTabsController` の戻り値。UI は view-model と操作関数だけを受け取る。
+ */
+export interface UseSavedTabsControllerReturn {
+  readonly viewModel: SavedTabsViewModel
+  readonly openSavedUrl: (
+    input: OpenSavedUrlControllerInput,
+  ) => Promise<OpenSavedUrlControllerResult>
+  readonly deleteTabGroup: (
+    input: DeleteTabGroupControllerInput,
+  ) => Promise<DeleteTabGroupControllerResult>
+  readonly restoreOpenedUrlsSnapshot: (
+    input: RestoreSnapshotControllerInput,
+  ) => Promise<RestoreSnapshotControllerResult>
+  readonly syncCategoryAssignments: (
+    input: SyncCategoryControllerInput,
+  ) => Promise<SyncCategoryControllerResult>
+  readonly removeUnreferencedUrlRecords: () => Promise<{
+    readonly removedCount: number
+  }>
+  readonly refresh: () => Promise<void>
+}
+
+export interface OpenSavedUrlControllerInput {
+  readonly urlRecordId: string
+  readonly origin: 'click' | 'externalDrop'
+  readonly settings: {
+    readonly removeTabAfterOpen: boolean
+    readonly removeTabAfterExternalDrop: boolean
+  }
+}
+
+export interface OpenSavedUrlControllerResult {
+  readonly openedUrl: string
+  readonly removedUrlRecordId: string | null
+}
+
+export interface DeleteTabGroupControllerInput {
+  readonly tabGroupId: string
+}
+
+export interface DeleteTabGroupControllerResult {
+  readonly removedTabGroupId: string
+  readonly removedUrlRecordIds: readonly string[]
+}
+
+export interface RestoreSnapshotControllerInput {
+  readonly snapshot: {
+    readonly savedTabs?: readonly TabGroup[]
+    readonly urlRecords?: readonly {
+      readonly id: string
+      readonly url: string
+      readonly title: string
+      readonly savedAt: number
+    }[]
+    readonly customProjects?: readonly CustomProject[]
+    readonly parentCategories?: readonly {
+      readonly id: string
+      readonly name: string
+      readonly domains: readonly string[]
+      readonly domainNames: readonly string[]
+    }[]
+  }
+}
+
+export interface RestoreSnapshotControllerResult {
+  readonly restoredTabGroupCount: number
+  readonly restoredUrlRecordCount: number
+}
+
+export interface SyncCategoryControllerInput {
+  readonly command?: {
+    readonly domain: string
+    readonly parentCategoryId: string
+  }
+}
+
+export interface SyncCategoryControllerResult {
+  readonly assignedTabGroupCount: number
+  readonly unassignedTabGroupCount: number
+  readonly updatedCategoryCount: number
+}
+
+interface ControllerState {
+  loading: boolean
+  error: string | null
+  tabGroups: readonly TabGroupViewModel[]
+  customProjects: readonly CustomProjectViewModel[]
+}
+
+const toCustomProjectViewModelFromEntity = (
+  project: CustomProject,
+): CustomProjectViewModel =>
+  toCustomProjectViewModel({
+    categories: [...project.categories],
+    createdAt: project.createdAt,
+    id: project.id,
+    name: project.name,
+    updatedAt: project.updatedAt,
+    urlIds: [...project.urlIds],
+  })
+
+const toTabGroupViewModelFromEntity = (group: TabGroup): TabGroupViewModel =>
+  toTabGroupViewModel({
+    domain: group.domain,
+    id: group.id,
+    parentCategoryId: group.parentCategoryId,
+    urlIds: [...group.urlIds],
+  })
+
+type BrandedString =
+  | UrlRecordId
+  | TabGroupId
+  | DomainName
+  | ParentCategoryId
+  | SavedAt
+  | Url
+
+/**
+ * branded ドメイン型へ安全側に倒してキャストする。
+ *
+ * presentation 層で受け取るのは `string` だが、use-case / command 層は
+ * branded 値を要求する。presentation はドメイン層と独立した存在で
+ * 値の検証は持たないため、`unknown` を経由した構造的キャストで受け渡す。
+ * runtime で型チェックが壊れる経路は domain layer の factory で防護する。
+ */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+const castToBranded = <T extends BrandedString>(value: string): T =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  value as unknown as T
+
+/**
+ * presentation 層の中心 controller hook。
+ *
+ * 責務:
+ * 1. repository から TabGroup / CustomProject を読み込み、view-model へ変換する。
+ * 2. application use-case を呼び、結果を view-model へ反映する。
+ * 3. loading / error 状態と、Undo 復元用の snapshot 保持を管理する。
+ *
+ * 非責務:
+ * - `chrome.*` の直接呼び出し (composition 層の adapter / repository 経由)
+ * - DOM 描画 (page / component 層)
+ * - Sonner 等の特定通知 UI への直接依存 (NotificationPort 経由)
+ */
+export const useSavedTabsController = (
+  input: UseSavedTabsControllerInput,
+): UseSavedTabsControllerReturn => {
+  const { deps, useCases, initialTabGroups, initialCustomProjects } = input
+  const {
+    openSavedUrl: openSavedUrlUseCase,
+    deleteTabGroup: deleteTabGroupUseCase,
+    restoreOpenedUrlsSnapshot: restoreOpenedUrlsSnapshotUseCase,
+    syncCategoryAssignments: syncCategoryAssignmentsUseCase,
+    removeUnreferencedUrlRecords: removeUnreferencedUrlRecordsUseCase,
+  } = useCases
+  const [state, setState] = useState<ControllerState>({
+    customProjects:
+      initialCustomProjects?.map(toCustomProjectViewModelFromEntity) ?? [],
+    error: null,
+    loading:
+      initialTabGroups === undefined || initialCustomProjects === undefined,
+    tabGroups: initialTabGroups?.map(toTabGroupViewModelFromEntity) ?? [],
+  })
+  const lastSnapshotRef = useRef<
+    RestoreSnapshotControllerInput['snapshot'] | null
+  >(null)
+
+  const setError = useCallback((message: string | null) => {
+    setState((prev) => ({ ...prev, error: message }))
+  }, [])
+
+  const refresh = useCallback(async () => {
+    setState((prev) => ({ ...prev, error: null, loading: true }))
+    try {
+      const [allTabGroups, allCustomProjects] = await Promise.all([
+        deps.tabGroupRepository.findAll(),
+        deps.customProjectRepository.findAll(),
+      ])
+      setState({
+        customProjects: allCustomProjects.map(
+          toCustomProjectViewModelFromEntity,
+        ),
+        error: null,
+        loading: false,
+        tabGroups: allTabGroups.map(toTabGroupViewModelFromEntity),
+      })
+    } catch (error) {
+      setError(error instanceof Error ? error.message : String(error))
+      setState((prev) => ({ ...prev, loading: false }))
+    }
+  }, [deps.customProjectRepository, deps.tabGroupRepository, setError])
+
+  const openSavedUrl = useCallback(
+    async (openInput: OpenSavedUrlControllerInput) => {
+      try {
+        const dto = await openSavedUrlUseCase({
+          origin: openInput.origin,
+          settings: openInput.settings,
+          urlRecordId: castToBranded<UrlRecordId>(openInput.urlRecordId),
+        })
+        if (dto.snapshot) {
+          lastSnapshotRef.current = {
+            customProjects: dto.snapshot.customProjects
+              ? [...dto.snapshot.customProjects]
+              : undefined,
+            parentCategories: dto.snapshot.parentCategories
+              ? dto.snapshot.parentCategories.map((category) => ({
+                  domainNames: [...category.domainNames],
+                  domains: [...category.domains],
+                  id: category.id,
+                  name: category.name,
+                }))
+              : undefined,
+            savedTabs: dto.snapshot.savedTabs
+              ? [...dto.snapshot.savedTabs]
+              : undefined,
+            urlRecords: dto.snapshot.urlRecords
+              ? dto.snapshot.urlRecords.map((record) => ({
+                  id: record.id,
+                  savedAt: record.savedAt,
+                  title: record.title,
+                  url: record.url,
+                }))
+              : undefined,
+          }
+        }
+        await refresh()
+        return {
+          openedUrl: dto.openedUrl,
+          removedUrlRecordId: dto.removedUrlRecordId,
+        }
+      } catch (error) {
+        setError(error instanceof Error ? error.message : String(error))
+        throw error
+      }
+    },
+    [refresh, setError, openSavedUrlUseCase],
+  )
+
+  const deleteTabGroup = useCallback(
+    async (deleteInput: DeleteTabGroupControllerInput) => {
+      try {
+        const dto = await deleteTabGroupUseCase({
+          tabGroupId: castToBranded<TabGroupId>(deleteInput.tabGroupId),
+        })
+        if (dto.snapshot) {
+          lastSnapshotRef.current = {
+            customProjects: dto.snapshot.customProjects
+              ? [...dto.snapshot.customProjects]
+              : undefined,
+            parentCategories: dto.snapshot.parentCategories
+              ? dto.snapshot.parentCategories.map((category) => ({
+                  domainNames: [...category.domainNames],
+                  domains: [...category.domains],
+                  id: category.id,
+                  name: category.name,
+                }))
+              : undefined,
+            savedTabs: dto.snapshot.savedTabs
+              ? [...dto.snapshot.savedTabs]
+              : undefined,
+            urlRecords: dto.snapshot.urlRecords
+              ? dto.snapshot.urlRecords.map((record) => ({
+                  id: record.id,
+                  savedAt: record.savedAt,
+                  title: record.title,
+                  url: record.url,
+                }))
+              : undefined,
+          }
+        }
+        await refresh()
+        return {
+          removedTabGroupId: dto.removedTabGroupId,
+          removedUrlRecordIds: [...dto.removedUrlRecordIds],
+        }
+      } catch (error) {
+        setError(error instanceof Error ? error.message : String(error))
+        throw error
+      }
+    },
+    [refresh, setError, deleteTabGroupUseCase],
+  )
+
+  const restoreOpenedUrlsSnapshot = useCallback(
+    async (restoreInput: RestoreSnapshotControllerInput) => {
+      const snapshot = restoreInput.snapshot
+      try {
+        const dto = await restoreOpenedUrlsSnapshotUseCase({
+          snapshot: {
+            ...(snapshot.customProjects
+              ? { customProjects: snapshot.customProjects }
+              : {}),
+            ...(snapshot.parentCategories
+              ? {
+                  parentCategories: snapshot.parentCategories.map(
+                    (category) => ({
+                      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+                      domainNames: [
+                        ...category.domainNames,
+                      ] as unknown as readonly DomainName[],
+                      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+                      domains: [
+                        ...category.domains,
+                      ] as unknown as readonly TabGroupId[],
+                      id: castToBranded<ParentCategoryId>(category.id),
+                      name: castToBranded<never>(category.name),
+                    }),
+                  ),
+                }
+              : {}),
+            ...(snapshot.savedTabs ? { savedTabs: snapshot.savedTabs } : {}),
+            ...(snapshot.urlRecords
+              ? {
+                  urlRecords: snapshot.urlRecords.map((record) => ({
+                    id: castToBranded<UrlRecordId>(record.id),
+                    savedAt: castToBranded<SavedAt>(String(record.savedAt)),
+                    title: record.title,
+                    url: castToBranded<Url>(record.url),
+                  })),
+                }
+              : {}),
+          },
+        })
+        lastSnapshotRef.current = null
+        await refresh()
+        return {
+          restoredTabGroupCount: dto.restoredTabGroups.length,
+          restoredUrlRecordCount: dto.restoredUrlRecords.length,
+        }
+      } catch (error) {
+        setError(error instanceof Error ? error.message : String(error))
+        throw error
+      }
+    },
+    [refresh, setError, restoreOpenedUrlsSnapshotUseCase],
+  )
+
+  const syncCategoryAssignments = useCallback(
+    async (syncInput: SyncCategoryControllerInput) => {
+      try {
+        const dto = await syncCategoryAssignmentsUseCase(
+          syncInput.command
+            ? {
+                command: {
+                  domain: castToBranded<DomainName>(syncInput.command.domain),
+                  parentCategoryId: castToBranded<ParentCategoryId>(
+                    syncInput.command.parentCategoryId,
+                  ),
+                },
+              }
+            : // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+              ({} as never),
+        )
+        await refresh()
+        return {
+          assignedTabGroupCount: dto.assignedTabGroupIds.length,
+          unassignedTabGroupCount: dto.unassignedTabGroupIds.length,
+          updatedCategoryCount: dto.updatedCategoryIds.length,
+        }
+      } catch (error) {
+        setError(error instanceof Error ? error.message : String(error))
+        throw error
+      }
+    },
+    [refresh, setError, syncCategoryAssignmentsUseCase],
+  )
+
+  const removeUnreferencedUrlRecords = useCallback(async () => {
+    try {
+      const dto = await removeUnreferencedUrlRecordsUseCase()
+      await refresh()
+      return { removedCount: dto.removedCount }
+    } catch (error) {
+      setError(error instanceof Error ? error.message : String(error))
+      throw error
+    }
+  }, [refresh, setError, removeUnreferencedUrlRecordsUseCase])
+
+  const viewModel = useMemo<SavedTabsViewModel>(() => {
+    if (
+      state.loading &&
+      state.tabGroups.length === 0 &&
+      state.customProjects.length === 0
+    ) {
+      return createEmptySavedTabsViewModel()
+    }
+    return createSavedTabsViewModel({
+      customProjects: state.customProjects,
+      error: state.error,
+      loading: state.loading,
+      tabGroups: state.tabGroups,
+    })
+  }, [state.customProjects, state.error, state.loading, state.tabGroups])
+
+  return {
+    deleteTabGroup,
+    openSavedUrl,
+    refresh,
+    removeUnreferencedUrlRecords,
+    restoreOpenedUrlsSnapshot,
+    syncCategoryAssignments,
+    viewModel,
+  }
+}

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.test.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.test.tsx
@@ -1,0 +1,253 @@
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { NotificationPort } from '../../application/ports/NotificationPort'
+import { createCustomProject } from '../../domain/entities/CustomProject'
+import { createTabGroup } from '../../domain/entities/TabGroup'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import { createSavedTabsUseCases } from '../../infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCasesDeps } from '../../infrastructure/composition/createSavedTabsUseCasesDeps'
+import { SavedTabsPage } from './SavedTabsPage'
+
+const createInMemoryDeps = (input: {
+  tabGroups?: ReturnType<typeof createTabGroup>[]
+  customProjects?: ReturnType<typeof createCustomProject>[]
+}): SavedTabsUseCasesDeps => {
+  const tabGroups = input.tabGroups ?? []
+  const customProjects = input.customProjects ?? []
+  const tabGroupRepository: TabGroupRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => tabGroups.map((group) => ({ ...group })),
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) => tabGroups.find((group) => group.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids)
+      for (let i = tabGroups.length - 1; i >= 0; i--) {
+        if (idSet.has(tabGroups[i]?.id ?? '')) {
+          tabGroups.splice(i, 1)
+        }
+      }
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (groups) => {
+      tabGroups.splice(0, tabGroups.length, ...groups.map((g) => ({ ...g })))
+    },
+  }
+  const customProjectRepository: CustomProjectRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => customProjects.map((project) => ({ ...project })),
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      customProjects.find((project) => project.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids)
+      for (let i = customProjects.length - 1; i >= 0; i--) {
+        if (idSet.has(customProjects[i]?.id ?? '')) {
+          customProjects.splice(i, 1)
+        }
+      }
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (projects) => {
+      customProjects.splice(
+        0,
+        customProjects.length,
+        ...projects.map((p) => ({ ...p })),
+      )
+    },
+  }
+  const urlRecordRepository: UrlRecordRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    findById: async () => null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async () => undefined,
+  }
+  const parentCategoryRepository: ParentCategoryRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    findById: async () => null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async () => undefined,
+  }
+  const browserTabPort: BrowserTabPort = {
+    // eslint-disable-next-line typescript/require-await
+    open: async (input: { url: string }) => ({ url: input.url }),
+  }
+  const notificationPort: NotificationPort = {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  }
+  return {
+    browserTabPort,
+    customProjectRepository,
+    notificationPort,
+    parentCategoryRepository,
+    tabGroupRepository,
+    urlRecordRepository,
+  }
+}
+
+describe('SavedTabsPage', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('initialTabGroups / initialCustomProjects を渡すと view-model へ反映する', () => {
+    const deps = createInMemoryDeps({})
+    const initialTabGroups = [
+      createTabGroup({
+        domain: 'example.com',
+        id: 'g1',
+        urlIds: [],
+      }),
+    ]
+    const initialCustomProjects = [
+      createCustomProject({
+        categories: [],
+        createdAt: 1,
+        id: 'p1',
+        name: 'Reading',
+        updatedAt: 1,
+        urlIds: [],
+      }),
+    ]
+    render(
+      <SavedTabsPage
+        deps={deps}
+        initialCustomProjects={initialCustomProjects}
+        initialTabGroups={initialTabGroups}
+      />,
+    )
+    const root = screen.getByTestId('saved-tabs-page-presentation')
+    expect(root.getAttribute('data-loading')).toBe('false')
+    expect(root.getAttribute('data-has-content')).toBe('true')
+  })
+
+  it('refresh ボタンで再フェッチが走る', async () => {
+    const deps = createInMemoryDeps({})
+    render(<SavedTabsPage deps={deps} />)
+    const root = screen.getByTestId('saved-tabs-page-presentation')
+    await waitFor(() => {
+      expect(root.getAttribute('data-loading')).toBe('false')
+    })
+    await act(async () => {
+      await Promise.resolve()
+      screen.getByText('refresh').click()
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(root.getAttribute('data-loading')).toBe('false')
+    })
+  })
+
+  it('deps と useCases を両方渡すと、contextValue の deps / useCases 分岐を使う', async () => {
+    const deps = createInMemoryDeps({})
+    const useCases = createSavedTabsUseCases(deps)
+    render(<SavedTabsPage deps={deps} useCases={useCases} />)
+    const root = await screen.findByTestId('saved-tabs-page-presentation')
+    await waitFor(() => {
+      expect(root.getAttribute('data-loading')).toBe('false')
+    })
+  })
+
+  it('deps 省略時は例外を投げる', () => {
+    expect(() => render(<SavedTabsPage />)).toThrow(
+      /SavedTabsPage: deps is required/,
+    )
+  })
+
+  it('deps の repository が変わると refresh ハンドラが新しくなる', async () => {
+    const initialDeps = createInMemoryDeps({})
+    const { customProjectRepository, tabGroupRepository } = createInMemoryDeps(
+      {},
+    )
+    const nextDeps: SavedTabsUseCasesDeps = {
+      ...initialDeps,
+      customProjectRepository,
+      tabGroupRepository,
+    }
+    const { rerender } = render(<SavedTabsPage deps={initialDeps} />)
+    const initialRoot = await screen.findByTestId(
+      'saved-tabs-page-presentation',
+    )
+    await waitFor(() => {
+      expect(initialRoot.getAttribute('data-loading')).toBe('false')
+    })
+    rerender(<SavedTabsPage deps={nextDeps} />)
+    await waitFor(() => {
+      expect(
+        screen
+          .getByTestId('saved-tabs-page-presentation')
+          .getAttribute('data-loading'),
+      ).toBe('false')
+    })
+  })
+
+  it('hasInitialData が false → true に変わると ref 判定が更新される', async () => {
+    const deps = createInMemoryDeps({})
+    const initialTabGroups = [
+      createTabGroup({ domain: 'example.com', id: 'g1', urlIds: [] }),
+    ]
+    const { rerender } = render(<SavedTabsPage deps={deps} />)
+    const initialRoot = await screen.findByTestId(
+      'saved-tabs-page-presentation',
+    )
+    await waitFor(() => {
+      expect(initialRoot.getAttribute('data-loading')).toBe('false')
+    })
+    // initial data を渡して再レンダー → hasInitialData が false → true に遷移
+    rerender(<SavedTabsPage deps={deps} initialTabGroups={initialTabGroups} />)
+    const nextRoot = screen.getByTestId('saved-tabs-page-presentation')
+    expect(nextRoot.getAttribute('data-loading')).toBe('false')
+  })
+
+  it('refresh 失敗で error 状態になるとエラーメッセージが表示される', async () => {
+    const failingTabGroupRepository = {
+      // eslint-disable-next-line typescript/require-await
+      findAll: async () => {
+        throw new Error('refresh failed')
+      },
+      // eslint-disable-next-line typescript/require-await
+      findById: async () => null,
+      // eslint-disable-next-line typescript/require-await
+      removeByIds: async () => undefined,
+      // eslint-disable-next-line typescript/require-await
+      saveAll: async () => undefined,
+    } as unknown as Parameters<typeof createInMemoryDeps>[0] extends never
+      ? never
+      : ReturnType<typeof createInMemoryDeps>['tabGroupRepository']
+    const baseDeps = createInMemoryDeps({})
+    const deps = {
+      ...baseDeps,
+      tabGroupRepository: failingTabGroupRepository,
+    }
+    render(<SavedTabsPage deps={deps} />)
+    await waitFor(() => {
+      expect(
+        screen
+          .getByTestId('saved-tabs-page-presentation')
+          .getAttribute('data-loading'),
+      ).toBe('false')
+    })
+    expect(
+      screen
+        .getByTestId('saved-tabs-page-presentation')
+        .getAttribute('data-error'),
+    ).toBe('refresh failed')
+  })
+})

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useRef } from 'react'
+
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import type { SavedTabsUseCases } from '../../infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCasesDeps } from '../../infrastructure/composition/createSavedTabsUseCasesDeps'
+import { createSavedTabsUseCasesContextValueFromDeps } from '../controllers/SavedTabsUseCasesContext'
+import { useSavedTabsController } from '../controllers/useSavedTabsController'
+import type { SavedTabsViewModel } from '../view-models/SavedTabsViewModel'
+
+/**
+ * `SavedTabsPage` の props。
+ *
+ * - `deps` / `useCases` を渡すと composition 済みの use-case が使える。
+ *   未指定なら `createSavedTabsUseCasesContextValue()` を内部で生成する。
+ * - `initialTabGroups` / `initialCustomProjects` は SSR / Storybook 用に
+ *   事前データを渡す補助。テストで repository を差し替えずに view-model を
+ *   検証したいときに使う。
+ */
+export interface SavedTabsPageProps {
+  readonly deps?: SavedTabsUseCasesDeps
+  readonly useCases?: SavedTabsUseCases
+  readonly initialTabGroups?: readonly TabGroup[]
+  readonly initialCustomProjects?: readonly CustomProject[]
+}
+
+/**
+ * `SavedTabsPage` 内部の controller 状態。
+ *
+ * ページ → controller フック → use-case → repository / port の流れを
+ * 一度だけ確立し、その戻り値を layout へ流す。
+ */
+export interface SavedTabsPageState {
+  readonly viewModel: SavedTabsViewModel
+  readonly refresh: () => Promise<void>
+  readonly controller: ReturnType<typeof useSavedTabsController>
+}
+
+/**
+ * `SavedTabsPage` のロジック hook。
+ *
+ * `SavedTabsPage` コンポーネントから分離してテスト可能にしている。
+ * コンポーネント側は view-model と controller を layout へ流すだけ。
+ */
+export const useSavedTabsPage = (
+  input: SavedTabsPageProps,
+): SavedTabsPageState => {
+  if (!input.deps) {
+    throw new Error(
+      'SavedTabsPage: deps is required. Use createSavedTabsUseCasesContextValue() at the call site for chrome real environment.',
+    )
+  }
+  const deps: SavedTabsUseCasesDeps = input.deps
+  const contextValue = useMemo(
+    () =>
+      input.useCases
+        ? { deps, useCases: input.useCases }
+        : createSavedTabsUseCasesContextValueFromDeps(deps),
+    [deps, input.useCases],
+  )
+  const controller = useSavedTabsController({
+    deps: contextValue.deps,
+    initialCustomProjects: input.initialCustomProjects,
+    initialTabGroups: input.initialTabGroups,
+    useCases: contextValue.useCases,
+  })
+  const refreshRef = useRef(controller.refresh)
+  if (refreshRef.current !== controller.refresh) {
+    refreshRef.current = controller.refresh
+  }
+  const hasInitialData = Boolean(
+    input.initialTabGroups ?? input.initialCustomProjects,
+  )
+  const hasInitialDataRef = useRef(hasInitialData)
+  if (hasInitialDataRef.current !== hasInitialData) {
+    hasInitialDataRef.current = hasInitialData
+  }
+  useEffect(() => {
+    if (hasInitialDataRef.current) {
+      return
+    }
+    void refreshRef.current()
+    // refresh は deps.customProjectRepository / deps.tabGroupRepository が
+    // 変わったときだけ新しくなる。初回 mount 時に 1 回だけ走ればよいため、
+    // ここでは依存配列を空にして再実行を抑止する。
+    // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
+  }, [])
+  return {
+    controller,
+    refresh: controller.refresh,
+    viewModel: controller.viewModel,
+  }
+}
+
+/**
+ * `SavedTabsPage` コンポーネント。
+ *
+ * presentation 層 page の薄い shell。controller フックを呼んで
+ * view-model を取り出し、layout 系の子要素へ流す。
+ *
+ * 旧 `SavedTabsApp` の layout 互換は別 issue（またはこの issue の
+ * フォローアップ）で `SavedTabsPresentationLayout` を作って差し替える。
+ */
+export const SavedTabsPage = (props: SavedTabsPageProps) => {
+  const { viewModel, refresh } = useSavedTabsPage(props)
+  return (
+    <div
+      data-testid='saved-tabs-page-presentation'
+      data-loading={viewModel.loading ? 'true' : 'false'}
+      data-error={viewModel.error ?? ''}
+      data-has-content={viewModel.hasContent ? 'true' : 'false'}
+    >
+      <p data-testid='saved-tabs-page-display-count'>
+        {viewModel.displayCount}
+      </p>
+      {viewModel.loading ? (
+        <p data-testid='saved-tabs-page-loading'>loading</p>
+      ) : null}
+      {viewModel.error ? (
+        <p data-testid='saved-tabs-page-error'>{viewModel.error}</p>
+      ) : null}
+      <button
+        type='button'
+        // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
+        onClick={() => {
+          void refresh()
+        }}
+      >
+        refresh
+      </button>
+    </div>
+  )
+}

--- a/src/contexts/saved-tabs/presentation/routes/SavedTabsRoute.tsx
+++ b/src/contexts/saved-tabs/presentation/routes/SavedTabsRoute.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react'
+
+import type { ViewMode } from '@/types/storage'
+
+import { SavedTabsPage } from '../pages/SavedTabsPage'
+
+/**
+ * `SavedTabsRoute` の props。
+ *
+ * WXT の `src/entrypoints/saved-tabs/` から渡される初期表示モードと、
+ * ナビゲート時のコールバックを受ける。`onViewModeNavigate` は未指定でも
+ * URL を `window.history.replaceState` で更新する（既存仕様と同じ）。
+ */
+export interface SavedTabsRouteProps {
+  readonly initialViewMode?: ViewMode
+  readonly isAiSidebarOpen?: boolean
+  readonly onViewModeNavigate?: (mode: ViewMode) => void
+}
+
+/**
+ * `SavedTabsRoute` の内部 hook: `ViewMode` を URL と state で同期する。
+ *
+ * 旧 `SavedTabsRoute` の `syncSavedTabsViewModeLocation` を
+ * presentation 層へ移譲する形。ナビゲートコールバックが指定されていれば
+ * それを使う（React Router などへの対応）。
+ */
+const useViewModeSync = (
+  initialViewMode: ViewMode | undefined,
+  onViewModeNavigate: ((mode: ViewMode) => void) | undefined,
+) => {
+  const [viewMode, setViewMode] = useState<ViewMode>(
+    initialViewMode ?? 'domain',
+  )
+  useEffect(() => {
+    if (onViewModeNavigate) {
+      onViewModeNavigate(viewMode)
+      return
+    }
+    if (typeof window === 'undefined') {
+      return
+    }
+    const nextHref =
+      viewMode === 'custom' ? '/saved-tabs-custom' : '/saved-tabs-domain'
+    const currentUrl = new URL(window.location.href)
+    if (currentUrl.pathname === nextHref) {
+      return
+    }
+    window.history.replaceState({}, '', nextHref)
+  }, [onViewModeNavigate, viewMode])
+  return { setViewMode, viewMode }
+}
+
+/**
+ * `SavedTabsRoute` presentation 版。
+ *
+ * 旧 `src/features/saved-tabs/routes/SavedTabsRoute.tsx` の代替。
+ * ページ (`SavedTabsPage`) をマウントし、URL / state 同期を担う。
+ *
+ * 実機 UI に出す要素は本ファイルではなく、`SavedTabsPage` 配下の
+ * `SavedTabsPresentationLayout`（別 issue で導入）側に集約する。
+ */
+export const SavedTabsRoute = ({
+  initialViewMode,
+  isAiSidebarOpen,
+  onViewModeNavigate,
+}: SavedTabsRouteProps) => {
+  const { viewMode } = useViewModeSync(initialViewMode, onViewModeNavigate)
+  return (
+    <SavedTabsRouteShell
+      viewMode={viewMode}
+      isAiSidebarOpen={isAiSidebarOpen ?? false}
+    />
+  )
+}
+
+/**
+ * 表示確認用のシェルコンポーネント。`SavedTabsPage` の状態と
+ * 現在の viewMode を data 属性で公開する。
+ */
+const SavedTabsRouteShell = ({
+  viewMode,
+  isAiSidebarOpen,
+}: {
+  viewMode: ViewMode
+  isAiSidebarOpen: boolean
+}) => {
+  return (
+    <div
+      data-testid='saved-tabs-route-presentation'
+      data-view-mode={viewMode}
+      data-ai-sidebar-open={isAiSidebarOpen ? 'true' : 'false'}
+    >
+      <SavedTabsPage />
+    </div>
+  )
+}

--- a/src/contexts/saved-tabs/presentation/view-models/CustomProjectViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/CustomProjectViewModel.ts
@@ -1,0 +1,54 @@
+/**
+ * presentation 層で扱う `CustomProject` の view-model。
+ *
+ * domain `CustomProject` を UI 描画に必要な形に丸めた読み取り専用モデル。
+ * 既存の `CustomProjectCard` / `CustomProjectSection` が要求する形に揃え、
+ * コンポーネントへそのまま props として渡せることを目標にする。
+ */
+export interface CustomProjectViewModel {
+  readonly id: string
+  readonly name: string
+  readonly urlIds: readonly string[]
+  readonly urls: readonly {
+    readonly id: string
+    readonly url: string
+    readonly title: string
+    readonly category?: string
+  }[]
+  readonly categories: readonly string[]
+  readonly categoryOrder: readonly string[]
+  readonly displayUrlCount: number
+  readonly hasUrls: boolean
+  readonly updatedAt: number
+  readonly createdAt: number
+}
+
+/**
+ * domain `CustomProject` を view-model へ変換する純関数。
+ */
+export const toCustomProjectViewModel = (project: {
+  id: string
+  name: string
+  urlIds?: string[]
+  urls?: { id: string; url: string; title: string; category?: string }[]
+  categories: string[]
+  categoryOrder?: string[]
+  createdAt: number
+  updatedAt: number
+}): CustomProjectViewModel => {
+  const urlIds = project.urlIds ?? []
+  const urls = project.urls ?? []
+  const displayUrlCount = urls.length > 0 ? urls.length : urlIds.length
+  return {
+    categories: project.categories,
+    categoryOrder: project.categoryOrder ?? project.categories,
+    createdAt: project.createdAt,
+    displayUrlCount,
+    hasUrls: displayUrlCount > 0,
+    id: project.id,
+    name: project.name,
+    updatedAt: project.updatedAt,
+    urlIds,
+    urls,
+  }
+}

--- a/src/contexts/saved-tabs/presentation/view-models/SavedTabsViewModel.test.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/SavedTabsViewModel.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+
+import { toCustomProjectViewModel } from './CustomProjectViewModel'
+import {
+  createEmptySavedTabsViewModel,
+  createSavedTabsViewModel,
+} from './SavedTabsViewModel'
+import { toTabGroupViewModel } from './TabGroupViewModel'
+
+describe('SavedTabsViewModel', () => {
+  describe('createEmptySavedTabsViewModel', () => {
+    it('loading=true / 空配列 / error=null を返す', () => {
+      const vm = createEmptySavedTabsViewModel()
+      expect(vm.loading).toBe(true)
+      expect(vm.tabGroups).toStrictEqual([])
+      expect(vm.customProjects).toStrictEqual([])
+      expect(vm.error).toBeNull()
+      expect(vm.displayCount).toBe(0)
+      expect(vm.hasContent).toBe(false)
+    })
+  })
+
+  describe('createSavedTabsViewModel', () => {
+    it('tabGroups / customProjects の displayUrlCount を合算する', () => {
+      const tabGroups = [
+        toTabGroupViewModel({
+          domain: 'example.com',
+          id: 'g1',
+          urlIds: ['u1', 'u2', 'u3'],
+        }),
+        toTabGroupViewModel({
+          domain: 'news.example',
+          id: 'g2',
+          urlIds: [],
+          urls: [
+            { id: 'u4', title: 'a', url: 'https://news.example/a' },
+            { id: 'u5', title: 'b', url: 'https://news.example/b' },
+          ],
+        }),
+      ]
+      const customProjects = [
+        toCustomProjectViewModel({
+          categories: [],
+          createdAt: 1,
+          id: 'p1',
+          name: 'Reading',
+          updatedAt: 1,
+          urlIds: ['u9', 'u10'],
+        }),
+      ]
+      const vm = createSavedTabsViewModel({
+        customProjects,
+        error: null,
+        loading: false,
+        tabGroups,
+      })
+      expect(vm.displayCount).toBe(7)
+      expect(vm.hasContent).toBe(true)
+      expect(vm.loading).toBe(false)
+      expect(vm.error).toBeNull()
+    })
+
+    it('error が non-null なら hasContent は true になり得る', () => {
+      const vm = createSavedTabsViewModel({
+        customProjects: [],
+        error: 'something went wrong',
+        loading: false,
+        tabGroups: [],
+      })
+      expect(vm.error).toBe('something went wrong')
+      expect(vm.hasContent).toBe(false)
+      expect(vm.displayCount).toBe(0)
+    })
+  })
+})
+
+describe('TabGroupViewModel.toTabGroupViewModel', () => {
+  it('urlIds / urls / subCategories から displayUrlCount と subCategoryCount を導出する', () => {
+    const vm = toTabGroupViewModel({
+      domain: 'example.com',
+      id: 'g1',
+      subCategories: ['a', 'b', 'c'],
+      urlIds: ['u1', 'u2'],
+      urls: [
+        {
+          id: 'u1',
+          subCategory: 'a',
+          title: 'x',
+          url: 'https://example.com/x',
+        },
+        {
+          id: 'u2',
+          subCategory: 'b',
+          title: 'y',
+          url: 'https://example.com/y',
+        },
+      ],
+    })
+    expect(vm.displayUrlCount).toBe(2)
+    expect(vm.subCategoryCount).toBe(3)
+    expect(vm.hasUrls).toBe(true)
+  })
+
+  it('urls が無く urlIds のみでも displayUrlCount を返す', () => {
+    const vm = toTabGroupViewModel({
+      domain: 'example.com',
+      id: 'g1',
+      urlIds: ['u1', 'u2', 'u3'],
+    })
+    expect(vm.displayUrlCount).toBe(3)
+    expect(vm.hasUrls).toBe(true)
+  })
+
+  it('urls / urlIds が空なら hasUrls=false', () => {
+    const vm = toTabGroupViewModel({
+      domain: 'example.com',
+      id: 'g1',
+    })
+    expect(vm.displayUrlCount).toBe(0)
+    expect(vm.hasUrls).toBe(false)
+  })
+})
+
+describe('CustomProjectViewModel.toCustomProjectViewModel', () => {
+  it('urls / urlIds から displayUrlCount を導出する', () => {
+    const vm = toCustomProjectViewModel({
+      categories: ['news', 'work'],
+      categoryOrder: ['work', 'news'],
+      createdAt: 1,
+      id: 'p1',
+      name: 'Reading',
+      updatedAt: 2,
+      urlIds: ['u1', 'u2'],
+    })
+    expect(vm.displayUrlCount).toBe(2)
+    expect(vm.hasUrls).toBe(true)
+    expect(vm.categories).toStrictEqual(['news', 'work'])
+    expect(vm.categoryOrder).toStrictEqual(['work', 'news'])
+  })
+
+  it('urls の長さを優先して displayUrlCount を返す', () => {
+    const vm = toCustomProjectViewModel({
+      categories: [],
+      createdAt: 1,
+      id: 'p1',
+      name: 'Reading',
+      updatedAt: 1,
+      urlIds: ['u1', 'u2', 'u3'],
+      urls: [
+        { id: 'u1', title: 'a', url: 'https://example.com/a' },
+        { id: 'u2', title: 'b', url: 'https://example.com/b' },
+      ],
+    })
+    expect(vm.displayUrlCount).toBe(2)
+  })
+
+  it('categoryOrder 未指定なら categories をそのまま使う', () => {
+    const vm = toCustomProjectViewModel({
+      categories: ['news'],
+      createdAt: 1,
+      id: 'p1',
+      name: 'Reading',
+      updatedAt: 2,
+    })
+    expect(vm.categoryOrder).toStrictEqual(['news'])
+  })
+})

--- a/src/contexts/saved-tabs/presentation/view-models/SavedTabsViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/SavedTabsViewModel.ts
@@ -1,0 +1,66 @@
+import type { CustomProjectViewModel } from './CustomProjectViewModel'
+import type { TabGroupViewModel } from './TabGroupViewModel'
+
+/**
+ * presentation 層で扱う SavedTabsPage 全体の view-model。
+ *
+ * controller hook (`useSavedTabsController`) が use-case 実行結果と
+ * 読み込み状態を組み合わせ、`SavedTabsPage` へそのまま渡す。
+ *
+ * UI コンポーネントは view-model だけを描画し、use-case の戻り値型や
+ * domain entity を直接参照しない。これにより presentation 層が
+ * application 層 interface 変更に振り回されにくくなる。
+ */
+export interface SavedTabsViewModel {
+  readonly loading: boolean
+  readonly error: string | null
+  readonly tabGroups: readonly TabGroupViewModel[]
+  readonly customProjects: readonly CustomProjectViewModel[]
+  readonly displayCount: number
+  readonly hasContent: boolean
+}
+
+/**
+ * 空の view-model を返す factory。loading 初期状態や error 時に使う。
+ */
+export const createEmptySavedTabsViewModel = (): SavedTabsViewModel => ({
+  customProjects: [],
+  displayCount: 0,
+  error: null,
+  hasContent: false,
+  loading: true,
+  tabGroups: [],
+})
+
+/**
+ * 任意の `tabGroups` / `customProjects` から view-model を構築する。
+ *
+ * 純粋関数として切り出すことで、controller hook の責務は
+ * 「repository / use-case を呼び、結果をこの関数へ流す」だけになる。
+ */
+export const createSavedTabsViewModel = ({
+  loading,
+  error,
+  tabGroups,
+  customProjects,
+}: {
+  loading: boolean
+  error: string | null
+  tabGroups: readonly TabGroupViewModel[]
+  customProjects: readonly CustomProjectViewModel[]
+}): SavedTabsViewModel => {
+  const displayCount =
+    tabGroups.reduce((total, group) => total + group.displayUrlCount, 0) +
+    customProjects.reduce(
+      (total, project) => total + project.displayUrlCount,
+      0,
+    )
+  return {
+    customProjects,
+    displayCount,
+    error,
+    hasContent: tabGroups.length > 0 || customProjects.length > 0,
+    loading,
+    tabGroups,
+  }
+}

--- a/src/contexts/saved-tabs/presentation/view-models/TabGroupViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/TabGroupViewModel.ts
@@ -1,0 +1,59 @@
+/**
+ * presentation 層で扱う `TabGroup` の view-model。
+ *
+ * domain `TabGroup` entity を UI 描画に必要な形に丸めた読み取り専用モデル。
+ * 既存の `src/features/saved-tabs/components/*` が要求する形と互換に保ち、
+ * コンポーネントへそのまま props として渡せることを目標にする。
+ *
+ * - `id` / `domain` / `urls` / `urlIds` は domain `TabGroup` と同じ意味。
+ * - `parentCategoryId` は未分類時に `undefined`。
+ * - `displayUrlCount` は 0 のとき空カード／非表示判定に利用する。
+ * - `subCategoryCount` は CategoryModal / CategoryGroup で「カテゴリ N 件」を
+ *   表示するための派生値。
+ */
+export interface TabGroupViewModel {
+  readonly id: string
+  readonly domain: string
+  readonly parentCategoryId: string | undefined
+  readonly urlIds: readonly string[]
+  readonly urls: readonly {
+    readonly id: string
+    readonly url: string
+    readonly title: string
+    readonly subCategory?: string
+  }[]
+  readonly displayUrlCount: number
+  readonly subCategoryCount: number
+  readonly hasUrls: boolean
+}
+
+/**
+ * domain `TabGroup` を view-model へ変換する純関数。
+ *
+ * presentation 層に閉じ、application 層では呼び出さない。
+ * repository / use-case が返した entity 配列を `SavedTabsController` が
+ * まとめてこの関数に通し、コンポーネントへ渡す。
+ */
+export const toTabGroupViewModel = (group: {
+  id: string
+  domain: string
+  parentCategoryId?: string
+  urlIds?: string[]
+  urls?: { id: string; url: string; title: string; subCategory?: string }[]
+  subCategories?: string[]
+}): TabGroupViewModel => {
+  const urlIds = group.urlIds ?? []
+  const urls = group.urls ?? []
+  const subCategories = group.subCategories ?? []
+  const displayUrlCount = urls.length > 0 ? urls.length : urlIds.length
+  return {
+    displayUrlCount,
+    domain: group.domain,
+    hasUrls: displayUrlCount > 0,
+    id: group.id,
+    parentCategoryId: group.parentCategoryId,
+    subCategoryCount: subCategories.length,
+    urlIds,
+    urls,
+  }
+}


### PR DESCRIPTION
- infrastructure/browser: ChromeBrowserTabAdapter / SonnerNotificationAdapter を追加し application 層の BrowserTabPort / NotificationPort interface へ適合
- infrastructure/composition: createSavedTabsUseCasesDeps / createSavedTabsUseCases を 追加し、repository interface と port を use-case へ注入する composition root を確立
- presentation/view-models: SavedTabsViewModel / TabGroupViewModel / CustomProjectViewModel を追加し、domain entity を UI 整形済みモデルへ変換
- presentation/controllers: useSavedTabsController を追加し、openSavedUrl / deleteTabGroup / restoreOpenedUrlsSnapshot / syncCategoryAssignments / removeUnreferencedUrlRecords の 5 use-case を呼び出す controller hook を実装 SavedTabsUseCasesContext / createSavedTabsUseCasesContextValue で use-case / deps の context 配布も対応
- presentation/pages: SavedTabsPage を追加し、controller + view-model を presentation 層の entry point として公開
- presentation/routes: SavedTabsRoute を追加し、ViewMode 同期付きの 新 presentation ルートを提供
- dddLayerGuard: presentation controller / view-model / page / infrastructure browser adapter / composition ファイルの存在と chrome.* / localStorage / sessionStorage を使わないことを 回帰テストで担保

検証: bun run format / lint / compile / test (1704 passed) / test:coverage 通過 新規追加 17 ファイル全て 100% coverage 達成

## 変更内容

<!-- 変更の詳細を記述してください -->

## チェックリスト

- [ ] ローカル環境でエラーになっていない
