### PR TITLE
test(#476): saved-tabs DDD 移行の end-to-end 回帰テストを追加

### DIFF
--- a/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
@@ -1,0 +1,768 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { NotificationPort } from '../../application/ports/NotificationPort'
+import { searchSavedTabs } from '../../domain/services/SavedTabsSearchService'
+import { createSavedTabsUseCases } from '../composition/createSavedTabsUseCases'
+import type { SavedTabsUseCasesDeps } from '../composition/createSavedTabsUseCasesDeps'
+import { createChromeCustomProjectRepository } from './chrome-storage/ChromeCustomProjectRepository'
+import { createChromeParentCategoryRepository } from './chrome-storage/ChromeParentCategoryRepository'
+import { createChromeTabGroupRepository } from './chrome-storage/ChromeTabGroupRepository'
+import type { ChromeStorageLocalPort } from './chrome-storage/ChromeUrlRecordRepository'
+import { createChromeUrlRecordRepository } from './chrome-storage/ChromeUrlRecordRepository'
+import {
+  CUSTOM_PROJECTS_KEY,
+  PARENT_CATEGORIES_KEY,
+  SAVED_TABS_KEY,
+  URLS_KEY,
+} from './chrome-storage/savedTabsStorageKeys'
+
+type StorageState = Record<string, unknown>
+
+const createPort = (state: StorageState): ChromeStorageLocalPort => {
+  // mock 内で await しない同期関数を async として書くため lint ルールを局所的に解除する
+  /* eslint-disable typescript/require-await */
+  return {
+    get: vi.fn((key: string) => Promise.resolve({ [key]: state[key] })),
+    remove: vi.fn((key: string) => {
+      // eslint-disable-next-line typescript/no-dynamic-delete
+      delete state[key]
+      return Promise.resolve()
+    }),
+    set: vi.fn((value: Record<string, unknown>) => {
+      Object.assign(state, value)
+      return Promise.resolve()
+    }),
+  }
+  /* eslint-enable typescript/require-await */
+}
+
+interface SpyBrowserTabPort {
+  readonly port: BrowserTabPort
+  readonly open: ReturnType<typeof vi.fn>
+  readonly opened: { active: boolean; url: string }[]
+}
+
+const createSpyBrowserTabPort = (
+  resolveActive: () => boolean,
+): SpyBrowserTabPort => {
+  const opened: { active: boolean; url: string }[] = []
+  const open = vi.fn((input: { url: string }) => {
+    opened.push({ active: resolveActive(), url: input.url })
+    return Promise.resolve({ url: input.url })
+  })
+  return {
+    open,
+    opened,
+    port: { open },
+  }
+}
+
+const createCaptureNotificationPort = (): {
+  notificationPort: NotificationPort
+  calls: { level: 'error' | 'info' | 'success'; message: string }[]
+} => {
+  const calls: { level: 'error' | 'info' | 'success'; message: string }[] = []
+  const push =
+    (level: 'error' | 'info' | 'success') => (input: { message: string }) => {
+      calls.push({ level, message: input.message })
+    }
+  return {
+    calls,
+    notificationPort: {
+      error: push('error'),
+      info: push('info'),
+      success: push('success'),
+    },
+  }
+}
+
+interface Bundle {
+  readonly deps: SavedTabsUseCasesDeps
+  readonly port: ChromeStorageLocalPort
+  readonly portState: StorageState
+  readonly browserTabPort: SpyBrowserTabPort
+  readonly notificationPort: ReturnType<typeof createCaptureNotificationPort>
+  readonly useCases: ReturnType<typeof createSavedTabsUseCases>
+}
+
+const createBundle = (initial: StorageState = {}): Bundle => {
+  const state: StorageState = { ...initial }
+  const port = createPort(state)
+  const browserTabPort = createSpyBrowserTabPort(() => true)
+  const notification = createCaptureNotificationPort()
+  const deps: SavedTabsUseCasesDeps = {
+    browserTabPort: browserTabPort.port,
+    customProjectRepository: createChromeCustomProjectRepository(port),
+    notificationPort: notification.notificationPort,
+    parentCategoryRepository: createChromeParentCategoryRepository(port),
+    tabGroupRepository: createChromeTabGroupRepository(port),
+    urlRecordRepository: createChromeUrlRecordRepository(port),
+  }
+  return {
+    browserTabPort,
+    deps,
+    notificationPort: notification,
+    port,
+    portState: state,
+    useCases: createSavedTabsUseCases(deps),
+  }
+}
+
+const buildLegacyFixture = (): StorageState => {
+  // 旧 `src/lib/storage/*` と同じ chrome.storage 形式を再現する
+  // フィクスチャ。rich な補助フィールド（urlSubCategories / subCategories /
+  // categoryKeywords など）を含め、DDD 移行で捨てられても writeback で
+  // 持ち越されることを保証する。
+  return {
+    [CUSTOM_PROJECTS_KEY]: [
+      {
+        categories: ['research'],
+        createdAt: 1_700_000_000_000,
+        id: 'project-research',
+        name: 'Q4 Research',
+        projectKeywords: {
+          domainKeywords: ['example.com'],
+          titleKeywords: ['research'],
+          urlKeywords: ['paper'],
+        },
+        updatedAt: 1_700_000_000_500,
+        urlIds: ['url-shared'],
+        urlMetadata: {
+          'url-shared': { category: 'research', notes: 'shared note' },
+        },
+        urls: [
+          {
+            category: 'research',
+            notes: 'shared note',
+            savedAt: 1_700_000_000_000,
+            title: 'Shared Article',
+            url: 'https://example.com/shared',
+          },
+        ],
+      },
+    ],
+    [PARENT_CATEGORIES_KEY]: [
+      {
+        domainNames: ['example.com'],
+        domains: ['group-example'],
+        id: 'cat-docs',
+        name: 'Docs',
+      },
+      {
+        domainNames: ['other.com'],
+        domains: ['group-other'],
+        id: 'cat-news',
+        name: 'News',
+      },
+    ],
+    [SAVED_TABS_KEY]: [
+      {
+        categoryKeywords: [{ categoryName: 'docs', keywords: ['doc', 'spec'] }],
+        domain: 'https://example.com',
+        id: 'group-example',
+        parentCategoryId: 'cat-docs',
+        savedAt: 1_700_000_000_000,
+        subCategories: ['docs'],
+        subCategoryOrder: ['docs'],
+        subCategoryOrderWithUncategorized: ['docs', 'uncategorized'],
+        urlIds: ['url-shared', 'url-example-only'],
+        urls: [
+          {
+            id: 'url-shared',
+            savedAt: 1_700_000_000_000,
+            subCategory: 'docs',
+            title: 'Shared Article',
+            url: 'https://example.com/shared',
+          },
+          {
+            id: 'url-example-only',
+            savedAt: 1_700_000_000_100,
+            subCategory: 'docs',
+            title: 'Example Only',
+            url: 'https://example.com/only',
+          },
+        ],
+        urlSubCategories: {
+          'url-example-only': 'docs',
+          'url-shared': 'docs',
+        },
+      },
+      {
+        domain: 'https://other.com',
+        id: 'group-other',
+        parentCategoryId: 'cat-news',
+        savedAt: 1_700_000_000_200,
+        urlIds: ['url-other-1'],
+        urls: [
+          {
+            id: 'url-other-1',
+            savedAt: 1_700_000_000_200,
+            title: 'Other 1',
+            url: 'https://other.com/1',
+          },
+        ],
+      },
+    ],
+    [URLS_KEY]: [
+      {
+        favIconUrl: 'https://example.com/favicon.ico',
+        id: 'url-shared',
+        savedAt: 1_700_000_000_000,
+        title: 'Shared Article',
+        url: 'https://example.com/shared',
+      },
+      {
+        id: 'url-example-only',
+        savedAt: 1_700_000_000_100,
+        title: 'Example Only',
+        url: 'https://example.com/only',
+      },
+      {
+        id: 'url-other-1',
+        savedAt: 1_700_000_000_200,
+        title: 'Other 1',
+        url: 'https://other.com/1',
+      },
+    ],
+  }
+}
+
+describe('savedTabs DDD 移行 後 回帰テスト', () => {
+  describe('legacy data → repository 読み出し', () => {
+    it('旧 chrome.storage の生データを repository が domain entity へ読み出せる', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      const tabGroups = await bundle.deps.tabGroupRepository.findAll()
+      const urlRecords = await bundle.deps.urlRecordRepository.findAll()
+      const parentCategories =
+        await bundle.deps.parentCategoryRepository.findAll()
+      const customProjects = await bundle.deps.customProjectRepository.findAll()
+
+      // group-example の domain は URL 形式から hostname へ正規化される
+      const exampleGroup = tabGroups.find(
+        (group) => group.id === 'group-example',
+      )
+      expect(exampleGroup?.domain).toBe('example.com')
+      expect(exampleGroup?.parentCategoryId).toBe('cat-docs')
+      expect(exampleGroup?.urlIds).toStrictEqual([
+        'url-shared',
+        'url-example-only',
+      ])
+      expect(tabGroups).toHaveLength(2)
+      expect(urlRecords).toHaveLength(3)
+      expect(parentCategories).toHaveLength(2)
+      expect(customProjects).toHaveLength(1)
+      expect(customProjects[0]?.urlIds).toStrictEqual(['url-shared'])
+    })
+
+    it('不正なレコードを混在させた storage でも有効 entity だけを返す', async () => {
+      const state = buildLegacyFixture()
+      const savedTabs = state[SAVED_TABS_KEY] as Record<string, unknown>[]
+      savedTabs.push({ domain: 'broken.example.com' })
+      savedTabs.push({ id: 'broken-2' })
+      const bundle = createBundle(state)
+      const tabGroups = await bundle.deps.tabGroupRepository.findAll()
+      expect(tabGroups.map((group) => group.id)).toStrictEqual([
+        'group-example',
+        'group-other',
+      ])
+    })
+  })
+
+  describe('URL open', () => {
+    it('use-case が BrowserTabPort.open を呼び出して URL を開く', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      const result = await bundle.useCases.openSavedUrl({
+        origin: 'click',
+        settings: {
+          removeTabAfterExternalDrop: false,
+          removeTabAfterOpen: false,
+        },
+        urlRecordId: 'url-example-only' as never,
+      })
+      expect(result.openedUrl).toBe('https://example.com/only')
+      expect(bundle.browserTabPort.open).toHaveBeenCalledWith({
+        url: 'https://example.com/only',
+      })
+    })
+
+    it('openUrlInBackground 設定 (resolveActive: false) は BrowserTabPort 経由で active: false に伝搬する', async () => {
+      // openUrlInBackground は chrome.tabs.create 時の `active` フラグを
+      // 制御する設定。DDD 移行でこの経路が壊れていないことを確認する
+      // ために、port options の resolveActive を経由して
+      // chrome.tabs.create({ active, url }) の active が伝搬することを検証。
+      const state = buildLegacyFixture()
+      const port = createPort(state)
+      const openSpy = vi.fn((input: { url: string }) =>
+        Promise.resolve({ url: input.url }),
+      )
+      const resolveActive = vi.fn(() => false)
+      const { createChromeBrowserTabAdapter } =
+        await import('../browser/ChromeBrowserTabAdapter')
+      const browserTabPort = createChromeBrowserTabAdapter(
+        { getApi: () => ({ tabs: { create: openSpy } }) },
+        { resolveActive },
+      )
+      const notification = createCaptureNotificationPort()
+      const deps: SavedTabsUseCasesDeps = {
+        browserTabPort,
+        customProjectRepository: createChromeCustomProjectRepository(port),
+        notificationPort: notification.notificationPort,
+        parentCategoryRepository: createChromeParentCategoryRepository(port),
+        tabGroupRepository: createChromeTabGroupRepository(port),
+        urlRecordRepository: createChromeUrlRecordRepository(port),
+      }
+      const useCases = createSavedTabsUseCases(deps)
+      await useCases.openSavedUrl({
+        origin: 'click',
+        settings: {
+          removeTabAfterExternalDrop: false,
+          removeTabAfterOpen: false,
+        },
+        urlRecordId: 'url-example-only' as never,
+      })
+      expect(resolveActive).toHaveBeenCalled()
+      expect(openSpy).toHaveBeenCalledWith({
+        active: false,
+        url: 'https://example.com/only',
+      })
+    })
+
+    it('removeTabAfterOpen=false のとき保存データを変更しない（storage に書き戻さない）', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      const setSpy = bundle.port.set as ReturnType<typeof vi.fn>
+      const initialSetCalls = setSpy.mock.calls.length
+      await bundle.useCases.openSavedUrl({
+        origin: 'click',
+        settings: {
+          removeTabAfterExternalDrop: false,
+          removeTabAfterOpen: false,
+        },
+        urlRecordId: 'url-example-only' as never,
+      })
+      expect(setSpy.mock.calls.length).toBe(initialSetCalls)
+      const urlRecords = await bundle.deps.urlRecordRepository.findAll()
+      expect(urlRecords.map((record) => record.id)).toContain(
+        'url-example-only',
+      )
+    })
+
+    it('removeTabAfterOpen=true のとき対象参照のみ削除し UrlRecord も消える', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      const result = await bundle.useCases.openSavedUrl({
+        origin: 'click',
+        settings: {
+          removeTabAfterExternalDrop: false,
+          removeTabAfterOpen: true,
+        },
+        urlRecordId: 'url-example-only' as never,
+      })
+      expect(result.removedUrlRecordId).toBe('url-example-only')
+      const tabGroups = await bundle.deps.tabGroupRepository.findAll()
+      const exampleGroup = tabGroups.find(
+        (group) => group.id === 'group-example',
+      )
+      // 対象 urlId だけが TabGroup から外れている
+      expect(exampleGroup?.urlIds).toStrictEqual(['url-shared'])
+      const urlRecords = await bundle.deps.urlRecordRepository.findAll()
+      expect(urlRecords.map((record) => record.id)).not.toContain(
+        'url-example-only',
+      )
+    })
+
+    it('CustomProject に参照されている UrlRecord は removeTabAfterOpen=true でも消えない', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      const result = await bundle.useCases.openSavedUrl({
+        origin: 'click',
+        settings: {
+          removeTabAfterExternalDrop: false,
+          removeTabAfterOpen: true,
+        },
+        urlRecordId: 'url-shared' as never,
+      })
+      // url-shared は project-research からの参照があるため UrlRecord は
+      // 削除されない（previous 状態での参照で判定する）
+      expect(result.removedUrlRecordId).toBeNull()
+      const urlRecords = await bundle.deps.urlRecordRepository.findAll()
+      expect(urlRecords.map((record) => record.id)).toContain('url-shared')
+      // ただし url-shared は TabGroup / CustomProject 双方から urlIds が
+      // 取り除かれている
+      const tabGroups = await bundle.deps.tabGroupRepository.findAll()
+      const exampleGroup = tabGroups.find(
+        (group) => group.id === 'group-example',
+      )
+      expect(exampleGroup?.urlIds).not.toContain('url-shared')
+      const customProjects = await bundle.deps.customProjectRepository.findAll()
+      expect(customProjects[0]?.urlIds).not.toContain('url-shared')
+    })
+  })
+
+  describe('Delete', () => {
+    it('単一 TabGroup を削除できる', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      const result = await bundle.useCases.deleteTabGroup({
+        tabGroupId: 'group-example' as never,
+      })
+      expect(result.removedTabGroupId).toBe('group-example')
+      const tabGroups = await bundle.deps.tabGroupRepository.findAll()
+      expect(tabGroups.map((group) => group.id)).toStrictEqual(['group-other'])
+    })
+
+    it('CustomProject 参照がある UrlRecord は消さず、TabGroup 専用 UrlRecord は同時に削除する', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      const result = await bundle.useCases.deleteTabGroup({
+        tabGroupId: 'group-example' as never,
+      })
+      // url-shared は project-research からの参照で残る
+      expect(result.removedUrlRecordIds).toStrictEqual(['url-example-only'])
+      const urlRecords = await bundle.deps.urlRecordRepository.findAll()
+      expect(urlRecords.map((record) => record.id).toSorted()).toStrictEqual(
+        ['url-other-1', 'url-shared'].toSorted(),
+      )
+    })
+
+    it('snapshot には実際に削除された UrlRecord のみを含む（他参照で残ったものは含まない）', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      const result = await bundle.useCases.deleteTabGroup({
+        tabGroupId: 'group-example' as never,
+      })
+      const savedTabs = result.snapshot.savedTabs ?? []
+      const urlRecords = result.snapshot.urlRecords ?? []
+      expect(savedTabs).toHaveLength(1)
+      expect(savedTabs[0]?.id).toBe('group-example')
+      // url-shared は CustomProject 側に残るので snapshot には含まれない
+      expect(urlRecords.map((record) => record.id)).toStrictEqual([
+        'url-example-only',
+      ])
+    })
+  })
+
+  describe('Restore / Undo', () => {
+    it('URL open 後の削除 snapshot から TabGroup と UrlRecord を復元できる', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      const opened = await bundle.useCases.openSavedUrl({
+        origin: 'click',
+        settings: {
+          removeTabAfterExternalDrop: false,
+          removeTabAfterOpen: true,
+        },
+        urlRecordId: 'url-example-only' as never,
+      })
+      expect(opened.snapshot).not.toBeNull()
+      const snapshot = opened.snapshot
+      if (!snapshot) {
+        return
+      }
+
+      // restore 前: example-only は storage から消えている
+      let urlRecords = await bundle.deps.urlRecordRepository.findAll()
+      expect(urlRecords.map((record) => record.id)).not.toContain(
+        'url-example-only',
+      )
+
+      const restored = await bundle.useCases.restoreOpenedUrlsSnapshot({
+        snapshot,
+      })
+      // snapshot には開いた時点の全 TabGroup が入っているので 2 件返る
+      expect(restored.restoredTabGroups).toHaveLength(2)
+      expect(restored.restoredTabGroups.map((group) => group.id)).toContain(
+        'group-example',
+      )
+      expect(restored.restoredUrlRecords.map((record) => record.id)).toContain(
+        'url-example-only',
+      )
+
+      // restore 後: storage にも entity として戻る
+      urlRecords = await bundle.deps.urlRecordRepository.findAll()
+      expect(urlRecords.map((record) => record.id)).toContain(
+        'url-example-only',
+      )
+    })
+
+    it('TabGroup 削除 snapshot から CustomProject 参照も復元できる', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      const deleted = await bundle.useCases.deleteTabGroup({
+        tabGroupId: 'group-example' as never,
+      })
+      const snapshot = deleted.snapshot
+
+      // restore 前: group-example は storage から消えている
+      let tabGroups = await bundle.deps.tabGroupRepository.findAll()
+      expect(tabGroups.map((group) => group.id)).not.toContain('group-example')
+
+      const restored = await bundle.useCases.restoreOpenedUrlsSnapshot({
+        snapshot,
+      })
+      expect(restored.restoredTabGroups.map((group) => group.id)).toContain(
+        'group-example',
+      )
+      // url-shared は CustomProject 側に残っていたので restore の戻り値には
+      // 含まれない（既存 project 側に居続ける）
+      expect(restored.restoredUrlRecords.map((record) => record.id)).toContain(
+        'url-example-only',
+      )
+
+      // restore 後: storage に group-example が戻り、url-example-only も復活
+      tabGroups = await bundle.deps.tabGroupRepository.findAll()
+      const restoredGroup = tabGroups.find(
+        (group) => group.id === 'group-example',
+      )
+      expect(restoredGroup?.urlIds).toContain('url-example-only')
+      // url-shared は CustomProject 側に居続けるので project-research の urlIds はそのまま
+      const customProjects = await bundle.deps.customProjectRepository.findAll()
+      expect(customProjects[0]?.urlIds).toContain('url-shared')
+    })
+  })
+
+  describe('Category / Search', () => {
+    it('バルク同期で parentCategoryId が無い TabGroup を domainName で割り当てる', async () => {
+      // parentCategoryId を持たない TabGroup を用意して同期で割り当てる
+      const state = buildLegacyFixture()
+      const savedTabs = state[SAVED_TABS_KEY] as Record<string, unknown>[]
+      const groupExample = savedTabs.find(
+        (entry) => entry.id === 'group-example',
+      )
+      if (groupExample) {
+        delete groupExample.parentCategoryId
+      }
+      const bundle = createBundle(state)
+      const result = await bundle.useCases.syncCategoryAssignments({})
+      expect(result.assignedTabGroupIds).toContain('group-example')
+      const tabGroups = await bundle.deps.tabGroupRepository.findAll()
+      const exampleGroup = tabGroups.find(
+        (group) => group.id === 'group-example',
+      )
+      expect(exampleGroup?.parentCategoryId).toBe('cat-docs')
+    })
+
+    it('単一ドメイン同期で該当 TabGroup を別 ParentCategory へ移動できる', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      const result = await bundle.useCases.syncCategoryAssignments({
+        command: {
+          domain: 'other.com' as never,
+          parentCategoryId: 'cat-docs' as never,
+        },
+      })
+      expect(result.assignedTabGroupIds).toContain('group-other')
+      const tabGroups = await bundle.deps.tabGroupRepository.findAll()
+      const otherGroup = tabGroups.find((group) => group.id === 'group-other')
+      expect(otherGroup?.parentCategoryId).toBe('cat-docs')
+    })
+
+    it('未分類の TabGroup は parentCategoryId が外れる', async () => {
+      const state = buildLegacyFixture()
+      // cat-docs の domainNames / domains を空にしてどの TabGroup も
+      // 該当しない状態にしたうえで、group-example の parentCategoryId を
+      // 存在しない id に強制する。解決時にどの lookup にもヒットしないので
+      // parentCategoryId が外れる（カテゴリ不一致 = 未分類）
+      const parentCategories = state[PARENT_CATEGORIES_KEY] as Record<
+        string,
+        unknown
+      >[]
+      const docsCategory = parentCategories.find(
+        (category) => category.id === 'cat-docs',
+      )
+      if (docsCategory) {
+        docsCategory.domainNames = []
+        docsCategory.domains = []
+      }
+      const savedTabs = state[SAVED_TABS_KEY] as Record<string, unknown>[]
+      const groupExample = savedTabs.find(
+        (entry) => entry.id === 'group-example',
+      )
+      if (groupExample) {
+        groupExample.parentCategoryId = 'cat-stale'
+      }
+      const bundle = createBundle(state)
+      const result = await bundle.useCases.syncCategoryAssignments({})
+      expect(result.unassignedTabGroupIds).toContain('group-example')
+      const tabGroups = await bundle.deps.tabGroupRepository.findAll()
+      const exampleGroup = tabGroups.find(
+        (group) => group.id === 'group-example',
+      )
+      expect(exampleGroup?.parentCategoryId).toBeUndefined()
+    })
+
+    it('検索フィルタは旧挙動（URL / title / domain / category）を維持する', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      const tabGroups = await bundle.deps.tabGroupRepository.findAll()
+      const urlRecords = await bundle.deps.urlRecordRepository.findAll()
+      const parentCategories =
+        await bundle.deps.parentCategoryRepository.findAll()
+
+      // URL 一致
+      const urlHit = searchSavedTabs({
+        categories: parentCategories,
+        contexts: tabGroups.map((group) => ({
+          group,
+          urls: urlRecords.filter((record) => group.urlIds.includes(record.id)),
+        })),
+        input: { query: 'shared' },
+      })
+      expect(urlHit).toHaveLength(1)
+      expect(urlHit[0]?.urls.map((url) => url.id)).toContain('url-shared')
+
+      // title 一致
+      const titleHit = searchSavedTabs({
+        categories: parentCategories,
+        contexts: tabGroups.map((group) => ({
+          group,
+          urls: urlRecords.filter((record) => group.urlIds.includes(record.id)),
+        })),
+        input: { query: 'Only' },
+      })
+      expect(titleHit).toHaveLength(1)
+      expect(titleHit[0]?.urls.map((url) => url.id)).toContain(
+        'url-example-only',
+      )
+
+      // domain 一致
+      const domainHit = searchSavedTabs({
+        categories: parentCategories,
+        contexts: tabGroups.map((group) => ({
+          group,
+          urls: urlRecords.filter((record) => group.urlIds.includes(record.id)),
+        })),
+        input: { query: 'other' },
+      })
+      expect(domainHit).toHaveLength(1)
+      expect(domainHit[0]?.urls.map((url) => url.id)).toContain('url-other-1')
+
+      // category 一致（カテゴリ名で group 全体がヒット）
+      const categoryHit = searchSavedTabs({
+        categories: parentCategories,
+        contexts: tabGroups.map((group) => ({
+          group,
+          urls: urlRecords.filter((record) => group.urlIds.includes(record.id)),
+        })),
+        input: { query: 'Docs' },
+      })
+      expect(categoryHit).toHaveLength(1)
+      expect(categoryHit[0]?.categoryMatched).toBe(true)
+      expect(categoryHit[0]?.urls.map((url) => url.id)).toContain('url-shared')
+      expect(categoryHit[0]?.urls.map((url) => url.id)).toContain(
+        'url-example-only',
+      )
+
+      // どの URL にも一致しない query
+      const noHit = searchSavedTabs({
+        categories: parentCategories,
+        contexts: tabGroups.map((group) => ({
+          group,
+          urls: urlRecords.filter((record) => group.urlIds.includes(record.id)),
+        })),
+        input: { query: 'no-such-needle-zzz' },
+      })
+      expect(noHit).toHaveLength(0)
+    })
+  })
+
+  describe('Round-trip (write → reload で永続化が壊れていないか)', () => {
+    it('use-case 実行後の storage が新形式として再パースできる', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      await bundle.useCases.deleteTabGroup({
+        tabGroupId: 'group-example' as never,
+      })
+      await bundle.useCases.syncCategoryAssignments({})
+
+      // 新しい repository インスタンスで再読み込みしても整合する
+      const freshPort = createPort(bundle.portState)
+      const freshDeps: SavedTabsUseCasesDeps = {
+        ...bundle.deps,
+        customProjectRepository: createChromeCustomProjectRepository(freshPort),
+        parentCategoryRepository:
+          createChromeParentCategoryRepository(freshPort),
+        tabGroupRepository: createChromeTabGroupRepository(freshPort),
+        urlRecordRepository: createChromeUrlRecordRepository(freshPort),
+      }
+      const tabGroups = await freshDeps.tabGroupRepository.findAll()
+      const urlRecords = await freshDeps.urlRecordRepository.findAll()
+      const parentCategories =
+        await freshDeps.parentCategoryRepository.findAll()
+      const customProjects = await freshDeps.customProjectRepository.findAll()
+
+      expect(tabGroups.map((group) => group.id)).toStrictEqual(['group-other'])
+      expect(urlRecords.map((record) => record.id)).toContain('url-shared')
+      expect(urlRecords.map((record) => record.id)).toContain('url-other-1')
+      expect(parentCategories).toHaveLength(2)
+      expect(customProjects).toHaveLength(1)
+
+      // rich な補助フィールドが writeback で消えていないこと
+      const savedTabsRaw = bundle.portState[SAVED_TABS_KEY] as Record<
+        string,
+        unknown
+      >[]
+      const otherRaw = savedTabsRaw.find((entry) => entry.id === 'group-other')
+      expect(otherRaw).toMatchObject({ domain: 'other.com', id: 'group-other' })
+    })
+
+    it('repository の writeback は entity → raw への写像で必須欠けを起こさない', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+      // 書き戻しを強制するために同期を呼ぶ
+      await bundle.useCases.syncCategoryAssignments({})
+      const savedUrlsRaw = bundle.portState[URLS_KEY] as Record<
+        string,
+        unknown
+      >[]
+      for (const raw of savedUrlsRaw) {
+        expect(raw.id).toBeTypeOf('string')
+        expect(raw.savedAt).toBeTypeOf('number')
+        expect(raw.title).toBeTypeOf('string')
+        expect(raw.url).toBeTypeOf('string')
+      }
+    })
+  })
+
+  describe('Snapshot / Undo 経由でも全エンティティが整合する', () => {
+    it('open → restore を繰り返しても entity の urlIds / parentCategoryId が壊れない', async () => {
+      const bundle = createBundle(buildLegacyFixture())
+
+      // 1 回目: open & restore
+      const first = await bundle.useCases.openSavedUrl({
+        origin: 'click',
+        settings: {
+          removeTabAfterExternalDrop: false,
+          removeTabAfterOpen: true,
+        },
+        urlRecordId: 'url-example-only' as never,
+      })
+      expect(first.snapshot).not.toBeNull()
+      if (first.snapshot) {
+        await bundle.useCases.restoreOpenedUrlsSnapshot({
+          snapshot: first.snapshot,
+        })
+      }
+
+      const tabGroups = await bundle.deps.tabGroupRepository.findAll()
+      const exampleGroup = tabGroups.find(
+        (group) => group.id === 'group-example',
+      )
+      expect(exampleGroup?.urlIds).toContain('url-example-only')
+      const urlRecords = await bundle.deps.urlRecordRepository.findAll()
+      expect(urlRecords.map((record) => record.id)).toContain(
+        'url-example-only',
+      )
+
+      // 2 回目: open & restore
+      const second = await bundle.useCases.openSavedUrl({
+        origin: 'click',
+        settings: {
+          removeTabAfterExternalDrop: false,
+          removeTabAfterOpen: true,
+        },
+        urlRecordId: 'url-example-only' as never,
+      })
+      expect(second.snapshot).not.toBeNull()
+      if (second.snapshot) {
+        await bundle.useCases.restoreOpenedUrlsSnapshot({
+          snapshot: second.snapshot,
+        })
+      }
+      const tabGroups2 = await bundle.deps.tabGroupRepository.findAll()
+      const exampleGroup2 = tabGroups2.find(
+        (group) => group.id === 'group-example',
+      )
+      expect(exampleGroup2?.urlIds).toContain('url-example-only')
+    })
+  })
+})


### PR DESCRIPTION
# \u007f{title} - Issue \\#{476}

\\#{476} \u306e\u30ea\u30af\u30a8\u30b9\u30c8\u3092\u57fa\u306b\u3001saved-tabs DDD \u79fb\u884c\u5f8c\u306e end-to-end \u56de\u5e30\u30c6\u30b9\u30c8\u3092\u8ffd\u52a0\u3057\u307e\u3057\u305f\u3002

## \u5909\u66f4\u5185\u5bb9

`src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts` \u3092\u65b0\u898f\u8ffd\u52a0\uff081\u30d5\u30a1\u30a4\u30eb\u30fb768 \u884c\uff09\u3002

`chrome.storage.local` \u306e\u30e2\u30c3\u30af\u30fbport\u30fbmapper\u30fbrepository\u30fbuse-case\u30fbwriteback \u3092\u4e00\u6c17\u901a\u7a7f\u3067\u901a\u3059 DDD \u7d71\u5408\u30c6\u30b9\u30c8\u3092\u69cb\u6210\u3057\u3001issue \u306e\u91cd\u70b9\u30c6\u30b9\u30c8\u30b1\u30fc\u30b9\u3092 19 \u30b1\u30fc\u30b9\u3067\u30ab\u30d0\u30fc\u3057\u307e\u3059\u3002

### \u30ab\u30d0\u30fc\u3059\u308b\u4e8b\u9805

- **legacy data \u2192 repository \u8aad\u307f\u51fa\u3057**: \u65e7 `chrome.storage.local` \u5f62\u5f0f\u306e\u751f\u30c7\u30fc\u30bf\uff08`urlSubCategories` / `subCategories` / `categoryKeywords` \u306a\u3069\u306e rich \u88dc\u52a9\u30d5\u30a3\u30fc\u30eb\u30c9\u4ed8\u304d\u30fb\u4e0d\u6b63\u30ec\u30b3\u30fc\u30c9\u6df7\u5728\uff09\u3092 repository \u304c entity \u5316
- **URL open**: `BrowserTabPort.open` \u547c\u3073\u51fa\u3057\u3001`openUrlInBackground` \u8a2d\u5b9a\uff08`resolveActive: false`\uff09\u304c `chrome.tabs.create({ active: false, url })` \u3078\u4f1d\u64ad\u3001`removeTabAfterOpen=false` \u3067 storage \u66f8\u304d\u623b\u3057\u306a\u3057\u3001`removeTabAfterOpen=true` \u3067\u5bfe\u8c61\u53c2\u7167\u306e\u307f\u524a\u9664\u3001CustomProject \u53c2\u7167\u304c\u3042\u308b UrlRecord \u306f\u6b8b\u308b
- **Delete**: \u5358\u4e00 TabGroup \u524a\u9664\u3001CustomProject \u53c2\u7167\u304c\u3042\u308b UrlRecord \u306f\u6b8b\u3059\u3001snapshot \u306b\u306f\u5b9f\u969b\u306b\u524a\u9664\u3055\u308c\u305f UrlRecord \u306e\u307f\u542b\u3080
- **Restore / Undo**: URL open \u5f8c\u306e snapshot \u304b\u3089 TabGroup \u3068 UrlRecord \u3092\u5fa9\u5143\u3001TabGroup \u524a\u9664 snapshot \u304b\u3089 CustomProject \u53c2\u7167\u3092\u5fa9\u5143
- **Category / Search**: \u30d0\u30eb\u30af\u540c\u671f\u30fb\u5358\u4e00\u30c9\u30e1\u30a4\u30f3\u540c\u671f\u30fb\u672a\u5206\u985e TabGroup \u306e `parentCategoryId` \u89e3\u9664\u3001\u691c\u7d22\u30d5\u30a3\u30eb\u30bf\uff08URL / title / domain / category\uff09\u306e\u65e7\u632f\u308b\u821e\u3044\u3092\u7dad\u6301
- **Round-trip**: use-case \u5b9f\u884c\u5f8c\u306e storage \u3092\u65b0 repository \u3067\u518d\u30d1\u30fc\u30b9\u53ef\u80fd\u3001entity \u2192 raw \u5199\u50cf\u3067\u5fc5\u9808\u6b20\u3051\u306a\u3057
- **open \u2192 restore \u7e70\u308a\u8fd4\u3057**: snapshot/Undo \u3092\u7e70\u308a\u8fd4\u3057\u3066\u3082 `urlIds` / `parentCategoryId` \u304c\u58ca\u308c\u306a\u3044

## \u30c1\u30a7\u30c3\u30af\u30ea\u30b9\u30c8

- [x] \u30ed\u30fc\u30ab\u30eb\u74b0\u5883\u3067\u30a8\u30e9\u30fc\u306b\u306a\u3063\u3066\u3044\u306a\u3044
- [x] `bun run compile` \u304c\u901a\u308b\uff08tsgo \u578b\u30c1\u30a7\u30c3\u30af OK\uff09
- [x] `bun run lint` \u304c\u901a\u308b\uff08oxlint 0 errors\uff09
- [x] `bun run format:check` \u304c\u901a\u308b
- [x] `bun run test:node` \u304c 1007/1007 \u901a\u308b
- [x] `bun run test`\uff08node + dom\uff09\u304c 1793/1793 \u901a\u308b
- [x] \u8ffd\u52a0\u30c6\u30b9\u30c8 19 \u30b1\u30fc\u30b9\u304c CI \u3067\u5b9f\u884c\u3055\u308c\u308b

## \u95a2\u9023 issue

- \\#{454} DDD \u69cb\u6210\u3078\u6bb5\u968e\u79fb\u884c\u3059\u308b\u305f\u3081\u306e\u5168\u4f53\u8a2d\u8a08\u3068\u5b9f\u88c5\u8a08\u753b
- \\#{469} saved-tabs \u306e composition root \u3092\u8ffd\u52a0\u3057\u3066 use-case \u3092\u7d44\u307f\u7acb\u3066\u308b
- \\#{470} handleOpenTab \u3092 OpenSavedUrlUseCase \u7d4c\u7531\u306b\u7f6e\u304d\u63db\u3048\u308b
- \\#{471} handleDeleteGroup \u3092 DeleteTabGroupUseCase \u7d4c\u7531\u306b\u7f6e\u304d\u63db\u3048\u308b
- \\#{472} restore / undo \u51e6\u7406\u3092 RestoreOpenedUrlsSnapshotUseCase \u7d4c\u7531\u306b\u7f6e\u304d\u63db\u3048\u308b
- \\#{473} saved-tabs presentation/controller \u3092\u5b9f\u884c\u7d4c\u8def\u306b\u63a5\u7d9a\u3059\u308b
- \\#{474} AppRouter \u306e saved-tabs route \u3092 contexts \u5074\u3078\u5207\u308a\u63db\u3048\u308b
- \\#{475} \u65e7 features/saved-tabs \u3068 lib/storage \u76f4\u63a5\u4f9d\u5b58\u3092\u524a\u6e1b\u30fb\u64a4\u53bb\u3059\u308b