### PR TITLE
feat(#474): AppRouter の saved-tabs route を contexts 側へ切り替え

### DIFF
--- a/src/contexts/saved-tabs/presentation/routes/SavedTabsRoute.tsx
+++ b/src/contexts/saved-tabs/presentation/routes/SavedTabsRoute.tsx
@@ -1,96 +1,17 @@
-import { useEffect, useState } from 'react'
-
-import type { ViewMode } from '@/types/storage'
-
-import { SavedTabsPage } from '../pages/SavedTabsPage'
-
 /**
- * `SavedTabsRoute` の props。
+ * contexts 側 `SavedTabsRoute` (production 実行経路)。
  *
- * WXT の `src/entrypoints/saved-tabs/` から渡される初期表示モードと、
- * ナビゲート時のコールバックを受ける。`onViewModeNavigate` は未指定でも
- * URL を `window.history.replaceState` で更新する（既存仕様と同じ）。
- */
-export interface SavedTabsRouteProps {
-  readonly initialViewMode?: ViewMode
-  readonly isAiSidebarOpen?: boolean
-  readonly onViewModeNavigate?: (mode: ViewMode) => void
-}
-
-/**
- * `SavedTabsRoute` の内部 hook: `ViewMode` を URL と state で同期する。
+ * 旧 `features/saved-tabs/routes/SavedTabsRoute` と同じ component を
+ * contexts 配下の path から読み込めるよう再エクスポートする。
  *
- * 旧 `SavedTabsRoute` の `syncSavedTabsViewModeLocation` を
- * presentation 層へ移譲する形。ナビゲートコールバックが指定されていれば
- * それを使う（React Router などへの対応）。
- */
-const useViewModeSync = (
-  initialViewMode: ViewMode | undefined,
-  onViewModeNavigate: ((mode: ViewMode) => void) | undefined,
-) => {
-  const [viewMode, setViewMode] = useState<ViewMode>(
-    initialViewMode ?? 'domain',
-  )
-  useEffect(() => {
-    if (onViewModeNavigate) {
-      onViewModeNavigate(viewMode)
-      return
-    }
-    if (typeof window === 'undefined') {
-      return
-    }
-    const nextHref =
-      viewMode === 'custom' ? '/saved-tabs-custom' : '/saved-tabs-domain'
-    const currentUrl = new URL(window.location.href)
-    if (currentUrl.pathname === nextHref) {
-      return
-    }
-    window.history.replaceState({}, '', nextHref)
-  }, [onViewModeNavigate, viewMode])
-  return { setViewMode, viewMode }
-}
-
-/**
- * `SavedTabsRoute` presentation 版。
+ * この Issue (#474) は DDD 移行の production 実行経路切り替え PR として
+ * AppRouter の lazy import 先を features から contexts 側へ向けることが
+ * 目的で、UI コンポーネントの contexts 移植は対象外。後続 Issue で
+ * contexts/presentation/components に Header / DomainModeContainer /
+ * CustomModeContainer などを移植し、`SavedTabsPresentationLayout` などを
+ * 用意して本ファイルを本物に置き換える。
  *
- * 旧 `src/features/saved-tabs/routes/SavedTabsRoute.tsx` の代替。
- * ページ (`SavedTabsPage`) をマウントし、URL / state 同期を担う。
- *
- * 実機 UI に出す要素は本ファイルではなく、`SavedTabsPage` 配下の
- * `SavedTabsPresentationLayout`（別 issue で導入）側に集約する。
+ * 旧 features 側の route / test は本 Issue のスコープ外として残し、
+ * 後続 Issue で整理する。
  */
-export const SavedTabsRoute = ({
-  initialViewMode,
-  isAiSidebarOpen,
-  onViewModeNavigate,
-}: SavedTabsRouteProps) => {
-  const { viewMode } = useViewModeSync(initialViewMode, onViewModeNavigate)
-  return (
-    <SavedTabsRouteShell
-      viewMode={viewMode}
-      isAiSidebarOpen={isAiSidebarOpen ?? false}
-    />
-  )
-}
-
-/**
- * 表示確認用のシェルコンポーネント。`SavedTabsPage` の状態と
- * 現在の viewMode を data 属性で公開する。
- */
-const SavedTabsRouteShell = ({
-  viewMode,
-  isAiSidebarOpen,
-}: {
-  viewMode: ViewMode
-  isAiSidebarOpen: boolean
-}) => {
-  return (
-    <div
-      data-testid='saved-tabs-route-presentation'
-      data-view-mode={viewMode}
-      data-ai-sidebar-open={isAiSidebarOpen ? 'true' : 'false'}
-    >
-      <SavedTabsPage />
-    </div>
-  )
-}
+export { SavedTabsRoute } from '@/features/saved-tabs/routes/SavedTabsRoute'

--- a/src/features/navigation/app/AppRouter.test.tsx
+++ b/src/features/navigation/app/AppRouter.test.tsx
@@ -51,7 +51,7 @@ vi.mock('@/features/i18n/context/I18nProvider', () => ({
   }),
 }))
 
-vi.mock('@/features/saved-tabs/routes/SavedTabsRoute', () => ({
+vi.mock('@/contexts/saved-tabs/presentation/routes/SavedTabsRoute', () => ({
   SavedTabsRoute: ({
     onViewModeNavigate,
     search,

--- a/src/features/navigation/app/AppRouter.tsx
+++ b/src/features/navigation/app/AppRouter.tsx
@@ -49,7 +49,7 @@ const PeriodicExecutionRoutePage = lazy(() =>
 )
 
 const SavedTabsRouteComponent = lazy(() =>
-  import('@/features/saved-tabs/routes/SavedTabsRoute').then(
+  import('@/contexts/saved-tabs/presentation/routes/SavedTabsRoute').then(
     ({ SavedTabsRoute }) => ({
       default: SavedTabsRoute,
     }),


### PR DESCRIPTION
## 変更内容

`AppRouter` の `/saved-tabs` route の lazy import を、旧 `features/saved-tabs/routes/SavedTabsRoute` から `contexts/saved-tabs/presentation/routes/SavedTabsRoute` へ切り替える。

contexts 側 `SavedTabsRoute` は当面、旧 features 側 route の re-export として実装し、production UI / 表示・主要操作の互換を維持する。旧 features 側 route と `SavedTabsPage` (stub) は本 Issue スコープ外として残置し、後続 Issue で `contexts/presentation/components` への UI 移植および旧 features 整理を行う。

## 対象

- `src/features/navigation/app/AppRouter.tsx`
- `src/contexts/saved-tabs/presentation/routes/SavedTabsRoute.tsx`
- `src/features/navigation/app/AppRouter.test.tsx` (mock path 更新)

## 対象外

- 旧 `features/saved-tabs` の削除 (後続 Issue)
- UI デザイン変更
- storage schema 変更
- AI Chat / Analytics / Options の route 変更

## 検証

- [x] ローカル環境でエラーになっていない
- `bun run compile`: 通過
- `bun run lint`: 0 warnings / 0 errors
- `bun run format:check`: 通過
- `bun run test`: 210 files / 1774 tests 通過
- `bun run test:coverage`: 99.13% (develop baseline と同等)

## 受け入れ条件

- [x] `AppRouter` が contexts 側の saved-tabs route を読み込んでいる
- [x] `/saved-tabs` の表示・主要操作が壊れていない (旧 features route を re-export する一時ブリッジで production UI を維持)
- [x] 旧 features 側の route を削除せず、後続 Issue に残せている
- [x] `bun run compile` が通る
- [x] 関連テストが通る

## 関連 Issue

- refs #474
- 関連: #454 (DDD 全体設計), #469-#473 (前提 Issue)

## 補足: 前提の扱い

Issue 前提の「contexts 側 `SavedTabsRoute` / `SavedTabsPage` が既存UIと同等に表示できること」に対し、現状 `SavedTabsPage` は stub 表示のみで未充足。本 PR では route 切り替えのみを対象とし、contexts 側 UI 移植 (`SavedTabsPresentationLayout` の導入、Header / DomainModeContainer / CustomModeContainer などの `contexts/presentation/components` への移植) は後続 Issue で扱う。

/cc @haruto-yamada1