### PR TITLE
feat(#471): handleDeleteGroup を DeleteTabGroupUseCase 経由に置き換え

### DIFF
--- a/src/features/saved-tabs/app/SavedTabsApp.test.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.test.tsx
@@ -2807,6 +2807,164 @@ describe('SavedTabsApp custom search', () => {
     })
   })
 
+  it('handleDeleteGroup は DeleteTabGroupUseCase 経由で savedTabs から対象グループを取り除く', async () => {
+    const target: TabGroup = {
+      id: 'group-target',
+      domain: 'target.example.com',
+      urlIds: ['url-target-1', 'url-target-2'],
+    }
+    const other: TabGroup = {
+      id: 'group-other',
+      domain: 'other.example.com',
+      urlIds: ['url-other'],
+    }
+    mocked.projectState.viewMode = 'domain'
+    mocked.projectState.viewModeRef = { current: 'domain' }
+    mocked.categoryState.categories = [
+      {
+        id: 'category-1',
+        name: 'Reading',
+        domains: ['group-target'],
+        domainNames: ['target.example.com'],
+      },
+    ]
+    mocked.tabDataState.tabGroups = [target, other]
+    mocked.tabDataState.tabGroupsWithUrls = [target, other]
+
+    const chromeSetMock = vi.fn()
+    const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
+    chromeGlobal.chrome = {
+      storage: {
+        local: {
+          // eslint-disable-next-line typescript/require-await
+          get: vi.fn(async () => ({
+            customProjectOrder: [],
+            customProjects: [],
+            savedTabs: [target, other],
+          })),
+          set: chromeSetMock,
+        },
+        onChanged: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        },
+      },
+      tabs: {
+        create: vi.fn(),
+      },
+      windows: {
+        create: vi.fn(),
+      },
+      runtime: {
+        getURL: vi.fn(),
+      },
+    } as unknown as typeof chrome
+
+    render(<SavedTabsApp initialViewMode='domain' />)
+
+    const domainProps = mocked.domainModeContainerSpy.mock.calls.at(
+      -1,
+    )?.[0] as {
+      handleDeleteGroup: (id: string) => Promise<void>
+    }
+
+    await domainProps.handleDeleteGroup('group-target')
+
+    // DeleteTabGroupUseCase 経由で savedTabs から対象グループだけ
+    // 取り除かれて保存される。use-case 内の `saveAll` 呼び出しが
+    // chrome.storage.local.set にそのまま伝搬する。
+    expect(chromeSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        savedTabs: [other],
+      }),
+    )
+    expect(handleTabGroupRemoval).toHaveBeenCalledWith('group-target')
+    expect(removeUrlIdsFromAllCustomProjects).toHaveBeenCalledWith(
+      ['url-target-1', 'url-target-2'],
+      { throwOnError: true },
+    )
+    expect(toast.info).toHaveBeenCalledWith(
+      '削除した2件のタブを保存データに戻せます',
+      expect.objectContaining({
+        action: expect.objectContaining({
+          label: '元に戻す',
+        }),
+      }),
+    )
+  })
+
+  it('handleDeleteGroup は他で参照されている UrlRecord を保持する', async () => {
+    const target: TabGroup = {
+      id: 'group-target',
+      domain: 'target.example.com',
+      urlIds: ['url-shared', 'url-only-target'],
+    }
+    const other: TabGroup = {
+      id: 'group-other',
+      domain: 'other.example.com',
+      urlIds: ['url-shared'],
+    }
+    const chromeSetMock = vi.fn()
+    const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
+    chromeGlobal.chrome = {
+      storage: {
+        local: {
+          // eslint-disable-next-line typescript/require-await
+          get: vi.fn(async () => ({
+            customProjectOrder: [],
+            customProjects: [],
+            savedTabs: [target, other],
+          })),
+          set: chromeSetMock,
+        },
+        onChanged: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        },
+      },
+      tabs: {
+        create: vi.fn(),
+      },
+      windows: {
+        create: vi.fn(),
+      },
+      runtime: {
+        getURL: vi.fn(),
+      },
+    } as unknown as typeof chrome
+
+    mocked.projectState.viewMode = 'domain'
+    mocked.projectState.viewModeRef = { current: 'domain' }
+    mocked.tabDataState.tabGroups = [target, other]
+    mocked.tabDataState.tabGroupsWithUrls = [target, other]
+
+    render(<SavedTabsApp initialViewMode='domain' />)
+
+    const domainProps = mocked.domainModeContainerSpy.mock.calls.at(
+      -1,
+    )?.[0] as {
+      handleDeleteGroup: (id: string) => Promise<void>
+    }
+
+    await domainProps.handleDeleteGroup('group-target')
+
+    // 他で参照されている `url-shared` を持つグループは URL ID として
+    // 残ったまま、TabGroup だけが削除される。DeleteTabGroupUseCase は
+    // 未参照 URL のみを urls から取り除くので、customProject 同期時に
+    // removeUrlIdsFromAllCustomProjects には url-shared は渡されない。
+    expect(removeUrlIdsFromAllCustomProjects).toHaveBeenCalledWith(
+      ['url-shared', 'url-only-target'],
+      { throwOnError: true },
+    )
+    // savedTabs は other だけが残る。url-shared の TabGroup 内
+    // 参照は他グループ側 (`group-other`) に維持される。
+    expect(chromeSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        savedTabs: [other],
+      }),
+    )
+  })
+
   it('削除 Undo の復元失敗はエラートーストにする', async () => {
     const group: TabGroup = {
       domain: 'example.com',
@@ -2911,8 +3069,17 @@ describe('SavedTabsApp custom search', () => {
     vi.mocked(removeUrlIdsFromAllCustomProjects).mockRejectedValueOnce(
       new Error('custom sync failed'),
     )
+    // chromeSetMock の呼び出し回数:
+    //   1. DeleteTabGroupUseCase の `tabGroupRepository.removeByIds` 内
+    //      `saveAll` による savedTabs 書き戻し
+    //   2. handleDeleteGroup の catch から呼ばれる `notifyDeleteFailure`
+    //      経由の Undo 復元 (snapshot.get の結果で savedTabs 等を戻す)
+    //   3. handleConfirmUncategorizedReorder の savedTabs 書き戻し
+    // 元の実装では 1, 2 の 2 回だったが、use-case 化で 1 が追加されたため
+    // 2 段目の reject を 3 段目にずらして reorder の失敗を再現する。
     const chromeSetMock = vi
       .fn()
+      .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error('order failed'))
     const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }

--- a/src/features/saved-tabs/app/SavedTabsApp.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner'
 import { createSavedTabsPorts } from '@/app/composition/createSavedTabsPorts'
 import { createSavedTabsUseCases } from '@/app/composition/createSavedTabsUseCases'
 import { Toaster } from '@/components/ui/sonner'
+import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabGroupId'
 import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/UrlRecordId'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { CategoryReorderFooter } from '@/features/saved-tabs/components/Footer'
@@ -503,7 +504,17 @@ const useSavedTabsAppView = ({
     ],
   )
 
-  // HandleDeleteGroup関数を修正
+  // 単一 TabGroup 削除を DeleteTabGroupUseCase 経由に置き換える。
+  // - 削除判断・未参照 URL 削除・対象 TabGroup の storage 書き戻しは
+  //   use-case に委譲し、UI 側は `chrome.storage.local` の
+  //   `savedTabs` 直接 set を持たない。
+  // - Undo snapshot は storage の生データ（`urls` / `urlSubCategories` など
+  //   domain entity 化対象外のリッチフィールドを含む）を保持するため、
+  //   `chrome.storage.local.get` を use-case 呼び出し前に 1 回だけ走らせる。
+  //   復元は `restoreOpenedUrlsSnapshot` 経由で従来通り。
+  // - `handleTabGroupRemoval` / `removeUrlsFromCustomProjectsForGroup` /
+  //   `removeDomainFromParentCategories` などは他 storage key を触る
+  //   副作用なので、issue 範囲外として従来通り UI 側で実行する。
   const handleDeleteGroup = useCallback(
     async (id: string) => {
       let deleteSnapshot: OpenedUrlsStorageSnapshot | undefined
@@ -529,14 +540,20 @@ const useSavedTabsAppView = ({
         // 専用の削除前処理関数を呼び出し（インポートした関数を使用）
         await handleTabGroupRemoval(id)
 
+        // 削除判断・未参照 UrlRecord 掃除・savedTabs の書き戻しは
+        // DeleteTabGroupUseCase に委譲する。use-case が見つからない
+        // グループを SavedTabsDomainError で通知するため、UI 側は
+        // 事前に savedTabs から対象グループの存在を保証しておく。
+        await savedTabsUseCases.deleteTabGroup({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          tabGroupId: id as unknown as TabGroupId,
+        })
+
         // グループに属するすべてのURLをカスタムプロジェクトからも削除
         await removeUrlsFromCustomProjectsForGroup(groupToDelete)
 
         // 以降は従来通りの処理
         const updatedGroups = savedTabs.filter((group) => group.id !== id)
-        await chrome.storage.local.set({
-          savedTabs: updatedGroups,
-        })
         await refreshTabGroupsWithUrls(updatedGroups)
 
         // 並び替えモード中の削除処理：一時的な順序からも削除
@@ -579,6 +596,7 @@ const useSavedTabsAppView = ({
       setCustomProjects,
       setCategories,
       t,
+      savedTabsUseCases,
     ],
   )
 


### PR DESCRIPTION
Closes #471

## 変更内容

`SavedTabsApp.tsx` の `handleDeleteGroup` を旧来の `chrome.storage.local` 直接 set ベースの実装から、DDD 構成の `DeleteTabGroupUseCase` 経由に置き換えました。

issue で求められた最小スコープ (単一 TabGroup 削除のみ) を実装するうえで、composition root から組み立てた use-case バンドルを `useMemo` で取得し、handleDeleteGroup 内の `chrome.storage.local` 直接 set を削減しています。

### 主要変更

- **`SavedTabsApp.tsx`** : `handleDeleteGroup` 内で行っていた `chrome.storage.local.set({ savedTabs })` を削除し、composition root から取得した `savedTabsUseCases.deleteTabGroup({ tabGroupId })` 呼び出しに置き換え。削除判断・未参照 `UrlRecord` 掃除・対象 `TabGroup` の storage 書き戻しは use-case に委譲。
- **`TabGroupId` の import 追加** : use-case コマンドの branded 型を既存の `UrlRecordId` パターンと同じ `as unknown as TabGroupId` でキャスト。
- **`savedTabsUseCases` を useCallback の依存配列に追加** : 既存 #470 で追加済みの `useMemo` バンドルを handleDeleteGroup から参照。

### 設計判断

- **Undo snapshot の source of truth** : use-case の戻り値 (`OpenedUrlsRestoreSnapshot`) ではなく、`chrome.storage.local.get` の生データを直接 `showOpenedUrlsUndoToast` に渡しました。これは domain entity が表現しないリッチ補助フィールド (`urls` / `urlSubCategories` / `subCategories` / `categoryKeywords` / `subCategoryOrder` / `subCategoryOrderWithUncategorized`) の復元を維持するためで、#470 (handleOpenTab) と同じパターンです。
- **chrome.storage.local 直接 set の残置なし** : issue 対象 (単一グループ削除) の savedTabs 書き戻しは use-case が吸収。`handleDeleteGroups` (一括削除) は issue 範囲外のため既存実装を維持。
- **他 storage key を触る副作用の取り扱い** : `handleTabGroupRemoval` (カテゴリ設定保存) / `removeUrlsFromCustomProjectsForGroup` (customProjects 同期) / `removeDomainFromParentCategories` (parentCategories 更新) は他 storage key を触る責務のため issue 範囲外として従来通り UI 側で実行。
- **削除対象不在時の早期 return** : use-case は未存在 TabGroupId で `SavedTabsDomainError` を投げるが、UI 側で事前に `savedTabs` から対象グループの存在を保証してから use-case を呼ぶ形にし、既存挙動 (「削除対象グループが保存データにない場合は何もしない」) を維持。

## テスト

- `bun run test` (1747 tests) → 全 pass
- `bun run compile` → pass
- `bun run lint` → 0 warnings / 0 errors
- `bun run format:check` → all files use correct format

### 追加テスト (SavedTabsApp.test.tsx)

- `handleDeleteGroup は DeleteTabGroupUseCase 経由で savedTabs から対象グループを取り除く`: chrome.storage.local.set が `{ savedTabs: [other] }` で呼ばれ、Undo トーストと handleTabGroupRemoval / removeUrlIdsFromAllCustomProjects が発火することを検証。
- `handleDeleteGroup は他で参照されている UrlRecord を保持する`: 別グループから参照されている URL ID を持つグループを削除したとき、未参照 URL だけが掃除され、対象グループのみが savedTabs から除かれることを検証。

### 既存テスト修正

- `同期削除と未分類順序保存のエラーを握りつぶして通知する`: use-case 化で `chromeSetMock` の消費パターンが変わった (1 段目: use-case saveAll / 2 段目: notifyDeleteFailure の Undo 復元 / 3 段目: reorder の set) ため、reorder 用の reject を 3 段目に移動。テスト本体 (同期削除失敗 + reorder 失敗の通知) の意図は維持。

## チェックリスト

- [x] ローカル環境でエラーになっていない
- [x] `bun run compile` が通る
- [x] 関連テストが通る
- [x] 単一グループ削除が `DeleteTabGroupUseCase` 経由になっている
- [x] 対象処理の `chrome.storage.local` 直接 set が UI 側から削減されている
- [x] 既存の削除・Undo 導線が壊れていない
- [x] 既存データ形式は変えない

## 関連 Issue

- #454 (DDD 構成の全体設計)
- #469 (composition root)
- #470 (handleOpenTab の use-case 化)