### PR TITLE
feat(#469): saved-tabs の app-level composition root を追加して use-case を組み立てる

### DIFF
--- a/src/app/composition/createSavedTabsPorts.test.ts
+++ b/src/app/composition/createSavedTabsPorts.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createSavedTabsPorts } from './createSavedTabsPorts'
+
+const setChromeApi = (api: unknown) => {
+  ;(globalThis as { chrome?: unknown }).chrome = api
+}
+
+const restoreChromeApi = () => {
+  delete (globalThis as { chrome?: unknown }).chrome
+}
+
+describe('createSavedTabsPorts (app/composition)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    restoreChromeApi()
+  })
+
+  afterEach(() => {
+    restoreChromeApi()
+  })
+
+  describe('chrome.tabs が利用可能な環境', () => {
+    it('browserTabPort.open が chrome.tabs.create を呼び結果の url を返す', async () => {
+      // eslint-disable-next-line typescript/require-await -- mock 用に同期的な async を意図
+      const create = vi.fn(async ({ url }: { url: string }) => ({ url }))
+      setChromeApi({ tabs: { create } })
+
+      const { browserTabPort } = createSavedTabsPorts()
+      const result = await browserTabPort.open({ url: 'https://example.com' })
+
+      expect(create).toHaveBeenCalledTimes(1)
+      expect(create).toHaveBeenCalledWith({
+        active: true,
+        url: 'https://example.com',
+      })
+      expect(result).toStrictEqual({ url: 'https://example.com' })
+    })
+
+    it('chrome.tabs.create の戻り値に url が無い場合は引数の url をそのまま返す', async () => {
+      // eslint-disable-next-line typescript/require-await -- mock 用に同期的な async を意図
+      const create = vi.fn(async () => undefined)
+      setChromeApi({ tabs: { create } })
+
+      const { browserTabPort } = createSavedTabsPorts()
+      const result = await browserTabPort.open({ url: 'https://example.com' })
+
+      expect(result).toStrictEqual({ url: 'https://example.com' })
+    })
+  })
+
+  describe('chrome.tabs が利用できない環境', () => {
+    it('browserTabPort.open が Error を投げる', async () => {
+      setChromeApi({})
+
+      const { browserTabPort } = createSavedTabsPorts()
+      await expect(
+        browserTabPort.open({ url: 'https://example.com' }),
+      ).rejects.toThrow('chrome.tabs.create is not available')
+    })
+
+    it('chrome 自体が未定義の環境でも browserTabPort.open が Error を投げる', async () => {
+      const { browserTabPort } = createSavedTabsPorts()
+      await expect(
+        browserTabPort.open({ url: 'https://example.com' }),
+      ).rejects.toThrow('chrome.tabs.create is not available')
+    })
+  })
+
+  describe('notificationPort', () => {
+    it('info / success / error が関数として公開される', () => {
+      const { notificationPort } = createSavedTabsPorts()
+      expect(notificationPort.info).toBeTypeOf('function')
+      expect(notificationPort.success).toBeTypeOf('function')
+      expect(notificationPort.error).toBeTypeOf('function')
+    })
+
+    it('action 無しで info を呼んでも例外を投げない', () => {
+      const { notificationPort } = createSavedTabsPorts()
+      expect(() => notificationPort.info({ message: 'hello' })).not.toThrow()
+    })
+  })
+})

--- a/src/app/composition/createSavedTabsPorts.ts
+++ b/src/app/composition/createSavedTabsPorts.ts
@@ -1,0 +1,51 @@
+import type { BrowserTabPort } from '@/contexts/saved-tabs/application/ports/BrowserTabPort'
+import type { NotificationPort } from '@/contexts/saved-tabs/application/ports/NotificationPort'
+import { createChromeBrowserTabAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter'
+import type { ChromeApiLike } from '@/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter'
+import { createSonnerNotificationAdapter } from '@/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter'
+
+/**
+ * `src/app/composition/` レベルで組み立てる、saved-tabs 用
+ * `Port` 実装のバンドル。
+ *
+ * `BrowserTabPort` は `chrome.tabs` をラップした `ChromeBrowserTabAdapter`、
+ * `NotificationPort` は `sonner` の `toast` をラップした
+ * `SonnerNotificationAdapter` で実装する。`application/ports/` の
+ * interface を満たすため、use-case 側からは adapter の詳細を隠せる。
+ */
+export interface SavedTabsPorts {
+  readonly browserTabPort: BrowserTabPort
+  readonly notificationPort: NotificationPort
+}
+
+interface ChromeApi extends ChromeApiLike {
+  readonly tabs?: ChromeApiLike['tabs'] & {
+    readonly create?: NonNullable<NonNullable<ChromeApiLike['tabs']>['create']>
+  }
+}
+
+const getChromeApi = (): ChromeApi | undefined =>
+  (globalThis as typeof globalThis & { chrome?: ChromeApi }).chrome
+
+/**
+ * saved-tabs 用 port 実装を生成する。
+ *
+ * `chrome` グローバルが利用できない環境（Storybook / SSR など）では
+ * `BrowserTabPort.open` を呼び出した瞬間に `Error` が投げられる。
+ * `NotificationPort` は `sonner.toast` が無い場合に
+ * `console.warn` / `console.error` にフォールバックするため、通知で
+ * use-case 全体を落とさない。
+ *
+ * @example
+ * ```ts
+ * const ports = createSavedTabsPorts()
+ * const opened = await ports.browserTabPort.open({ url: 'https://example.com' })
+ * ports.notificationPort.info({ message: '開きました' })
+ * ```
+ */
+export const createSavedTabsPorts = (): SavedTabsPorts => ({
+  browserTabPort: createChromeBrowserTabAdapter({
+    getApi: () => getChromeApi(),
+  }),
+  notificationPort: createSonnerNotificationAdapter(),
+})

--- a/src/app/composition/createSavedTabsRepositories.test.ts
+++ b/src/app/composition/createSavedTabsRepositories.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChromeStorageLocalPort } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUrlRecordRepository'
+import { SavedTabsRepositoryUnavailableError } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUrlRecordRepository'
+import * as chromeStorageModule from '@/lib/browser/chrome-storage'
+
+import { createSavedTabsRepositories } from './createSavedTabsRepositories'
+
+vi.mock('@/lib/browser/chrome-storage', async () => {
+  const actual = await vi.importActual<typeof chromeStorageModule>(
+    '@/lib/browser/chrome-storage',
+  )
+  return {
+    ...actual,
+    getChromeStorageLocal: vi.fn(),
+  }
+})
+
+const getChromeStorageLocal = chromeStorageModule.getChromeStorageLocal
+
+type StorageState = Record<string, unknown>
+
+const createPort = (state: StorageState): ChromeStorageLocalPort => {
+  /* eslint-disable typescript/require-await */
+  return {
+    get: vi.fn((key: string) => Promise.resolve({ [key]: state[key] })),
+    remove: vi.fn((key: string) => {
+      // dynamic key 削除は storage エミュレーション上不可避免
+      // eslint-disable-next-line typescript/no-dynamic-delete
+      delete state[key]
+      return Promise.resolve()
+    }),
+    set: vi.fn((value: Record<string, unknown>) => {
+      Object.assign(state, value)
+      return Promise.resolve()
+    }),
+  }
+  /* eslint-enable typescript/require-await */
+}
+
+const buildChromeStorageLocal = (state: StorageState) =>
+  ({
+    get: (key: string) => Promise.resolve({ [key]: state[key] }),
+    remove: (key: string) => {
+      // eslint-disable-next-line typescript/no-dynamic-delete
+      delete state[key]
+      return Promise.resolve()
+    },
+    set: (value: Record<string, unknown>) => {
+      Object.assign(state, value)
+      return Promise.resolve()
+    },
+    // eslint-disable-next-line typescript/no-explicit-any
+  }) as any
+
+describe('createSavedTabsRepositories (app/composition)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('chrome.storage.local が利用可能な環境', () => {
+    it('4 つの repository interface を返し、それぞれが 4 関数を持つ', () => {
+      const state: StorageState = {}
+      vi.mocked(getChromeStorageLocal).mockReturnValue(
+        buildChromeStorageLocal(state),
+      )
+
+      const repositories = createSavedTabsRepositories()
+
+      expect(repositories.tabGroupRepository.findAll).toBeTypeOf('function')
+      expect(repositories.tabGroupRepository.findById).toBeTypeOf('function')
+      expect(repositories.tabGroupRepository.saveAll).toBeTypeOf('function')
+      expect(repositories.tabGroupRepository.removeByIds).toBeTypeOf('function')
+
+      expect(repositories.urlRecordRepository.findAll).toBeTypeOf('function')
+      expect(repositories.urlRecordRepository.findById).toBeTypeOf('function')
+      expect(repositories.urlRecordRepository.saveAll).toBeTypeOf('function')
+      expect(repositories.urlRecordRepository.removeByIds).toBeTypeOf(
+        'function',
+      )
+
+      expect(repositories.parentCategoryRepository.findAll).toBeTypeOf(
+        'function',
+      )
+      expect(repositories.parentCategoryRepository.findById).toBeTypeOf(
+        'function',
+      )
+      expect(repositories.parentCategoryRepository.saveAll).toBeTypeOf(
+        'function',
+      )
+      expect(repositories.parentCategoryRepository.removeByIds).toBeTypeOf(
+        'function',
+      )
+
+      expect(repositories.customProjectRepository.findAll).toBeTypeOf(
+        'function',
+      )
+      expect(repositories.customProjectRepository.findById).toBeTypeOf(
+        'function',
+      )
+      expect(repositories.customProjectRepository.saveAll).toBeTypeOf(
+        'function',
+      )
+      expect(repositories.customProjectRepository.removeByIds).toBeTypeOf(
+        'function',
+      )
+    })
+
+    it('findAll / saveAll を通じて chrome.storage.local の get / set を使う', async () => {
+      const state: StorageState = {
+        'tabbin:savedTabs': [],
+        'tabbin:urls': [],
+        'tabbin:parentCategories': [],
+        'tabbin:customProjects': [],
+      }
+      const port = createPort(state)
+      vi.mocked(getChromeStorageLocal).mockReturnValue({
+        get: port.get,
+        remove: port.remove,
+        set: port.set,
+        // eslint-disable-next-line typescript/no-explicit-any
+      } as any)
+
+      const repositories = createSavedTabsRepositories()
+
+      await Promise.all([
+        repositories.tabGroupRepository.findAll(),
+        repositories.urlRecordRepository.findAll(),
+        repositories.parentCategoryRepository.findAll(),
+        repositories.customProjectRepository.findAll(),
+      ])
+      await repositories.tabGroupRepository.saveAll([])
+
+      expect(port.get).toHaveBeenCalled()
+      expect(port.set).toHaveBeenCalled()
+    })
+  })
+
+  describe('chrome.storage.local が利用できない環境', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+      vi.mocked(getChromeStorageLocal).mockReturnValue(null)
+    })
+
+    afterEach(() => {
+      warnSpy.mockRestore()
+    })
+
+    it('createSavedTabsRepositories 呼び出しが SavedTabsRepositoryUnavailableError を投げる (eager 検出)', () => {
+      expect(() => createSavedTabsRepositories()).toThrow(
+        SavedTabsRepositoryUnavailableError,
+      )
+    })
+  })
+})

--- a/src/app/composition/createSavedTabsRepositories.ts
+++ b/src/app/composition/createSavedTabsRepositories.ts
@@ -1,0 +1,66 @@
+import type { CustomProjectRepository } from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
+import type { ParentCategoryRepository } from '@/contexts/saved-tabs/domain/repositories/ParentCategoryRepository'
+import type { TabGroupRepository } from '@/contexts/saved-tabs/domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '@/contexts/saved-tabs/domain/repositories/UrlRecordRepository'
+import { createChromeCustomProjectRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository'
+import { createChromeParentCategoryRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeParentCategoryRepository'
+import { createChromeTabGroupRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository'
+import type { ChromeStorageLocalPort } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUrlRecordRepository'
+import { createChromeUrlRecordRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUrlRecordRepository'
+import { getChromeStorageLocal } from '@/lib/browser/chrome-storage'
+
+/**
+ * `src/app/composition/` レベルで組み立てる、saved-tabs 用
+ * `Repository` 実装のバンドル。
+ *
+ * 各 `Chrome*Repository` は `domain/repositories/` の interface だけを
+ * 公開し、保存先は `chrome.storage.local` に閉じる。`chrome.storage.local`
+ * が利用できない環境で repository 関数を呼び出すと
+ * `SavedTabsRepositoryUnavailableError` が投げられる。
+ */
+export interface SavedTabsRepositories {
+  readonly tabGroupRepository: TabGroupRepository
+  readonly urlRecordRepository: UrlRecordRepository
+  readonly parentCategoryRepository: ParentCategoryRepository
+  readonly customProjectRepository: CustomProjectRepository
+}
+
+const createChromeStorageLocalPort = (): ChromeStorageLocalPort | null => {
+  const local = getChromeStorageLocal()
+  if (!local) {
+    return null
+  }
+  return {
+    get: (key) => local.get(key),
+    remove: (key) => local.remove(key),
+    set: (value) => local.set(value),
+  }
+}
+
+/**
+ * `chrome.storage.local` ベースの saved-tabs 用 repository 群を生成する。
+ *
+ * chrome.storage.local を 1 度だけ取得して 4 つの repository へ共有するため、
+ * repository ごとの `getChromeStorageLocal()` 呼び出しと差異が出ない範囲で
+ * 少しだけ効率的になっている。
+ *
+ * `chrome.storage.local` が無い環境（Storybook / テストなど chrome 不在）で
+ * 呼び出された場合、各 repository 関数は
+ * `SavedTabsRepositoryUnavailableError` を投げる。presentation 層は
+ * loading 状態や初期化エラーとしてこれをハンドルする想定。
+ *
+ * @example
+ * ```ts
+ * const repositories = createSavedTabsRepositories()
+ * const groups = await repositories.tabGroupRepository.findAll()
+ * ```
+ */
+export const createSavedTabsRepositories = (): SavedTabsRepositories => {
+  const port = createChromeStorageLocalPort()
+  return {
+    customProjectRepository: createChromeCustomProjectRepository(port),
+    parentCategoryRepository: createChromeParentCategoryRepository(port),
+    tabGroupRepository: createChromeTabGroupRepository(port),
+    urlRecordRepository: createChromeUrlRecordRepository(port),
+  }
+}

--- a/src/app/composition/createSavedTabsUseCases.test.ts
+++ b/src/app/composition/createSavedTabsUseCases.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import * as chromeStorageModule from '@/lib/browser/chrome-storage'
+
+import { createSavedTabsUseCases } from './createSavedTabsUseCases'
+
+vi.mock('@/lib/browser/chrome-storage', async () => {
+  const actual = await vi.importActual<typeof chromeStorageModule>(
+    '@/lib/browser/chrome-storage',
+  )
+  return {
+    ...actual,
+    getChromeStorageLocal: vi.fn(),
+  }
+})
+
+const getChromeStorageLocal = chromeStorageModule.getChromeStorageLocal
+
+const setChromeApi = (api: unknown) => {
+  ;(globalThis as { chrome?: unknown }).chrome = api
+}
+
+const restoreChromeApi = () => {
+  delete (globalThis as { chrome?: unknown }).chrome
+}
+
+const buildChromeStorageLocal = (state: Record<string, unknown>) =>
+  ({
+    get: (key: string) => Promise.resolve({ [key]: state[key] }),
+    remove: (key: string) => {
+      // eslint-disable-next-line typescript/no-dynamic-delete
+      delete state[key]
+      return Promise.resolve()
+    },
+    set: (value: Record<string, unknown>) => {
+      Object.assign(state, value)
+      return Promise.resolve()
+    },
+    // eslint-disable-next-line typescript/no-explicit-any
+  }) as any
+
+describe('createSavedTabsUseCases (app/composition)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    restoreChromeApi()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    restoreChromeApi()
+  })
+
+  it('5 つの use-case 関数を持つバンドルを返す', () => {
+    vi.mocked(getChromeStorageLocal).mockReturnValue(
+      buildChromeStorageLocal({}),
+    )
+    setChromeApi({
+      // eslint-disable-next-line typescript/require-await -- mock 用に同期的な async を意図
+      tabs: { create: vi.fn(async () => ({ url: 'https://example.com' })) },
+    })
+
+    const useCases = createSavedTabsUseCases()
+
+    expect(useCases.openSavedUrl).toBeTypeOf('function')
+    expect(useCases.deleteTabGroup).toBeTypeOf('function')
+    expect(useCases.restoreOpenedUrlsSnapshot).toBeTypeOf('function')
+    expect(useCases.syncCategoryAssignments).toBeTypeOf('function')
+    expect(useCases.removeUnreferencedUrlRecords).toBeTypeOf('function')
+  })
+
+  it('removeUnreferencedUrlRecords のような副作用無しの use-case は何もせずに正常終了する', async () => {
+    const state: Record<string, unknown> = {
+      'tabbin:savedTabs': [],
+      'tabbin:urls': [],
+      'tabbin:parentCategories': [],
+      'tabbin:customProjects': [],
+    }
+    vi.mocked(getChromeStorageLocal).mockReturnValue(
+      buildChromeStorageLocal(state),
+    )
+    setChromeApi({
+      // eslint-disable-next-line typescript/require-await -- mock 用に同期的な async を意図
+      tabs: { create: vi.fn(async () => ({ url: 'https://example.com' })) },
+    })
+
+    const useCases = createSavedTabsUseCases()
+    const result = await useCases.removeUnreferencedUrlRecords()
+
+    expect(result).toStrictEqual({ removedCount: 0, removedUrlRecordIds: [] })
+  })
+
+  it('chrome.storage.local 不在環境でバンドル生成が chrome.storage.local 由来のエラーを投げる (eager 検出)', () => {
+    vi.mocked(getChromeStorageLocal).mockReturnValue(null)
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined)
+    setChromeApi({})
+
+    try {
+      expect(() => createSavedTabsUseCases()).toThrow(/chrome\.storage\.local/)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+})

--- a/src/app/composition/createSavedTabsUseCases.ts
+++ b/src/app/composition/createSavedTabsUseCases.ts
@@ -1,0 +1,59 @@
+import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/SavedTabsUseCases'
+import { createDeleteTabGroupUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteTabGroupUseCase'
+import { createOpenSavedUrlUseCase } from '@/contexts/saved-tabs/application/use-cases/OpenSavedUrlUseCase'
+import { createRemoveUnreferencedUrlRecordsUseCase } from '@/contexts/saved-tabs/application/use-cases/RemoveUnreferencedUrlRecordsUseCase'
+import { createRestoreOpenedUrlsSnapshotUseCase } from '@/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase'
+import { createSyncCategoryAssignmentsUseCase } from '@/contexts/saved-tabs/application/use-cases/SyncCategoryAssignmentsUseCase'
+
+import { createSavedTabsPorts } from './createSavedTabsPorts'
+import { createSavedTabsRepositories } from './createSavedTabsRepositories'
+
+/**
+ * `src/app/composition/` レベルの composition root。
+ *
+ * `chrome.storage.local` ベースの repository 実装と
+ * `chrome.tabs` / `sonner` ベースの port 実装を 1 度だけ組み立て、
+ * そこから `saved-tabs` の優先 use-case 5 種を生成して返す。
+ *
+ * この関数以降、UI / hook / テストは
+ * `chrome.*` API を直接触れず、use-case だけを呼び出す形になる。
+ *
+ * @example
+ * ```ts
+ * const useCases = createSavedTabsUseCases()
+ * await useCases.openSavedUrl({ urlRecordId, origin: 'click', settings })
+ * ```
+ */
+export const createSavedTabsUseCases = (): SavedTabsUseCases => {
+  const repositories = createSavedTabsRepositories()
+  const ports = createSavedTabsPorts()
+
+  return {
+    deleteTabGroup: createDeleteTabGroupUseCase({
+      customProjectRepository: repositories.customProjectRepository,
+      tabGroupRepository: repositories.tabGroupRepository,
+      urlRecordRepository: repositories.urlRecordRepository,
+    }),
+    openSavedUrl: createOpenSavedUrlUseCase({
+      browserTabPort: ports.browserTabPort,
+      customProjectRepository: repositories.customProjectRepository,
+      tabGroupRepository: repositories.tabGroupRepository,
+      urlRecordRepository: repositories.urlRecordRepository,
+    }),
+    removeUnreferencedUrlRecords: createRemoveUnreferencedUrlRecordsUseCase({
+      customProjectRepository: repositories.customProjectRepository,
+      tabGroupRepository: repositories.tabGroupRepository,
+      urlRecordRepository: repositories.urlRecordRepository,
+    }),
+    restoreOpenedUrlsSnapshot: createRestoreOpenedUrlsSnapshotUseCase({
+      customProjectRepository: repositories.customProjectRepository,
+      parentCategoryRepository: repositories.parentCategoryRepository,
+      tabGroupRepository: repositories.tabGroupRepository,
+      urlRecordRepository: repositories.urlRecordRepository,
+    }),
+    syncCategoryAssignments: createSyncCategoryAssignmentsUseCase({
+      parentCategoryRepository: repositories.parentCategoryRepository,
+      tabGroupRepository: repositories.tabGroupRepository,
+    }),
+  }
+}

--- a/src/contexts/saved-tabs/application/SavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/application/SavedTabsUseCases.ts
@@ -1,0 +1,32 @@
+import type { DeleteTabGroupUseCase } from './use-cases/DeleteTabGroupUseCase'
+import type { OpenSavedUrlUseCase } from './use-cases/OpenSavedUrlUseCase'
+import type { RemoveUnreferencedUrlRecordsUseCase } from './use-cases/RemoveUnreferencedUrlRecordsUseCase'
+import type { RestoreOpenedUrlsSnapshotUseCase } from './use-cases/RestoreOpenedUrlsSnapshotUseCase'
+import type { SyncCategoryAssignmentsUseCase } from './use-cases/SyncCategoryAssignmentsUseCase'
+
+/**
+ * `saved-tabs` の優先 use-case を 1 つに束ねたバンドル interface。
+ *
+ * presentation / composition 層はこの interface 越しに use-case を受け取り、
+ * UI からは個別関数を呼び出す。`domain` 層・`application` 層には
+ * React / chrome.* / storage への直接依存を持ち込まない方針のため、
+ * この interface も pure な関数シグネチャだけを公開する。
+ *
+ * バンドル化することで:
+ * - composition root からの取得窓口を 1 つに絞り、
+ *   個別 use-case を presentation 各所から個別 import する散らかりを防ぐ。
+ * - presentation hook の dependency array に use-case オブジェクトを 1 個
+ *   渡せば済む形にして、テスト時の差し替えを簡単にする。
+ * - 新しい use-case を追加するときに presentation 側の import 修正を
+ *   最小化（必要なら interface に追加するだけ）する。
+ *
+ * 実装は `src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts`
+ * および `src/app/composition/createSavedTabsUseCases.ts` が提供する。
+ */
+export interface SavedTabsUseCases {
+  readonly openSavedUrl: OpenSavedUrlUseCase
+  readonly deleteTabGroup: DeleteTabGroupUseCase
+  readonly restoreOpenedUrlsSnapshot: RestoreOpenedUrlsSnapshotUseCase
+  readonly syncCategoryAssignments: SyncCategoryAssignmentsUseCase
+  readonly removeUnreferencedUrlRecords: RemoveUnreferencedUrlRecordsUseCase
+}

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -364,4 +364,109 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       })
     }
   })
+
+  describe('issue #469: app-level composition root が追加されている', () => {
+    const appCompositionFiles = [
+      'src/app/composition/createSavedTabsRepositories.ts',
+      'src/app/composition/createSavedTabsPorts.ts',
+      'src/app/composition/createSavedTabsUseCases.ts',
+    ]
+
+    for (const file of appCompositionFiles) {
+      it(`${file} が存在する`, () => {
+        const source = readFileSync(resolve(repoRoot, file), 'utf8')
+        expect(source.length).toBeGreaterThan(0)
+      })
+    }
+
+    it('createSavedTabsRepositories は 4 つの Chrome*Repository を組み立てる', () => {
+      const source = readFileSync(
+        resolve(repoRoot, 'src/app/composition/createSavedTabsRepositories.ts'),
+        'utf8',
+      )
+      expect(source).toContain('createChromeTabGroupRepository')
+      expect(source).toContain('createChromeUrlRecordRepository')
+      expect(source).toContain('createChromeParentCategoryRepository')
+      expect(source).toContain('createChromeCustomProjectRepository')
+    })
+
+    it('createSavedTabsPorts は ChromeBrowserTabAdapter / SonnerNotificationAdapter を組み立てる', () => {
+      const source = readFileSync(
+        resolve(repoRoot, 'src/app/composition/createSavedTabsPorts.ts'),
+        'utf8',
+      )
+      expect(source).toContain('createChromeBrowserTabAdapter')
+      expect(source).toContain('createSonnerNotificationAdapter')
+    })
+
+    it('createSavedTabsUseCases は 5 つの use-case を返す', () => {
+      const source = readFileSync(
+        resolve(repoRoot, 'src/app/composition/createSavedTabsUseCases.ts'),
+        'utf8',
+      )
+      expect(source).toContain('createOpenSavedUrlUseCase')
+      expect(source).toContain('createDeleteTabGroupUseCase')
+      expect(source).toContain('createRestoreOpenedUrlsSnapshotUseCase')
+      expect(source).toContain('createSyncCategoryAssignmentsUseCase')
+      expect(source).toContain('createRemoveUnreferencedUrlRecordsUseCase')
+    })
+
+    it('app/composition 配下は React / @/components / @/features/*/components を import しない', () => {
+      for (const file of appCompositionFiles) {
+        const source = readFileSync(resolve(repoRoot, file), 'utf8')
+        expect(source, `${file} should not import react`).not.toMatch(
+          /from\s+['"]react['"]/,
+        )
+        expect(source, `${file} should not import @/components`).not.toMatch(
+          /from\s+['"]@\/components/,
+        )
+        expect(
+          source,
+          `${file} should not import @/features/*/components`,
+        ).not.toMatch(/from\s+['"]@\/features\/[^/]+\/components/)
+      }
+    })
+  })
+
+  describe('issue #469: application 層に SavedTabsUseCases 型が追加されている', () => {
+    it('application/SavedTabsUseCases.ts が存在する', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/SavedTabsUseCases.ts',
+        ),
+        'utf8',
+      )
+      expect(source.length).toBeGreaterThan(0)
+    })
+
+    it('application/SavedTabsUseCases.ts は 5 つの use-case プロパティを export する', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/SavedTabsUseCases.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toMatch(/openSavedUrl/)
+      expect(source).toMatch(/deleteTabGroup/)
+      expect(source).toMatch(/restoreOpenedUrlsSnapshot/)
+      expect(source).toMatch(/syncCategoryAssignments/)
+      expect(source).toMatch(/removeUnreferencedUrlRecords/)
+    })
+
+    it('application/SavedTabsUseCases.ts は React / chrome.* / 永続化 API を import しない', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/SavedTabsUseCases.ts',
+        ),
+        'utf8',
+      )
+      expect(source).not.toMatch(/from\s+['"]react['"]/)
+      expect(source).not.toMatch(/from\s+['"]chrome['"]/)
+      expect(source).not.toMatch(/from\s+['"]sonner['"]/)
+      expect(source).not.toMatch(/chrome\.storage\./)
+    })
+  })
 })

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts
@@ -1,30 +1,22 @@
+import type { SavedTabsUseCases } from '../../application/SavedTabsUseCases'
 import { createDeleteTabGroupUseCase } from '../../application/use-cases/DeleteTabGroupUseCase'
-import type { DeleteTabGroupUseCase } from '../../application/use-cases/DeleteTabGroupUseCase'
 import { createOpenSavedUrlUseCase } from '../../application/use-cases/OpenSavedUrlUseCase'
-import type { OpenSavedUrlUseCase } from '../../application/use-cases/OpenSavedUrlUseCase'
 import { createRemoveUnreferencedUrlRecordsUseCase } from '../../application/use-cases/RemoveUnreferencedUrlRecordsUseCase'
-import type { RemoveUnreferencedUrlRecordsUseCase } from '../../application/use-cases/RemoveUnreferencedUrlRecordsUseCase'
 import { createRestoreOpenedUrlsSnapshotUseCase } from '../../application/use-cases/RestoreOpenedUrlsSnapshotUseCase'
-import type { RestoreOpenedUrlsSnapshotUseCase } from '../../application/use-cases/RestoreOpenedUrlsSnapshotUseCase'
 import { createSyncCategoryAssignmentsUseCase } from '../../application/use-cases/SyncCategoryAssignmentsUseCase'
-import type { SyncCategoryAssignmentsUseCase } from '../../application/use-cases/SyncCategoryAssignmentsUseCase'
 import type { SavedTabsUseCasesDeps } from './createSavedTabsUseCasesDeps'
 
 /**
  * presentation 層（controller hook / page）へ公開する SavedTabs の
- * 主要 use-case バンドル。
+ * 主要 use-case バンドル interface の re-export。
  *
- * 各 use-case は repository 実装と port 実装を
- * `createSavedTabsUseCasesDeps()` から受け取り、純関数として保持する。
- * React 側はこのバンドルから個別 use-case を取り出して呼び出す。
+ * `SavedTabsUseCases` interface の source of truth は
+ * `application/SavedTabsUseCases.ts` に集約し、ここでは依存先
+ * import を壊さないための型 re-export だけを保つ。`SavedTabsUseCases` を
+ * `infrastructure/composition/` 配下から import している既存テスト
+ * （`useSavedTabsController.test.ts` など）の互換性維持が目的。
  */
-export interface SavedTabsUseCases {
-  readonly openSavedUrl: OpenSavedUrlUseCase
-  readonly deleteTabGroup: DeleteTabGroupUseCase
-  readonly restoreOpenedUrlsSnapshot: RestoreOpenedUrlsSnapshotUseCase
-  readonly syncCategoryAssignments: SyncCategoryAssignmentsUseCase
-  readonly removeUnreferencedUrlRecords: RemoveUnreferencedUrlRecordsUseCase
-}
+export type { SavedTabsUseCases }
 
 /**
  * `SavedTabsUseCasesDeps` から `SavedTabsUseCases` を組み立てる composition 関数。

--- a/vitest.ci.config.ts
+++ b/vitest.ci.config.ts
@@ -88,6 +88,7 @@ export default defineConfig({
             'src/utils/**/*.test.ts',
             'src/constants/**/*.test.ts',
             'src/contexts/**/*.test.ts',
+            'src/app/**/*.test.ts',
             'src/features/**/lib/**/*.test.ts',
             'src/features/i18n/lib/**/*.test.ts',
             'src/features/analytics/**/*.test.ts',


### PR DESCRIPTION
## 変更内容

Issue #469 対応。`src/contexts/saved-tabs/` の DDD 実装を、production の実行経路から組み立てられるよう app-level composition root を追加する。

### 追加

- `src/app/composition/createSavedTabsRepositories.ts` — `chrome.storage.local` ベースの 4 つの `Chrome*Repository` を 1 ポート共有で組み立てる
- `src/app/composition/createSavedTabsPorts.ts` — `ChromeBrowserTabAdapter` + `SonnerNotificationAdapter` を組み立てる
- `src/app/composition/createSavedTabsUseCases.ts` — 上記 2 つから use-case 5 種を生成して `SavedTabsUseCases` バンドルを返す
- `src/contexts/saved-tabs/application/SavedTabsUseCases.ts` — use-case バンドル interface (source of truth)
- 各ファイルの `*.test.ts` (合計 12 テスト)

### 変更

- `src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts` — `SavedTabsUseCases` interface を application 側へ移し、型 re-export に変更 (既存 import の互換性維持)
- `src/contexts/saved-tabs/dddLayerGuard.test.ts` — issue #469 用のファイル存在・依存方向ガードを追加
- `vitest.ci.config.ts` — `src/app/**/*.test.ts` を node project の include に追加

## 受け入れ条件

- ✅ composition root から saved-tabs use-case 群を取得できる (`createSavedTabsUseCases()` を 1 回呼ぶだけ)
- ✅ use-case の生成は `src/app/composition/` に閉じている (presentation / component 側に散らばっていない)
- ✅ domain / application / infrastructure の依存方向を維持 (oxlint guard テストで機械的に検証)
- ✅ `bun run compile` 通過
- ✅ 既存テスト通過 (1726 tests)

## チェックリスト

- [x] ローカル環境でエラーになっていない (`bun run test` 1726 tests pass / `bun run lint` 0 errors / `bun run compile` pass)
- [x] `bun run format:check` 通過
- [ ] UI 変更なし (composition root の追加のみ)
- [x] 関連 issue #469 をリンク

## 補足

- 既存 `infrastructure/composition/createSavedTabsUseCases*.ts` は context 内部の composition として残し、新 `src/app/composition/` は app-level の composition root として並置。後続 PR で `presentation` / `AppRouter` 側を use-case 経由へ切り替える想定。
- `SavedTabsApp.tsx` の大規模修正 / `AppRouter` の route 切替 / 既存 `features/saved-tabs` 削除は issue の制約通り未実施。
- ベース branch は develop (直近の #457 / #458 / #459 と同パターン)。

Closes #469