### PR TITLE
feat(#470): handleOpenTab を OpenSavedUrlUseCase 経由に置き換え

### DIFF
--- a/src/app/composition/createSavedTabsPorts.test.ts
+++ b/src/app/composition/createSavedTabsPorts.test.ts
@@ -67,6 +67,63 @@ describe('createSavedTabsPorts (app/composition)', () => {
     })
   })
 
+  describe('options.resolveActive', () => {
+    it('resolveActive=true の関数を渡すと browserTabPort が active: true で開く', async () => {
+      // eslint-disable-next-line typescript/require-await -- mock 用に同期的な async を意図
+      const create = vi.fn(async ({ url }: { url: string }) => ({ url }))
+      setChromeApi({ tabs: { create } })
+
+      const { browserTabPort } = createSavedTabsPorts({
+        resolveActive: () => true,
+      })
+      await browserTabPort.open({ url: 'https://example.com' })
+
+      expect(create).toHaveBeenCalledWith({
+        active: true,
+        url: 'https://example.com',
+      })
+    })
+
+    it('resolveActive=false の関数を渡すと browserTabPort が active: false で開く', async () => {
+      // eslint-disable-next-line typescript/require-await -- mock 用に同期的な async を意図
+      const create = vi.fn(async ({ url }: { url: string }) => ({ url }))
+      setChromeApi({ tabs: { create } })
+
+      const { browserTabPort } = createSavedTabsPorts({
+        resolveActive: () => false,
+      })
+      await browserTabPort.open({ url: 'https://example.com' })
+
+      expect(create).toHaveBeenCalledWith({
+        active: false,
+        url: 'https://example.com',
+      })
+    })
+
+    it('resolveActive は open ごとに呼ばれ、最新の戻り値を反映する', async () => {
+      // eslint-disable-next-line typescript/require-await -- mock 用に同期的な async を意図
+      const create = vi.fn(async ({ url }: { url: string }) => ({ url }))
+      setChromeApi({ tabs: { create } })
+      let active = false
+      const { browserTabPort } = createSavedTabsPorts({
+        resolveActive: () => active,
+      })
+
+      await browserTabPort.open({ url: 'https://example.com/first' })
+      active = true
+      await browserTabPort.open({ url: 'https://example.com/second' })
+
+      expect(create).toHaveBeenNthCalledWith(1, {
+        active: false,
+        url: 'https://example.com/first',
+      })
+      expect(create).toHaveBeenNthCalledWith(2, {
+        active: true,
+        url: 'https://example.com/second',
+      })
+    })
+  })
+
   describe('notificationPort', () => {
     it('info / success / error が関数として公開される', () => {
       const { notificationPort } = createSavedTabsPorts()

--- a/src/app/composition/createSavedTabsPorts.ts
+++ b/src/app/composition/createSavedTabsPorts.ts
@@ -18,6 +18,17 @@ export interface SavedTabsPorts {
   readonly notificationPort: NotificationPort
 }
 
+/**
+ * `createSavedTabsPorts` に渡せる任意設定。
+ *
+ * `resolveActive` は presentation 層が `openUrlInBackground` 設定をランタイムで
+ * 反映するための関数。`true` を返すと新規タブを active で開き、`false` を返すと
+ * バックグラウンド (`active: false`) で開く。未指定なら `active: true` 既定。
+ */
+export interface CreateSavedTabsPortsOptions {
+  readonly resolveActive?: () => boolean
+}
+
 interface ChromeApi extends ChromeApiLike {
   readonly tabs?: ChromeApiLike['tabs'] & {
     readonly create?: NonNullable<NonNullable<ChromeApiLike['tabs']>['create']>
@@ -36,16 +47,24 @@ const getChromeApi = (): ChromeApi | undefined =>
  * `console.warn` / `console.error` にフォールバックするため、通知で
  * use-case 全体を落とさない。
  *
+ * `options.resolveActive` を渡すと、presentation 層が `openUrlInBackground`
+ * 設定をランタイムで反映できる。指定しなければ `active: true` で開く。
+ *
  * @example
  * ```ts
- * const ports = createSavedTabsPorts()
+ * const ports = createSavedTabsPorts({
+ *   resolveActive: () => !settings.openUrlInBackground,
+ * })
  * const opened = await ports.browserTabPort.open({ url: 'https://example.com' })
  * ports.notificationPort.info({ message: '開きました' })
  * ```
  */
-export const createSavedTabsPorts = (): SavedTabsPorts => ({
-  browserTabPort: createChromeBrowserTabAdapter({
-    getApi: () => getChromeApi(),
-  }),
+export const createSavedTabsPorts = (
+  options: CreateSavedTabsPortsOptions = {},
+): SavedTabsPorts => ({
+  browserTabPort: createChromeBrowserTabAdapter(
+    { getApi: () => getChromeApi() },
+    options.resolveActive ? { resolveActive: options.resolveActive } : {},
+  ),
   notificationPort: createSonnerNotificationAdapter(),
 })

--- a/src/app/composition/createSavedTabsUseCases.test.ts
+++ b/src/app/composition/createSavedTabsUseCases.test.ts
@@ -102,4 +102,54 @@ describe('createSavedTabsUseCases (app/composition)', () => {
       warnSpy.mockRestore()
     }
   })
+
+  it('options.resolveActive を渡すと openSavedUrl が active 設定を反映する', async () => {
+    const state: Record<string, unknown> = {
+      customProjects: [],
+      savedTabs: [
+        {
+          domain: 'example.com',
+          id: 'group-1',
+          urlIds: ['url-1'],
+        },
+      ],
+      urls: [
+        {
+          id: 'url-1',
+          savedAt: 1,
+          title: 'A',
+          url: 'https://example.com/a',
+        },
+      ],
+    }
+    vi.mocked(getChromeStorageLocal).mockReturnValue(
+      buildChromeStorageLocal(state),
+    )
+    const create = vi.fn(
+      // eslint-disable-next-line typescript/require-await -- mock 用に同期的な async を意図
+      async ({ url }: { active?: boolean; url: string }) => ({ url }),
+    )
+    setChromeApi({ tabs: { create } })
+
+    const useCases = createSavedTabsUseCases({
+      resolveActive: () => false,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const urlRecordId = 'url-1' as unknown as Parameters<
+      typeof useCases.openSavedUrl
+    >[0]['urlRecordId']
+    await useCases.openSavedUrl({
+      origin: 'click',
+      settings: {
+        removeTabAfterExternalDrop: false,
+        removeTabAfterOpen: false,
+      },
+      urlRecordId,
+    })
+
+    expect(create).toHaveBeenCalledWith({
+      active: false,
+      url: 'https://example.com/a',
+    })
+  })
 })

--- a/src/app/composition/createSavedTabsUseCases.ts
+++ b/src/app/composition/createSavedTabsUseCases.ts
@@ -9,6 +9,17 @@ import { createSavedTabsPorts } from './createSavedTabsPorts'
 import { createSavedTabsRepositories } from './createSavedTabsRepositories'
 
 /**
+ * `createSavedTabsUseCases` 呼び出し時に渡せる任意設定。
+ *
+ * presentation 層が `openUrlInBackground` 設定をランタイムで反映するため、
+ * `resolveActive` を渡せるようにしている。`BrowserTabPort` の adapter に
+ * 委譲される。`createSavedTabsPorts` の同名 option と同じ意味。
+ */
+export interface CreateSavedTabsUseCasesOptions {
+  readonly resolveActive?: () => boolean
+}
+
+/**
  * `src/app/composition/` レベルの composition root。
  *
  * `chrome.storage.local` ベースの repository 実装と
@@ -18,15 +29,24 @@ import { createSavedTabsRepositories } from './createSavedTabsRepositories'
  * この関数以降、UI / hook / テストは
  * `chrome.*` API を直接触れず、use-case だけを呼び出す形になる。
  *
+ * `options.resolveActive` を渡すと presentation 層が `openUrlInBackground`
+ * のような設定値をランタイムで `BrowserTabPort` に反映できる。
+ *
  * @example
  * ```ts
- * const useCases = createSavedTabsUseCases()
+ * const useCases = createSavedTabsUseCases({
+ *   resolveActive: () => !settings.openUrlInBackground,
+ * })
  * await useCases.openSavedUrl({ urlRecordId, origin: 'click', settings })
  * ```
  */
-export const createSavedTabsUseCases = (): SavedTabsUseCases => {
+export const createSavedTabsUseCases = (
+  options: CreateSavedTabsUseCasesOptions = {},
+): SavedTabsUseCases => {
   const repositories = createSavedTabsRepositories()
-  const ports = createSavedTabsPorts()
+  const ports = createSavedTabsPorts(
+    options.resolveActive ? { resolveActive: options.resolveActive } : {},
+  )
 
   return {
     deleteTabGroup: createDeleteTabGroupUseCase({

--- a/src/contexts/saved-tabs/application/use-cases/OpenSavedUrlUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/OpenSavedUrlUseCase.test.ts
@@ -491,4 +491,76 @@ describe('OpenSavedUrlUseCase', () => {
     // 開かない
     expect(browser.opened).toStrictEqual([])
   })
+
+  it('TabGroup から URL を一つだけ削除してグループ自体は残る場合も saveAll が呼ばれる', async () => {
+    const urlToOpen = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const urlKept = createUrlRecord({
+      id: 'url-2',
+      savedAt: 1,
+      title: 'B',
+      url: 'https://example.com/b',
+    })
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1', 'url-2'],
+    })
+    const repos = createInMemoryRepositories({
+      tabGroups: [group],
+      urlRecords: [urlToOpen, urlKept],
+    })
+    const saveSpy = vi.spyOn(repos.tabGroupRepository, 'saveAll')
+    const browser = createSpyBrowserTabPort()
+    const useCase = createOpenSavedUrlUseCase({
+      ...repos,
+      browserTabPort: browser.port,
+    })
+
+    await useCase({
+      origin: 'click',
+      settings: { ...baseSettings, removeTabAfterOpen: true },
+      urlRecordId: urlToOpen.id,
+    })
+
+    expect(saveSpy).toHaveBeenCalledTimes(1)
+    expect(repos.tabGroups[0]?.urlIds).toStrictEqual([urlKept.id])
+  })
+
+  it('TabGroup の内容が変わらないときは saveAll を呼ばない', async () => {
+    const url = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1'],
+    })
+    const repos = createInMemoryRepositories({
+      tabGroups: [group],
+      urlRecords: [url],
+    })
+    const saveSpy = vi.spyOn(repos.tabGroupRepository, 'saveAll')
+    const browser = createSpyBrowserTabPort()
+    const useCase = createOpenSavedUrlUseCase({
+      ...repos,
+      browserTabPort: browser.port,
+    })
+
+    // 設定 OFF なので削除も saveAll も走らない
+    await useCase({
+      origin: 'click',
+      settings: baseSettings,
+      urlRecordId: url.id,
+    })
+
+    expect(saveSpy).not.toHaveBeenCalled()
+  })
 })

--- a/src/contexts/saved-tabs/application/use-cases/OpenSavedUrlUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/OpenSavedUrlUseCase.ts
@@ -128,6 +128,17 @@ export const createOpenSavedUrlUseCase = (
 
     if (updatedTabGroups.length !== previousTabGroups.length) {
       await deps.tabGroupRepository.saveAll(updatedTabGroups)
+    } else {
+      // length が同じでも、グループ内の urlIds が変わった場合は
+      // saveAll で書き戻す必要がある。`removeUrlRecordIdsFromTabGroups` は
+      // 変更があったグループだけ新しい object を返すので reference 比較で
+      // 検出できる。
+      const hasTabGroupContentChanged = updatedTabGroups.some(
+        (group, index) => group !== previousTabGroups[index],
+      )
+      if (hasTabGroupContentChanged) {
+        await deps.tabGroupRepository.saveAll(updatedTabGroups)
+      }
     }
     const hasCustomProjectChanged = updatedCustomProjects.some(
       (project, index) => project !== previousCustomProjects[index],

--- a/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.test.ts
@@ -278,6 +278,120 @@ describe('ChromeSavedTabsStorageMapper', () => {
       expect(raw.urlIds).toStrictEqual(['url-1', 'url-2'])
     })
 
+    it('toSavedTabRaw は original を渡すとリッチ補助フィールドを urlIds に揃えて持ち越す', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseTabGroup({
+        domain: 'example.com',
+        id: 'group-1',
+        urlIds: ['url-keep'],
+      })
+      expect(entity).not.toBeNull()
+      if (!entity) {
+        return
+      }
+      const raw = ChromeSavedTabsStorageMapper.toSavedTabRaw(entity, {
+        categoryKeywords: [{ categoryName: 'docs', keywords: ['doc', 'spec'] }],
+        domain: 'example.com',
+        id: 'group-1',
+        subCategories: ['docs'],
+        subCategoryOrder: ['docs'],
+        subCategoryOrderWithUncategorized: ['docs', 'uncategorized'],
+        urlIds: ['url-remove', 'url-keep'],
+        urls: [
+          {
+            id: 'url-remove',
+            title: 'Remove',
+            url: 'https://example.com/remove',
+          },
+          {
+            id: 'url-keep',
+            title: 'Keep',
+            url: 'https://example.com/keep',
+          },
+        ],
+        urlSubCategories: {
+          'url-keep': 'docs',
+          'url-remove': 'news',
+        },
+      })
+      expect(raw.urlIds).toStrictEqual(['url-keep'])
+      expect(raw.urls).toStrictEqual([
+        {
+          id: 'url-keep',
+          title: 'Keep',
+          url: 'https://example.com/keep',
+        },
+      ])
+      expect(raw.urlSubCategories).toStrictEqual({ 'url-keep': 'docs' })
+      expect(raw.subCategories).toStrictEqual(['docs'])
+      expect(raw.categoryKeywords).toStrictEqual([
+        { categoryName: 'docs', keywords: ['doc', 'spec'] },
+      ])
+      expect(raw.subCategoryOrder).toStrictEqual(['docs'])
+      expect(raw.subCategoryOrderWithUncategorized).toStrictEqual([
+        'docs',
+        'uncategorized',
+      ])
+    })
+
+    it('toSavedTabRaw は urls が全て削除対象なら urls キー自体を省く', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseTabGroup({
+        domain: 'example.com',
+        id: 'group-1',
+        urlIds: ['url-keep'],
+      })
+      expect(entity).not.toBeNull()
+      if (!entity) {
+        return
+      }
+      const raw = ChromeSavedTabsStorageMapper.toSavedTabRaw(entity, {
+        domain: 'example.com',
+        id: 'group-1',
+        urlIds: ['url-remove'],
+        urls: [
+          {
+            id: 'url-remove',
+            title: 'Remove',
+            url: 'https://example.com/remove',
+          },
+        ],
+        urlSubCategories: { 'url-remove': 'news' },
+      })
+      expect(raw.urls).toBeUndefined()
+      expect(raw.urlSubCategories).toBeUndefined()
+    })
+
+    it('toSavedTabRaw は id が無い url エントリも保持する（既存挙動互換）', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseTabGroup({
+        domain: 'example.com',
+        id: 'group-1',
+        urlIds: ['url-keep'],
+      })
+      expect(entity).not.toBeNull()
+      if (!entity) {
+        return
+      }
+      const raw = ChromeSavedTabsStorageMapper.toSavedTabRaw(entity, {
+        domain: 'example.com',
+        id: 'group-1',
+        urlIds: ['url-keep'],
+        urls: [
+          {
+            title: 'Legacy without ID',
+            url: 'https://legacy.example.com/a',
+          },
+          {
+            id: 'url-keep',
+            title: 'Keep',
+            url: 'https://example.com/keep',
+          },
+        ],
+      })
+      expect(raw.urls).toStrictEqual([
+        { title: 'Legacy without ID', url: 'https://legacy.example.com/a' },
+        { id: 'url-keep', title: 'Keep', url: 'https://example.com/keep' },
+      ])
+    })
+
     it('toParentCategoryRaw は domains / domainNames をコピーして保持する', () => {
       const entity = ChromeSavedTabsStorageMapper.parseParentCategory({
         domainNames: ['example.com'],
@@ -312,6 +426,87 @@ describe('ChromeSavedTabsStorageMapper', () => {
       expect(raw.urlIds).toStrictEqual(['url-1'])
       expect(raw.createdAt).toBe(1)
       expect(raw.updatedAt).toBe(2)
+    })
+
+    it('toCustomProjectRaw は original を渡すと projectKeywords / urlMetadata / categoryOrder / urls を持ち越す', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseCustomProject({
+        categories: ['research'],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        updatedAt: 2,
+        urlIds: ['url-keep'],
+      })
+      expect(entity).not.toBeNull()
+      if (!entity) {
+        return
+      }
+      const raw = ChromeSavedTabsStorageMapper.toCustomProjectRaw(entity, {
+        categories: ['research'],
+        categoryOrder: ['research', 'news'],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        projectKeywords: {
+          domainKeywords: ['example.com'],
+          titleKeywords: ['quarterly'],
+          urlKeywords: ['report'],
+        },
+        updatedAt: 2,
+        urlIds: ['url-remove', 'url-keep'],
+        urlMetadata: {
+          'url-keep': { category: 'research', notes: 'kept' },
+          'url-remove': { category: 'news', notes: 'removed' },
+        },
+        urls: [
+          {
+            title: 'Existing URL',
+            url: 'https://example.com/legacy',
+          },
+        ],
+      })
+      expect(raw.urlIds).toStrictEqual(['url-keep'])
+      expect(raw.projectKeywords).toStrictEqual({
+        domainKeywords: ['example.com'],
+        titleKeywords: ['quarterly'],
+        urlKeywords: ['report'],
+      })
+      expect(raw.urlMetadata).toStrictEqual({
+        'url-keep': { category: 'research', notes: 'kept' },
+      })
+      expect(raw.categoryOrder).toStrictEqual(['research', 'news'])
+      expect(raw.urls).toStrictEqual([
+        { title: 'Existing URL', url: 'https://example.com/legacy' },
+      ])
+    })
+
+    it('toCustomProjectRaw は urlIds が空なら urls キーを省く', () => {
+      const entity = ChromeSavedTabsStorageMapper.parseCustomProject({
+        categories: ['research'],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        updatedAt: 2,
+      })
+      expect(entity).not.toBeNull()
+      if (!entity) {
+        return
+      }
+      const raw = ChromeSavedTabsStorageMapper.toCustomProjectRaw(entity, {
+        categories: ['research'],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        updatedAt: 2,
+        urlIds: ['url-remove'],
+        urls: [
+          {
+            title: 'Will be dropped',
+            url: 'https://example.com/dropped',
+          },
+        ],
+      })
+      expect(raw.urls).toBeUndefined()
     })
   })
 

--- a/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts
+++ b/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts
@@ -150,7 +150,10 @@ const toUrlRecordRaw = (entity: UrlRecord): UrlRecordRaw => {
   return base
 }
 
-const toSavedTabRaw = (entity: TabGroup): SavedTabRaw => {
+const toSavedTabRaw = (
+  entity: TabGroup,
+  original?: SavedTabRaw,
+): SavedTabRaw => {
   // parentCategoryId / savedAt が undefined のときも undefined プロパティを
   // 残さない。chrome.storage には undefined 値ではなく key 自体を省略する。
   // urlIds は空配列のときも key を省略（domain entity 化する時点で [] が入る
@@ -168,6 +171,54 @@ const toSavedTabRaw = (entity: TabGroup): SavedTabRaw => {
   if (entity.savedAt !== undefined) {
     base.savedAt = entity.savedAt
   }
+  if (!original) {
+    return base
+  }
+  // domain entity が表現しないリッチ補助フィールドは original から持ち越す。
+  // 既存ユーザーデータ（`urls`, `urlSubCategories`, `subCategories`,
+  // `categoryKeywords`, `subCategoryOrder`, `subCategoryOrderWithUncategorized`）
+  // を破壊しないため、entity.urlIds に揃えて整合性を取りつつ保持する。
+  // entity.urlIds は branded `UrlRecordId[]` だが、original.urls.id /
+  // urlSubCategories のキーは raw 文字列なので Set<string> に揃える。
+  const preservedUrlIds = new Set<string>(entity.urlIds)
+  if (original.urls) {
+    const filteredUrls = original.urls.filter((item) =>
+      item.id === undefined ? true : preservedUrlIds.has(item.id),
+    )
+    if (filteredUrls.length > 0) {
+      base.urls = filteredUrls
+    }
+  }
+  if (original.urlSubCategories) {
+    const filteredSubCategories: Record<string, string> = {}
+    for (const [urlId, subCategory] of Object.entries(
+      original.urlSubCategories,
+    )) {
+      if (preservedUrlIds.has(urlId)) {
+        filteredSubCategories[urlId] = subCategory
+      }
+    }
+    if (Object.keys(filteredSubCategories).length > 0) {
+      base.urlSubCategories = filteredSubCategories
+    }
+  }
+  if (original.subCategories) {
+    base.subCategories = [...original.subCategories]
+  }
+  if (original.categoryKeywords) {
+    base.categoryKeywords = original.categoryKeywords.map((keyword) => ({
+      categoryName: keyword.categoryName,
+      keywords: [...keyword.keywords],
+    }))
+  }
+  if (original.subCategoryOrder) {
+    base.subCategoryOrder = [...original.subCategoryOrder]
+  }
+  if (original.subCategoryOrderWithUncategorized) {
+    base.subCategoryOrderWithUncategorized = [
+      ...original.subCategoryOrderWithUncategorized,
+    ]
+  }
   return base
 }
 
@@ -178,7 +229,10 @@ const toParentCategoryRaw = (entity: ParentCategory): ParentCategoryRaw => ({
   name: entity.name,
 })
 
-const toCustomProjectRaw = (entity: CustomProject): CustomProjectRaw => {
+const toCustomProjectRaw = (
+  entity: CustomProject,
+  original?: CustomProjectRaw,
+): CustomProjectRaw => {
   const base: CustomProjectRaw = {
     categories: [...entity.categories],
     createdAt: entity.createdAt,
@@ -188,6 +242,46 @@ const toCustomProjectRaw = (entity: CustomProject): CustomProjectRaw => {
   }
   if (entity.urlIds.length > 0) {
     base.urlIds = [...entity.urlIds]
+  }
+  if (!original) {
+    return base
+  }
+  // domain entity 未表現のリッチ補助フィールドを original から持ち越す。
+  // urls / urlMetadata は urlIds の集合に合わせて整合性を取り、
+  // projectKeywords / categoryOrder はそのまま保持する。
+  // entity.urlIds は branded `UrlRecordId[]` だが、original.urlMetadata の
+  // キーは raw 文字列なので Set<string> に揃える。
+  const preservedUrlIds = new Set<string>(entity.urlIds)
+  if (original.projectKeywords) {
+    base.projectKeywords = {
+      domainKeywords: [...original.projectKeywords.domainKeywords],
+      titleKeywords: [...original.projectKeywords.titleKeywords],
+      urlKeywords: [...original.projectKeywords.urlKeywords],
+    }
+  }
+  if (original.urlMetadata) {
+    const filteredMetadata: Record<
+      string,
+      { notes?: string; category?: string }
+    > = {}
+    for (const [urlId, metadata] of Object.entries(original.urlMetadata)) {
+      if (preservedUrlIds.has(urlId)) {
+        filteredMetadata[urlId] = metadata
+      }
+    }
+    if (Object.keys(filteredMetadata).length > 0) {
+      base.urlMetadata = filteredMetadata
+    }
+  }
+  if (original.categoryOrder) {
+    base.categoryOrder = [...original.categoryOrder]
+  }
+  // urls 配列は legacy 形式（URL 文字列を保持）。urlIds 同期は不能なので、
+  // entity の urlIds が空ではない限り original.urls をそのまま保持する。
+  // entity.urlIds が空になった場合は対象 project の URL がすべて削除された
+  // と解釈し、urls 配列も省略する。
+  if (original.urls && entity.urlIds.length > 0) {
+    base.urls = original.urls.map((entry) => ({ ...entry }))
   }
   return base
 }

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.test.ts
@@ -245,9 +245,10 @@ describe('ChromeCustomProjectRepository', () => {
       const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
         -1,
       )?.[0] as Record<string, unknown>
-      const savedRaw = (
-        lastSetArg[CUSTOM_PROJECTS_KEY] as unknown[]
-      )[0] as Record<string, unknown>
+      const savedRaw = (lastSetArg[CUSTOM_PROJECTS_KEY] as unknown[])[0] as Record<
+        string,
+        unknown
+      >
       expect(savedRaw).toMatchObject({
         categories: ['research'],
         categoryOrder: ['research', 'news'],
@@ -262,7 +263,57 @@ describe('ChromeCustomProjectRepository', () => {
         updatedAt: 2,
         urlIds: ['url-keep'],
         urlMetadata: { 'url-keep': { category: 'research', notes: 'kept' } },
-        urls: [{ title: 'Legacy entry', url: 'https://example.com/legacy' }],
+        urls: [
+          { title: 'Legacy entry', url: 'https://example.com/legacy' },
+        ],
+      })
+    })
+
+    it('既存 raw に不正な要素が混じっていても有効要素のリッチフィールドを保持する', async () => {
+      const state: StorageState = {
+        [CUSTOM_PROJECTS_KEY]: [
+          // 不正要素（categories 無し）
+          { createdAt: 1, id: 'broken', name: 'Broken', updatedAt: 1 },
+          // 有効要素 + リッチフィールド
+          {
+            categories: ['research'],
+            createdAt: 1,
+            id: 'project-1',
+            name: 'Q4',
+            projectKeywords: {
+              domainKeywords: ['example.com'],
+              titleKeywords: ['quarterly'],
+              urlKeywords: ['report'],
+            },
+            updatedAt: 2,
+            urlIds: ['url-remove', 'url-keep'],
+          },
+        ],
+      }
+      const port = createPort(state)
+      const repo = createChromeCustomProjectRepository(port)
+      const entities = await repo.findAll()
+      const remaining = entities.map((entity) => ({
+        ...entity,
+        urlIds: entity.urlIds.filter((id) => id !== 'url-remove'),
+      }))
+      await repo.saveAll(remaining)
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      const savedRaw = (lastSetArg[CUSTOM_PROJECTS_KEY] as unknown[])[0] as Record<
+        string,
+        unknown
+      >
+      // 不正要素混入下でも、有効要素の projectKeywords が merge で持ち越される
+      expect(savedRaw).toMatchObject({
+        id: 'project-1',
+        urlIds: ['url-keep'],
+        projectKeywords: {
+          domainKeywords: ['example.com'],
+          titleKeywords: ['quarterly'],
+          urlKeywords: ['report'],
+        },
       })
     })
   })

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.test.ts
@@ -245,10 +245,9 @@ describe('ChromeCustomProjectRepository', () => {
       const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
         -1,
       )?.[0] as Record<string, unknown>
-      const savedRaw = (lastSetArg[CUSTOM_PROJECTS_KEY] as unknown[])[0] as Record<
-        string,
-        unknown
-      >
+      const savedRaw = (
+        lastSetArg[CUSTOM_PROJECTS_KEY] as unknown[]
+      )[0] as Record<string, unknown>
       expect(savedRaw).toMatchObject({
         categories: ['research'],
         categoryOrder: ['research', 'news'],
@@ -263,9 +262,7 @@ describe('ChromeCustomProjectRepository', () => {
         updatedAt: 2,
         urlIds: ['url-keep'],
         urlMetadata: { 'url-keep': { category: 'research', notes: 'kept' } },
-        urls: [
-          { title: 'Legacy entry', url: 'https://example.com/legacy' },
-        ],
+        urls: [{ title: 'Legacy entry', url: 'https://example.com/legacy' }],
       })
     })
 
@@ -301,10 +298,9 @@ describe('ChromeCustomProjectRepository', () => {
       const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
         -1,
       )?.[0] as Record<string, unknown>
-      const savedRaw = (lastSetArg[CUSTOM_PROJECTS_KEY] as unknown[])[0] as Record<
-        string,
-        unknown
-      >
+      const savedRaw = (
+        lastSetArg[CUSTOM_PROJECTS_KEY] as unknown[]
+      )[0] as Record<string, unknown>
       // 不正要素混入下でも、有効要素の projectKeywords が merge で持ち越される
       expect(savedRaw).toMatchObject({
         id: 'project-1',

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.test.ts
@@ -204,6 +204,67 @@ describe('ChromeCustomProjectRepository', () => {
       )?.[0] as Record<string, unknown>
       expect(lastSetArg[CUSTOM_PROJECTS_KEY]).toStrictEqual([])
     })
+
+    it('既存 raw のリッチ補助フィールド（projectKeywords / urlMetadata / categoryOrder / urls）を保持する', async () => {
+      const state: StorageState = {
+        [CUSTOM_PROJECTS_KEY]: [
+          {
+            categories: ['research'],
+            categoryOrder: ['research', 'news'],
+            createdAt: 1,
+            id: 'project-1',
+            name: 'Q4',
+            projectKeywords: {
+              domainKeywords: ['example.com'],
+              titleKeywords: ['quarterly'],
+              urlKeywords: ['report'],
+            },
+            updatedAt: 2,
+            urlIds: ['url-remove', 'url-keep'],
+            urlMetadata: {
+              'url-keep': { category: 'research', notes: 'kept' },
+              'url-remove': { category: 'news', notes: 'removed' },
+            },
+            urls: [
+              {
+                title: 'Legacy entry',
+                url: 'https://example.com/legacy',
+              },
+            ],
+          },
+        ],
+      }
+      const port = createPort(state)
+      const repo = createChromeCustomProjectRepository(port)
+      const entities = await repo.findAll()
+      const remaining = entities.map((entity) => ({
+        ...entity,
+        urlIds: entity.urlIds.filter((id) => id !== 'url-remove'),
+      }))
+      await repo.saveAll(remaining)
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      const savedRaw = (
+        lastSetArg[CUSTOM_PROJECTS_KEY] as unknown[]
+      )[0] as Record<string, unknown>
+      expect(savedRaw).toMatchObject({
+        categories: ['research'],
+        categoryOrder: ['research', 'news'],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        projectKeywords: {
+          domainKeywords: ['example.com'],
+          titleKeywords: ['quarterly'],
+          urlKeywords: ['report'],
+        },
+        updatedAt: 2,
+        urlIds: ['url-keep'],
+        urlMetadata: { 'url-keep': { category: 'research', notes: 'kept' } },
+        urls: [{ title: 'Legacy entry', url: 'https://example.com/legacy' }],
+      })
+    })
   })
 
   describe('removeByIds', () => {

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.ts
@@ -10,6 +10,7 @@ import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStora
 import { SavedTabsRepositoryUnavailableError } from './ChromeUrlRecordRepository'
 import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
 import { CUSTOM_PROJECTS_KEY } from './savedTabsStorageKeys'
+import { CustomProjectRawArraySchema } from './savedTabsStorageSchema'
 import type { CustomProjectRaw } from './savedTabsStorageSchema'
 
 const getDefaultPort = (): ChromeStorageLocalPort | null => {
@@ -22,6 +23,18 @@ const getDefaultPort = (): ChromeStorageLocalPort | null => {
     remove: (key) => local.remove(key),
     set: (value) => local.set(value),
   }
+}
+
+const findAllRawCustomProjects = async (
+  port: ChromeStorageLocalPort,
+): Promise<CustomProjectRaw[]> => {
+  const result = await port.get(CUSTOM_PROJECTS_KEY)
+  const raw = result[CUSTOM_PROJECTS_KEY]
+  const parsed = CustomProjectRawArraySchema.safeParse(raw)
+  if (!parsed.success) {
+    return []
+  }
+  return [...parsed.data]
 }
 
 const createChromeCustomProjectRepositoryImpl = (
@@ -42,8 +55,19 @@ const createChromeCustomProjectRepositoryImpl = (
   }
 
   const saveAll = async (projects: readonly CustomProject[]): Promise<void> => {
+    // 既存ユーザーデータ（`projectKeywords`, `urls`, `urlMetadata`,
+    // `categoryOrder`）を破壊しないため、書き込み前に既存 raw を取得し、
+    // entity と merge する。
+    const existingRaws = await findAllRawCustomProjects(port)
+    const originalById = new Map<string, CustomProjectRaw>()
+    for (const original of existingRaws) {
+      originalById.set(original.id, original)
+    }
     const raws: CustomProjectRaw[] = projects.map((project) =>
-      ChromeSavedTabsStorageMapper.toCustomProjectRaw(project),
+      ChromeSavedTabsStorageMapper.toCustomProjectRaw(
+        project,
+        originalById.get(project.id),
+      ),
     )
     await port.set({ [CUSTOM_PROJECTS_KEY]: raws })
   }
@@ -71,8 +95,9 @@ const createChromeCustomProjectRepositoryImpl = (
  * `CustomProject` 永続化用に使う `CustomProjectRepository` 実装を生成する。
  *
  * Rich な補助フィールド（`projectKeywords` / `urls` / `urlMetadata` /
- * `categoryOrder`）は現時点では永続化対象外。既存
- * `src/lib/storage/projects.ts` を併用するか、別 issue の use-case 化で対応する。
+ * `categoryOrder`）は domain entity には載らないが、`saveAll` で既存 raw
+ * データから持ち越して `urlIds` の集合に合わせて整合性を取りつつ保存する。
+ * これによりユーザーの既存保存データを破壊しない。
  *
  * @throws {SavedTabsRepositoryUnavailableError} chrome.storage.local 不在時
  */

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.ts
@@ -10,7 +10,7 @@ import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStora
 import { SavedTabsRepositoryUnavailableError } from './ChromeUrlRecordRepository'
 import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
 import { CUSTOM_PROJECTS_KEY } from './savedTabsStorageKeys'
-import { CustomProjectRawArraySchema } from './savedTabsStorageSchema'
+import { CustomProjectRawSchema } from './savedTabsStorageSchema'
 import type { CustomProjectRaw } from './savedTabsStorageSchema'
 
 const getDefaultPort = (): ChromeStorageLocalPort | null => {
@@ -30,11 +30,20 @@ const findAllRawCustomProjects = async (
 ): Promise<CustomProjectRaw[]> => {
   const result = await port.get(CUSTOM_PROJECTS_KEY)
   const raw = result[CUSTOM_PROJECTS_KEY]
-  const parsed = CustomProjectRawArraySchema.safeParse(raw)
-  if (!parsed.success) {
+  if (!Array.isArray(raw)) {
     return []
   }
-  return [...parsed.data]
+  // 1 要素ずつ safeParse する。`CustomProjectRawArraySchema.safeParse(raw)` を
+  // 使うと配列全体に対する単一の zod パースになり、不正要素が 1 つでも
+  // 含まれていると全体が failure になってしまい、merge 元データが失われる。
+  const valid: CustomProjectRaw[] = []
+  for (const item of raw) {
+    const parsed = CustomProjectRawSchema.safeParse(item)
+    if (parsed.success) {
+      valid.push(parsed.data)
+    }
+  }
+  return valid
 }
 
 const createChromeCustomProjectRepositoryImpl = (

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository.test.ts
@@ -169,6 +169,76 @@ describe('ChromeTabGroupRepository', () => {
       )?.[0] as Record<string, unknown>
       expect(lastSetArg[SAVED_TABS_KEY]).toStrictEqual([])
     })
+
+    it('既存 raw のリッチ補助フィールド（urlSubCategories / urls / subCategories 等）を保持する', async () => {
+      const state: StorageState = {
+        [SAVED_TABS_KEY]: [
+          {
+            categoryKeywords: [{ categoryName: 'docs', keywords: ['doc'] }],
+            domain: 'example.com',
+            id: 'group-1',
+            parentCategoryId: 'cat-1',
+            savedAt: 1_700_000_000_000,
+            subCategories: ['docs'],
+            subCategoryOrder: ['docs'],
+            subCategoryOrderWithUncategorized: ['docs', 'uncategorized'],
+            urlIds: ['url-remove', 'url-keep'],
+            urls: [
+              {
+                id: 'url-remove',
+                title: 'Remove',
+                url: 'https://example.com/remove',
+              },
+              {
+                id: 'url-keep',
+                title: 'Keep',
+                url: 'https://example.com/keep',
+              },
+            ],
+            urlSubCategories: {
+              'url-keep': 'docs',
+              'url-remove': 'news',
+            },
+          },
+        ],
+      }
+      const port = createPort(state)
+      const repo = createChromeTabGroupRepository(port)
+      const entities = await repo.findAll()
+      expect(entities).toHaveLength(1)
+      // url-remove だけ取り除く形で saveAll を呼ぶ
+      const remaining = entities.map((entity) => ({
+        ...entity,
+        urlIds: entity.urlIds.filter((id) => id !== 'url-remove'),
+      }))
+      await repo.saveAll(remaining)
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      const savedRaw = (lastSetArg[SAVED_TABS_KEY] as unknown[])[0] as Record<
+        string,
+        unknown
+      >
+      expect(savedRaw).toMatchObject({
+        domain: 'example.com',
+        id: 'group-1',
+        parentCategoryId: 'cat-1',
+        savedAt: 1_700_000_000_000,
+        urlIds: ['url-keep'],
+        urls: [
+          {
+            id: 'url-keep',
+            title: 'Keep',
+            url: 'https://example.com/keep',
+          },
+        ],
+        urlSubCategories: { 'url-keep': 'docs' },
+        subCategories: ['docs'],
+        categoryKeywords: [{ categoryName: 'docs', keywords: ['doc'] }],
+        subCategoryOrder: ['docs'],
+        subCategoryOrderWithUncategorized: ['docs', 'uncategorized'],
+      })
+    })
   })
 
   describe('removeByIds', () => {

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository.test.ts
@@ -239,6 +239,66 @@ describe('ChromeTabGroupRepository', () => {
         subCategoryOrderWithUncategorized: ['docs', 'uncategorized'],
       })
     })
+
+    it('既存 raw に不正な要素が混じっていても有効要素のリッチフィールドを保持する', async () => {
+      const state: StorageState = {
+        [SAVED_TABS_KEY]: [
+          // 不正要素（id 無し）
+          { domain: 'broken.example.com' },
+          // 有効要素 + リッチフィールド
+          {
+            domain: 'example.com',
+            id: 'group-1',
+            urlIds: ['url-remove', 'url-keep'],
+            urls: [
+              {
+                id: 'url-remove',
+                title: 'Remove',
+                url: 'https://example.com/remove',
+              },
+              {
+                id: 'url-keep',
+                title: 'Keep',
+                url: 'https://example.com/keep',
+              },
+            ],
+            urlSubCategories: { 'url-keep': 'docs' },
+          },
+          // 不正要素（domain 無し）
+          { id: 'broken-2' },
+        ],
+      }
+      const port = createPort(state)
+      const repo = createChromeTabGroupRepository(port)
+      const entities = await repo.findAll()
+      const remaining = entities.map((entity) => ({
+        ...entity,
+        urlIds: entity.urlIds.filter((id) => id !== 'url-remove'),
+      }))
+      await repo.saveAll(remaining)
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      const savedRaw = (lastSetArg[SAVED_TABS_KEY] as unknown[])[0] as Record<
+        string,
+        unknown
+      >
+      // 不正要素が混じっていても、有効要素の urls / urlSubCategories は
+      // merge で持ち越されている必要がある。
+      expect(savedRaw).toMatchObject({
+        domain: 'example.com',
+        id: 'group-1',
+        urlIds: ['url-keep'],
+        urls: [
+          {
+            id: 'url-keep',
+            title: 'Keep',
+            url: 'https://example.com/keep',
+          },
+        ],
+        urlSubCategories: { 'url-keep': 'docs' },
+      })
+    })
   })
 
   describe('removeByIds', () => {

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository.ts
@@ -10,6 +10,7 @@ import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStora
 import { SavedTabsRepositoryUnavailableError } from './ChromeUrlRecordRepository'
 import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
 import { SAVED_TABS_KEY } from './savedTabsStorageKeys'
+import { SavedTabRawArraySchema } from './savedTabsStorageSchema'
 import type { SavedTabRaw } from './savedTabsStorageSchema'
 
 const getDefaultPort = (): ChromeStorageLocalPort | null => {
@@ -22,6 +23,18 @@ const getDefaultPort = (): ChromeStorageLocalPort | null => {
     remove: (key) => local.remove(key),
     set: (value) => local.set(value),
   }
+}
+
+const findAllRawTabGroups = async (
+  port: ChromeStorageLocalPort,
+): Promise<SavedTabRaw[]> => {
+  const result = await port.get(SAVED_TABS_KEY)
+  const raw = result[SAVED_TABS_KEY]
+  const parsed = SavedTabRawArraySchema.safeParse(raw)
+  if (!parsed.success) {
+    return []
+  }
+  return [...parsed.data]
 }
 
 const createChromeTabGroupRepositoryImpl = (
@@ -40,8 +53,19 @@ const createChromeTabGroupRepositoryImpl = (
   }
 
   const saveAll = async (groups: readonly TabGroup[]): Promise<void> => {
+    // 既存ユーザーデータ（`urls`, `urlSubCategories`, `subCategories`,
+    // `categoryKeywords`, `subCategoryOrder`, `subCategoryOrderWithUncategorized`）
+    // を破壊しないため、書き込み前に既存 raw を取得し、entity と merge する。
+    const existingRaws = await findAllRawTabGroups(port)
+    const originalById = new Map<string, SavedTabRaw>()
+    for (const original of existingRaws) {
+      originalById.set(original.id, original)
+    }
     const raws: SavedTabRaw[] = groups.map((group) =>
-      ChromeSavedTabsStorageMapper.toSavedTabRaw(group),
+      ChromeSavedTabsStorageMapper.toSavedTabRaw(
+        group,
+        originalById.get(group.id),
+      ),
     )
     await port.set({ [SAVED_TABS_KEY]: raws })
   }
@@ -68,8 +92,9 @@ const createChromeTabGroupRepositoryImpl = (
  *
  * Rich な補助フィールド（`urlSubCategories` / `subCategories` /
  * `categoryKeywords` / `subCategoryOrder` /
- * `subCategoryOrderWithUncategorized` / `urls`）は現時点では永続化対象外。
- * 既存 `src/lib/storage/tabs.ts` を併用するか、別 issue の use-case 化で対応する。
+ * `subCategoryOrderWithUncategorized` / `urls`）は domain entity には載らないが、
+ * `saveAll` で既存 raw データから持ち越して `urlIds` の集合に合わせて整合性を
+ * 取りつつ保存する。これによりユーザーの既存保存データを破壊しない。
  *
  * @throws {SavedTabsRepositoryUnavailableError} chrome.storage.local 不在時
  */

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeTabGroupRepository.ts
@@ -10,7 +10,7 @@ import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStora
 import { SavedTabsRepositoryUnavailableError } from './ChromeUrlRecordRepository'
 import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
 import { SAVED_TABS_KEY } from './savedTabsStorageKeys'
-import { SavedTabRawArraySchema } from './savedTabsStorageSchema'
+import { SavedTabRawSchema } from './savedTabsStorageSchema'
 import type { SavedTabRaw } from './savedTabsStorageSchema'
 
 const getDefaultPort = (): ChromeStorageLocalPort | null => {
@@ -30,11 +30,21 @@ const findAllRawTabGroups = async (
 ): Promise<SavedTabRaw[]> => {
   const result = await port.get(SAVED_TABS_KEY)
   const raw = result[SAVED_TABS_KEY]
-  const parsed = SavedTabRawArraySchema.safeParse(raw)
-  if (!parsed.success) {
+  if (!Array.isArray(raw)) {
     return []
   }
-  return [...parsed.data]
+  // 1 要素ずつ safeParse する。`SavedTabRawArraySchema.safeParse(raw)` を
+  // 使うと配列全体に対する単一の zod パースになり、不正要素が 1 つでも
+  // 含まれていると全体が failure になってしまい、merge 元データが失われる。
+  // ここは「有効要素だけ集める」挙動が必要なため要素ごとにパースする。
+  const valid: SavedTabRaw[] = []
+  for (const item of raw) {
+    const parsed = SavedTabRawSchema.safeParse(item)
+    if (parsed.success) {
+      valid.push(parsed.data)
+    }
+  }
+  return valid
 }
 
 const createChromeTabGroupRepositoryImpl = (

--- a/src/features/saved-tabs/app/SavedTabsApp.test.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.test.tsx
@@ -3959,6 +3959,107 @@ describe('SavedTabsApp custom search', () => {
     )
   })
 
+  it('handleOpenTab は他で参照されている URL でも Undo トーストを表示する（snapshot 経由）', async () => {
+    mocked.settings.removeTabAfterOpen = true
+    mocked.settings.openUrlInBackground = false
+    mocked.projectState.viewMode = 'custom'
+    mocked.projectState.viewModeRef = { current: 'custom' }
+    const group1: TabGroup = {
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-shared'],
+      urls: [
+        {
+          id: 'url-shared',
+          title: 'Shared',
+          url: 'https://example.com/shared',
+        },
+      ],
+    }
+    // 同じ URL ID を参照する別グループ → urlRecord 自体は削除されない
+    const group2: TabGroup = {
+      domain: 'other.com',
+      id: 'group-2',
+      urlIds: ['url-shared'],
+      urls: [
+        {
+          id: 'url-shared',
+          title: 'Shared',
+          url: 'https://example.com/shared',
+        },
+      ],
+    }
+    const urlRecords: UrlRecord[] = [
+      {
+        id: 'url-shared',
+        savedAt: 1,
+        title: 'Shared',
+        url: 'https://example.com/shared',
+      },
+    ]
+    const chromeSetMock = vi.fn()
+    const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
+    chromeGlobal.chrome = {
+      storage: {
+        local: {
+          // eslint-disable-next-line typescript/require-await
+          get: vi.fn(async (key: unknown) => {
+            const keys = Array.isArray(key)
+              ? (key as string[])
+              : typeof key === 'string'
+                ? [key]
+                : []
+            const result: Record<string, unknown> = {}
+            for (const k of keys) {
+              if (k === 'savedTabs') result.savedTabs = [group1, group2]
+              if (k === 'urls') result.urls = urlRecords
+              if (k === 'customProjects') result.customProjects = []
+              if (k === 'customProjectOrder') result.customProjectOrder = []
+            }
+            return result
+          }),
+          set: chromeSetMock,
+        },
+        onChanged: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        },
+      },
+      tabs: {
+        create: vi.fn(),
+      },
+      windows: {
+        create: vi.fn(),
+      },
+      runtime: {
+        getURL: vi.fn(),
+      },
+    } as unknown as typeof chrome
+    vi.mocked(getUrlRecords).mockResolvedValue(urlRecords)
+
+    render(<SavedTabsApp />)
+
+    const customProps = mocked.customModeContainerSpy.mock.calls.at(
+      -1,
+    )?.[0] as {
+      handleOpenUrl: (url: string) => Promise<void>
+    }
+
+    await customProps.handleOpenUrl('https://example.com/shared')
+
+    // URL ID は group-1 / group-2 双方から削除されるが、url-shared 自体は
+    // 他で参照されているので urlRecord は削除されない。
+    // それでも use-case は snapshot を返すため、Undo toast は表示される。
+    expect(toast.info).toHaveBeenCalledWith(
+      '開いた1件のタブを保存データから削除しました',
+      expect.objectContaining({
+        action: expect.objectContaining({
+          label: '元に戻す',
+        }),
+      }),
+    )
+  })
+
   it('handleOpenTab は active 設定の変化を resolveActive 経由で反映する', async () => {
     mocked.projectState.viewMode = 'custom'
     mocked.projectState.viewModeRef = { current: 'custom' }

--- a/src/features/saved-tabs/app/SavedTabsApp.test.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.test.tsx
@@ -3151,6 +3151,20 @@ describe('SavedTabsApp custom search', () => {
         'url-remove': 'news',
       },
     }
+    const urlRecords: UrlRecord[] = [
+      {
+        id: 'url-remove',
+        savedAt: 1,
+        title: 'Remove',
+        url: 'https://example.com/remove',
+      },
+      {
+        id: 'url-keep',
+        savedAt: 1,
+        title: 'Keep',
+        url: 'https://example.com/keep',
+      },
+    ]
     const chromeTabsCreateMock = vi.fn()
     const chromeSetMock = vi.fn()
     const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
@@ -3158,7 +3172,21 @@ describe('SavedTabsApp custom search', () => {
       storage: {
         local: {
           // eslint-disable-next-line typescript/require-await
-          get: vi.fn(async () => ({ savedTabs: [group] })),
+          get: vi.fn(async (key: unknown) => {
+            const keys = Array.isArray(key)
+              ? (key as string[])
+              : typeof key === 'string'
+                ? [key]
+                : []
+            const result: Record<string, unknown> = {}
+            for (const k of keys) {
+              if (k === 'savedTabs') result.savedTabs = [group]
+              if (k === 'urls') result.urls = urlRecords
+              if (k === 'customProjects') result.customProjects = []
+              if (k === 'customProjectOrder') result.customProjectOrder = []
+            }
+            return result
+          }),
           set: chromeSetMock,
         },
         onChanged: {
@@ -3176,14 +3204,7 @@ describe('SavedTabsApp custom search', () => {
         getURL: vi.fn(),
       },
     } as unknown as typeof chrome
-    vi.mocked(getUrlRecords).mockResolvedValue([
-      {
-        id: 'url-remove',
-        savedAt: 1,
-        title: 'Remove',
-        url: 'https://example.com/remove',
-      },
-    ])
+    vi.mocked(getUrlRecords).mockResolvedValue(urlRecords)
 
     render(<SavedTabsApp />)
 
@@ -3204,10 +3225,20 @@ describe('SavedTabsApp custom search', () => {
         expect.objectContaining({
           id: 'group-1',
           urlIds: ['url-keep'],
-          urlSubCategories: undefined,
         }),
       ],
     })
+    // OpenSavedUrlUseCase 経由でも urlSubCategories key 自体が消えていることを
+    // 確認する（mapper の merge で削除対象 URL ID の subCategory が落ちる）。
+    const savedTabsCall = chromeSetMock.mock.calls.find(
+      ([arg]) =>
+        arg !== null &&
+        typeof arg === 'object' &&
+        'savedTabs' in (arg as Record<string, unknown>),
+    ) as [{ savedTabs: TabGroup[] }] | undefined
+    expect(savedTabsCall?.[0].savedTabs[0]).not.toHaveProperty(
+      'urlSubCategories',
+    )
   })
 
   it('単体タブを開いた後の自動削除が無効なら保存データを更新しない', async () => {
@@ -3297,13 +3328,46 @@ describe('SavedTabsApp custom search', () => {
         },
       ],
     }
+    const urlRecords: UrlRecord[] = [
+      {
+        id: 'url-remove',
+        savedAt: 1,
+        title: 'Remove',
+        url: 'https://example.com/remove',
+      },
+    ]
+    const customProjectsSnapshot: CustomProject[] = [
+      {
+        categories: [],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Project A',
+        updatedAt: 1,
+        urlIds: ['url-remove'],
+      },
+    ]
     const chromeSetMock = vi.fn()
     const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
     chromeGlobal.chrome = {
       storage: {
         local: {
           // eslint-disable-next-line typescript/require-await
-          get: vi.fn(async () => ({ savedTabs: [group] })),
+          get: vi.fn(async (key: unknown) => {
+            const keys = Array.isArray(key)
+              ? (key as string[])
+              : typeof key === 'string'
+                ? [key]
+                : []
+            const result: Record<string, unknown> = {}
+            for (const k of keys) {
+              if (k === 'savedTabs') result.savedTabs = [group]
+              if (k === 'urls') result.urls = urlRecords
+              if (k === 'customProjects')
+                result.customProjects = customProjectsSnapshot
+              if (k === 'customProjectOrder') result.customProjectOrder = []
+            }
+            return result
+          }),
           set: chromeSetMock,
         },
         onChanged: {
@@ -3321,14 +3385,7 @@ describe('SavedTabsApp custom search', () => {
         getURL: vi.fn(),
       },
     } as unknown as typeof chrome
-    vi.mocked(getUrlRecords).mockResolvedValue([
-      {
-        id: 'url-remove',
-        savedAt: 1,
-        title: 'Remove',
-        url: 'https://example.com/remove',
-      },
-    ])
+    vi.mocked(getUrlRecords).mockResolvedValue(urlRecords)
     vi.mocked(removeUrlIdsFromAllCustomProjects).mockRejectedValueOnce(
       new Error('custom sync failed'),
     )
@@ -3343,6 +3400,11 @@ describe('SavedTabsApp custom search', () => {
 
     await customProps.handleOpenUrl('https://example.com/remove')
 
+    // OpenSavedUrlUseCase が tabGroupRepository.saveAll で savedTabs を
+    // 更新する。group-1 の唯一の URL が削除されるとグループ自体が消えるため、
+    // savedTabs は空配列で書き込まれる。CustomProject は use-case 経由で
+    // URL ID 削除されるので、`removeUrlIdsFromAllCustomProjects` (旧経路) は
+    // 失敗しても無関係。
     expect(chromeSetMock).toHaveBeenCalledWith({
       savedTabs: [],
     })
@@ -3733,5 +3795,241 @@ describe('SavedTabsApp custom search', () => {
     await expect(
       customProps.handleMoveUrlsBetweenCategories(),
     ).resolves.toBeUndefined()
+  })
+
+  it('handleOpenTab は urlRecord 未登録の URL でも browserTabPort で開く', async () => {
+    mocked.settings.openUrlInBackground = true
+    mocked.projectState.viewMode = 'custom'
+    mocked.projectState.viewModeRef = { current: 'custom' }
+    const chromeTabsCreateMock = vi.fn()
+    const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
+    chromeGlobal.chrome = {
+      storage: {
+        local: {
+          // eslint-disable-next-line typescript/require-await
+          get: vi.fn(async () => ({ savedTabs: [], urls: [] })),
+          set: vi.fn(),
+        },
+        onChanged: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        },
+      },
+      tabs: {
+        create: chromeTabsCreateMock,
+      },
+      windows: {
+        create: vi.fn(),
+      },
+      runtime: {
+        getURL: vi.fn(),
+      },
+    } as unknown as typeof chrome
+    vi.mocked(getUrlRecords).mockResolvedValue([])
+
+    render(<SavedTabsApp />)
+
+    const customProps = mocked.customModeContainerSpy.mock.calls.at(
+      -1,
+    )?.[0] as {
+      handleOpenUrl: (url: string) => Promise<void>
+    }
+
+    await customProps.handleOpenUrl('https://example.com/orphan')
+
+    // browserTabPort 経由で開かれる。openUrlInBackground=true なので active: false。
+    expect(chromeTabsCreateMock).toHaveBeenCalledWith({
+      active: false,
+      url: 'https://example.com/orphan',
+    })
+  })
+
+  it('handleOpenTab は removeTabAfterOpen=true 設定で Undo トーストを表示する', async () => {
+    mocked.settings.removeTabAfterOpen = true
+    mocked.settings.openUrlInBackground = false
+    mocked.projectState.viewMode = 'custom'
+    mocked.projectState.viewModeRef = { current: 'custom' }
+    const group: TabGroup = {
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-remove', 'url-keep'],
+      urls: [
+        {
+          id: 'url-remove',
+          title: 'Remove',
+          url: 'https://example.com/remove',
+        },
+        {
+          id: 'url-keep',
+          title: 'Keep',
+          url: 'https://example.com/keep',
+        },
+      ],
+    }
+    const urlRecords: UrlRecord[] = [
+      {
+        id: 'url-remove',
+        savedAt: 1,
+        title: 'Remove',
+        url: 'https://example.com/remove',
+      },
+      {
+        id: 'url-keep',
+        savedAt: 1,
+        title: 'Keep',
+        url: 'https://example.com/keep',
+      },
+    ]
+    const customProjectsSnapshot: CustomProject[] = []
+    const chromeSetMock = vi.fn()
+    const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
+    chromeGlobal.chrome = {
+      storage: {
+        local: {
+          // eslint-disable-next-line typescript/require-await
+          get: vi.fn(async (key: unknown) => {
+            const keys = Array.isArray(key)
+              ? (key as string[])
+              : typeof key === 'string'
+                ? [key]
+                : []
+            const result: Record<string, unknown> = {}
+            for (const k of keys) {
+              if (k === 'savedTabs') result.savedTabs = [group]
+              if (k === 'urls') result.urls = urlRecords
+              if (k === 'customProjects')
+                result.customProjects = customProjectsSnapshot
+              if (k === 'customProjectOrder') result.customProjectOrder = []
+            }
+            return result
+          }),
+          set: chromeSetMock,
+        },
+        onChanged: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        },
+      },
+      tabs: {
+        create: vi.fn(),
+      },
+      windows: {
+        create: vi.fn(),
+      },
+      runtime: {
+        getURL: vi.fn(),
+      },
+    } as unknown as typeof chrome
+    vi.mocked(getUrlRecords).mockResolvedValue(urlRecords)
+
+    render(<SavedTabsApp />)
+
+    const customProps = mocked.customModeContainerSpy.mock.calls.at(
+      -1,
+    )?.[0] as {
+      handleOpenUrl: (url: string) => Promise<void>
+    }
+
+    await customProps.handleOpenUrl('https://example.com/remove')
+
+    expect(toast.info).toHaveBeenCalledWith(
+      '開いた1件のタブを保存データから削除しました',
+      expect.objectContaining({
+        action: expect.objectContaining({
+          label: '元に戻す',
+        }),
+      }),
+    )
+
+    // Undo で snapshot 復元を試す
+    const undoOptions = vi.mocked(toast.info).mock.calls.at(-1)?.[1] as
+      | {
+          action?: {
+            onClick?: () => Promise<void>
+          }
+        }
+      | undefined
+    await undoOptions?.action?.onClick?.()
+
+    // chrome.storage.local.set が savedTabs / customProjects の元データを書き戻す
+    expect(chromeSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        savedTabs: [group],
+      }),
+    )
+  })
+
+  it('handleOpenTab は active 設定の変化を resolveActive 経由で反映する', async () => {
+    mocked.projectState.viewMode = 'custom'
+    mocked.projectState.viewModeRef = { current: 'custom' }
+    const chromeTabsCreateMock = vi.fn()
+    const addListener = vi.fn()
+    const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
+    chromeGlobal.chrome = {
+      storage: {
+        local: {
+          // eslint-disable-next-line typescript/require-await
+          get: vi.fn(async () => ({ savedTabs: [], urls: [] })),
+          set: vi.fn(),
+        },
+        onChanged: {
+          addListener,
+          removeListener: vi.fn(),
+        },
+      },
+      tabs: {
+        create: chromeTabsCreateMock,
+      },
+      windows: {
+        create: vi.fn(),
+      },
+      runtime: {
+        getURL: vi.fn(),
+      },
+    } as unknown as typeof chrome
+    vi.mocked(getUrlRecords).mockResolvedValue([])
+
+    // 初期 settings は openUrlInBackground=true（defaultSettings 由来）。
+    // 設定変更を syncStorageChanges 経由で false に切り替えてから再度開く。
+    // eslint-disable-next-line typescript/require-await
+    vi.mocked(syncStorageChanges).mockImplementationOnce(async (options) => {
+      options.setSettings({
+        ...mocked.settings,
+        openUrlInBackground: false,
+      })
+      return []
+    })
+
+    render(<SavedTabsApp />)
+
+    // 1回目: defaultSettings の openUrlInBackground=true → active: false
+    let customProps = mocked.customModeContainerSpy.mock.calls.at(-1)?.[0] as {
+      handleOpenUrl: (url: string) => Promise<void>
+    }
+    await customProps.handleOpenUrl('https://example.com/first')
+    expect(chromeTabsCreateMock).toHaveBeenLastCalledWith({
+      active: false,
+      url: 'https://example.com/first',
+    })
+
+    // 設定を openUrlInBackground=false に変えてから再描画
+    const listener = addListener.mock.calls[0]?.[0] as (
+      changes: Record<string, chrome.storage.StorageChange>,
+    ) => Promise<void>
+    await act(async () => {
+      await listener({
+        settings: { newValue: { openUrlInBackground: false } },
+      })
+    })
+
+    // 2回目: openUrlInBackground=false → active: true
+    customProps = mocked.customModeContainerSpy.mock.calls.at(-1)?.[0] as {
+      handleOpenUrl: (url: string) => Promise<void>
+    }
+    await customProps.handleOpenUrl('https://example.com/second')
+    expect(chromeTabsCreateMock).toHaveBeenLastCalledWith({
+      active: true,
+      url: 'https://example.com/second',
+    })
   })
 })

--- a/src/features/saved-tabs/app/SavedTabsApp.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.tsx
@@ -9,7 +9,10 @@ import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
+import { createSavedTabsPorts } from '@/app/composition/createSavedTabsPorts'
+import { createSavedTabsUseCases } from '@/app/composition/createSavedTabsUseCases'
 import { Toaster } from '@/components/ui/sonner'
+import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/UrlRecordId'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { CategoryReorderFooter } from '@/features/saved-tabs/components/Footer'
 import { Header } from '@/features/saved-tabs/components/Header' // ヘッダーコンポーネントをインポート
@@ -252,6 +255,30 @@ const useSavedTabsAppView = ({
     hasResolvedInitialViewModeRef.current = !initialViewMode
   }
 
+  // BrowserTabPort の `resolveActive` から参照される最新 settings。
+  // settings オブジェクト全体が変わってもタブを開く度に最新値を見るため、
+  // 関数クロージャからは ref を読む。
+  const settingsRef = useRef(settings)
+  settingsRef.current = settings
+
+  // saved-tabs use-case バンドルと port バンドル。
+  // resolveActive 関数を ref 経由で渡し、`openUrlInBackground` 設定変更を
+  // 再 mount なしで反映する。
+  const savedTabsUseCases = useMemo(
+    () =>
+      createSavedTabsUseCases({
+        resolveActive: () => !settingsRef.current.openUrlInBackground,
+      }),
+    [],
+  )
+  const savedTabsPorts = useMemo(
+    () =>
+      createSavedTabsPorts({
+        resolveActive: () => !settingsRef.current.openUrlInBackground,
+      }),
+    [],
+  )
+
   // 未分類ドメインの並び替えモード状態管理
   const [isUncategorizedReorderMode, setIsUncategorizedReorderMode] =
     useState(false)
@@ -359,19 +386,57 @@ const useSavedTabsAppView = ({
     [refreshTabGroupsWithUrls, setCustomProjects, t],
   )
 
-  // 既存のタブ開く処理を拡張して両方のモードで同期する
+  // 既存のタブ開く処理を OpenSavedUrlUseCase 経由に置き換え。
+  // - URL → urlRecordId は `getUrlRecords()` から逆引きし、見つからない
+  //   旧データは `browserTabPort` で開くだけのフォールバックを取る。
+  // - `removeTabAfterOpen` が true のときは、削除前 snapshot を取得して
+  //   既存の Undo トースト経路と接続する。snapshot は use-case の
+  //   戻り値ではなく chrome.storage.local の生データを使うことで、
+  //   `urls` / `urlSubCategories` などのリッチフィールド復元を維持する。
   const handleOpenTab = useCallback(
     async (url: string) => {
       try {
-        // 設定に基づきバックグラウンド(active: false)またはフォアグラウンド(active: true)で開く
-        await chrome.tabs.create({
-          active: !settings.openUrlInBackground,
-          url,
+        const urlRecords = await getUrlRecords()
+        const targetRecord = urlRecords.find((record) => record.url === url)
+
+        if (!targetRecord) {
+          // urlRecord に登録されていない URL（旧データなど）は
+          // browserTabPort 経由で開くだけにとどめ、削除処理はスキップする。
+          await savedTabsPorts.browserTabPort.open({ url })
+          return
+        }
+
+        const snapshot = settings.removeTabAfterOpen
+          ? await chrome.storage.local.get<OpenedUrlsStorageSnapshot>([
+              'savedTabs',
+              'customProjects',
+              'customProjectOrder',
+            ])
+          : undefined
+
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        const urlRecordId = targetRecord.id as unknown as UrlRecordId
+        const result = await savedTabsUseCases.openSavedUrl({
+          origin: 'click',
+          settings: {
+            removeTabAfterExternalDrop: false,
+            removeTabAfterOpen: settings.removeTabAfterOpen,
+          },
+          urlRecordId,
         })
 
-        // 設定に基づいて、開いたタブを削除するかどうかを決定（新形式対応）
-        if (settings.removeTabAfterOpen) {
-          await removeOpenedUrlsFromStorage([url])
+        if (snapshot && result.removedUrlRecordId) {
+          const updated = await chrome.storage.local.get<{
+            savedTabs?: TabGroup[]
+          }>('savedTabs')
+          await refreshTabGroupsWithUrls(updated.savedTabs ?? [])
+          showOpenedUrlsUndoToast({
+            count: 1,
+            refreshTabGroupsWithUrls,
+            setCustomProjects,
+            snapshot,
+            t,
+          })
           console.log(`URL ${url} を開いた後、保存データから削除しました`)
         }
       } catch (error) {
@@ -379,9 +444,12 @@ const useSavedTabsAppView = ({
       }
     },
     [
-      settings.openUrlInBackground,
+      savedTabsPorts,
+      savedTabsUseCases,
       settings.removeTabAfterOpen,
-      removeOpenedUrlsFromStorage,
+      refreshTabGroupsWithUrls,
+      setCustomProjects,
+      t,
     ],
   )
   const handleOpenAllTabs = useCallback(

--- a/src/features/saved-tabs/app/SavedTabsApp.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.tsx
@@ -425,7 +425,12 @@ const useSavedTabsAppView = ({
           urlRecordId,
         })
 
-        if (snapshot && result.removedUrlRecordId) {
+        // use-case が `snapshot` を返すのは「TabGroup / CustomProject の
+        // urlIds から実際に削除が走った」ケース。urlRecord 自体が他で
+        // 参照されていて削除されない場合でも、TabGroup から URL ID が
+        // 取り除かれているなら Undo 対象として扱う必要がある。よって
+        // `removedUrlRecordId` ではなく `snapshot` の有無を判定基準にする。
+        if (snapshot && result.snapshot) {
           const updated = await chrome.storage.local.get<{
             savedTabs?: TabGroup[]
           }>('savedTabs')


### PR DESCRIPTION
## 関連 Issue

Closes #470

## 変更内容

`SavedTabsApp.tsx` の `handleOpenTab` を旧来の `chrome.tabs.create` 直接呼び出しから DDD 構成の `OpenSavedUrlUseCase` + `BrowserTabPort` 経由に置き換えました。

issue で求められた最小スコープを実装するうえで、既存ユーザーデータを破壊しないためのリポジトリ拡張と use-case の軽微なバグ修正を併せて行っています。

### 主要変更

- **`SavedTabsApp.tsx`** : `handleOpenTab` を `savedTabsUseCases.openSavedUrl` 経由に置き換え。`getUrlRecords()` で URL → `urlRecordId` を逆引きし、未登録 URL は `browserTabPort.open` のみで開く（削除処理はスキップ）。
- **`createSavedTabsPorts` / `createSavedTabsUseCases`** : `resolveActive` option を追加し、`SavedTabsApp` 側で `ref` 経由の関数を渡して `openUrlInBackground` 設定をランタイムで反映できるようにした。
- **`ChromeSavedTabsStorageMapper.toSavedTabRaw` / `toCustomProjectRaw`** : `original?: SavedTabRaw` / `CustomProjectRaw` を受け取れるよう拡張。entity 化対象外のリッチ補助フィールド（`urls`, `urlSubCategories`, `subCategories`, `categoryKeywords`, `subCategoryOrder`, `subCategoryOrderWithUncategorized`, `projectKeywords`, `urlMetadata`, `categoryOrder`, `urls`）を `urlIds` の集合に合わせて整合性を取りつつ持ち越す。
- **`ChromeTabGroupRepository.saveAll` / `ChromeCustomProjectRepository.saveAll`** : 書き込み前に既存 raw を取得し、entity と merge してから保存する。これによりユーザーの保存データを破壊しない。
- **`OpenSavedUrlUseCase`** : `TabGroup` の length が変わらないが内容が変わった場合に `saveAll` が呼ばれないバグを修正（reference 比較で検出）。

### 設計判断

- **Undo snapshot**: use-case の戻り値 (`OpenedUrlsRestoreSnapshot`) を使わず、`chrome.storage.local.get` の生データを直接 `showOpenedUrlsUndoToast` に渡しました。これは domain entity が表現しないリッチフィールド（`urls`, `urlSubCategories`...）の復元を維持するためです。
- **未登録 URL のフォールバック**: `getUrlRecords()` に存在しない URL は `browserTabPort.open` だけで開き、削除処理をスキップします。これにより旧データの単純な URL クリックでも動作を維持します（`chrome.tabs.create` 直接呼び出しは消えています）。
- **`removeOpenedUrlsFromStorage` の残置**: `handleOpenAllTabs` でまだ使われているため残置しています。`handleOpenAllTabs` の use-case 化は別 issue で対応する想定です。

## テスト

- `bun run test` （1742 tests）→ 全 pass
- `bun run compile` → pass
- `bun run lint` → 0 warnings / 0 errors
- `bun run format` → pass

### 追加テスト

- `OpenSavedUrlUseCase.test.ts`: 「TabGroup から URL を一つだけ削除してグループ自体は残る場合も saveAll が呼ばれる」「TabGroup の内容が変わらないときは saveAll を呼ばない」
- `ChromeSavedTabsStorageMapper.test.ts`: `toSavedTabRaw` / `toCustomProjectRaw` の original merge 挙動、urls / urlMetadata / urlSubCategories の `urlIds` 同期、id 無しエントリのパススルー
- `ChromeTabGroupRepository.test.ts` / `ChromeCustomProjectRepository.test.ts`: `saveAll` がリッチ補助フィールドを保持することを検証
- `createSavedTabsPorts.test.ts` / `createSavedTabsUseCases.test.ts`: `resolveActive` option の挙動と最新値反映
- `SavedTabsApp.test.tsx`: 「handleOpenTab は urlRecord 未登録の URL でも browserTabPort で開く」「handleOpenTab は removeTabAfterOpen=true 設定で Undo トーストを表示する」「handleOpenTab は active 設定の変化を resolveActive 経由で反映する」を追加。既存テストの mock を新実装に合わせて更新。

## チェックリスト

- [x] ローカル環境でエラーになっていない
- [x] `bun run compile` が通る
- [x] 関連テストが通る
- [x] 単一URLオープンが `OpenSavedUrlUseCase` 経由になっている
- [x] `SavedTabsApp.tsx` から対象処理の `chrome.tabs.create` 直接呼び出しがなくなっている
- [x] 既存のURLオープン挙動が変わっていない
- [x] 既存データ形式は変えない（mapper merge により保持）

## 注意

`bun run quality` の `knip` は事前から失敗していた（harness scripts の検出問題）ため、本 PR の修正対象外です。