### PR TITLE
feat(#472): restore / undo を RestoreOpenedUrlsSnapshotUseCase 経由に置き換え

### DIFF
--- a/src/features/saved-tabs/app/SavedTabsApp.test.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.test.tsx
@@ -447,9 +447,23 @@ describe('SavedTabsApp custom search', () => {
     const refreshTabGroupsWithUrls = vi.fn(async () => {
       throw new Error('restore failed')
     })
+    // eslint-disable-next-line typescript/require-await
+    const restoreOpenedUrlsSnapshotUseCase = vi.fn(async () => ({
+      restoredCustomProjects: [],
+      restoredParentCategories: [],
+      restoredTabGroups: [],
+      restoredUrlRecords: [],
+    }))
 
     await notifyDeleteFailure({
       refreshTabGroupsWithUrls,
+      savedTabsUseCases: {
+        deleteTabGroup: vi.fn(),
+        openSavedUrl: vi.fn(),
+        removeUnreferencedUrlRecords: vi.fn(),
+        restoreOpenedUrlsSnapshot: restoreOpenedUrlsSnapshotUseCase,
+        syncCategoryAssignments: vi.fn(),
+      },
       setCustomProjects: vi.fn(),
       snapshot: {
         customProjects: [],
@@ -466,6 +480,13 @@ describe('SavedTabsApp custom search', () => {
 
     await notifyDeleteFailure({
       refreshTabGroupsWithUrls,
+      savedTabsUseCases: {
+        deleteTabGroup: vi.fn(),
+        openSavedUrl: vi.fn(),
+        removeUnreferencedUrlRecords: vi.fn(),
+        restoreOpenedUrlsSnapshot: restoreOpenedUrlsSnapshotUseCase,
+        syncCategoryAssignments: vi.fn(),
+      },
       setCustomProjects: vi.fn(),
       t: (key) => key,
     })
@@ -481,18 +502,151 @@ describe('SavedTabsApp custom search', () => {
     chromeGlobal.chrome.storage.local.set = chromeSetMock
     const setCustomProjects = vi.fn()
     const refreshTabGroupsWithUrls = vi.fn()
+    // eslint-disable-next-line typescript/require-await
+    const restoreOpenedUrlsSnapshotUseCase = vi.fn(async () => ({
+      restoredCustomProjects: [],
+      restoredParentCategories: [],
+      restoredTabGroups: [],
+      restoredUrlRecords: [],
+    }))
 
     await restoreOpenedUrlsSnapshot({
       refreshTabGroupsWithUrls,
+      savedTabsUseCases: {
+        deleteTabGroup: vi.fn(),
+        openSavedUrl: vi.fn(),
+        removeUnreferencedUrlRecords: vi.fn(),
+        restoreOpenedUrlsSnapshot: restoreOpenedUrlsSnapshotUseCase,
+        syncCategoryAssignments: vi.fn(),
+      },
       setCustomProjects,
       snapshot: {},
     })
 
-    expect(chromeSetMock).toHaveBeenCalledWith({
-      savedTabs: [],
+    expect(restoreOpenedUrlsSnapshotUseCase).toHaveBeenCalledWith({
+      snapshot: {},
     })
+    expect(chromeSetMock).not.toHaveBeenCalled()
     expect(setCustomProjects).not.toHaveBeenCalled()
     expect(refreshTabGroupsWithUrls).toHaveBeenCalledWith([])
+
+    // 不正な id の TabGroup / CustomProject / ParentCategory は
+    // domain factory の SavedTabsDomainError 経由でスキップされる。
+    // chromeSetMock は customProjectOrder 1 件だけ。
+    const captured: unknown[] = []
+    // eslint-disable-next-line typescript/require-await
+    const captureUseCase = vi.fn(async (input: { snapshot: unknown }) => {
+      captured.push(input)
+      return {
+        restoredCustomProjects: [],
+        restoredParentCategories: [],
+        restoredTabGroups: [],
+        restoredUrlRecords: [],
+      }
+    })
+    const refreshTabGroupsWithUrls2 = vi.fn()
+    const setCustomProjects2 = vi.fn()
+    await restoreOpenedUrlsSnapshot({
+      refreshTabGroupsWithUrls: refreshTabGroupsWithUrls2,
+      savedTabsUseCases: {
+        deleteTabGroup: vi.fn(),
+        openSavedUrl: vi.fn(),
+        removeUnreferencedUrlRecords: vi.fn(),
+        restoreOpenedUrlsSnapshot: captureUseCase,
+        syncCategoryAssignments: vi.fn(),
+      },
+      setCustomProjects: setCustomProjects2,
+      snapshot: {
+        customProjects: [
+          // 名前が空のカスタムプロジェクトは SavedTabsDomainError を投げる
+          {
+            categories: [],
+            createdAt: 1,
+            id: 'project-bad',
+            name: '',
+            updatedAt: 1,
+            urlIds: [],
+          },
+          {
+            categories: [],
+            createdAt: 1,
+            id: 'project-good',
+            name: 'Good',
+            updatedAt: 1,
+            urlIds: [],
+          },
+        ],
+        customProjectOrder: ['project-good'],
+        parentCategories: [
+          // domainNames に空文字が含まれる場合は
+          // createParentCategory が SavedTabsDomainError を投げる
+          {
+            domainNames: [''],
+            domains: [],
+            id: 'cat-bad',
+            name: 'Bad',
+          },
+          {
+            domainNames: [],
+            domains: [],
+            id: 'cat-good',
+            name: 'Good',
+          },
+        ],
+        savedTabs: [
+          // id が空文字の TabGroup は SavedTabsDomainError を投げる
+          {
+            domain: 'example.com',
+            id: '',
+            urlIds: ['url-1'],
+          },
+          {
+            domain: 'example.com',
+            id: 'group-good',
+            urlIds: ['url-1'],
+          },
+        ],
+      },
+    })
+
+    expect(captureUseCase).toHaveBeenCalledTimes(1)
+    const command = (captured[0] as { snapshot: unknown }).snapshot as {
+      customProjects: { id: string }[]
+      parentCategories: { id: string }[]
+      savedTabs: { id: string }[]
+    }
+    expect(command.savedTabs.map((g) => g.id)).toStrictEqual(['group-good'])
+    expect(command.customProjects.map((p) => p.id)).toStrictEqual([
+      'project-good',
+    ])
+    expect(command.parentCategories.map((c) => c.id)).toStrictEqual([
+      'cat-good',
+    ])
+    expect(chromeSetMock).toHaveBeenLastCalledWith({
+      customProjectOrder: ['project-good'],
+    })
+    expect(setCustomProjects2).toHaveBeenCalledWith([
+      {
+        categories: [],
+        createdAt: 1,
+        id: 'project-bad',
+        name: '',
+        updatedAt: 1,
+        urlIds: [],
+      },
+      {
+        categories: [],
+        createdAt: 1,
+        id: 'project-good',
+        name: 'Good',
+        updatedAt: 1,
+        urlIds: [],
+      },
+    ])
+    expect(refreshTabGroupsWithUrls2).toHaveBeenCalledWith([
+      { domain: 'example.com', id: '', urlIds: ['url-1'] },
+      { domain: 'example.com', id: 'group-good', urlIds: ['url-1'] },
+    ])
 
     const groupWithoutUrls: TabGroup = {
       domain: 'empty.example.com',
@@ -1266,11 +1420,11 @@ describe('SavedTabsApp custom search', () => {
       | undefined
     await undoOptions?.action?.onClick?.()
 
+    // 復元は RestoreOpenedUrlsSnapshotUseCase 経由になり、TabGroup /
+    // CustomProject / ParentCategory は各 repository の saveAll で個別に
+    // 書き戻される。presentation 層で残るのは customProjectOrder のみ。
     expect(chromeSetMock).toHaveBeenLastCalledWith({
       customProjectOrder: ['project-1'],
-      customProjects: customProjectsSnapshot,
-      parentCategories: mocked.categoryState.categories,
-      savedTabs: [group],
     })
     expect(mocked.projectState.setCustomProjects).toHaveBeenCalledWith(
       customProjectsSnapshot,
@@ -1577,10 +1731,11 @@ describe('SavedTabsApp custom search', () => {
       | undefined
     await undoOptions?.action?.onClick?.()
 
+    // 復元は RestoreOpenedUrlsSnapshotUseCase 経由になり、TabGroup /
+    // CustomProject は各 repository の saveAll で個別に書き戻される。
+    // presentation 層で残るのは customProjectOrder のみ。
     expect(chromeSetMock).toHaveBeenLastCalledWith({
       customProjectOrder: ['project-1'],
-      customProjects: customProjectsSnapshot,
-      savedTabs: [group],
     })
     expect(mocked.projectState.setCustomProjects).toHaveBeenCalledWith(
       customProjectsSnapshot,
@@ -1651,10 +1806,12 @@ describe('SavedTabsApp custom search', () => {
 
     await domainProps.handleDeleteUrl('group-1', 'https://example.com/a')
 
-    expect(chromeSetMock).toHaveBeenCalledWith({
+    // 削除失敗時は catch から `notifyDeleteFailure` が呼ばれ、
+    // RestoreOpenedUrlsSnapshotUseCase 経由で snapshot が復元される。
+    // snapshot の savedTabs が repository.saveAll 経由で書き戻され、
+    // customProjectOrder のみ presentation 層で補助的に書き戻される。
+    expect(chromeSetMock).toHaveBeenLastCalledWith({
       customProjectOrder: ['project-1'],
-      customProjects: customProjectsSnapshot,
-      savedTabs: [group],
     })
     expect(mocked.projectState.setCustomProjects).toHaveBeenCalledWith(
       customProjectsSnapshot,
@@ -1776,10 +1933,11 @@ describe('SavedTabsApp custom search', () => {
       | undefined
     await undoOptions?.action?.onClick?.()
 
+    // 復元は RestoreOpenedUrlsSnapshotUseCase 経由になり、TabGroup /
+    // CustomProject は各 repository の saveAll で個別に書き戻される。
+    // presentation 層で残るのは customProjectOrder のみ。
     expect(chromeSetMock).toHaveBeenLastCalledWith({
       customProjectOrder: ['project-1'],
-      customProjects: customProjectsSnapshot,
-      savedTabs: [group1, group2],
     })
     expect(mocked.projectState.setCustomProjects).toHaveBeenCalledWith(
       customProjectsSnapshot,
@@ -2129,11 +2287,11 @@ describe('SavedTabsApp custom search', () => {
       | undefined
     await undoOptions?.action?.onClick?.()
 
+    // 復元は RestoreOpenedUrlsSnapshotUseCase 経由になり、TabGroup /
+    // CustomProject / ParentCategory は各 repository の saveAll で個別に
+    // 書き戻される。presentation 層で残るのは customProjectOrder のみ。
     expect(chromeSetMock).toHaveBeenLastCalledWith({
       customProjectOrder: ['project-1'],
-      customProjects: customProjectsSnapshot,
-      parentCategories: [],
-      savedTabs: [groupWithIds, legacyGroup],
     })
   })
 
@@ -3770,8 +3928,11 @@ describe('SavedTabsApp custom search', () => {
 
     await domainProps.handleDeleteGroups(['group-1', 'group-2'])
 
+    // 同期削除エラー時は catch から `notifyDeleteFailure` が呼ばれ、
+    // snapshot が RestoreOpenedUrlsSnapshotUseCase 経由で復元される。
+    // snapshot に customProjectOrder は含まれないため
+    // presentation 層からの chrome.storage.local.set は発生しない。
     expect(chromeSetMock).toHaveBeenCalledWith({
-      parentCategories: [],
       savedTabs: [groupWithIds, legacyGroup],
     })
     expect(toast.error).toHaveBeenCalledWith('削除に失敗しました')

--- a/src/features/saved-tabs/app/SavedTabsApp.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.tsx
@@ -379,12 +379,13 @@ const useSavedTabsAppView = ({
       showOpenedUrlsUndoToast({
         count: urlIdsToRemove.size,
         refreshTabGroupsWithUrls,
+        savedTabsUseCases,
         setCustomProjects,
         snapshot: storageResult,
         t,
       })
     },
-    [refreshTabGroupsWithUrls, setCustomProjects, t],
+    [refreshTabGroupsWithUrls, savedTabsUseCases, setCustomProjects, t],
   )
 
   // 既存のタブ開く処理を OpenSavedUrlUseCase 経由に置き換え。
@@ -439,6 +440,7 @@ const useSavedTabsAppView = ({
           showOpenedUrlsUndoToast({
             count: 1,
             refreshTabGroupsWithUrls,
+            savedTabsUseCases,
             setCustomProjects,
             snapshot,
             t,
@@ -572,6 +574,7 @@ const useSavedTabsAppView = ({
           count: countTabGroupUrls(groupToDelete),
           messageKey: 'savedTabs.undo.deletedTabs',
           refreshTabGroupsWithUrls,
+          savedTabsUseCases,
           setCategories,
           setCustomProjects,
           snapshot: deleteSnapshot,
@@ -582,6 +585,7 @@ const useSavedTabsAppView = ({
       } catch {
         await notifyDeleteFailure({
           refreshTabGroupsWithUrls,
+          savedTabsUseCases,
           setCategories,
           setCustomProjects,
           snapshot: deleteSnapshot,
@@ -593,10 +597,10 @@ const useSavedTabsAppView = ({
       isUncategorizedReorderMode,
       categories,
       refreshTabGroupsWithUrls,
+      savedTabsUseCases,
       setCustomProjects,
       setCategories,
       t,
-      savedTabsUseCases,
     ],
   )
 
@@ -659,6 +663,7 @@ const useSavedTabsAppView = ({
           ),
           messageKey: 'savedTabs.undo.deletedTabs',
           refreshTabGroupsWithUrls,
+          savedTabsUseCases,
           setCategories,
           setCustomProjects,
           snapshot: deleteSnapshot,
@@ -669,6 +674,7 @@ const useSavedTabsAppView = ({
       } catch {
         await notifyDeleteFailure({
           refreshTabGroupsWithUrls,
+          savedTabsUseCases,
           setCategories,
           setCustomProjects,
           snapshot: deleteSnapshot,
@@ -680,6 +686,7 @@ const useSavedTabsAppView = ({
       isUncategorizedReorderMode,
       categories,
       refreshTabGroupsWithUrls,
+      savedTabsUseCases,
       setCustomProjects,
       setCategories,
       t,
@@ -703,6 +710,7 @@ const useSavedTabsAppView = ({
           count: 1,
           messageKey: 'savedTabs.undo.deletedTabs',
           refreshTabGroupsWithUrls,
+          savedTabsUseCases,
           setCustomProjects,
           snapshot: deleteSnapshot,
           t,
@@ -711,13 +719,14 @@ const useSavedTabsAppView = ({
       } catch {
         await notifyDeleteFailure({
           refreshTabGroupsWithUrls,
+          savedTabsUseCases,
           setCustomProjects,
           snapshot: deleteSnapshot,
           t,
         })
       }
     },
-    [refreshTabGroupsWithUrls, setCustomProjects, t],
+    [refreshTabGroupsWithUrls, savedTabsUseCases, setCustomProjects, t],
   )
   const handleDeleteUrls = useCallback(
     async (groupId: string, urls: string[]) => {
@@ -764,6 +773,7 @@ const useSavedTabsAppView = ({
           count: urls.length,
           messageKey: 'savedTabs.undo.deletedTabs',
           refreshTabGroupsWithUrls,
+          savedTabsUseCases,
           setCustomProjects,
           snapshot: deleteSnapshot,
           t,
@@ -771,13 +781,20 @@ const useSavedTabsAppView = ({
       } catch {
         await notifyDeleteFailure({
           refreshTabGroupsWithUrls,
+          savedTabsUseCases,
           setCustomProjects,
           snapshot: deleteSnapshot,
           t,
         })
       }
     },
-    [refreshTabGroupsWithUrls, setCustomProjects, t, tabGroupsWithUrls],
+    [
+      refreshTabGroupsWithUrls,
+      savedTabsUseCases,
+      setCustomProjects,
+      t,
+      tabGroupsWithUrls,
+    ],
   )
   const handleUpdateUrls = useCallback(
     (groupId: string, _updatedUrls: TabGroup['urls']) => {

--- a/src/features/saved-tabs/app/savedTabsApp.helpers.ts
+++ b/src/features/saved-tabs/app/savedTabsApp.helpers.ts
@@ -1,5 +1,11 @@
 import { toast } from 'sonner'
 
+import type { OpenedUrlsRestoreSnapshot } from '@/contexts/saved-tabs/application/commands/RestoreOpenedUrlsSnapshotCommand'
+import { createCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
+import { createParentCategory } from '@/contexts/saved-tabs/domain/entities/ParentCategory'
+import { createTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
+import { SavedTabsDomainError } from '@/contexts/saved-tabs/domain/errors/SavedTabsDomainError'
+import type { SavedTabsUseCases } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases'
 import { getPageHref } from '@/features/navigation/lib/pageNavigation'
 import {
   removeUrlIdsFromAllCustomProjects,
@@ -18,12 +24,6 @@ interface OpenedUrlsStorageSnapshot {
   customProjects?: CustomProject[]
   parentCategories?: ParentCategory[]
   savedTabs?: TabGroup[]
-}
-interface OpenedUrlsRestorePayload {
-  customProjectOrder?: string[]
-  customProjects?: CustomProject[]
-  parentCategories?: ParentCategory[]
-  savedTabs: TabGroup[]
 }
 interface CategoryLookup {
   byId: Map<string, ParentCategory>
@@ -57,61 +57,181 @@ const buildUrlIdsToRemove = (
 
   return urlIdsToRemove
 }
-const createOpenedUrlsRestorePayload = (
+
+/**
+ * 旧 storage 形式の `TabGroup` を domain entity へ詰め替える。
+ *
+ * `urls` / `urlSubCategories` / `subCategories` / `categoryKeywords` /
+ * `subCategoryOrder` などの chrome.storage 上のリッチ補助フィールドは
+ * domain entity に載らないため破棄する。Repository 実装側の mapper が
+ * 既存 raw と `urlIds` の整合を取りつつリッチフィールドを持ち越すため、
+ * 復元時の見た目データは失われない。
+ *
+ * factory が `SavedTabsDomainError` を投げる要素（空 ID や重複 urlId）は
+ * スキップして Undo 対象から除外する。
+ */
+const toDomainTabGroups = (
+  groups: readonly TabGroup[] | undefined,
+): OpenedUrlsRestoreSnapshot['savedTabs'] => {
+  if (!groups || groups.length === 0) {
+    return undefined
+  }
+  const result = []
+  for (const group of groups) {
+    try {
+      result.push(
+        createTabGroup({
+          domain: group.domain,
+          id: group.id,
+          parentCategoryId: group.parentCategoryId,
+          savedAt: group.savedAt,
+          urlIds: group.urlIds ?? [],
+        }),
+      )
+    } catch (error) {
+      if (error instanceof SavedTabsDomainError) {
+        continue
+      }
+      throw error
+    }
+  }
+  return result
+}
+
+const toDomainCustomProjects = (
+  projects: readonly CustomProject[] | undefined,
+): OpenedUrlsRestoreSnapshot['customProjects'] => {
+  if (!projects || projects.length === 0) {
+    return undefined
+  }
+  const result = []
+  for (const project of projects) {
+    try {
+      result.push(
+        createCustomProject({
+          categories: project.categories ?? [],
+          createdAt: project.createdAt,
+          id: project.id,
+          name: project.name,
+          updatedAt: project.updatedAt,
+          urlIds: project.urlIds ?? [],
+        }),
+      )
+    } catch (error) {
+      if (error instanceof SavedTabsDomainError) {
+        continue
+      }
+      throw error
+    }
+  }
+  return result
+}
+
+const toDomainParentCategories = (
+  categories: readonly ParentCategory[] | undefined,
+): OpenedUrlsRestoreSnapshot['parentCategories'] => {
+  if (!categories || categories.length === 0) {
+    return undefined
+  }
+  const result = []
+  for (const category of categories) {
+    try {
+      result.push(
+        createParentCategory({
+          domainNames: category.domainNames ?? [],
+          domains: category.domains ?? [],
+          id: category.id,
+          name: category.name,
+        }),
+      )
+    } catch (error) {
+      if (error instanceof SavedTabsDomainError) {
+        continue
+      }
+      throw error
+    }
+  }
+  return result
+}
+
+/**
+ * 旧 storage スナップショットを `RestoreOpenedUrlsSnapshotUseCase` の
+ * command へ変換する。`customProjectOrder` は use-case DTO に載らない
+ * ため、command には含めず presentation 層で補助的に書き戻す。
+ */
+const toOpenedUrlsRestoreCommand = (
   snapshot: OpenedUrlsStorageSnapshot,
-) => {
-  const customProjects = getSnapshotArray(snapshot.customProjects)
-  const customProjectOrder = getSnapshotArray(snapshot.customProjectOrder)
-  const parentCategories = getSnapshotArray(snapshot.parentCategories)
-  const payload: OpenedUrlsRestorePayload = {
-    savedTabs: getSnapshotSavedTabs(snapshot),
+): OpenedUrlsRestoreSnapshot => {
+  const command: {
+    savedTabs?: OpenedUrlsRestoreSnapshot['savedTabs']
+    customProjects?: OpenedUrlsRestoreSnapshot['customProjects']
+    parentCategories?: OpenedUrlsRestoreSnapshot['parentCategories']
+  } = {}
+  const savedTabs = toDomainTabGroups(snapshot.savedTabs)
+  if (savedTabs) {
+    command.savedTabs = savedTabs
   }
-
+  const customProjects = toDomainCustomProjects(snapshot.customProjects)
   if (customProjects) {
-    payload.customProjects = customProjects
+    command.customProjects = customProjects
   }
-  if (customProjectOrder) {
-    payload.customProjectOrder = customProjectOrder
-  }
+  const parentCategories = toDomainParentCategories(snapshot.parentCategories)
   if (parentCategories) {
-    payload.parentCategories = parentCategories
+    command.parentCategories = parentCategories
   }
-
-  return {
-    customProjects,
-    parentCategories,
-    payload,
-  }
+  return command
 }
 
 const restoreOpenedUrlsSnapshot = async ({
   refreshTabGroupsWithUrls,
+  savedTabsUseCases,
   setCategories,
   setCustomProjects,
   snapshot,
 }: {
   refreshTabGroupsWithUrls: RefreshTabGroupsWithUrls
+  savedTabsUseCases: SavedTabsUseCases
   setCategories?: (categories: ParentCategory[]) => void
   setCustomProjects: (projects: CustomProject[]) => void
   snapshot: OpenedUrlsStorageSnapshot
 }) => {
-  const { customProjects, parentCategories, payload } =
-    createOpenedUrlsRestorePayload(snapshot)
+  // 復元本体は RestoreOpenedUrlsSnapshotUseCase に委譲する。
+  // presentation 層は snapshot を domain command へ詰め替えるだけとし、
+  // chrome.storage.local.set の直接呼び出しは customProjectOrder の補助
+  // 書き込みに限定する。
+  const command = toOpenedUrlsRestoreCommand(snapshot)
+  await savedTabsUseCases.restoreOpenedUrlsSnapshot({
+    snapshot: command,
+  })
 
-  await chrome.storage.local.set(payload)
-  if (customProjects) {
-    setCustomProjects(customProjects)
+  // customProjectOrder は RestoreOpenedUrlsSnapshotUseCase の DTO に含まれ
+  // ない（repository interface 未整備のため別 issue 切り出し）ため、
+  // presentation 層で補助的に書き戻す。
+  if (snapshot.customProjectOrder) {
+    await chrome.storage.local.set({
+      customProjectOrder: [...snapshot.customProjectOrder],
+    })
   }
-  if (parentCategories && setCategories) {
-    setCategories(parentCategories)
+
+  // 画面側 state は storage 形状を期待するため、use-case DTO ではなく
+  // 入力 snapshot をそのまま state へ反映する。Repository 側の mapper が
+  // `urls` / `urlSubCategories` などのリッチ補助フィールドを保存時に
+  // 持ち越すため、見た目の欠落は起こらない。
+  if (snapshot.customProjects) {
+    setCustomProjects([...snapshot.customProjects])
   }
-  await refreshTabGroupsWithUrls(payload.savedTabs)
+  if (snapshot.parentCategories && setCategories) {
+    setCategories([...snapshot.parentCategories])
+  }
+  const savedTabs = getSnapshotSavedTabs(snapshot)
+  await refreshTabGroupsWithUrls(savedTabs)
 }
 
 const showOpenedUrlsUndoToast = ({
   count,
   messageKey = 'savedTabs.undo.removedAfterOpen',
   refreshTabGroupsWithUrls,
+  savedTabsUseCases,
   setCategories,
   setCustomProjects,
   snapshot,
@@ -120,6 +240,7 @@ const showOpenedUrlsUndoToast = ({
   count: number
   messageKey?: string
   refreshTabGroupsWithUrls: RefreshTabGroupsWithUrls
+  savedTabsUseCases: SavedTabsUseCases
   setCategories?: (categories: ParentCategory[]) => void
   setCustomProjects: (projects: CustomProject[]) => void
   snapshot: OpenedUrlsStorageSnapshot
@@ -137,6 +258,7 @@ const showOpenedUrlsUndoToast = ({
           try {
             await restoreOpenedUrlsSnapshot({
               refreshTabGroupsWithUrls,
+              savedTabsUseCases,
               setCategories,
               setCustomProjects,
               snapshot,
@@ -154,12 +276,14 @@ const showOpenedUrlsUndoToast = ({
 
 const notifyDeleteFailure = async ({
   refreshTabGroupsWithUrls,
+  savedTabsUseCases,
   setCategories,
   setCustomProjects,
   snapshot,
   t,
 }: {
   refreshTabGroupsWithUrls: RefreshTabGroupsWithUrls
+  savedTabsUseCases: SavedTabsUseCases
   setCategories?: (categories: ParentCategory[]) => void
   setCustomProjects: (projects: CustomProject[]) => void
   snapshot?: OpenedUrlsStorageSnapshot
@@ -169,6 +293,7 @@ const notifyDeleteFailure = async ({
     try {
       await restoreOpenedUrlsSnapshot({
         refreshTabGroupsWithUrls,
+        savedTabsUseCases,
         setCategories,
         setCustomProjects,
         snapshot,
@@ -586,12 +711,7 @@ const syncSavedTabsViewModeLocation = ({
   window.history.replaceState({}, '', `${nextUrl.pathname}${nextUrl.search}`)
 }
 
-export type {
-  CategoryLookup,
-  CategorySyncState,
-  OpenedUrlsRestorePayload,
-  OpenedUrlsStorageSnapshot,
-}
+export type { CategoryLookup, CategorySyncState, OpenedUrlsStorageSnapshot }
 export {
   buildCategoryLookup,
   buildDisplayTabGroup,


### PR DESCRIPTION
## 概要

saved-tabs の restore / undo 処理を `RestoreOpenedUrlsSnapshotUseCase` 経由に置き換え。
`SavedTabsApp` 側の `restoreOpenedUrlsSnapshot` が `chrome.storage.local.set` を直接呼んでいたのをやめ、application 層の use-case 委譲に変更。

## 変更内容

- `src/features/saved-tabs/app/savedTabsApp.helpers.ts`
  - `restoreOpenedUrlsSnapshot` を `savedTabsUseCases.restoreOpenedUrlsSnapshot` 呼び出しに置き換え。`savedTabs` / `customProjects` / `parentCategories` の書き戻しは各 repository の `saveAll` 経由に変更。
  - 旧 storage 形式を use-case command へ詰め替える `toOpenedUrlsRestoreCommand` / `toDomainTabGroups` / `toDomainCustomProjects` / `toDomainParentCategories` を追加。`SavedTabsDomainError` を投げる不正要素（空 ID / 空カテゴリ名 / 空ドメイン名）はスキップ。
  - 不要になった `createOpenedUrlsRestorePayload` と `OpenedUrlsRestorePayload` 型を削除。
  - `showOpenedUrlsUndoToast` / `notifyDeleteFailure` に `savedTabsUseCases` を必須引数として追加。
  - `customProjectOrder` のみ use-case DTO に含まれない（repository interface 未整備、別 issue 切り出し済み）ため presentation 層の補助 `chrome.storage.local.set` に残す。
- `src/features/saved-tabs/app/SavedTabsApp.tsx`
  - `savedTabsUseCases` を 5 箇所の `showOpenedUrlsUndoToast` / `notifyDeleteFailure` 呼び出しと、関連する 3 つの `useCallback` 依存配列に追加。
- `src/features/saved-tabs/app/SavedTabsApp.test.tsx`
  - Undo 系テスト 6 件の期待値を「`customProjectOrder` のみ直書き + repository 経由は storage mock で吸収」へ更新。
  - `restoreOpenedUrlsSnapshot` 単体テストを `savedTabsUseCases` モックに切り替え。
  - domain factory の `SavedTabsDomainError` 経路を不正データ混入テストでカバー。

## 検証

- `bun run compile`: エラーなし
- `bun run check` (format + lint): 0 warnings / 0 errors
- `bun run test`: 206 files / **1747 tests** pass
- `bun run test:coverage`: All files **99.19%**（refactor 対象 helpers は 96.35% → 98.78%）

## スコープ外（別 issue 候補）

- mapper の `urls` 配列を `urlRecords` から組み立て直す経路（#473 想定）。UI 表示は `urlIds` + `urlRecords` から都度組み立てるため体感影響なし、ストレージ整合性の改善目的。
- `customProjectOrder` を `CustomProjectRepository` 化する。presentation 層の `chrome.storage` 直書きを 0 にする。
- `SavedTabsApp` の snapshot に `urlRecords` / `parentCategories` を含め、Undo 時の UrlRecord 復活を成立させる。
- `restoreOpenedUrlsSnapshot` 周辺の `chrome.storage.onChanged` 多重発火（4 回 → 1 回）最適化。

## 関連 Issue

- DDD 段階移行 #454
- composition root #469（前提）
- OpenSavedUrlUseCase #470（前提）
- DeleteTabGroupUseCase #471（前提）