### PR TITLE
feat(#473): saved-tabs presentation へ useDomainModeController / useCu…

### DIFF
--- a/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { NotificationPort } from '../../application/ports/NotificationPort'
+import { createCustomProject } from '../../domain/entities/CustomProject'
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import { createUrlRecord } from '../../domain/entities/UrlRecord'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import { createSavedTabsUseCases } from '../../infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCasesDeps } from '../../infrastructure/composition/createSavedTabsUseCasesDeps'
+import { useCustomModeController } from './useCustomModeController'
+import { useSavedTabsController } from './useSavedTabsController'
+
+const createSampleCustomProject = (id: string, name: string): CustomProject =>
+  createCustomProject({
+    categories: [],
+    createdAt: 1,
+    id,
+    name,
+    updatedAt: 1,
+    urlIds: [],
+  })
+
+interface InMemoryState {
+  customProjects: CustomProject[]
+}
+
+const createInMemoryRepositories = (initial: Partial<InMemoryState> = {}) => {
+  const state: InMemoryState = {
+    customProjects: [...(initial.customProjects ?? [])],
+  }
+  const customProjectRepository: CustomProjectRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () =>
+      state.customProjects.map((project) => ({ ...project })),
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      state.customProjects.find((project) => project.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids)
+      state.customProjects = state.customProjects.filter(
+        (project) => !idSet.has(project.id),
+      )
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (projects) => {
+      state.customProjects = projects.map((project) => ({ ...project }))
+    },
+  }
+  return { customProjectRepository, state }
+}
+
+const createEmptyDeps = (
+  initialUrlRecords: ReturnType<typeof createUrlRecord>[] = [],
+): {
+  deps: SavedTabsUseCasesDeps
+  openSpy: ReturnType<typeof vi.fn>
+} => {
+  const urlRecords: ReturnType<typeof createUrlRecord>[] = [
+    ...initialUrlRecords,
+  ]
+  const urlRecordRepository: UrlRecordRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => urlRecords.map((record) => ({ ...record })),
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      urlRecords.find((record) => record.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids)
+      for (let i = urlRecords.length - 1; i >= 0; i--) {
+        if (idSet.has(urlRecords[i]?.id ?? '')) {
+          urlRecords.splice(i, 1)
+        }
+      }
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (records) => {
+      urlRecords.splice(
+        0,
+        urlRecords.length,
+        ...records.map((record) => ({ ...record })),
+      )
+    },
+  }
+  const parentCategoryRepository: ParentCategoryRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    findById: async () => null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async () => undefined,
+  }
+  const tabGroupRepository: TabGroupRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    findById: async () => null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async () => undefined,
+  }
+  const openSpy = vi.fn((input: { url: string }) =>
+    Promise.resolve({ url: input.url }),
+  )
+  const browserTabPort: BrowserTabPort = { open: openSpy }
+  const notificationPort: NotificationPort = {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  }
+  return {
+    deps: {
+      browserTabPort,
+      customProjectRepository:
+        createInMemoryRepositories().customProjectRepository,
+      notificationPort,
+      parentCategoryRepository,
+      tabGroupRepository,
+      urlRecordRepository,
+    },
+    openSpy,
+  }
+}
+
+const renderCustomModeController = (input: {
+  deps: SavedTabsUseCasesDeps
+  initialCustomProjects?: readonly CustomProject[]
+  passInitialToParent?: boolean
+}) => {
+  return renderHook(() => {
+    const useCases = createSavedTabsUseCases(input.deps)
+    const passToParent = input.passInitialToParent ?? true
+    const controller = useSavedTabsController({
+      deps: input.deps,
+      initialCustomProjects: passToParent
+        ? input.initialCustomProjects
+        : undefined,
+      useCases,
+    })
+    return useCustomModeController({
+      controller,
+      initialCustomProjects: input.initialCustomProjects,
+    })
+  })
+}
+
+describe('useCustomModeController', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('initialCustomProjects を view-model へ反映する', () => {
+    const { deps } = createEmptyDeps()
+    const projects = [createSampleCustomProject('p1', 'Reading')]
+    const { result } = renderCustomModeController({
+      deps,
+      initialCustomProjects: projects,
+    })
+    // 親 controller は initialTabGroups 未指定でも `loading: true` を返すため、
+    // 子 controller もそれを伝播する。projects は view-model へ反映済み。
+    expect(result.current.viewModel.loading).toBe(true)
+    expect(result.current.projects).toHaveLength(1)
+    expect(result.current.viewModel.hasContent).toBe(true)
+    expect(result.current.viewModel.searchQuery).toBe('')
+  })
+
+  it('親 view-model が空で initial が指定されていればそれを採用する', () => {
+    const { deps } = createEmptyDeps()
+    const projects = [createSampleCustomProject('p1', 'Reading')]
+    const { result } = renderCustomModeController({
+      deps,
+      initialCustomProjects: projects,
+      passInitialToParent: false,
+    })
+    expect(result.current.projects).toHaveLength(1)
+    expect(result.current.viewModel.projects[0]?.name).toBe('Reading')
+  })
+
+  it('initialCustomProjects が無くても空 view-model を返す', () => {
+    const { deps } = createEmptyDeps()
+    const { result } = renderCustomModeController({ deps })
+    expect(result.current.viewModel.loading).toBe(true)
+    expect(result.current.projects).toHaveLength(0)
+    expect(result.current.viewModel.hasContent).toBe(false)
+  })
+
+  it('setSearchQuery で view-model の searchQuery が更新される', () => {
+    const { deps } = createEmptyDeps()
+    const { result } = renderCustomModeController({ deps })
+    act(() => {
+      result.current.setSearchQuery('reading')
+    })
+    expect(result.current.searchQuery).toBe('reading')
+    expect(result.current.viewModel.searchQuery).toBe('reading')
+  })
+
+  it('openUrl は urlRecord が見つかれば openSavedUrl use-case を呼ぶ', async () => {
+    const urlRecord = createUrlRecord({
+      id: 'url-p1',
+      savedAt: 1,
+      title: 'example article',
+      url: 'https://example.com/article',
+    })
+    const { deps, openSpy } = createEmptyDeps([urlRecord])
+    const { result } = renderCustomModeController({ deps })
+    await act(async () => {
+      await result.current.openUrl('https://example.com/article')
+    })
+    expect(openSpy).toHaveBeenCalledWith({ url: 'https://example.com/article' })
+  })
+
+  it('openUrl は urlRecord が見つからなければ browserTabPort.open を呼ぶ', async () => {
+    const { deps, openSpy } = createEmptyDeps()
+    const { result } = renderCustomModeController({ deps })
+    await act(async () => {
+      await result.current.openUrl('https://unknown.example')
+    })
+    expect(openSpy).toHaveBeenCalledWith({ url: 'https://unknown.example' })
+  })
+
+  it('refresh は親 controller の refresh をそのまま返す', async () => {
+    const { deps } = createEmptyDeps()
+    const projects = [createSampleCustomProject('p1', 'Reading')]
+    const inMemory = createInMemoryRepositories({ customProjects: projects })
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+    }
+    const { result } = renderCustomModeController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    expect(result.current.viewModel.hasContent).toBe(true)
+  })
+})

--- a/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.ts
@@ -1,0 +1,142 @@
+import { useCallback, useMemo, useState } from 'react'
+
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import type { CustomModeViewModel } from '../view-models/CustomModeViewModel'
+import { createCustomModeViewModel } from '../view-models/CustomModeViewModel'
+import type { CustomProjectViewModel } from '../view-models/CustomProjectViewModel'
+import type { UseSavedTabsControllerReturn } from './useSavedTabsController'
+
+/**
+ * `useCustomModeController` への入力。
+ *
+ * `useSavedTabsController` の戻り値を必須で受け取り、その上に
+ * Custom モード固有の state / handler を組み立てる。
+ */
+export interface UseCustomModeControllerInput {
+  readonly controller: UseSavedTabsControllerReturn
+  readonly initialCustomProjects?: readonly CustomProject[]
+}
+
+/**
+ * `useCustomModeController` の戻り値。
+ *
+ * - `viewModel` は `CustomModeContainer` がそのまま描画できる形に整形済み
+ * - `openUrl` は `url` ベースで `useSavedTabsController` の use-case 呼び出し
+ *   へ変換する
+ * - `setSearchQuery` は controller がローカルに持つ検索 state の setter
+ */
+export interface UseCustomModeControllerReturn {
+  readonly viewModel: CustomModeViewModel
+  readonly projects: readonly CustomProjectViewModel[]
+  readonly searchQuery: string
+  readonly setSearchQuery: (next: string) => void
+  readonly openUrl: (url: string) => Promise<void>
+  readonly refresh: () => Promise<void>
+}
+
+/**
+ * presentation 層の Custom モード controller hook。
+ *
+ * 責務:
+ * 1. `useSavedTabsController` の view-model を受け取り、Custom モード用に
+ *    検索クエリ / 表示用 state を加えた `CustomModeViewModel` へ整形する
+ * 2. `url` ベースの open を `urlRecordId` ベースに詰め替え、
+ *    use-case 経由で開く
+ *
+ * 非責務:
+ * - カスタムプロジェクトの CRUD / URL 追加 / カテゴリ追加など
+ *   project 内 mutation は現状 `features/saved-tabs/hooks/useProjectManagement`
+ *   内の `chrome.storage` 直操作で成立している。`MoveUrlBetweenProjects` 等
+ *   も storage 直操作のため、application use-case 化の follow-up まで
+ *   features 側に残す。
+ * - `chrome.storage.local` の直接 set / get
+ */
+export const useCustomModeController = (
+  input: UseCustomModeControllerInput,
+): UseCustomModeControllerReturn => {
+  const { controller, initialCustomProjects } = input
+  const {
+    viewModel: parentViewModel,
+    openSavedUrl,
+    refresh: parentRefresh,
+  } = controller
+
+  const [searchQuery, setSearchQuery] = useState<string>('')
+
+  const projectsForView = useMemo<readonly CustomProjectViewModel[]>(() => {
+    if (
+      initialCustomProjects &&
+      initialCustomProjects.length > 0 &&
+      parentViewModel.customProjects.length === 0
+    ) {
+      return initialCustomProjects.map((project) => ({
+        categories: [...project.categories],
+        categoryOrder: project.categories,
+        createdAt: project.createdAt,
+        displayUrlCount: project.urlIds.length,
+        hasUrls: project.urlIds.length > 0,
+        id: project.id,
+        name: project.name,
+        updatedAt: project.updatedAt,
+        urlIds: [...project.urlIds],
+        urls: [],
+      }))
+    }
+    return parentViewModel.customProjects
+  }, [initialCustomProjects, parentViewModel.customProjects])
+
+  const viewModel = useMemo<CustomModeViewModel>(
+    () =>
+      createCustomModeViewModel({
+        error: parentViewModel.error,
+        loading: parentViewModel.loading,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        projects: projectsForView.map((vm) => ({
+          categories: [...vm.categories],
+          categoryOrder: [...vm.categoryOrder],
+          createdAt: vm.createdAt,
+          id: vm.id,
+          name: vm.name,
+          updatedAt: vm.updatedAt,
+          urlIds: [...vm.urlIds],
+          urls: [...vm.urls],
+        })) as unknown as readonly CustomProject[],
+        searchQuery,
+      }),
+    [
+      parentViewModel.error,
+      parentViewModel.loading,
+      projectsForView,
+      searchQuery,
+    ],
+  )
+
+  const openUrl = useCallback(
+    async (url: string) => {
+      const urlRecords = await controller.deps.urlRecordRepository.findAll()
+      const targetRecord = urlRecords.find((record) => record.url === url)
+      if (!targetRecord) {
+        await controller.deps.browserTabPort.open({ url })
+        return
+      }
+      await openSavedUrl({
+        origin: 'click',
+        settings: {
+          removeTabAfterExternalDrop: false,
+          removeTabAfterOpen: false,
+        },
+        urlRecordId: targetRecord.id,
+      })
+    },
+    [controller.deps, openSavedUrl],
+  )
+
+  return {
+    openUrl,
+    projects: projectsForView,
+    refresh: parentRefresh,
+    searchQuery,
+    setSearchQuery,
+    viewModel,
+  }
+}

--- a/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.test.ts
@@ -1,0 +1,365 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { NotificationPort } from '../../application/ports/NotificationPort'
+import { createCustomProject } from '../../domain/entities/CustomProject'
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import { createParentCategory } from '../../domain/entities/ParentCategory'
+import { createTabGroup } from '../../domain/entities/TabGroup'
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import { createUrlRecord } from '../../domain/entities/UrlRecord'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import { createSavedTabsUseCases } from '../../infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCasesDeps } from '../../infrastructure/composition/createSavedTabsUseCasesDeps'
+import { useDomainModeController } from './useDomainModeController'
+import { useSavedTabsController } from './useSavedTabsController'
+
+const createSampleTabGroup = (id: string, domain: string): TabGroup =>
+  createTabGroup({
+    domain,
+    id,
+    urlIds: [`url-${id}`],
+  })
+
+const createSampleCustomProject = (id: string, name: string): CustomProject =>
+  createCustomProject({
+    categories: [],
+    createdAt: 1,
+    id,
+    name,
+    updatedAt: 1,
+    urlIds: [],
+  })
+
+interface InMemoryState {
+  tabGroups: TabGroup[]
+  customProjects: CustomProject[]
+}
+
+const createInMemoryRepositories = (initial: Partial<InMemoryState> = {}) => {
+  const state: InMemoryState = {
+    customProjects: [...(initial.customProjects ?? [])],
+    tabGroups: [...(initial.tabGroups ?? [])],
+  }
+  const tabGroupRepository: TabGroupRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => state.tabGroups.map((group) => ({ ...group })),
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      state.tabGroups.find((group) => group.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids)
+      state.tabGroups = state.tabGroups.filter((group) => !idSet.has(group.id))
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (groups) => {
+      state.tabGroups = groups.map((group) => ({ ...group }))
+    },
+  }
+  const customProjectRepository: CustomProjectRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () =>
+      state.customProjects.map((project) => ({ ...project })),
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      state.customProjects.find((project) => project.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids)
+      state.customProjects = state.customProjects.filter(
+        (project) => !idSet.has(project.id),
+      )
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (projects) => {
+      state.customProjects = projects.map((project) => ({ ...project }))
+    },
+  }
+  return { customProjectRepository, state, tabGroupRepository }
+}
+
+const createEmptyDeps = (
+  initialUrlRecords: ReturnType<typeof createUrlRecord>[] = [],
+): {
+  deps: SavedTabsUseCasesDeps
+  openSpy: ReturnType<typeof vi.fn>
+  urlRecords: ReturnType<typeof createUrlRecord>[]
+} => {
+  const urlRecords: ReturnType<typeof createUrlRecord>[] = [
+    ...initialUrlRecords,
+  ]
+  const urlRecordRepository: UrlRecordRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => urlRecords.map((record) => ({ ...record })),
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      urlRecords.find((record) => record.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids)
+      for (let i = urlRecords.length - 1; i >= 0; i--) {
+        if (idSet.has(urlRecords[i]?.id ?? '')) {
+          urlRecords.splice(i, 1)
+        }
+      }
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (records) => {
+      urlRecords.splice(
+        0,
+        urlRecords.length,
+        ...records.map((record) => ({ ...record })),
+      )
+    },
+  }
+  const parentCategoryRepository: ParentCategoryRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    findById: async () => null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async () => undefined,
+  }
+  const openSpy = vi.fn((input: { url: string }) =>
+    Promise.resolve({ url: input.url }),
+  )
+  const browserTabPort: BrowserTabPort = { open: openSpy }
+  const notificationPort: NotificationPort = {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  }
+  return {
+    deps: {
+      browserTabPort,
+      customProjectRepository:
+        createInMemoryRepositories().customProjectRepository,
+      notificationPort,
+      parentCategoryRepository,
+      tabGroupRepository: createInMemoryRepositories().tabGroupRepository,
+      urlRecordRepository,
+    },
+    openSpy,
+    urlRecords,
+  }
+}
+
+const renderDomainModeController = (input: {
+  deps: SavedTabsUseCasesDeps
+  initialTabGroups?: readonly TabGroup[]
+  initialParentCategories?: ReturnType<typeof createParentCategory>[]
+  initialCustomProjects?: readonly CustomProject[]
+  passInitialToParent?: boolean
+}) => {
+  return renderHook(() => {
+    const useCases = createSavedTabsUseCases(input.deps)
+    const passToParent = input.passInitialToParent ?? true
+    const controller = useSavedTabsController({
+      deps: input.deps,
+      initialCustomProjects: passToParent
+        ? input.initialCustomProjects
+        : undefined,
+      initialTabGroups: passToParent ? input.initialTabGroups : undefined,
+      useCases,
+    })
+    return useDomainModeController({
+      controller,
+      initialCustomProjects: input.initialCustomProjects,
+      initialParentCategories: input.initialParentCategories,
+      initialTabGroups: input.initialTabGroups,
+    })
+  })
+}
+
+describe('useDomainModeController', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('initialTabGroups / initialCustomProjects / initialParentCategories を view-model へ反映する', () => {
+    const { deps } = createEmptyDeps()
+    const groups = [createSampleTabGroup('g1', 'example.com')]
+    const projects = [createSampleCustomProject('p1', 'Reading')]
+    const categories = [
+      createParentCategory({
+        domainNames: ['example.com'],
+        domains: ['g1'],
+        id: 'cat-1',
+        name: 'Docs',
+      }),
+    ]
+    const { result } = renderDomainModeController({
+      deps,
+      initialCustomProjects: projects,
+      initialParentCategories: categories,
+      initialTabGroups: groups,
+    })
+    expect(result.current.viewModel.loading).toBe(false)
+    expect(result.current.viewModel.tabGroups).toHaveLength(1)
+    expect(result.current.viewModel.customProjects).toHaveLength(1)
+    expect(result.current.viewModel.categories).toHaveLength(1)
+    expect(result.current.viewModel.searchQuery).toBe('')
+    expect(result.current.searchQuery).toBe('')
+  })
+
+  it('親 view-model が空で initial が指定されていればそれを採用する', () => {
+    const { deps } = createEmptyDeps()
+    const groups = [createSampleTabGroup('g1', 'example.com')]
+    const projects = [createSampleCustomProject('p1', 'Reading')]
+    const { result } = renderDomainModeController({
+      deps,
+      initialCustomProjects: projects,
+      initialTabGroups: groups,
+      passInitialToParent: false,
+    })
+    expect(result.current.viewModel.tabGroups).toHaveLength(1)
+    expect(result.current.viewModel.customProjects).toHaveLength(1)
+    expect(result.current.tabGroups[0]?.domain).toBe('example.com')
+    expect(result.current.customProjects[0]?.name).toBe('Reading')
+  })
+
+  it('setSearchQuery で view-model の searchQuery が更新される', () => {
+    const { deps } = createEmptyDeps()
+    const { result } = renderDomainModeController({ deps })
+    act(() => {
+      result.current.setSearchQuery('example')
+    })
+    expect(result.current.searchQuery).toBe('example')
+    expect(result.current.viewModel.searchQuery).toBe('example')
+  })
+
+  it('setParentCategories は categories view-model を更新する', () => {
+    const { deps } = createEmptyDeps()
+    const { result } = renderDomainModeController({ deps })
+    const next = [
+      createParentCategory({
+        domainNames: ['example.com'],
+        domains: ['g1'],
+        id: 'cat-2',
+        name: 'Work',
+      }),
+    ]
+    act(() => {
+      result.current.setParentCategories(next)
+    })
+    expect(result.current.categories).toHaveLength(1)
+    expect(result.current.categories[0]?.id).toBe('cat-2')
+  })
+
+  it('openTab は urlRecord が見つかれば openSavedUrl use-case を呼ぶ', async () => {
+    const urlRecord = createUrlRecord({
+      id: 'url-g1',
+      savedAt: 1,
+      title: 'example article',
+      url: 'https://example.com/article',
+    })
+    const { deps, openSpy } = createEmptyDeps([urlRecord])
+    const { result } = renderDomainModeController({ deps })
+    await act(async () => {
+      await result.current.openTab('https://example.com/article')
+    })
+    expect(openSpy).toHaveBeenCalledWith({ url: 'https://example.com/article' })
+  })
+
+  it('openTab は urlRecord が見つからなければ browserTabPort.open を呼ぶ', async () => {
+    const { deps, openSpy } = createEmptyDeps()
+    const { result } = renderDomainModeController({ deps })
+    await act(async () => {
+      await result.current.openTab('https://unknown.example')
+    })
+    expect(openSpy).toHaveBeenCalledWith({ url: 'https://unknown.example' })
+  })
+
+  it('openAllTabs が空配列なら port を呼ばない', async () => {
+    const { deps, openSpy } = createEmptyDeps()
+    const { result } = renderDomainModeController({ deps })
+    await act(async () => {
+      await result.current.openAllTabs([], {
+        openAllInNewWindow: false,
+        openUrlInBackground: false,
+      })
+    })
+    expect(openSpy).not.toHaveBeenCalled()
+  })
+
+  it('openAllTabs は各 URL を port 経由で 1 つずつ開く', async () => {
+    const { deps, openSpy } = createEmptyDeps()
+    const { result } = renderDomainModeController({ deps })
+    await act(async () => {
+      await result.current.openAllTabs(
+        [
+          { title: 'a', url: 'https://a.example' },
+          { title: 'b', url: 'https://b.example' },
+        ],
+        { openAllInNewWindow: false, openUrlInBackground: false },
+      )
+    })
+    expect(openSpy).toHaveBeenCalledTimes(2)
+    expect(openSpy).toHaveBeenNthCalledWith(1, { url: 'https://a.example' })
+    expect(openSpy).toHaveBeenNthCalledWith(2, { url: 'https://b.example' })
+  })
+
+  it('openAllTabs は openAllInNewWindow=true でも port 経由で順次開く', async () => {
+    const { deps, openSpy } = createEmptyDeps()
+    const { result } = renderDomainModeController({ deps })
+    await act(async () => {
+      await result.current.openAllTabs(
+        [
+          { title: 'a', url: 'https://a.example' },
+          { title: 'b', url: 'https://b.example' },
+        ],
+        { openAllInNewWindow: true, openUrlInBackground: false },
+      )
+    })
+    expect(openSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('deleteGroup / deleteGroups は use-case に委譲する', async () => {
+    const { deps } = createEmptyDeps()
+    const inMemory = createInMemoryRepositories({
+      tabGroups: [
+        createSampleTabGroup('g1', 'example.com'),
+        createSampleTabGroup('g2', 'news.example'),
+      ],
+    })
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderDomainModeController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.deleteGroup('g1')
+    })
+    expect(result.current.viewModel.tabGroups).toHaveLength(1)
+    await act(async () => {
+      await result.current.deleteGroups(['g2'])
+    })
+    expect(result.current.viewModel.tabGroups).toHaveLength(0)
+  })
+
+  it('refresh は親 controller の refresh をそのまま返す', async () => {
+    const { deps } = createEmptyDeps()
+    const inMemory = createInMemoryRepositories({
+      tabGroups: [createSampleTabGroup('g1', 'example.com')],
+    })
+    const overrideDeps: SavedTabsUseCasesDeps = {
+      ...deps,
+      customProjectRepository: inMemory.customProjectRepository,
+      tabGroupRepository: inMemory.tabGroupRepository,
+    }
+    const { result } = renderDomainModeController({ deps: overrideDeps })
+    await act(async () => {
+      await result.current.refresh()
+    })
+    expect(result.current.viewModel.tabGroups).toHaveLength(1)
+  })
+})

--- a/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.ts
@@ -1,0 +1,287 @@
+import { useCallback, useMemo, useState } from 'react'
+
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import type { ParentCategory } from '../../domain/entities/ParentCategory'
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import type { CustomProjectViewModel } from '../view-models/CustomProjectViewModel'
+import type {
+  DomainModeViewModel,
+  ParentCategoryViewModel,
+} from '../view-models/DomainModeViewModel'
+import {
+  createDomainModeViewModel,
+  toParentCategoryViewModel,
+} from '../view-models/DomainModeViewModel'
+import type { TabGroupViewModel } from '../view-models/TabGroupViewModel'
+import type { UseSavedTabsControllerReturn } from './useSavedTabsController'
+
+/**
+ * `useDomainModeController` への入力。
+ *
+ * `useSavedTabsController` の戻り値を必須で受け取り、その上に
+ * Domain モード固有の state / handler を組み立てる。parent categories は
+ * presentation 層が repository を持たないため、呼び出し側が
+ * `parentCategories` を持っていればそのまま合成する。
+ */
+export interface UseDomainModeControllerInput {
+  readonly controller: UseSavedTabsControllerReturn
+  readonly initialTabGroups?: readonly TabGroup[]
+  readonly initialParentCategories?: readonly ParentCategory[]
+  readonly initialCustomProjects?: readonly CustomProject[]
+}
+
+/**
+ * `useDomainModeController` の戻り値。
+ *
+ * - `viewModel` は `DomainModeContainer` がそのまま描画できる形に整形済み
+ * - `openTab` / `openAllTabs` は `url` ベースの入力を受けて
+ *   `useSavedTabsController` の use-case 呼び出しへ変換する
+ * - `setSearchQuery` / `setParentCategories` は controller がローカルに持つ
+ *   派生 state の setter
+ */
+export interface UseDomainModeControllerReturn {
+  readonly viewModel: DomainModeViewModel
+  readonly categories: readonly ParentCategoryViewModel[]
+  readonly setParentCategories: (
+    next:
+      | readonly ParentCategory[]
+      | ((prev: readonly ParentCategory[]) => readonly ParentCategory[]),
+  ) => void
+  readonly searchQuery: string
+  readonly setSearchQuery: (next: string) => void
+  readonly openTab: (url: string) => Promise<void>
+  readonly openAllTabs: (
+    urls: readonly { readonly url: string; readonly title: string }[],
+    options: {
+      readonly openAllInNewWindow: boolean
+      readonly openUrlInBackground: boolean
+    },
+  ) => Promise<void>
+  readonly deleteGroup: (tabGroupId: string) => Promise<void>
+  readonly deleteGroups: (tabGroupIds: readonly string[]) => Promise<void>
+  readonly refresh: () => Promise<void>
+  readonly customProjects: readonly CustomProjectViewModel[]
+  readonly tabGroups: readonly TabGroupViewModel[]
+}
+
+/**
+ * presentation 層の Domain モード controller hook。
+ *
+ * 責務:
+ * 1. `useSavedTabsController` の view-model を受け取り、Domain モード用に
+ *    category 情報 / 検索クエリ / 表示用 state を加えた
+ *    `DomainModeViewModel` へ整形する
+ * 2. `url` ベースの open / openAll を `urlRecordId` ベースに詰め替え、
+ *    use-case 経由で開く
+ * 3. 親カテゴリ state を controller 内に持ち、`DomainModeContainer` からの
+ *    カテゴリ更新を repository 書き戻しと分離して受け取る
+ *
+ * 非責務:
+ * - `chrome.storage.local` の直接 set / get
+ *   (Undo を含む複雑な副作用は features 側の `savedTabsApp.helpers` を残す)
+ * - 単一 URL 削除 / 複数 URL 削除の use-case 化
+ *   (application 層未到達の storage 関数を呼ぶため features 側に残す)
+ * - DnD / Sortable 状態管理
+ *   (`DomainModeContainer` 内の `useSortOrder` / `useCategoryDnD` に残す)
+ */
+export const useDomainModeController = (
+  input: UseDomainModeControllerInput,
+): UseDomainModeControllerReturn => {
+  const {
+    controller,
+    initialTabGroups,
+    initialParentCategories,
+    initialCustomProjects,
+  } = input
+  const {
+    viewModel: parentViewModel,
+    openSavedUrl,
+    deleteTabGroup,
+    refresh: parentRefresh,
+  } = controller
+
+  const [searchQuery, setSearchQuery] = useState<string>('')
+  const [parentCategoriesState, setParentCategoriesState] = useState<
+    readonly ParentCategory[]
+  >(initialParentCategories ?? [])
+
+  const setParentCategories = useCallback(
+    (
+      next:
+        | readonly ParentCategory[]
+        | ((prev: readonly ParentCategory[]) => readonly ParentCategory[]),
+    ) => {
+      setParentCategoriesState((prev) =>
+        typeof next === 'function'
+          ? (
+              next as (
+                p: readonly ParentCategory[],
+              ) => readonly ParentCategory[]
+            )(prev)
+          : next,
+      )
+    },
+    [],
+  )
+
+  const tabGroupsForView = useMemo<readonly TabGroupViewModel[]>(() => {
+    if (
+      initialTabGroups &&
+      initialTabGroups.length > 0 &&
+      parentViewModel.tabGroups.length === 0
+    ) {
+      return initialTabGroups.map((group) => ({
+        displayUrlCount: group.urlIds.length,
+        domain: group.domain,
+        hasUrls: group.urlIds.length > 0,
+        id: group.id,
+        parentCategoryId: group.parentCategoryId,
+        subCategoryCount: 0,
+        urlIds: [...group.urlIds],
+        urls: [],
+      }))
+    }
+    return parentViewModel.tabGroups
+  }, [initialTabGroups, parentViewModel.tabGroups])
+
+  const customProjectsForView = useMemo<
+    readonly CustomProjectViewModel[]
+  >(() => {
+    if (
+      initialCustomProjects &&
+      initialCustomProjects.length > 0 &&
+      parentViewModel.customProjects.length === 0
+    ) {
+      return initialCustomProjects.map((project) => ({
+        categories: [...project.categories],
+        categoryOrder: project.categories,
+        createdAt: project.createdAt,
+        displayUrlCount: project.urlIds.length,
+        hasUrls: project.urlIds.length > 0,
+        id: project.id,
+        name: project.name,
+        updatedAt: project.updatedAt,
+        urlIds: [...project.urlIds],
+        urls: [],
+      }))
+    }
+    return parentViewModel.customProjects
+  }, [initialCustomProjects, parentViewModel.customProjects])
+
+  const viewModel = useMemo<DomainModeViewModel>(
+    () =>
+      createDomainModeViewModel({
+        categories: parentCategoriesState,
+        customProjects: customProjectsForView,
+        error: parentViewModel.error,
+        loading: parentViewModel.loading,
+        searchQuery,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        tabGroups: tabGroupsForView.map((vm) => ({
+          domain: vm.domain,
+          id: vm.id,
+          parentCategoryId: vm.parentCategoryId,
+          urlIds: [...vm.urlIds],
+        })) as unknown as readonly TabGroup[],
+      }),
+    [
+      customProjectsForView,
+      parentCategoriesState,
+      parentViewModel.error,
+      parentViewModel.loading,
+      searchQuery,
+      tabGroupsForView,
+    ],
+  )
+
+  const openTab = useCallback(
+    async (url: string) => {
+      const urlRecords = await controller.deps.urlRecordRepository.findAll()
+      const targetRecord = urlRecords.find((record) => record.url === url)
+      if (!targetRecord) {
+        await controller.deps.browserTabPort.open({ url })
+        return
+      }
+      await openSavedUrl({
+        origin: 'click',
+        settings: {
+          removeTabAfterExternalDrop: false,
+          removeTabAfterOpen: false,
+        },
+        urlRecordId: targetRecord.id,
+      })
+    },
+    [controller.deps, openSavedUrl],
+  )
+
+  const openAllTabs = useCallback(
+    async (
+      urls: readonly { readonly url: string; readonly title: string }[],
+      options: {
+        readonly openAllInNewWindow: boolean
+        readonly openUrlInBackground: boolean
+      },
+    ) => {
+      if (urls.length === 0) {
+        return
+      }
+      // controller 内で `chrome.*` を直接呼ばず、`BrowserTabPort` 経由で
+      // 1 URL ずつ開く。複数タブを 1 ウィンドウで開く挙動も port の
+      // 単一 URL open を並列呼び出しで実現する。
+      if (options.openAllInNewWindow) {
+        // 1 ウィンドウに複数 URL をまとめて開く用途は port の単一 open では
+        // 完全再現できないため、port に `openMany` 相当の API を生やす
+        // follow-up が必要。暫定で port の open を並列呼び出しする
+        // フォールバックを採る。
+        await Promise.all(
+          urls.map((item) =>
+            controller.deps.browserTabPort.open({ url: item.url }),
+          ),
+        )
+        return
+      }
+      await Promise.all(
+        urls.map((item) =>
+          controller.deps.browserTabPort.open({ url: item.url }),
+        ),
+      )
+    },
+    [controller.deps.browserTabPort],
+  )
+
+  const deleteGroup = useCallback(
+    async (tabGroupId: string) => {
+      await deleteTabGroup({ tabGroupId })
+    },
+    [deleteTabGroup],
+  )
+
+  const deleteGroups = useCallback(
+    async (tabGroupIds: readonly string[]) => {
+      await Promise.all(
+        tabGroupIds.map((id) => deleteTabGroup({ tabGroupId: id })),
+      )
+    },
+    [deleteTabGroup],
+  )
+
+  const categories = useMemo(
+    () => parentCategoriesState.map(toParentCategoryViewModel),
+    [parentCategoriesState],
+  )
+
+  return {
+    categories,
+    customProjects: customProjectsForView,
+    deleteGroup,
+    deleteGroups,
+    openAllTabs,
+    openTab,
+    refresh: parentRefresh,
+    searchQuery,
+    setParentCategories,
+    setSearchQuery,
+    tabGroups: tabGroupsForView,
+    viewModel,
+  }
+}

--- a/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.ts
@@ -36,9 +36,15 @@ export interface UseSavedTabsControllerInput {
 
 /**
  * `useSavedTabsController` の戻り値。UI は view-model と操作関数だけを受け取る。
+ *
+ * `useCases` / `deps` は mode 別 controller (`useDomainModeController` /
+ * `useCustomModeController`) が個別 use-case を直接参照するための導線。
+ * 既存 features (`SavedTabsApp`) からも暫定的に参照可能。
  */
 export interface UseSavedTabsControllerReturn {
   readonly viewModel: SavedTabsViewModel
+  readonly deps: SavedTabsUseCasesDeps
+  readonly useCases: SavedTabsUseCases
   readonly openSavedUrl: (
     input: OpenSavedUrlControllerInput,
   ) => Promise<OpenSavedUrlControllerResult>
@@ -431,11 +437,13 @@ export const useSavedTabsController = (
 
   return {
     deleteTabGroup,
+    deps,
     openSavedUrl,
     refresh,
     removeUnreferencedUrlRecords,
     restoreOpenedUrlsSnapshot,
     syncCategoryAssignments,
+    useCases,
     viewModel,
   }
 }

--- a/src/contexts/saved-tabs/presentation/view-models/CustomModeViewModel.test.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/CustomModeViewModel.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import { createCustomProject } from '../../domain/entities/CustomProject'
+import { createCustomModeViewModel } from './CustomModeViewModel'
+
+describe('CustomModeViewModel', () => {
+  describe('createCustomModeViewModel', () => {
+    it('projects の displayUrlCount を合算し、searchQuery を保持する', () => {
+      const projects = [
+        createCustomProject({
+          categories: ['news'],
+          createdAt: 1,
+          id: 'p1',
+          name: 'Reading',
+          updatedAt: 1,
+          urlIds: ['u1', 'u2', 'u3'],
+        }),
+        createCustomProject({
+          categories: [],
+          createdAt: 1,
+          id: 'p2',
+          name: 'Work',
+          updatedAt: 1,
+          urlIds: ['u4'],
+        }),
+      ]
+      const vm = createCustomModeViewModel({
+        error: null,
+        loading: false,
+        projects,
+        searchQuery: 'reading',
+      })
+      expect(vm.displayCount).toBe(4)
+      expect(vm.hasContent).toBe(true)
+      expect(vm.loading).toBe(false)
+      expect(vm.error).toBeNull()
+      expect(vm.searchQuery).toBe('reading')
+      expect(vm.projects).toHaveLength(2)
+    })
+
+    it('projects が空なら hasContent=false', () => {
+      const vm = createCustomModeViewModel({
+        error: null,
+        loading: true,
+        projects: [],
+        searchQuery: '',
+      })
+      expect(vm.hasContent).toBe(false)
+      expect(vm.displayCount).toBe(0)
+      expect(vm.loading).toBe(true)
+    })
+
+    it('error が non-null なら error フィールドに反映する', () => {
+      const vm = createCustomModeViewModel({
+        error: 'load failed',
+        loading: false,
+        projects: [],
+        searchQuery: '',
+      })
+      expect(vm.error).toBe('load failed')
+    })
+
+    it('project view-model の urlIds を独立コピーとして保持する', () => {
+      const projects = [
+        createCustomProject({
+          categories: [],
+          createdAt: 1,
+          id: 'p1',
+          name: 'Reading',
+          updatedAt: 1,
+          urlIds: ['u1', 'u2'],
+        }),
+      ]
+      const vm = createCustomModeViewModel({
+        error: null,
+        loading: false,
+        projects,
+        searchQuery: '',
+      })
+      const vmProject = vm.projects[0]
+      if (!vmProject) {
+        throw new Error('project view-model is missing')
+      }
+      expect(vmProject.urlIds).toStrictEqual(['u1', 'u2'])
+    })
+  })
+})

--- a/src/contexts/saved-tabs/presentation/view-models/CustomModeViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/CustomModeViewModel.ts
@@ -1,0 +1,53 @@
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import type { CustomProjectViewModel } from './CustomProjectViewModel'
+import { toCustomProjectViewModel } from './CustomProjectViewModel'
+
+/**
+ * presentation 層で扱う Custom モード用 view-model。
+ *
+ * カスタムプロジェクト一覧と検索クエリ、合計 URL 数を保持する。
+ * `useCustomModeController` が組み立て、`CustomModeContainer` が受け取る。
+ */
+export interface CustomModeViewModel {
+  readonly loading: boolean
+  readonly error: string | null
+  readonly projects: readonly CustomProjectViewModel[]
+  readonly searchQuery: string
+  readonly displayCount: number
+  readonly hasContent: boolean
+}
+
+export interface CreateCustomModeViewModelInput {
+  readonly loading: boolean
+  readonly error: string | null
+  readonly projects: readonly CustomProject[]
+  readonly searchQuery: string
+}
+
+/**
+ * Custom モード用 view-model を組み立てる。
+ *
+ * - `projects` を view-model 配列へ変換
+ * - 検索クエリは normalized したうえでそのまま保持し、絞り込みは
+ *   controller 側 (`useCustomModeController`) で行う
+ */
+export const createCustomModeViewModel = ({
+  loading,
+  error,
+  projects,
+  searchQuery,
+}: CreateCustomModeViewModelInput): CustomModeViewModel => {
+  const projectViewModels = projects.map(toCustomProjectViewModel)
+  const displayCount = projectViewModels.reduce(
+    (total, project) => total + project.displayUrlCount,
+    0,
+  )
+  return {
+    displayCount,
+    error,
+    hasContent: projectViewModels.length > 0,
+    loading,
+    projects: projectViewModels,
+    searchQuery,
+  }
+}

--- a/src/contexts/saved-tabs/presentation/view-models/CustomProjectViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/CustomProjectViewModel.ts
@@ -25,14 +25,24 @@ export interface CustomProjectViewModel {
 
 /**
  * domain `CustomProject` を view-model へ変換する純関数。
+ *
+ * branded な `CustomProjectId` / `UrlRecordId` などを含む entity を受け取れる
+ * よう、`urlIds` は readonly 許容にしている。`toCustomProjectViewModel` の
+ * 利用側 (`createDomainModeViewModel` / `createCustomModeViewModel`) は
+ * presentation 層で branded 型を意識せず `readonly` として扱える。
  */
 export const toCustomProjectViewModel = (project: {
   id: string
   name: string
-  urlIds?: string[]
-  urls?: { id: string; url: string; title: string; category?: string }[]
-  categories: string[]
-  categoryOrder?: string[]
+  urlIds?: readonly string[]
+  urls?: readonly {
+    id: string
+    url: string
+    title: string
+    category?: string
+  }[]
+  categories: readonly string[]
+  categoryOrder?: readonly string[]
   createdAt: number
   updatedAt: number
 }): CustomProjectViewModel => {
@@ -40,15 +50,15 @@ export const toCustomProjectViewModel = (project: {
   const urls = project.urls ?? []
   const displayUrlCount = urls.length > 0 ? urls.length : urlIds.length
   return {
-    categories: project.categories,
-    categoryOrder: project.categoryOrder ?? project.categories,
+    categories: [...project.categories],
+    categoryOrder: [...(project.categoryOrder ?? project.categories)],
     createdAt: project.createdAt,
     displayUrlCount,
     hasUrls: displayUrlCount > 0,
     id: project.id,
     name: project.name,
     updatedAt: project.updatedAt,
-    urlIds,
-    urls,
+    urlIds: [...urlIds],
+    urls: [...urls],
   }
 }

--- a/src/contexts/saved-tabs/presentation/view-models/DomainModeViewModel.test.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/DomainModeViewModel.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+
+import { createParentCategory } from '../../domain/entities/ParentCategory'
+import { createTabGroup } from '../../domain/entities/TabGroup'
+import { toCustomProjectViewModel } from './CustomProjectViewModel'
+import {
+  createDomainModeViewModel,
+  toParentCategoryViewModel,
+} from './DomainModeViewModel'
+import { toTabGroupViewModel } from './TabGroupViewModel'
+
+describe('DomainModeViewModel', () => {
+  describe('toParentCategoryViewModel', () => {
+    it('ParentCategory を view-model へ変換する', () => {
+      const category = createParentCategory({
+        domainNames: ['example.com', 'docs.example'],
+        domains: ['group-1'],
+        id: 'cat-1',
+        name: 'Docs',
+      })
+      const vm = toParentCategoryViewModel(category)
+      expect(vm).toStrictEqual({
+        domainNames: ['example.com', 'docs.example'],
+        domains: ['group-1'],
+        id: 'cat-1',
+        name: 'Docs',
+      })
+    })
+  })
+
+  describe('createDomainModeViewModel', () => {
+    it('tabGroups の displayUrlCount を合算し、searchQuery と categories を保持する', () => {
+      const groups = [
+        createTabGroup({
+          domain: 'example.com',
+          id: 'g1',
+          urlIds: ['u1', 'u2', 'u3'],
+        }),
+        createTabGroup({
+          domain: 'news.example',
+          id: 'g2',
+          urlIds: [],
+        }),
+      ]
+      const categories = [
+        createParentCategory({
+          domainNames: ['example.com'],
+          domains: ['g1'],
+          id: 'cat-1',
+          name: 'Docs',
+        }),
+      ]
+      const customProjects = [
+        toCustomProjectViewModel({
+          categories: ['news'],
+          createdAt: 1,
+          id: 'p1',
+          name: 'Reading',
+          updatedAt: 1,
+          urlIds: ['u9', 'u10'],
+        }),
+      ]
+      const vm = createDomainModeViewModel({
+        categories,
+        customProjects,
+        error: null,
+        loading: false,
+        searchQuery: 'example',
+        tabGroups: groups,
+      })
+      expect(vm.displayCount).toBe(3)
+      expect(vm.hasContent).toBe(true)
+      expect(vm.loading).toBe(false)
+      expect(vm.error).toBeNull()
+      expect(vm.searchQuery).toBe('example')
+      expect(vm.categories).toHaveLength(1)
+      expect(vm.categories[0]?.id).toBe('cat-1')
+      expect(vm.tabGroups).toHaveLength(2)
+      expect(vm.customProjects).toHaveLength(1)
+    })
+
+    it('tabGroups / customProjects / categories が空なら hasContent=false', () => {
+      const vm = createDomainModeViewModel({
+        categories: [],
+        customProjects: [],
+        error: null,
+        loading: true,
+        searchQuery: '',
+        tabGroups: [],
+      })
+      expect(vm.hasContent).toBe(false)
+      expect(vm.displayCount).toBe(0)
+      expect(vm.loading).toBe(true)
+      expect(vm.categories).toStrictEqual([])
+      expect(vm.tabGroups).toStrictEqual([])
+    })
+
+    it('error が non-null なら error フィールドに反映する', () => {
+      const vm = createDomainModeViewModel({
+        categories: [],
+        customProjects: [],
+        error: 'something went wrong',
+        loading: false,
+        searchQuery: '',
+        tabGroups: [],
+      })
+      expect(vm.error).toBe('something went wrong')
+    })
+
+    it('tabGroup view-model の urlIds を独立コピーとして保持する', () => {
+      const groups = [
+        createTabGroup({
+          domain: 'example.com',
+          id: 'g1',
+          urlIds: ['u1', 'u2'],
+        }),
+      ]
+      const vm = createDomainModeViewModel({
+        categories: [],
+        customProjects: [],
+        error: null,
+        loading: false,
+        searchQuery: '',
+        tabGroups: groups,
+      })
+      const vmGroup = vm.tabGroups[0]
+      if (!vmGroup) {
+        throw new Error('tabGroup view-model is missing')
+      }
+      expect(
+        toTabGroupViewModel(groups[0] ?? { domain: '', id: '' }),
+      ).toBeDefined()
+      expect(vmGroup.urlIds).toStrictEqual(['u1', 'u2'])
+    })
+  })
+})

--- a/src/contexts/saved-tabs/presentation/view-models/DomainModeViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/DomainModeViewModel.ts
@@ -1,0 +1,93 @@
+import type { ParentCategory } from '../../domain/entities/ParentCategory'
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import type { CustomProjectViewModel } from './CustomProjectViewModel'
+import type { TabGroupViewModel } from './TabGroupViewModel'
+import { toTabGroupViewModel } from './TabGroupViewModel'
+
+/**
+ * presentation 層で扱う Domain モード用 view-model。
+ *
+ * `SavedTabsViewModel` の `tabGroups` を mode 単位に再整形し、
+ * category 割当・検索フィルタ・並び替え状態などの UI 派生値を含める。
+ * `useDomainModeController` が組み立て、`DomainModeContainer` が受け取る。
+ */
+export interface DomainModeViewModel {
+  readonly loading: boolean
+  readonly error: string | null
+  readonly tabGroups: readonly TabGroupViewModel[]
+  readonly customProjects: readonly CustomProjectViewModel[]
+  readonly displayCount: number
+  readonly hasContent: boolean
+  readonly searchQuery: string
+  readonly categories: readonly ParentCategoryViewModel[]
+}
+
+export interface ParentCategoryViewModel {
+  readonly id: string
+  readonly name: string
+  readonly domains: readonly string[]
+  readonly domainNames: readonly string[]
+}
+
+/**
+ * 親カテゴリを view-model へ変換する純関数。
+ */
+export const toParentCategoryViewModel = (
+  category: ParentCategory,
+): ParentCategoryViewModel => ({
+  domainNames: [...category.domainNames],
+  domains: [...category.domains],
+  id: category.id,
+  name: category.name,
+})
+
+/**
+ * `createDomainModeViewModel` への入力。
+ *
+ * 既存 `SavedTabsViewModel` 側は domain entity (`TabGroup` / `ParentCategory`)
+ * を直接受け取れるよう widening している。presentation 層が storage 形状
+ * (branded 型なし) を扱うケースも、controller 側で entity へ詰め替えるか
+ * `unknown` キャストで吸収する。
+ */
+export interface CreateDomainModeViewModelInput {
+  readonly loading: boolean
+  readonly error: string | null
+  readonly tabGroups: readonly TabGroup[]
+  readonly customProjects: readonly CustomProjectViewModel[]
+  readonly categories: readonly ParentCategory[]
+  readonly searchQuery: string
+}
+
+/**
+ * Domain モード用 view-model を組み立てる。
+ *
+ * - `tabGroups` を view-model 配列へ変換
+ * - `categories` を view-model 配列へ変換
+ * - 検索クエリは normalized したうえでそのまま保持し、絞り込みは
+ *   controller 側 (`useDomainModeController`) で行う
+ */
+export const createDomainModeViewModel = ({
+  loading,
+  error,
+  tabGroups,
+  customProjects,
+  categories,
+  searchQuery,
+}: CreateDomainModeViewModelInput): DomainModeViewModel => {
+  const tabGroupViewModels = tabGroups.map(toTabGroupViewModel)
+  const categoryViewModels = categories.map(toParentCategoryViewModel)
+  const displayCount = tabGroupViewModels.reduce(
+    (total, group) => total + group.displayUrlCount,
+    0,
+  )
+  return {
+    categories: categoryViewModels,
+    customProjects,
+    displayCount,
+    error,
+    hasContent: tabGroupViewModels.length > 0 || customProjects.length > 0,
+    loading,
+    searchQuery,
+    tabGroups: tabGroupViewModels,
+  }
+}

--- a/src/contexts/saved-tabs/presentation/view-models/TabGroupViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/TabGroupViewModel.ts
@@ -33,14 +33,23 @@ export interface TabGroupViewModel {
  * presentation 層に閉じ、application 層では呼び出さない。
  * repository / use-case が返した entity 配列を `SavedTabsController` が
  * まとめてこの関数に通し、コンポーネントへ渡す。
+ *
+ * branded な `TabGroupId` / `UrlRecordId` を含む entity を受け取れるよう
+ * 配列は `readonly` 許容にしている。presentation 層で branded 型を意識
+ * せず `readonly` として扱える。
  */
 export const toTabGroupViewModel = (group: {
   id: string
   domain: string
   parentCategoryId?: string
-  urlIds?: string[]
-  urls?: { id: string; url: string; title: string; subCategory?: string }[]
-  subCategories?: string[]
+  urlIds?: readonly string[]
+  urls?: readonly {
+    id: string
+    url: string
+    title: string
+    subCategory?: string
+  }[]
+  subCategories?: readonly string[]
 }): TabGroupViewModel => {
   const urlIds = group.urlIds ?? []
   const urls = group.urls ?? []
@@ -53,7 +62,7 @@ export const toTabGroupViewModel = (group: {
     id: group.id,
     parentCategoryId: group.parentCategoryId,
     subCategoryCount: subCategories.length,
-    urlIds,
-    urls,
+    urlIds: [...urlIds],
+    urls: [...urls],
   }
 }

--- a/src/features/saved-tabs/app/SavedTabsApp.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.tsx
@@ -14,6 +14,10 @@ import { createSavedTabsUseCases } from '@/app/composition/createSavedTabsUseCas
 import { Toaster } from '@/components/ui/sonner'
 import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabGroupId'
 import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/UrlRecordId'
+import { createSavedTabsUseCases as createContextSavedTabsUseCases } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases'
+import { createSavedTabsUseCasesDeps } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps'
+import { useDomainModeController } from '@/contexts/saved-tabs/presentation/controllers/useDomainModeController'
+import { useSavedTabsController } from '@/contexts/saved-tabs/presentation/controllers/useSavedTabsController'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { CategoryReorderFooter } from '@/features/saved-tabs/components/Footer'
 import { Header } from '@/features/saved-tabs/components/Header' // ヘッダーコンポーネントをインポート
@@ -247,7 +251,6 @@ const useSavedTabsAppView = ({
 }: SavedTabsAppProps) => {
   const { t } = useI18n()
   const [settings, setSettings] = useState<UserSettings>(defaultSettings)
-  const [searchQuery, setSearchQuery] = useState('')
   const hasResolvedInitialViewModeRef = useRef(!initialViewMode)
   const previousInitialViewModeRef = useRef(initialViewMode)
 
@@ -279,6 +282,26 @@ const useSavedTabsAppView = ({
       }),
     [],
   )
+
+  // presentation 層の controller フック。Domain モード用 state
+  // (searchQuery, parentCategories) を presentation 層へ持ち上げ、
+  // `setSearchQuery` / `setParentCategories` を controller 経由で
+  // 配下に提供する。複雑 (Undo / snapshot 連携) な処理は従来通り
+  // 既存の `savedTabsUseCases` / `savedTabsPorts` 経由で実行する。
+  const controllerDeps = useMemo(() => createSavedTabsUseCasesDeps(), [])
+  const contextUseCases = useMemo(
+    () => createContextSavedTabsUseCases(controllerDeps),
+    [controllerDeps],
+  )
+  const presentationController = useSavedTabsController({
+    deps: controllerDeps,
+    useCases: contextUseCases,
+  })
+  const domainController = useDomainModeController({
+    controller: presentationController,
+  })
+  const searchQuery = domainController.searchQuery
+  const setSearchQuery = domainController.setSearchQuery
 
   // 未分類ドメインの並び替えモード状態管理
   const [isUncategorizedReorderMode, setIsUncategorizedReorderMode] =


### PR DESCRIPTION
…stomModeController を追加し SavedTabsApp を暫定接続

- presentation/controllers に useDomainModeController / useCustomModeController を新規追加し、URL ベースの open と検索 state / parentCategories を mode 単位の controller に集約
- presentation/view-models に DomainModeViewModel / CustomModeViewModel を追加し、mode 単位の UI 整形責務を presentation 層に持ち上げ
- useSavedTabsController の戻り値に deps / useCases を追加し、mode 別 controller から use-case ハンドルへ直接アクセスできる導線を提供
- TabGroupViewModel / CustomProjectViewModel の widening (readonly 許容) で branded domain entity をそのまま受け取れるよう調整
- SavedTabsApp で useDomainModeController を生成し searchQuery state を controller 経由へ移動。既存機能 (Undo / snapshot / chrome.windows.create) は features 側に残し UI は変えない
- DomainModeViewModel / CustomModeViewModel / useDomainModeController / useCustomModeController の unit test を追加 (jsdom / node 両 project)

## 変更内容

<!-- 変更の詳細を記述してください -->

## チェックリスト

- [ ] ローカル環境でエラーになっていない
