### PR TITLE
[DDD] saved-tabs の残操作を application use-case 経由に置き換える

### DIFF
--- a/src/app/composition/createSavedTabsPorts.ts
+++ b/src/app/composition/createSavedTabsPorts.ts
@@ -1,7 +1,9 @@
 import type { BrowserTabPort } from '@/contexts/saved-tabs/application/ports/BrowserTabPort'
+import type { BrowserWindowPort } from '@/contexts/saved-tabs/application/ports/BrowserWindowPort'
 import type { NotificationPort } from '@/contexts/saved-tabs/application/ports/NotificationPort'
 import { createChromeBrowserTabAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter'
 import type { ChromeApiLike } from '@/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter'
+import { createChromeBrowserWindowAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeBrowserWindowAdapter'
 import { createSonnerNotificationAdapter } from '@/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter'
 
 /**
@@ -9,12 +11,14 @@ import { createSonnerNotificationAdapter } from '@/contexts/saved-tabs/infrastru
  * `Port` 実装のバンドル。
  *
  * `BrowserTabPort` は `chrome.tabs` をラップした `ChromeBrowserTabAdapter`、
+ * `BrowserWindowPort` は `chrome.windows` をラップした `ChromeBrowserWindowAdapter`、
  * `NotificationPort` は `sonner` の `toast` をラップした
  * `SonnerNotificationAdapter` で実装する。`application/ports/` の
  * interface を満たすため、use-case 側からは adapter の詳細を隠せる。
  */
 export interface SavedTabsPorts {
   readonly browserTabPort: BrowserTabPort
+  readonly browserWindowPort: BrowserWindowPort
   readonly notificationPort: NotificationPort
 }
 
@@ -33,16 +37,28 @@ interface ChromeApi extends ChromeApiLike {
   readonly tabs?: ChromeApiLike['tabs'] & {
     readonly create?: NonNullable<NonNullable<ChromeApiLike['tabs']>['create']>
   }
+  readonly windows?: {
+    readonly create?: (createProperties: {
+      readonly focused?: boolean
+      readonly url?: readonly string[] | string
+    }) =>
+      | Promise<
+          { readonly tabs?: readonly { readonly url?: string }[] } | undefined
+        >
+      | undefined
+  }
 }
 
 const getChromeApi = (): ChromeApi | undefined =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   (globalThis as typeof globalThis & { chrome?: ChromeApi }).chrome
 
 /**
  * saved-tabs 用 port 実装を生成する。
  *
  * `chrome` グローバルが利用できない環境（Storybook / SSR など）では
- * `BrowserTabPort.open` を呼び出した瞬間に `Error` が投げられる。
+ * `BrowserTabPort.open` / `BrowserWindowPort.openWithUrls` を
+ * 呼び出した瞬間に `Error` が投げられる。
  * `NotificationPort` は `sonner.toast` が無い場合に
  * `console.warn` / `console.error` にフォールバックするため、通知で
  * use-case 全体を落とさない。
@@ -66,5 +82,8 @@ export const createSavedTabsPorts = (
     { getApi: () => getChromeApi() },
     options.resolveActive ? { resolveActive: options.resolveActive } : {},
   ),
+  browserWindowPort: createChromeBrowserWindowAdapter({
+    getApi: () => getChromeApi(),
+  }),
   notificationPort: createSonnerNotificationAdapter(),
 })

--- a/src/app/composition/createSavedTabsUseCases.ts
+++ b/src/app/composition/createSavedTabsUseCases.ts
@@ -1,5 +1,9 @@
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/SavedTabsUseCases'
+import { createDeleteSavedUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase'
+import { createDeleteSavedUrlUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase'
+import { createDeleteTabGroupsUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteTabGroupsUseCase'
 import { createDeleteTabGroupUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteTabGroupUseCase'
+import { createOpenAllSavedUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/OpenAllSavedUrlsUseCase'
 import { createOpenSavedUrlUseCase } from '@/contexts/saved-tabs/application/use-cases/OpenSavedUrlUseCase'
 import { createRemoveUnreferencedUrlRecordsUseCase } from '@/contexts/saved-tabs/application/use-cases/RemoveUnreferencedUrlRecordsUseCase'
 import { createRestoreOpenedUrlsSnapshotUseCase } from '@/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase'
@@ -23,8 +27,8 @@ export interface CreateSavedTabsUseCasesOptions {
  * `src/app/composition/` レベルの composition root。
  *
  * `chrome.storage.local` ベースの repository 実装と
- * `chrome.tabs` / `sonner` ベースの port 実装を 1 度だけ組み立て、
- * そこから `saved-tabs` の優先 use-case 5 種を生成して返す。
+ * `chrome.tabs` / `chrome.windows` / `sonner` ベースの port 実装を
+ * 1 度だけ組み立て、そこから `saved-tabs` の優先 use-case を生成して返す。
  *
  * この関数以降、UI / hook / テストは
  * `chrome.*` API を直接触れず、use-case だけを呼び出す形になる。
@@ -49,7 +53,29 @@ export const createSavedTabsUseCases = (
   )
 
   return {
+    deleteSavedUrl: createDeleteSavedUrlUseCase({
+      customProjectRepository: repositories.customProjectRepository,
+      tabGroupRepository: repositories.tabGroupRepository,
+      urlRecordRepository: repositories.urlRecordRepository,
+    }),
+    deleteSavedUrls: createDeleteSavedUrlsUseCase({
+      customProjectRepository: repositories.customProjectRepository,
+      tabGroupRepository: repositories.tabGroupRepository,
+      urlRecordRepository: repositories.urlRecordRepository,
+    }),
     deleteTabGroup: createDeleteTabGroupUseCase({
+      customProjectRepository: repositories.customProjectRepository,
+      tabGroupRepository: repositories.tabGroupRepository,
+      urlRecordRepository: repositories.urlRecordRepository,
+    }),
+    deleteTabGroups: createDeleteTabGroupsUseCase({
+      customProjectRepository: repositories.customProjectRepository,
+      tabGroupRepository: repositories.tabGroupRepository,
+      urlRecordRepository: repositories.urlRecordRepository,
+    }),
+    openAllSavedUrls: createOpenAllSavedUrlsUseCase({
+      browserTabPort: ports.browserTabPort,
+      browserWindowPort: ports.browserWindowPort,
       customProjectRepository: repositories.customProjectRepository,
       tabGroupRepository: repositories.tabGroupRepository,
       urlRecordRepository: repositories.urlRecordRepository,

--- a/src/contexts/saved-tabs/application/SavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/application/SavedTabsUseCases.ts
@@ -1,4 +1,8 @@
+import type { DeleteSavedUrlsUseCase } from './use-cases/DeleteSavedUrlsUseCase'
+import type { DeleteSavedUrlUseCase } from './use-cases/DeleteSavedUrlUseCase'
+import type { DeleteTabGroupsUseCase } from './use-cases/DeleteTabGroupsUseCase'
 import type { DeleteTabGroupUseCase } from './use-cases/DeleteTabGroupUseCase'
+import type { OpenAllSavedUrlsUseCase } from './use-cases/OpenAllSavedUrlsUseCase'
 import type { OpenSavedUrlUseCase } from './use-cases/OpenSavedUrlUseCase'
 import type { RemoveUnreferencedUrlRecordsUseCase } from './use-cases/RemoveUnreferencedUrlRecordsUseCase'
 import type { RestoreOpenedUrlsSnapshotUseCase } from './use-cases/RestoreOpenedUrlsSnapshotUseCase'
@@ -25,7 +29,11 @@ import type { SyncCategoryAssignmentsUseCase } from './use-cases/SyncCategoryAss
  */
 export interface SavedTabsUseCases {
   readonly openSavedUrl: OpenSavedUrlUseCase
+  readonly openAllSavedUrls: OpenAllSavedUrlsUseCase
   readonly deleteTabGroup: DeleteTabGroupUseCase
+  readonly deleteTabGroups: DeleteTabGroupsUseCase
+  readonly deleteSavedUrl: DeleteSavedUrlUseCase
+  readonly deleteSavedUrls: DeleteSavedUrlsUseCase
   readonly restoreOpenedUrlsSnapshot: RestoreOpenedUrlsSnapshotUseCase
   readonly syncCategoryAssignments: SyncCategoryAssignmentsUseCase
   readonly removeUnreferencedUrlRecords: RemoveUnreferencedUrlRecordsUseCase

--- a/src/contexts/saved-tabs/application/commands/DeleteSavedUrlCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/DeleteSavedUrlCommand.ts
@@ -1,0 +1,26 @@
+import type { TabGroupId } from '../../domain/value-objects/TabGroupId'
+
+/**
+ * `DeleteSavedUrlUseCase` の入力。
+ *
+ * 既存 `SavedTabsApp.tsx` の `handleDeleteUrl` 相当の責務を
+ * 1 つの use-case にまとめる。`tabGroupId` で対象 `TabGroup` を特定し、
+ * `url` で削除する URL 文字列を指定する。
+ *
+ * URL 文字列 → `UrlRecordId` の逆引きは use-case 内で
+ * `UrlRecordRepository.findAll` を通じて行う。`UrlRecord` が
+ * 見つからない URL は `SavedTabsDomainError` を投げる。
+ *
+ * @example
+ * ```ts
+ * const command: DeleteSavedUrlCommand = {
+ *   tabGroupId,
+ *   url: 'https://example.com/a',
+ * }
+ * const result = await deleteSavedUrlUseCase(command)
+ * ```
+ */
+export interface DeleteSavedUrlCommand {
+  readonly tabGroupId: TabGroupId
+  readonly url: string
+}

--- a/src/contexts/saved-tabs/application/commands/DeleteSavedUrlsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/DeleteSavedUrlsCommand.ts
@@ -1,0 +1,25 @@
+import type { TabGroupId } from '../../domain/value-objects/TabGroupId'
+
+/**
+ * `DeleteSavedUrlsUseCase` の入力。
+ *
+ * 既存 `SavedTabsApp.tsx` の `handleDeleteUrls` 相当の責務を
+ * 1 つの use-case にまとめる。`tabGroupId` で対象 `TabGroup` を特定し、
+ * `urls` で削除する URL 文字列配列を指定する。
+ *
+ * 1 件以上の URL を削除した場合のみ DTO を返す。`urls` が空配列のときは
+ * no-op として空の DTO を返す。
+ *
+ * @example
+ * ```ts
+ * const command: DeleteSavedUrlsCommand = {
+ *   tabGroupId,
+ *   urls: ['https://example.com/a', 'https://example.com/b'],
+ * }
+ * const result = await deleteSavedUrlsUseCase(command)
+ * ```
+ */
+export interface DeleteSavedUrlsCommand {
+  readonly tabGroupId: TabGroupId
+  readonly urls: readonly string[]
+}

--- a/src/contexts/saved-tabs/application/commands/DeleteTabGroupsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/DeleteTabGroupsCommand.ts
@@ -1,0 +1,23 @@
+import type { TabGroupId } from '../../domain/value-objects/TabGroupId'
+
+/**
+ * `DeleteTabGroupsUseCase` の入力。
+ *
+ * 既存 `SavedTabsApp.tsx` の `handleDeleteGroups` 相当の責務を
+ * 1 つの use-case にまとめる。複数の `TabGroupId` を一括で受け取り、
+ * 1 件も対象がない場合は no-op として扱う。
+ *
+ * 単一の `DeleteTabGroupUseCase` と API シグネチャを揃えるため、
+ * `tabGroupIds` 配列は空でも許可する（use-case 側で早期 return する）。
+ *
+ * @example
+ * ```ts
+ * const command: DeleteTabGroupsCommand = {
+ *   tabGroupIds: [tabGroupId1, tabGroupId2],
+ * }
+ * const result = await deleteTabGroupsUseCase(command)
+ * ```
+ */
+export interface DeleteTabGroupsCommand {
+  readonly tabGroupIds: readonly TabGroupId[]
+}

--- a/src/contexts/saved-tabs/application/commands/OpenAllSavedUrlsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/OpenAllSavedUrlsCommand.ts
@@ -1,0 +1,36 @@
+/**
+ * `OpenAllSavedUrlsUseCase` の入力。
+ *
+ * 既存の `SavedTabsApp.tsx` の `handleOpenAllTabs` 相当の責務を
+ * 1 つの use-case にまとめる。`urls` は開く対象の URL 文字列配列、
+ * `mode` で「新規ウィンドウでまとめて開く」「既存タブとして 1 つずつ開く」
+ * を使い分ける。
+ *
+ * `openUrlInBackground` 設定は use-case には渡さず、composition 層が
+ * `BrowserTabPort` の `resolveActive` へ反映する形にする
+ * （`OpenSavedUrlUseCase` と同じパターン）。
+ *
+ * `removeTabAfterOpen` が `true` のときは、開いたあとに保存タブ
+ * （`TabGroup` / `CustomProject`）から該当 URL を削除する。
+ *
+ * @example
+ * ```ts
+ * const command: OpenAllSavedUrlsCommand = {
+ *   mode: 'newWindow',
+ *   removeTabAfterOpen: false,
+ *   urls: ['https://example.com/a', 'https://example.com/b'],
+ * }
+ * const result = await openAllSavedUrlsUseCase(command)
+ * ```
+ */
+export type OpenAllSavedUrlsMode = 'newWindow' | 'backgroundTabs'
+
+export interface OpenAllSavedUrlsCommand {
+  readonly urls: readonly string[]
+  readonly mode: OpenAllSavedUrlsMode
+  /**
+   * 開いたあとに保存タブから削除するかの設定値。
+   * presentation 層がユーザーの preferences から取得して注入する。
+   */
+  readonly removeTabAfterOpen: boolean
+}

--- a/src/contexts/saved-tabs/application/dto/DeletedSavedUrlDto.ts
+++ b/src/contexts/saved-tabs/application/dto/DeletedSavedUrlDto.ts
@@ -1,0 +1,27 @@
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import type { UrlRecord } from '../../domain/entities/UrlRecord'
+import type { UrlRecordId } from '../../domain/value-objects/UrlRecordId'
+import type { OpenedUrlsRestoreSnapshot } from '../commands/RestoreOpenedUrlsSnapshotCommand'
+
+/**
+ * `DeleteSavedUrlUseCase` の結果 DTO。
+ *
+ * `removedUrlRecordId` は実際に `UrlRecordRepository.removeByIds` で
+ * 削除された `UrlRecordId`（他で参照されていなければ削除される）。
+ * 他で参照されているために `UrlRecord` が残った場合は `null` を返す。
+ *
+ * `removedTabGroupId` は対象 `TabGroup` の ID。`urlIds` 配列から
+ * 該当 `UrlRecordId` を取り除いた結果 `TabGroup` が空になった場合は
+ * その `TabGroup` 自体が削除される。`null` の場合は `TabGroup` が
+ * 残ったことを示す。
+ *
+ * `snapshot` は Undo 用。`savedTabs` には対象 `TabGroup` の
+ * 削除前スナップショットを、`urlRecords` には実際に削除された
+ * `UrlRecord` の配列を格納する。1 件も削除されなかったケースでは `null`。
+ */
+export interface DeletedSavedUrlDto {
+  readonly removedUrlRecordId: UrlRecordId | null
+  readonly removedTabGroupId: TabGroup['id'] | null
+  readonly removedUrlRecord: UrlRecord | null
+  readonly snapshot: OpenedUrlsRestoreSnapshot | null
+}

--- a/src/contexts/saved-tabs/application/dto/DeletedSavedUrlsDto.ts
+++ b/src/contexts/saved-tabs/application/dto/DeletedSavedUrlsDto.ts
@@ -1,0 +1,30 @@
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import type { UrlRecord } from '../../domain/entities/UrlRecord'
+import type { UrlRecordId } from '../../domain/value-objects/UrlRecordId'
+import type { OpenedUrlsRestoreSnapshot } from '../commands/RestoreOpenedUrlsSnapshotCommand'
+
+/**
+ * `DeleteSavedUrlsUseCase` の結果 DTO。
+ *
+ * `removedUrlRecordIds` は実際に削除された `UrlRecordId` 配列
+ * （他で参照されていなければ削除される）。他で参照されている
+ * ために `UrlRecord` が残った場合は `removedUrlRecordIds` には
+ * 含まれない。
+ *
+ * `removedUrlRecords` は実際に削除された `UrlRecord` の配列。
+ * Undo 時に「消した UrlRecord を戻す」用途に使う。
+ *
+ * `removedTabGroupIds` は対象 `TabGroup` のうち、`urlIds` 配列から
+ * 該当 `UrlRecordId` をすべて取り除いた結果空になって削除されたもの。
+ * `TabGroup` が残った場合はその ID は含まれない。
+ *
+ * `snapshot` は Undo 用。`savedTabs` には削除された `TabGroup` の
+ * 削除前スナップショットを、`urlRecords` には実際に削除された
+ * `UrlRecord` の配列を格納する。1 件も削除されなかったケースでは `null`。
+ */
+export interface DeletedSavedUrlsDto {
+  readonly removedUrlRecordIds: readonly UrlRecordId[]
+  readonly removedUrlRecords: readonly UrlRecord[]
+  readonly removedTabGroupIds: readonly TabGroup['id'][]
+  readonly snapshot: OpenedUrlsRestoreSnapshot | null
+}

--- a/src/contexts/saved-tabs/application/dto/DeletedTabGroupsDto.ts
+++ b/src/contexts/saved-tabs/application/dto/DeletedTabGroupsDto.ts
@@ -1,0 +1,32 @@
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import type { TabGroupId } from '../../domain/value-objects/TabGroupId'
+import type { UrlRecordId } from '../../domain/value-objects/UrlRecordId'
+import type { OpenedUrlsRestoreSnapshot } from '../commands/RestoreOpenedUrlsSnapshotCommand'
+
+/**
+ * `DeleteTabGroupsUseCase` の結果 DTO。
+ *
+ * 削除成功時のみ返る。Undo に必要なデータを `snapshot` にまとめ、
+ * presentation 層が `RestoreOpenedUrlsSnapshotUseCase` へそのまま渡せる
+ * 形にしてある。
+ *
+ * `removedTabGroupIds` は実際に削除された TabGroup の ID 配列。
+ * 入力で指定した `tabGroupIds` のうち、storage 上に存在しなかったものは
+ * 含まれない（filter 結果）。
+ *
+ * `removedUrlRecordIds` は削除された TabGroup に属していた `UrlRecord` の
+ * うち、削除後にどの TabGroup / CustomProject からも参照されなくなった
+ * もの。空配列なら「他で参照されていたため UrlRecord は保持された」ことを示す。
+ */
+export interface DeletedTabGroupsDto {
+  readonly removedTabGroupIds: readonly TabGroupId[]
+  readonly removedUrlRecordIds: readonly UrlRecordId[]
+  /**
+   * 復元に必要なスナップショット。
+   * presentation 層が Undo を発火する際に `RestoreOpenedUrlsSnapshotCommand`
+   * へそのまま渡せる形。
+   */
+  readonly snapshot: OpenedUrlsRestoreSnapshot & {
+    readonly savedTabs: readonly TabGroup[]
+  }
+}

--- a/src/contexts/saved-tabs/application/dto/OpenedUrlsDto.ts
+++ b/src/contexts/saved-tabs/application/dto/OpenedUrlsDto.ts
@@ -1,0 +1,24 @@
+import type { UrlRecord } from '../../domain/entities/UrlRecord'
+import type { UrlRecordId } from '../../domain/value-objects/UrlRecordId'
+import type { OpenedUrlsRestoreSnapshot } from '../commands/RestoreOpenedUrlsSnapshotCommand'
+
+/**
+ * `OpenAllSavedUrlsUseCase` の結果 DTO。
+ *
+ * `openedUrls` は実際にブラウザで開いた URL 文字列配列。
+ * `removedUrlRecordIds` は `removeTabAfterOpen` 設定と
+ * 参照関係（他で参照されているか）に基づいて削除された
+ * `UrlRecordId` 集合。空配列なら「削除されなかった」ことを示す。
+ *
+ * `removedUrlRecords` は実際に `UrlRecordRepository.removeByIds` で
+ * 削除された `UrlRecord` の配列。Undo 時に「消した UrlRecord を戻す」用途に使う。
+ *
+ * `snapshot` は `RestoreOpenedUrlsSnapshotCommand` へそのまま渡せる形。
+ * 削除が発生しなかったケースでは `null`。
+ */
+export interface OpenedUrlsDto {
+  readonly openedUrls: readonly string[]
+  readonly removedUrlRecordIds: readonly UrlRecordId[]
+  readonly removedUrlRecords: readonly UrlRecord[]
+  readonly snapshot: OpenedUrlsRestoreSnapshot | null
+}

--- a/src/contexts/saved-tabs/application/ports/BrowserWindowPort.ts
+++ b/src/contexts/saved-tabs/application/ports/BrowserWindowPort.ts
@@ -1,0 +1,38 @@
+/**
+ * `chrome.windows.create` 相当の操作を抽象化する port。
+ *
+ * application 層は `chrome.*` API を直接呼ばず、本 port 経由で
+ * 「複数 URL を新規ウィンドウでまとめて開く」操作を依頼する。
+ * infrastructure 層が `ChromeBrowserWindowAdapter` などで
+ * 本 port を実装し、composition 層で use-case へ注入する。
+ *
+ * 返り値は開いた URL 配列だけを返し、ウィンドウ ID などの詳細には
+ * 依存しない。Undo 用スナップショットや presentation 側の表示更新は
+ * URL 文字列だけで十分判定できるため、port の最小 interface を保つ。
+ *
+ * @example
+ * ```ts
+ * const port: BrowserWindowPort = createChromeBrowserWindowAdapter()
+ * const result = await port.openWithUrls({ urls: ['https://example.com'] })
+ * console.log(result.urls)
+ * ```
+ */
+export interface BrowserWindowPort {
+  /**
+   * 指定 URL 群を 1 つの新規ウィンドウでまとめて開き、
+   * 開いた URL 配列を返す。
+   *
+   * 拡張機能によっては `chrome.windows.create({ url })` のみを
+   * サポートするため、本 port も複数 URL を 1 度に開く挙動に
+   * 正規化する。呼び出し側は「どのウィンドウが開いたか」の ID を
+   * 知る必要がないため、ID を返さない（必要になった時点で port を拡張する）。
+   *
+   * 失敗時（permission 不足・URL 不正など）は `Error` を投げる。
+   * 1 件でも失敗した場合は部分成功とせず、呼び出し側で例外ハンドリング
+   * させる方針。
+   */
+  openWithUrls: (input: {
+    readonly urls: readonly string[]
+    readonly focused?: boolean
+  }) => Promise<{ readonly urls: readonly string[] }>
+}

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest'
+
+import { createCustomProject } from '../../domain/entities/CustomProject'
+import { createTabGroup } from '../../domain/entities/TabGroup'
+import { createUrlRecord } from '../../domain/entities/UrlRecord'
+import { SavedTabsDomainError } from '../../domain/errors/SavedTabsDomainError'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import type { DeleteSavedUrlUseCaseDeps } from './DeleteSavedUrlUseCase'
+import { createDeleteSavedUrlUseCase } from './DeleteSavedUrlUseCase'
+
+interface Repositories {
+  tabGroupRepository: TabGroupRepository
+  urlRecordRepository: UrlRecordRepository
+  customProjectRepository: CustomProjectRepository
+}
+
+const createInMemoryRepositories = (
+  initial: {
+    tabGroups?: ReturnType<typeof createTabGroup>[]
+    urlRecords?: ReturnType<typeof createUrlRecord>[]
+    customProjects?: ReturnType<typeof createCustomProject>[]
+  } = {},
+): Repositories & DeleteSavedUrlUseCaseDeps => {
+  const tabGroups: ReturnType<typeof createTabGroup>[] = [
+    ...(initial.tabGroups ?? []),
+  ]
+  const urlRecords: ReturnType<typeof createUrlRecord>[] = [
+    ...(initial.urlRecords ?? []),
+  ]
+  const customProjects: ReturnType<typeof createCustomProject>[] = [
+    ...(initial.customProjects ?? []),
+  ]
+  const tabGroupRepository: TabGroupRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [...tabGroups],
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) => tabGroups.find((group) => group.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids.map((id) => id))
+      const next = tabGroups.filter((group) => !idSet.has(group.id))
+      tabGroups.splice(0, tabGroups.length, ...next)
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (groups) => {
+      tabGroups.splice(0, tabGroups.length, ...groups)
+    },
+  }
+  const urlRecordRepository: UrlRecordRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [...urlRecords],
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      urlRecords.find((record) => record.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids.map((id) => id))
+      const next = urlRecords.filter((record) => !idSet.has(record.id))
+      urlRecords.splice(0, urlRecords.length, ...next)
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (records) => {
+      urlRecords.splice(0, urlRecords.length, ...records)
+    },
+  }
+  const customProjectRepository: CustomProjectRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [...customProjects],
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      customProjects.find((project) => project.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (projects) => {
+      customProjects.splice(0, customProjects.length, ...projects)
+    },
+  }
+  return {
+    customProjectRepository,
+    tabGroupRepository,
+    urlRecordRepository,
+  }
+}
+
+describe('DeleteSavedUrlUseCase', () => {
+  it('指定した URL を TabGroup と UrlRecord から削除する', async () => {
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1', 'url-2'],
+    })
+    const url1 = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const url2 = createUrlRecord({
+      id: 'url-2',
+      savedAt: 1,
+      title: 'B',
+      url: 'https://example.com/b',
+    })
+    const repos = createInMemoryRepositories({
+      tabGroups: [group],
+      urlRecords: [url1, url2],
+    })
+    const useCase = createDeleteSavedUrlUseCase(repos)
+
+    const result = await useCase({
+      tabGroupId: group.id,
+      url: 'https://example.com/a',
+    })
+
+    expect(result.removedUrlRecordId).toBe('url-1')
+    expect(result.removedUrlRecord?.id).toBe('url-1')
+    expect(result.removedTabGroupId).toBeNull()
+    expect(result.snapshot).not.toBeNull()
+    const remaining = await repos.tabGroupRepository.findAll()
+    expect(remaining[0].urlIds).toStrictEqual(['url-2'])
+    const remainingRecords = await repos.urlRecordRepository.findAll()
+    expect(remainingRecords.map((record) => record.id)).toStrictEqual(['url-2'])
+  })
+
+  it('最後の URL を削除した場合は TabGroup も削除する', async () => {
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1'],
+    })
+    const url1 = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const repos = createInMemoryRepositories({
+      tabGroups: [group],
+      urlRecords: [url1],
+    })
+    const useCase = createDeleteSavedUrlUseCase(repos)
+
+    const result = await useCase({
+      tabGroupId: group.id,
+      url: 'https://example.com/a',
+    })
+
+    expect(result.removedUrlRecordId).toBe('url-1')
+    expect(result.removedTabGroupId).toBe(group.id)
+    await expect(repos.tabGroupRepository.findAll()).resolves.toStrictEqual([])
+  })
+
+  it('他で参照されている UrlRecord は削除せず残す', async () => {
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1'],
+    })
+    const project = createCustomProject({
+      categories: [],
+      createdAt: 1,
+      id: 'project-1',
+      name: 'P',
+      updatedAt: 1,
+      urlIds: ['url-1'],
+    })
+    const url1 = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const repos = createInMemoryRepositories({
+      customProjects: [project],
+      tabGroups: [group],
+      urlRecords: [url1],
+    })
+    const useCase = createDeleteSavedUrlUseCase(repos)
+
+    const result = await useCase({
+      tabGroupId: group.id,
+      url: 'https://example.com/a',
+    })
+
+    // UrlRecord は project に参照されているため削除されない。
+    // 一方、group から URL を取り除いた結果 urlIds が空になるため
+    // group 自体は削除される（既存 removeUrlFromTabGroup と同じ挙動）。
+    expect(result.removedUrlRecordId).toBeNull()
+    expect(result.removedTabGroupId).toBe(group.id)
+    expect(result.removedUrlRecord).toBeNull()
+    expect(result.snapshot).not.toBeNull()
+    await expect(repos.tabGroupRepository.findAll()).resolves.toStrictEqual([])
+    const remainingRecords = await repos.urlRecordRepository.findAll()
+    expect(remainingRecords.map((record) => record.id)).toStrictEqual(['url-1'])
+  })
+
+  it('TabGroup に該当 URL が無い場合は no-op', async () => {
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-2'],
+    })
+    const url1 = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const repos = createInMemoryRepositories({
+      tabGroups: [group],
+      urlRecords: [url1],
+    })
+    const useCase = createDeleteSavedUrlUseCase(repos)
+
+    const result = await useCase({
+      tabGroupId: group.id,
+      url: 'https://example.com/a',
+    })
+
+    expect(result.removedUrlRecordId).toBeNull()
+    expect(result.snapshot).toBeNull()
+    const remainingTabGroups = await repos.tabGroupRepository.findAll()
+    expect(remainingTabGroups[0].urlIds).toStrictEqual(['url-2'])
+  })
+
+  it('存在しない TabGroup のときは SavedTabsDomainError を投げる', async () => {
+    const repos = createInMemoryRepositories()
+    const useCase = createDeleteSavedUrlUseCase(repos)
+
+    await expect(
+      useCase({
+        tabGroupId: 'missing' as never,
+        url: 'https://example.com/a',
+      }),
+    ).rejects.toBeInstanceOf(SavedTabsDomainError)
+  })
+
+  it('UrlRecord に登録されていない URL のときは SavedTabsDomainError を投げる', async () => {
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: [],
+    })
+    const repos = createInMemoryRepositories({ tabGroups: [group] })
+    const useCase = createDeleteSavedUrlUseCase(repos)
+
+    await expect(
+      useCase({
+        tabGroupId: group.id,
+        url: 'https://example.com/a',
+      }),
+    ).rejects.toBeInstanceOf(SavedTabsDomainError)
+  })
+})

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.test.ts
@@ -153,7 +153,7 @@ describe('DeleteSavedUrlUseCase', () => {
     await expect(repos.tabGroupRepository.findAll()).resolves.toStrictEqual([])
   })
 
-  it('他で参照されている UrlRecord は削除せず残す', async () => {
+  it('CustomProject からも url id を取り除き、UrlRecord も未参照なら削除する', async () => {
     const group = createTabGroup({
       domain: 'example.com',
       id: 'group-1',
@@ -185,14 +185,54 @@ describe('DeleteSavedUrlUseCase', () => {
       url: 'https://example.com/a',
     })
 
-    // UrlRecord は project に参照されているため削除されない。
-    // 一方、group から URL を取り除いた結果 urlIds が空になるため
-    // group 自体は削除される（既存 removeUrlFromTabGroup と同じ挙動）。
-    expect(result.removedUrlRecordId).toBeNull()
+    // group / project の双方から url-1 を取り除き、参照箇所が無くなるため
+    // UrlRecord も削除される。group の urlIds が空になるので group 自体も削除。
+    expect(result.removedUrlRecordId).toBe('url-1')
     expect(result.removedTabGroupId).toBe(group.id)
-    expect(result.removedUrlRecord).toBeNull()
+    expect(result.removedUrlRecord?.id).toBe('url-1')
     expect(result.snapshot).not.toBeNull()
+    expect(result.snapshot?.customProjects).toContainEqual(project)
     await expect(repos.tabGroupRepository.findAll()).resolves.toStrictEqual([])
+    const remainingProjects = await repos.customProjectRepository.findAll()
+    expect(remainingProjects[0].urlIds).toStrictEqual([])
+    const remainingRecords = await repos.urlRecordRepository.findAll()
+    expect(remainingRecords.map((record) => record.id)).toStrictEqual([])
+  })
+
+  it('別 group が同じ UrlRecord を参照している場合は削除しない', async () => {
+    const targetGroup = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1'],
+    })
+    const otherGroup = createTabGroup({
+      domain: 'other.com',
+      id: 'group-2',
+      urlIds: ['url-1'],
+    })
+    const url1 = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const repos = createInMemoryRepositories({
+      tabGroups: [targetGroup, otherGroup],
+      urlRecords: [url1],
+    })
+    const useCase = createDeleteSavedUrlUseCase(repos)
+
+    const result = await useCase({
+      tabGroupId: targetGroup.id,
+      url: 'https://example.com/a',
+    })
+
+    // 他 group から参照されているので UrlRecord は残す。
+    // targetGroup 単体では urlIds が空になるので group 自体は削除。
+    expect(result.removedUrlRecordId).toBeNull()
+    expect(result.removedTabGroupId).toBe(targetGroup.id)
+    const remainingTabGroups = await repos.tabGroupRepository.findAll()
+    expect(remainingTabGroups.map((g) => g.id)).toStrictEqual([otherGroup.id])
     const remainingRecords = await repos.urlRecordRepository.findAll()
     expect(remainingRecords.map((record) => record.id)).toStrictEqual(['url-1'])
   })

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.ts
@@ -1,3 +1,4 @@
+import type { CustomProject } from '../../domain/entities/CustomProject'
 import type { TabGroup } from '../../domain/entities/TabGroup'
 import type { UrlRecord } from '../../domain/entities/UrlRecord'
 import { SavedTabsDomainError } from '../../domain/errors/SavedTabsDomainError'
@@ -35,8 +36,12 @@ export type DeleteSavedUrlUseCase = (
  *    `SavedTabsDomainError` を投げる。
  * 3. 該当 `UrlRecordId` を `TabGroup` の `urlIds` から取り除く。
  *    `urlIds` が空になった場合は `TabGroup` 自体を削除する。
- * 4. 該当 `UrlRecord` が他で参照されていなければ `UrlRecordRepository.removeByIds` で削除する。
- * 5. Undo 用 snapshot を `DeletedSavedUrlDto` にまとめて返す。
+ * 4. 同じ `UrlRecordId` を参照している `CustomProject` の `urlIds` からも
+ *    取り除き、storage を書き戻す（旧 `removeUrlFromTabGroup` の
+ *    `removeUrlFromAllCustomProjects` 相当）。
+ * 5. 残った参照（他 `TabGroup` / `CustomProject`）が無ければ
+ *    `UrlRecordRepository.removeByIds` で `UrlRecord` 自体を削除する。
+ * 6. Undo 用 snapshot を `DeletedSavedUrlDto` にまとめて返す。
  *
  * 1 件も `UrlRecord` が消せず `TabGroup` も変更なしのケースでは
  * `snapshot: null` を返す。
@@ -85,6 +90,7 @@ export const createDeleteSavedUrlUseCase = (
 
     const previousGroup: TabGroup = targetGroup
     const previousUrlRecord: UrlRecord = targetUrlRecord
+    const previousCustomProjects: readonly CustomProject[] = allCustomProjects
 
     // 該当 URL を TabGroup から取り除く。
     const remainingUrlIds = targetGroup.urlIds.filter(
@@ -99,11 +105,29 @@ export const createDeleteSavedUrlUseCase = (
             : group,
         )
 
+    // 同じ URL を保持している CustomProject からも取り除く。
+    // 旧 `removeUrlFromTabGroup` の `removeUrlFromAllCustomProjects` 相当で、
+    // custom モード上に幽霊表示が残らないようにする。
+    const updatedCustomProjects: readonly CustomProject[] =
+      allCustomProjects.map((project) => {
+        const remaining = project.urlIds.filter(
+          (urlId) => urlId !== targetUrlId,
+        )
+        if (remaining.length === project.urlIds.length) {
+          return project
+        }
+        return { ...project, urlIds: remaining }
+      })
+
     // UrlRecord が他で参照されていなければ削除する。
+    // 参照判定は更新後の TabGroup / CustomProject 全体で行う。
+    // target group が urlIds 空で削除された場合 (`isGroupEmpty = true`) も
+    // 他 TabGroup からの参照は残るので `updatedGroups` をそのまま渡し、
+    // `origin` パラメータで当該 group を除外判定させる。
     const stillReferenced = isUrlRecordReferencedElsewhere({
-      customProjects: allCustomProjects,
+      customProjects: updatedCustomProjects,
       origin: { id: targetGroup.id, kind: 'tabGroup' },
-      tabGroups: isGroupEmpty ? [] : updatedGroups,
+      tabGroups: updatedGroups,
       urlRecordId: targetUrlId,
     })
 
@@ -112,6 +136,14 @@ export const createDeleteSavedUrlUseCase = (
       updatedGroups.some((group, index) => group !== allTabGroups[index])
     ) {
       await deps.tabGroupRepository.saveAll(updatedGroups)
+    }
+    if (
+      updatedCustomProjects.length !== allCustomProjects.length ||
+      updatedCustomProjects.some(
+        (project, index) => project !== allCustomProjects[index],
+      )
+    ) {
+      await deps.customProjectRepository.saveAll(updatedCustomProjects)
     }
 
     let removedUrlRecordId: UrlRecordId | null = null
@@ -133,9 +165,12 @@ export const createDeleteSavedUrlUseCase = (
       }
     }
 
+    // Undo 用 snapshot には pre-mutation の TabGroup / CustomProject /
+    // UrlRecord を含めて、RestoreOpenedUrlsSnapshotUseCase が
+    // storage を正確に巻き戻せるようにする。
     const snapshot: OpenedUrlsRestoreSnapshot = {
       customProjectOrder: undefined,
-      customProjects: undefined,
+      customProjects: previousCustomProjects,
       parentCategories: undefined,
       savedTabs: isGroupEmpty ? [previousGroup] : [],
       urlRecords: removedUrlRecord ? [previousUrlRecord] : [],

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.ts
@@ -1,0 +1,151 @@
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import type { UrlRecord } from '../../domain/entities/UrlRecord'
+import { SavedTabsDomainError } from '../../domain/errors/SavedTabsDomainError'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import { isUrlRecordReferencedElsewhere } from '../../domain/services/UrlReferenceService'
+import type { UrlRecordId } from '../../domain/value-objects/UrlRecordId'
+import type { DeleteSavedUrlCommand } from '../commands/DeleteSavedUrlCommand'
+import type { OpenedUrlsRestoreSnapshot } from '../commands/RestoreOpenedUrlsSnapshotCommand'
+import type { DeletedSavedUrlDto } from '../dto/DeletedSavedUrlDto'
+
+/**
+ * `DeleteSavedUrlUseCase` が依存する repository 群。
+ */
+export interface DeleteSavedUrlUseCaseDeps {
+  readonly tabGroupRepository: TabGroupRepository
+  readonly urlRecordRepository: UrlRecordRepository
+  readonly customProjectRepository: CustomProjectRepository
+}
+
+/**
+ * `DeleteSavedUrlUseCase` の関数型。
+ */
+export type DeleteSavedUrlUseCase = (
+  command: DeleteSavedUrlCommand,
+) => Promise<DeletedSavedUrlDto>
+
+/**
+ * `DeleteSavedUrlUseCase` を生成する。
+ *
+ * 責務:
+ * 1. 対象 `TabGroup` を取得する。見つからなければ `SavedTabsDomainError` を投げる。
+ * 2. URL 文字列から `UrlRecord` を逆引きする。見つからなければ
+ *    `SavedTabsDomainError` を投げる。
+ * 3. 該当 `UrlRecordId` を `TabGroup` の `urlIds` から取り除く。
+ *    `urlIds` が空になった場合は `TabGroup` 自体を削除する。
+ * 4. 該当 `UrlRecord` が他で参照されていなければ `UrlRecordRepository.removeByIds` で削除する。
+ * 5. Undo 用 snapshot を `DeletedSavedUrlDto` にまとめて返す。
+ *
+ * 1 件も `UrlRecord` が消せず `TabGroup` も変更なしのケースでは
+ * `snapshot: null` を返す。
+ */
+export const createDeleteSavedUrlUseCase = (
+  deps: DeleteSavedUrlUseCaseDeps,
+): DeleteSavedUrlUseCase => {
+  return async (command) => {
+    const [allTabGroups, allUrlRecords, allCustomProjects] = await Promise.all([
+      deps.tabGroupRepository.findAll(),
+      deps.urlRecordRepository.findAll(),
+      deps.customProjectRepository.findAll(),
+    ])
+
+    const targetGroup = allTabGroups.find(
+      (group) => group.id === command.tabGroupId,
+    )
+    if (!targetGroup) {
+      throw new SavedTabsDomainError(
+        '削除対象の TabGroup が見つかりません',
+        'TAB_GROUP_NOT_FOUND',
+      )
+    }
+
+    const targetUrlRecord = allUrlRecords.find(
+      (record) => record.url === command.url,
+    )
+    if (!targetUrlRecord) {
+      throw new SavedTabsDomainError(
+        '削除対象の UrlRecord が見つかりません',
+        'URL_RECORD_NOT_FOUND',
+      )
+    }
+
+    const targetUrlId: UrlRecordId = targetUrlRecord.id
+    const isReferencedInGroup = targetGroup.urlIds.includes(targetUrlId)
+    if (!isReferencedInGroup) {
+      // 対象 TabGroup に該当 URL が無い場合は no-op。
+      return {
+        removedTabGroupId: null,
+        removedUrlRecord: null,
+        removedUrlRecordId: null,
+        snapshot: null,
+      }
+    }
+
+    const previousGroup: TabGroup = targetGroup
+    const previousUrlRecord: UrlRecord = targetUrlRecord
+
+    // 該当 URL を TabGroup から取り除く。
+    const remainingUrlIds = targetGroup.urlIds.filter(
+      (urlId) => urlId !== targetUrlId,
+    )
+    const isGroupEmpty = remainingUrlIds.length === 0
+    const updatedGroups = isGroupEmpty
+      ? allTabGroups.filter((group) => group.id !== targetGroup.id)
+      : allTabGroups.map((group) =>
+          group.id === targetGroup.id
+            ? { ...group, urlIds: remainingUrlIds }
+            : group,
+        )
+
+    // UrlRecord が他で参照されていなければ削除する。
+    const stillReferenced = isUrlRecordReferencedElsewhere({
+      customProjects: allCustomProjects,
+      origin: { id: targetGroup.id, kind: 'tabGroup' },
+      tabGroups: isGroupEmpty ? [] : updatedGroups,
+      urlRecordId: targetUrlId,
+    })
+
+    if (
+      updatedGroups.length !== allTabGroups.length ||
+      updatedGroups.some((group, index) => group !== allTabGroups[index])
+    ) {
+      await deps.tabGroupRepository.saveAll(updatedGroups)
+    }
+
+    let removedUrlRecordId: UrlRecordId | null = null
+    if (!stillReferenced) {
+      await deps.urlRecordRepository.removeByIds([targetUrlId])
+      removedUrlRecordId = targetUrlId
+    }
+
+    const removedUrlRecord: UrlRecord | null =
+      removedUrlRecordId !== null ? previousUrlRecord : null
+
+    if (removedUrlRecordId === null && !isGroupEmpty) {
+      // 副作用なし（参照中 URL を TabGroup からも外せなかった）ので snapshot 不要。
+      return {
+        removedTabGroupId: null,
+        removedUrlRecord: null,
+        removedUrlRecordId: null,
+        snapshot: null,
+      }
+    }
+
+    const snapshot: OpenedUrlsRestoreSnapshot = {
+      customProjectOrder: undefined,
+      customProjects: undefined,
+      parentCategories: undefined,
+      savedTabs: isGroupEmpty ? [previousGroup] : [],
+      urlRecords: removedUrlRecord ? [previousUrlRecord] : [],
+    }
+
+    return {
+      removedTabGroupId: isGroupEmpty ? previousGroup.id : null,
+      removedUrlRecord,
+      removedUrlRecordId,
+      snapshot,
+    }
+  }
+}

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.test.ts
@@ -166,7 +166,7 @@ describe('DeleteSavedUrlsUseCase', () => {
     await expect(repos.tabGroupRepository.findAll()).resolves.toStrictEqual([])
   })
 
-  it('他で参照されている UrlRecord は削除せず残す', async () => {
+  it('CustomProject からも url id を取り除き、未参照なら UrlRecord を削除する', async () => {
     const group = createTabGroup({
       domain: 'example.com',
       id: 'group-1',
@@ -204,7 +204,56 @@ describe('DeleteSavedUrlsUseCase', () => {
       urls: ['https://example.com/a', 'https://example.com/b'],
     })
 
+    // group / project 双方から url-1 / url-2 を取り除き、参照が無くなった
+    // ため UrlRecord も両方削除される。group は urlIds が空になり削除。
+    expect(result.removedUrlRecordIds).toStrictEqual(['url-1', 'url-2'])
+    expect(result.removedTabGroupIds).toStrictEqual([group.id])
+    expect(result.snapshot).not.toBeNull()
+    expect(result.snapshot?.customProjects).toContainEqual(project)
+    expect(
+      (await repos.urlRecordRepository.findAll()).map((record) => record.id),
+    ).toStrictEqual([])
+    const remainingProjects = await repos.customProjectRepository.findAll()
+    expect(remainingProjects[0].urlIds).toStrictEqual([])
+  })
+
+  it('別 group が同じ UrlRecord を参照している場合はその UrlRecord を残す', async () => {
+    const targetGroup = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1', 'url-2'],
+    })
+    const otherGroup = createTabGroup({
+      domain: 'other.com',
+      id: 'group-2',
+      urlIds: ['url-1'],
+    })
+    const url1 = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const url2 = createUrlRecord({
+      id: 'url-2',
+      savedAt: 1,
+      title: 'B',
+      url: 'https://example.com/b',
+    })
+    const repos = createInMemoryRepositories({
+      tabGroups: [targetGroup, otherGroup],
+      urlRecords: [url1, url2],
+    })
+    const useCase = createDeleteSavedUrlsUseCase(repos)
+
+    const result = await useCase({
+      tabGroupId: targetGroup.id,
+      urls: ['https://example.com/a', 'https://example.com/b'],
+    })
+
+    // url-1 は otherGroup からの参照があるため残す。url-2 は単独で削除。
     expect(result.removedUrlRecordIds).toStrictEqual(['url-2'])
+    expect(result.removedTabGroupIds).toStrictEqual([targetGroup.id])
     expect(
       (await repos.urlRecordRepository.findAll()).map((record) => record.id),
     ).toStrictEqual(['url-1'])

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest'
+
+import { createCustomProject } from '../../domain/entities/CustomProject'
+import { createTabGroup } from '../../domain/entities/TabGroup'
+import { createUrlRecord } from '../../domain/entities/UrlRecord'
+import { SavedTabsDomainError } from '../../domain/errors/SavedTabsDomainError'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import type { DeleteSavedUrlsUseCaseDeps } from './DeleteSavedUrlsUseCase'
+import { createDeleteSavedUrlsUseCase } from './DeleteSavedUrlsUseCase'
+
+interface Repositories {
+  tabGroupRepository: TabGroupRepository
+  urlRecordRepository: UrlRecordRepository
+  customProjectRepository: CustomProjectRepository
+}
+
+const createInMemoryRepositories = (
+  initial: {
+    tabGroups?: ReturnType<typeof createTabGroup>[]
+    urlRecords?: ReturnType<typeof createUrlRecord>[]
+    customProjects?: ReturnType<typeof createCustomProject>[]
+  } = {},
+): Repositories & DeleteSavedUrlsUseCaseDeps => {
+  const tabGroups: ReturnType<typeof createTabGroup>[] = [
+    ...(initial.tabGroups ?? []),
+  ]
+  const urlRecords: ReturnType<typeof createUrlRecord>[] = [
+    ...(initial.urlRecords ?? []),
+  ]
+  const customProjects: ReturnType<typeof createCustomProject>[] = [
+    ...(initial.customProjects ?? []),
+  ]
+  const tabGroupRepository: TabGroupRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [...tabGroups],
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) => tabGroups.find((group) => group.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids.map((id) => id))
+      const next = tabGroups.filter((group) => !idSet.has(group.id))
+      tabGroups.splice(0, tabGroups.length, ...next)
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (groups) => {
+      tabGroups.splice(0, tabGroups.length, ...groups)
+    },
+  }
+  const urlRecordRepository: UrlRecordRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [...urlRecords],
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      urlRecords.find((record) => record.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids.map((id) => id))
+      const next = urlRecords.filter((record) => !idSet.has(record.id))
+      urlRecords.splice(0, urlRecords.length, ...next)
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (records) => {
+      urlRecords.splice(0, urlRecords.length, ...records)
+    },
+  }
+  const customProjectRepository: CustomProjectRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [...customProjects],
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      customProjects.find((project) => project.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (projects) => {
+      customProjects.splice(0, customProjects.length, ...projects)
+    },
+  }
+  return {
+    customProjectRepository,
+    tabGroupRepository,
+    urlRecordRepository,
+  }
+}
+
+describe('DeleteSavedUrlsUseCase', () => {
+  it('指定した URL を TabGroup と UrlRecord から一括削除する', async () => {
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1', 'url-2', 'url-3'],
+    })
+    const url1 = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const url2 = createUrlRecord({
+      id: 'url-2',
+      savedAt: 1,
+      title: 'B',
+      url: 'https://example.com/b',
+    })
+    const url3 = createUrlRecord({
+      id: 'url-3',
+      savedAt: 1,
+      title: 'C',
+      url: 'https://example.com/c',
+    })
+    const repos = createInMemoryRepositories({
+      tabGroups: [group],
+      urlRecords: [url1, url2, url3],
+    })
+    const useCase = createDeleteSavedUrlsUseCase(repos)
+
+    const result = await useCase({
+      tabGroupId: group.id,
+      urls: ['https://example.com/a', 'https://example.com/b'],
+    })
+
+    expect(result.removedUrlRecordIds).toStrictEqual(['url-1', 'url-2'])
+    expect(result.removedUrlRecords.map((r) => r.id)).toStrictEqual([
+      'url-1',
+      'url-2',
+    ])
+    expect(result.removedTabGroupIds).toStrictEqual([])
+    const remainingTabGroups = await repos.tabGroupRepository.findAll()
+    expect(remainingTabGroups[0].urlIds).toStrictEqual(['url-3'])
+    const remainingRecords = await repos.urlRecordRepository.findAll()
+    expect(remainingRecords.map((record) => record.id)).toStrictEqual(['url-3'])
+  })
+
+  it('全 URL を削除した場合は TabGroup も削除する', async () => {
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1', 'url-2'],
+    })
+    const url1 = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const url2 = createUrlRecord({
+      id: 'url-2',
+      savedAt: 1,
+      title: 'B',
+      url: 'https://example.com/b',
+    })
+    const repos = createInMemoryRepositories({
+      tabGroups: [group],
+      urlRecords: [url1, url2],
+    })
+    const useCase = createDeleteSavedUrlsUseCase(repos)
+
+    const result = await useCase({
+      tabGroupId: group.id,
+      urls: ['https://example.com/a', 'https://example.com/b'],
+    })
+
+    expect(result.removedTabGroupIds).toStrictEqual([group.id])
+    await expect(repos.tabGroupRepository.findAll()).resolves.toStrictEqual([])
+  })
+
+  it('他で参照されている UrlRecord は削除せず残す', async () => {
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1', 'url-2'],
+    })
+    const project = createCustomProject({
+      categories: [],
+      createdAt: 1,
+      id: 'project-1',
+      name: 'P',
+      updatedAt: 1,
+      urlIds: ['url-1'],
+    })
+    const url1 = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const url2 = createUrlRecord({
+      id: 'url-2',
+      savedAt: 1,
+      title: 'B',
+      url: 'https://example.com/b',
+    })
+    const repos = createInMemoryRepositories({
+      customProjects: [project],
+      tabGroups: [group],
+      urlRecords: [url1, url2],
+    })
+    const useCase = createDeleteSavedUrlsUseCase(repos)
+
+    const result = await useCase({
+      tabGroupId: group.id,
+      urls: ['https://example.com/a', 'https://example.com/b'],
+    })
+
+    expect(result.removedUrlRecordIds).toStrictEqual(['url-2'])
+    expect(
+      (await repos.urlRecordRepository.findAll()).map((record) => record.id),
+    ).toStrictEqual(['url-1'])
+  })
+
+  it('空配列のときは port を呼ばず早期 return する', async () => {
+    const repos = createInMemoryRepositories()
+    const useCase = createDeleteSavedUrlsUseCase(repos)
+
+    const result = await useCase({
+      tabGroupId: 'group-1' as never,
+      urls: [],
+    })
+
+    expect(result.snapshot).toBeNull()
+    expect(result.removedUrlRecordIds).toStrictEqual([])
+    expect(result.removedTabGroupIds).toStrictEqual([])
+  })
+
+  it('存在しない TabGroup のときは SavedTabsDomainError を投げる', async () => {
+    const repos = createInMemoryRepositories()
+    const useCase = createDeleteSavedUrlsUseCase(repos)
+
+    await expect(
+      useCase({
+        tabGroupId: 'missing' as never,
+        urls: ['https://example.com/a'],
+      }),
+    ).rejects.toBeInstanceOf(SavedTabsDomainError)
+  })
+
+  it('UrlRecord に 1 件も該当が無いときは SavedTabsDomainError を投げる', async () => {
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: [],
+    })
+    const repos = createInMemoryRepositories({ tabGroups: [group] })
+    const useCase = createDeleteSavedUrlsUseCase(repos)
+
+    await expect(
+      useCase({
+        tabGroupId: group.id,
+        urls: ['https://example.com/a'],
+      }),
+    ).rejects.toBeInstanceOf(SavedTabsDomainError)
+  })
+})

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.ts
@@ -1,0 +1,166 @@
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import type { UrlRecord } from '../../domain/entities/UrlRecord'
+import { SavedTabsDomainError } from '../../domain/errors/SavedTabsDomainError'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import { isUrlRecordReferencedElsewhere } from '../../domain/services/UrlReferenceService'
+import type { UrlRecordId } from '../../domain/value-objects/UrlRecordId'
+import type { DeleteSavedUrlsCommand } from '../commands/DeleteSavedUrlsCommand'
+import type { OpenedUrlsRestoreSnapshot } from '../commands/RestoreOpenedUrlsSnapshotCommand'
+import type { DeletedSavedUrlsDto } from '../dto/DeletedSavedUrlsDto'
+
+/**
+ * `DeleteSavedUrlsUseCase` が依存する repository 群。
+ */
+export interface DeleteSavedUrlsUseCaseDeps {
+  readonly tabGroupRepository: TabGroupRepository
+  readonly urlRecordRepository: UrlRecordRepository
+  readonly customProjectRepository: CustomProjectRepository
+}
+
+/**
+ * `DeleteSavedUrlsUseCase` の関数型。
+ */
+export type DeleteSavedUrlsUseCase = (
+  command: DeleteSavedUrlsCommand,
+) => Promise<DeletedSavedUrlsDto>
+
+/**
+ * `DeleteSavedUrlsUseCase` を生成する。
+ *
+ * 責務:
+ * 1. 対象 `TabGroup` を取得する。見つからなければ `SavedTabsDomainError` を投げる。
+ * 2. URL 文字列群を `UrlRecordId` 群へ逆引きする。1 件も引けない場合は
+ *    `SavedTabsDomainError` を投げる。
+ * 3. 該当 `UrlRecordId` を `TabGroup` の `urlIds` から取り除く。
+ *    `urlIds` が空になった場合は `TabGroup` 自体を削除する。
+ * 4. 他で参照されていない `UrlRecord` を `UrlRecordRepository.removeByIds` で削除する。
+ * 5. Undo 用 snapshot を `DeletedSavedUrlsDto` にまとめて返す。
+ *
+ * 1 件も削除できなかったケース（urls が空、storage に該当が無い、
+ * TabGroup の urlIds に 1 件も含まれていない）では `snapshot: null` を返す。
+ */
+export const createDeleteSavedUrlsUseCase = (
+  deps: DeleteSavedUrlsUseCaseDeps,
+): DeleteSavedUrlsUseCase => {
+  return async (command) => {
+    if (command.urls.length === 0) {
+      return {
+        removedTabGroupIds: [],
+        removedUrlRecordIds: [],
+        removedUrlRecords: [],
+        snapshot: null,
+      }
+    }
+
+    const [allTabGroups, allUrlRecords, allCustomProjects] = await Promise.all([
+      deps.tabGroupRepository.findAll(),
+      deps.urlRecordRepository.findAll(),
+      deps.customProjectRepository.findAll(),
+    ])
+
+    const targetGroup = allTabGroups.find(
+      (group) => group.id === command.tabGroupId,
+    )
+    if (!targetGroup) {
+      throw new SavedTabsDomainError(
+        '削除対象の TabGroup が見つかりません',
+        'TAB_GROUP_NOT_FOUND',
+      )
+    }
+
+    const targetUrlSet = new Set(command.urls)
+    const targetUrlRecords = allUrlRecords.filter((record) =>
+      targetUrlSet.has(record.url),
+    )
+    if (targetUrlRecords.length === 0) {
+      throw new SavedTabsDomainError(
+        '削除対象の UrlRecord が見つかりません',
+        'URL_RECORD_NOT_FOUND',
+      )
+    }
+
+    const previousGroup: TabGroup = targetGroup
+    const previousUrlRecords: UrlRecord[] = targetUrlRecords
+    const targetUrlIds = new Set<UrlRecordId>(
+      targetUrlRecords.map((record) => record.id),
+    )
+
+    const groupHasMatch = targetGroup.urlIds.some((urlId) =>
+      targetUrlIds.has(urlId),
+    )
+    if (!groupHasMatch) {
+      // 対象 TabGroup に該当 URL が 1 つも無い場合は no-op。
+      return {
+        removedTabGroupIds: [],
+        removedUrlRecordIds: [],
+        removedUrlRecords: [],
+        snapshot: null,
+      }
+    }
+
+    const remainingUrlIds = targetGroup.urlIds.filter(
+      (urlId) => !targetUrlIds.has(urlId),
+    )
+    const isGroupEmpty = remainingUrlIds.length === 0
+    const updatedGroups = isGroupEmpty
+      ? allTabGroups.filter((group) => group.id !== targetGroup.id)
+      : allTabGroups.map((group) =>
+          group.id === targetGroup.id
+            ? { ...group, urlIds: remainingUrlIds }
+            : group,
+        )
+
+    const urlRecordsToDelete: UrlRecordId[] = []
+    for (const recordId of targetUrlIds) {
+      const stillReferenced = isUrlRecordReferencedElsewhere({
+        customProjects: allCustomProjects,
+        origin: { id: targetGroup.id, kind: 'tabGroup' },
+        tabGroups: isGroupEmpty ? [] : updatedGroups,
+        urlRecordId: recordId,
+      })
+      if (!stillReferenced) {
+        urlRecordsToDelete.push(recordId)
+      }
+    }
+
+    if (
+      updatedGroups.length !== allTabGroups.length ||
+      updatedGroups.some((group, index) => group !== allTabGroups[index])
+    ) {
+      await deps.tabGroupRepository.saveAll(updatedGroups)
+    }
+    if (urlRecordsToDelete.length > 0) {
+      await deps.urlRecordRepository.removeByIds(urlRecordsToDelete)
+    }
+
+    const removedUrlRecords = previousUrlRecords.filter((record) =>
+      urlRecordsToDelete.includes(record.id),
+    )
+
+    if (urlRecordsToDelete.length === 0 && !isGroupEmpty) {
+      return {
+        removedTabGroupIds: [],
+        removedUrlRecordIds: [],
+        removedUrlRecords: [],
+        snapshot: null,
+      }
+    }
+
+    const snapshot: OpenedUrlsRestoreSnapshot = {
+      customProjectOrder: undefined,
+      customProjects: undefined,
+      parentCategories: undefined,
+      savedTabs: isGroupEmpty ? [previousGroup] : [],
+      urlRecords: removedUrlRecords,
+    }
+
+    return {
+      removedTabGroupIds: isGroupEmpty ? [previousGroup.id] : [],
+      removedUrlRecordIds: urlRecordsToDelete,
+      removedUrlRecords,
+      snapshot,
+    }
+  }
+}

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.ts
@@ -1,3 +1,4 @@
+import type { CustomProject } from '../../domain/entities/CustomProject'
 import type { TabGroup } from '../../domain/entities/TabGroup'
 import type { UrlRecord } from '../../domain/entities/UrlRecord'
 import { SavedTabsDomainError } from '../../domain/errors/SavedTabsDomainError'
@@ -35,8 +36,11 @@ export type DeleteSavedUrlsUseCase = (
  *    `SavedTabsDomainError` を投げる。
  * 3. 該当 `UrlRecordId` を `TabGroup` の `urlIds` から取り除く。
  *    `urlIds` が空になった場合は `TabGroup` 自体を削除する。
- * 4. 他で参照されていない `UrlRecord` を `UrlRecordRepository.removeByIds` で削除する。
- * 5. Undo 用 snapshot を `DeletedSavedUrlsDto` にまとめて返す。
+ * 4. 同じ `UrlRecordId` を参照している `CustomProject` の `urlIds` からも
+ *    取り除き、storage を書き戻す（旧 `removeUrlsFromTabGroup` の
+ *    `removeUrlIdsFromAllCustomProjects` 相当）。
+ * 5. 他で参照されていない `UrlRecord` を `UrlRecordRepository.removeByIds` で削除する。
+ * 6. Undo 用 snapshot を `DeletedSavedUrlsDto` にまとめて返す。
  *
  * 1 件も削除できなかったケース（urls が空、storage に該当が無い、
  * TabGroup の urlIds に 1 件も含まれていない）では `snapshot: null` を返す。
@@ -83,6 +87,7 @@ export const createDeleteSavedUrlsUseCase = (
 
     const previousGroup: TabGroup = targetGroup
     const previousUrlRecords: UrlRecord[] = targetUrlRecords
+    const previousCustomProjects: readonly CustomProject[] = allCustomProjects
     const targetUrlIds = new Set<UrlRecordId>(
       targetUrlRecords.map((record) => record.id),
     )
@@ -112,12 +117,27 @@ export const createDeleteSavedUrlsUseCase = (
             : group,
         )
 
+    // 同じ URL を保持している CustomProject からも取り除く。
+    const updatedCustomProjects: readonly CustomProject[] =
+      allCustomProjects.map((project) => {
+        const remaining = project.urlIds.filter(
+          (urlId) => !targetUrlIds.has(urlId),
+        )
+        if (remaining.length === project.urlIds.length) {
+          return project
+        }
+        return { ...project, urlIds: remaining }
+      })
+
     const urlRecordsToDelete: UrlRecordId[] = []
     for (const recordId of targetUrlIds) {
+      // target group が urlIds 空で削除された場合 (`isGroupEmpty = true`) も
+      // 他 TabGroup からの参照は残るので `updatedGroups` をそのまま渡し、
+      // `origin` パラメータで当該 group を除外判定させる。
       const stillReferenced = isUrlRecordReferencedElsewhere({
-        customProjects: allCustomProjects,
+        customProjects: updatedCustomProjects,
         origin: { id: targetGroup.id, kind: 'tabGroup' },
-        tabGroups: isGroupEmpty ? [] : updatedGroups,
+        tabGroups: updatedGroups,
         urlRecordId: recordId,
       })
       if (!stillReferenced) {
@@ -130,6 +150,14 @@ export const createDeleteSavedUrlsUseCase = (
       updatedGroups.some((group, index) => group !== allTabGroups[index])
     ) {
       await deps.tabGroupRepository.saveAll(updatedGroups)
+    }
+    if (
+      updatedCustomProjects.length !== allCustomProjects.length ||
+      updatedCustomProjects.some(
+        (project, index) => project !== allCustomProjects[index],
+      )
+    ) {
+      await deps.customProjectRepository.saveAll(updatedCustomProjects)
     }
     if (urlRecordsToDelete.length > 0) {
       await deps.urlRecordRepository.removeByIds(urlRecordsToDelete)
@@ -150,7 +178,7 @@ export const createDeleteSavedUrlsUseCase = (
 
     const snapshot: OpenedUrlsRestoreSnapshot = {
       customProjectOrder: undefined,
-      customProjects: undefined,
+      customProjects: previousCustomProjects,
       parentCategories: undefined,
       savedTabs: isGroupEmpty ? [previousGroup] : [],
       urlRecords: removedUrlRecords,

--- a/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupsUseCase.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest'
+
+import { createCustomProject } from '../../domain/entities/CustomProject'
+import { createTabGroup } from '../../domain/entities/TabGroup'
+import { createUrlRecord } from '../../domain/entities/UrlRecord'
+import { SavedTabsDomainError } from '../../domain/errors/SavedTabsDomainError'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import type { DeleteTabGroupsUseCaseDeps } from './DeleteTabGroupsUseCase'
+import { createDeleteTabGroupsUseCase } from './DeleteTabGroupsUseCase'
+
+interface Repositories {
+  tabGroupRepository: TabGroupRepository
+  urlRecordRepository: UrlRecordRepository
+  customProjectRepository: CustomProjectRepository
+}
+
+const createInMemoryRepositories = (
+  initial: {
+    tabGroups?: ReturnType<typeof createTabGroup>[]
+    urlRecords?: ReturnType<typeof createUrlRecord>[]
+    customProjects?: ReturnType<typeof createCustomProject>[]
+  } = {},
+): Repositories & DeleteTabGroupsUseCaseDeps => {
+  const tabGroups: ReturnType<typeof createTabGroup>[] = [
+    ...(initial.tabGroups ?? []),
+  ]
+  const urlRecords: ReturnType<typeof createUrlRecord>[] = [
+    ...(initial.urlRecords ?? []),
+  ]
+  const customProjects: ReturnType<typeof createCustomProject>[] = [
+    ...(initial.customProjects ?? []),
+  ]
+  const tabGroupRepository: TabGroupRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [...tabGroups],
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) => tabGroups.find((group) => group.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids.map((id) => id))
+      const next = tabGroups.filter((group) => !idSet.has(group.id))
+      tabGroups.splice(0, tabGroups.length, ...next)
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (groups) => {
+      tabGroups.splice(0, tabGroups.length, ...groups)
+    },
+  }
+  const urlRecordRepository: UrlRecordRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [...urlRecords],
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      urlRecords.find((record) => record.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids.map((id) => id))
+      const next = urlRecords.filter((record) => !idSet.has(record.id))
+      urlRecords.splice(0, urlRecords.length, ...next)
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (records) => {
+      urlRecords.splice(0, urlRecords.length, ...records)
+    },
+  }
+  const customProjectRepository: CustomProjectRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [...customProjects],
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      customProjects.find((project) => project.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (projects) => {
+      customProjects.splice(0, customProjects.length, ...projects)
+    },
+  }
+  return {
+    customProjectRepository,
+    tabGroupRepository,
+    urlRecordRepository,
+  }
+}
+
+describe('DeleteTabGroupsUseCase', () => {
+  it('指定した複数の TabGroup を一括で削除する', async () => {
+    const group1 = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1'],
+    })
+    const group2 = createTabGroup({
+      domain: 'foo.com',
+      id: 'group-2',
+      urlIds: ['url-2'],
+    })
+    const other = createTabGroup({
+      domain: 'other.com',
+      id: 'group-3',
+      urlIds: [],
+    })
+    const url1 = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const url2 = createUrlRecord({
+      id: 'url-2',
+      savedAt: 1,
+      title: 'B',
+      url: 'https://foo.com/b',
+    })
+    const repos = createInMemoryRepositories({
+      tabGroups: [group1, group2, other],
+      urlRecords: [url1, url2],
+    })
+    const useCase = createDeleteTabGroupsUseCase(repos)
+
+    const result = await useCase({
+      tabGroupIds: [group1.id, group2.id],
+    })
+
+    expect(result.removedTabGroupIds).toStrictEqual([group1.id, group2.id])
+    expect(result.removedUrlRecordIds).toStrictEqual(['url-1', 'url-2'])
+    expect(result.snapshot.savedTabs).toStrictEqual([group1, group2])
+    expect(
+      (await repos.tabGroupRepository.findAll()).map((group) => group.id),
+    ).toStrictEqual([other.id])
+    await expect(repos.urlRecordRepository.findAll()).resolves.toStrictEqual([])
+  })
+
+  it('存在しない ID は無視し、見つかったものだけ削除する', async () => {
+    const target = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1'],
+    })
+    const repos = createInMemoryRepositories({
+      tabGroups: [target],
+      urlRecords: [
+        createUrlRecord({
+          id: 'url-1',
+          savedAt: 1,
+          title: 'A',
+          url: 'https://example.com/a',
+        }),
+      ],
+    })
+    const useCase = createDeleteTabGroupsUseCase(repos)
+
+    const result = await useCase({
+      tabGroupIds: [target.id, 'non-existent' as typeof target.id],
+    })
+
+    expect(result.removedTabGroupIds).toStrictEqual([target.id])
+    expect(
+      (await repos.tabGroupRepository.findAll()).map((group) => group.id),
+    ).toStrictEqual([])
+  })
+
+  it('他で参照されている UrlRecord は削除せず残す', async () => {
+    const target = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1', 'url-2'],
+    })
+    const project = createCustomProject({
+      categories: [],
+      createdAt: 1,
+      id: 'project-1',
+      name: 'P',
+      updatedAt: 1,
+      urlIds: ['url-2'],
+    })
+    const url1 = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const url2 = createUrlRecord({
+      id: 'url-2',
+      savedAt: 1,
+      title: 'B',
+      url: 'https://example.com/b',
+    })
+    const repos = createInMemoryRepositories({
+      customProjects: [project],
+      tabGroups: [target],
+      urlRecords: [url1, url2],
+    })
+    const useCase = createDeleteTabGroupsUseCase(repos)
+
+    const result = await useCase({ tabGroupIds: [target.id] })
+
+    expect(result.removedUrlRecordIds).toStrictEqual(['url-1'])
+    expect(
+      (await repos.urlRecordRepository.findAll()).map((record) => record.id),
+    ).toStrictEqual(['url-2'])
+  })
+
+  it('空配列のときは no-op で空の snapshot を返す', async () => {
+    const repos = createInMemoryRepositories()
+    const useCase = createDeleteTabGroupsUseCase(repos)
+
+    const result = await useCase({ tabGroupIds: [] })
+
+    expect(result.removedTabGroupIds).toStrictEqual([])
+    expect(result.removedUrlRecordIds).toStrictEqual([])
+    expect(result.snapshot.savedTabs).toStrictEqual([])
+  })
+
+  it('storage 上に 1 件も対象が無いときは SavedTabsDomainError を投げる', async () => {
+    const repos = createInMemoryRepositories()
+    const useCase = createDeleteTabGroupsUseCase(repos)
+
+    await expect(
+      useCase({ tabGroupIds: ['missing' as never] }),
+    ).rejects.toBeInstanceOf(SavedTabsDomainError)
+  })
+})

--- a/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupsUseCase.ts
@@ -1,0 +1,124 @@
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import { SavedTabsDomainError } from '../../domain/errors/SavedTabsDomainError'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import { filterUnreferencedUrlRecords } from '../../domain/services/UrlReferenceService'
+import type { TabGroupId } from '../../domain/value-objects/TabGroupId'
+import type { DeleteTabGroupsCommand } from '../commands/DeleteTabGroupsCommand'
+import type { OpenedUrlsRestoreSnapshot } from '../commands/RestoreOpenedUrlsSnapshotCommand'
+import type { DeletedTabGroupsDto } from '../dto/DeletedTabGroupsDto'
+
+/**
+ * `DeleteTabGroupsUseCase` が依存する repository 群。
+ */
+export interface DeleteTabGroupsUseCaseDeps {
+  readonly tabGroupRepository: TabGroupRepository
+  readonly urlRecordRepository: UrlRecordRepository
+  readonly customProjectRepository: CustomProjectRepository
+}
+
+/**
+ * `DeleteTabGroupsUseCase` の関数型。
+ */
+export type DeleteTabGroupsUseCase = (
+  command: DeleteTabGroupsCommand,
+) => Promise<DeletedTabGroupsDto>
+
+/**
+ * `DeleteTabGroupsUseCase` を生成する。
+ *
+ * 責務:
+ * 1. 入力 `tabGroupIds` に対応する `TabGroup` を取得する。storage 上に
+ *    見つからない ID は無視する（1 件も見つからない場合は
+ *    `DeletedTabGroupNotFoundError` ではなく、空の `removedTabGroupIds` を返す
+ *    no-op として扱う）。
+ * 2. 削除後にどの `TabGroup` / `CustomProject` からも参照されなくなる
+ *    `UrlRecordId` を `filterUnreferencedUrlRecords` で抽出する。
+ *    他の集約から参照されている `UrlRecord` は削除しない。
+ * 3. 対象 `TabGroup` を `TabGroupRepository.removeByIds` で削除する。
+ * 4. 未参照になった `UrlRecord` を `UrlRecordRepository.removeByIds` で削除する。
+ *    削除対象が 0 件のときは repository を呼ばない。
+ * 5. Undo 用 snapshot を `DeletedTabGroupsDto` にまとめて返す。
+ *
+ * `CustomProjectRepository` は参照判定にだけ使い、書き込みはしない
+ * （CustomProject 側の参照は `TabGroup` 削除では変わらないため）。
+ */
+export const createDeleteTabGroupsUseCase = (
+  deps: DeleteTabGroupsUseCaseDeps,
+): DeleteTabGroupsUseCase => {
+  return async (command) => {
+    if (command.tabGroupIds.length === 0) {
+      return {
+        removedTabGroupIds: [],
+        removedUrlRecordIds: [],
+        snapshot: {
+          customProjectOrder: undefined,
+          customProjects: undefined,
+          parentCategories: undefined,
+          savedTabs: [],
+          urlRecords: [],
+        },
+      }
+    }
+
+    const [allTabGroups, allUrlRecords, allCustomProjects] = await Promise.all([
+      deps.tabGroupRepository.findAll(),
+      deps.urlRecordRepository.findAll(),
+      deps.customProjectRepository.findAll(),
+    ])
+
+    const targetIdSet = new Set<TabGroupId>(command.tabGroupIds)
+    const targetGroups: TabGroup[] = allTabGroups.filter((group) =>
+      targetIdSet.has(group.id),
+    )
+    if (targetGroups.length === 0) {
+      throw new SavedTabsDomainError(
+        '削除対象の TabGroup が見つかりません',
+        'TAB_GROUP_NOT_FOUND',
+      )
+    }
+
+    const targetGroupIds = new Set(targetGroups.map((group) => group.id))
+    const remainingTabGroups = allTabGroups.filter(
+      (group) => !targetGroupIds.has(group.id),
+    )
+
+    const urlRecordsInTarget = allUrlRecords.filter((record) =>
+      targetGroups.some((group) => group.urlIds.includes(record.id)),
+    )
+    const unreferenced = filterUnreferencedUrlRecords({
+      customProjects: allCustomProjects,
+      tabGroups: remainingTabGroups,
+      urlRecords: urlRecordsInTarget,
+    })
+    const removedUrlRecordIds = unreferenced.map((record) => record.id)
+
+    await deps.tabGroupRepository.removeByIds(
+      targetGroups.map((group) => group.id),
+    )
+    if (removedUrlRecordIds.length > 0) {
+      await deps.urlRecordRepository.removeByIds(removedUrlRecordIds)
+    }
+
+    const removedUrlRecords = allUrlRecords.filter((record) =>
+      removedUrlRecordIds.includes(record.id),
+    )
+
+    const snapshot: OpenedUrlsRestoreSnapshot & {
+      readonly savedTabs: readonly TabGroup[]
+    } = {
+      customProjectOrder: undefined,
+      customProjects: undefined,
+      parentCategories: undefined,
+      savedTabs: targetGroups,
+      urlRecords: removedUrlRecords,
+    }
+
+    return {
+      removedTabGroupIds: targetGroups.map((group) => group.id),
+      removedUrlRecordIds,
+      snapshot,
+    }
+  }
+}

--- a/src/contexts/saved-tabs/application/use-cases/OpenAllSavedUrlsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/OpenAllSavedUrlsUseCase.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createCustomProject } from '../../domain/entities/CustomProject'
+import { createTabGroup } from '../../domain/entities/TabGroup'
+import { createUrlRecord } from '../../domain/entities/UrlRecord'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import type { BrowserTabPort } from '../ports/BrowserTabPort'
+import type { BrowserWindowPort } from '../ports/BrowserWindowPort'
+import { createOpenAllSavedUrlsUseCase } from './OpenAllSavedUrlsUseCase'
+
+interface Repositories {
+  tabGroupRepository: TabGroupRepository
+  urlRecordRepository: UrlRecordRepository
+  customProjectRepository: CustomProjectRepository
+}
+
+const createInMemoryRepositories = (
+  initial: {
+    tabGroups?: ReturnType<typeof createTabGroup>[]
+    urlRecords?: ReturnType<typeof createUrlRecord>[]
+    customProjects?: ReturnType<typeof createCustomProject>[]
+  } = {},
+): Repositories => {
+  const tabGroups: ReturnType<typeof createTabGroup>[] = [
+    ...(initial.tabGroups ?? []),
+  ]
+  const urlRecords: ReturnType<typeof createUrlRecord>[] = [
+    ...(initial.urlRecords ?? []),
+  ]
+  const customProjects: ReturnType<typeof createCustomProject>[] = [
+    ...(initial.customProjects ?? []),
+  ]
+  const tabGroupRepository: TabGroupRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [...tabGroups],
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) => tabGroups.find((group) => group.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids.map((id) => id))
+      const next = tabGroups.filter((group) => !idSet.has(group.id))
+      tabGroups.splice(0, tabGroups.length, ...next)
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (groups) => {
+      tabGroups.splice(0, tabGroups.length, ...groups)
+    },
+  }
+  const urlRecordRepository: UrlRecordRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [...urlRecords],
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      urlRecords.find((record) => record.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids.map((id) => id))
+      const next = urlRecords.filter((record) => !idSet.has(record.id))
+      urlRecords.splice(0, urlRecords.length, ...next)
+    },
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (records) => {
+      urlRecords.splice(0, urlRecords.length, ...records)
+    },
+  }
+  const customProjectRepository: CustomProjectRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [...customProjects],
+    // eslint-disable-next-line typescript/require-await
+    findById: async (id) =>
+      customProjects.find((project) => project.id === id) ?? null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async (projects) => {
+      customProjects.splice(0, customProjects.length, ...projects)
+    },
+  }
+  return { customProjectRepository, tabGroupRepository, urlRecordRepository }
+}
+
+const createSpyBrowserTabPort = (): {
+  port: BrowserTabPort
+  opened: { url: string }[]
+} => {
+  const opened: { url: string }[] = []
+  const port: BrowserTabPort = {
+    // eslint-disable-next-line typescript/require-await
+    open: async (input) => {
+      opened.push(input)
+      return { url: input.url }
+    },
+  }
+  return { opened, port }
+}
+
+const createSpyBrowserWindowPort = (): {
+  port: BrowserWindowPort
+  opened: { urls: readonly string[]; focused?: boolean }[]
+} => {
+  const opened: { urls: readonly string[]; focused?: boolean }[] = []
+  const port: BrowserWindowPort = {
+    // eslint-disable-next-line typescript/require-await
+    openWithUrls: vi.fn(async (input) => {
+      opened.push({ focused: input.focused, urls: [...input.urls] })
+      return { urls: [...input.urls] }
+    }),
+  }
+  return { opened, port }
+}
+
+describe('OpenAllSavedUrlsUseCase', () => {
+  it('mode=backgroundTabs のときは BrowserTabPort.open を各 URL で呼び出す', async () => {
+    const repos = createInMemoryRepositories()
+    const tab = createSpyBrowserTabPort()
+    const win = createSpyBrowserWindowPort()
+    const useCase = createOpenAllSavedUrlsUseCase({
+      ...repos,
+      browserTabPort: tab.port,
+      browserWindowPort: win.port,
+    })
+
+    const result = await useCase({
+      mode: 'backgroundTabs',
+      removeTabAfterOpen: false,
+      urls: ['https://example.com/a', 'https://example.com/b'],
+    })
+
+    expect(tab.opened).toStrictEqual([
+      { url: 'https://example.com/a' },
+      { url: 'https://example.com/b' },
+    ])
+    expect(win.opened).toStrictEqual([])
+    expect(result.openedUrls).toStrictEqual([
+      'https://example.com/a',
+      'https://example.com/b',
+    ])
+    expect(result.snapshot).toBeNull()
+  })
+
+  it('mode=newWindow のときは BrowserWindowPort.openWithUrls を 1 度だけ呼ぶ', async () => {
+    const repos = createInMemoryRepositories()
+    const tab = createSpyBrowserTabPort()
+    const win = createSpyBrowserWindowPort()
+    const useCase = createOpenAllSavedUrlsUseCase({
+      ...repos,
+      browserTabPort: tab.port,
+      browserWindowPort: win.port,
+    })
+
+    await useCase({
+      mode: 'newWindow',
+      removeTabAfterOpen: false,
+      urls: ['https://example.com/a', 'https://example.com/b'],
+    })
+
+    expect(win.opened).toStrictEqual([
+      {
+        focused: true,
+        urls: ['https://example.com/a', 'https://example.com/b'],
+      },
+    ])
+    expect(tab.opened).toStrictEqual([])
+  })
+
+  it('設定 OFF のときは TabGroup / CustomProject / UrlRecord を変更しない', async () => {
+    const url = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1'],
+    })
+    const project = createCustomProject({
+      categories: [],
+      createdAt: 1,
+      id: 'project-1',
+      name: 'P',
+      updatedAt: 1,
+      urlIds: ['url-1'],
+    })
+    const repos = createInMemoryRepositories({
+      customProjects: [project],
+      tabGroups: [group],
+      urlRecords: [url],
+    })
+    const tab = createSpyBrowserTabPort()
+    const win = createSpyBrowserWindowPort()
+    const useCase = createOpenAllSavedUrlsUseCase({
+      ...repos,
+      browserTabPort: tab.port,
+      browserWindowPort: win.port,
+    })
+
+    const result = await useCase({
+      mode: 'backgroundTabs',
+      removeTabAfterOpen: false,
+      urls: ['https://example.com/a'],
+    })
+
+    expect(result.removedUrlRecordIds).toStrictEqual([])
+    expect(result.removedUrlRecords).toStrictEqual([])
+    expect(result.snapshot).toBeNull()
+    expect((await repos.tabGroupRepository.findAll())[0].urlIds).toStrictEqual([
+      'url-1',
+    ])
+    expect(
+      (await repos.customProjectRepository.findAll())[0].urlIds,
+    ).toStrictEqual(['url-1'])
+    expect(
+      (await repos.urlRecordRepository.findAll()).map((r) => r.id),
+    ).toStrictEqual(['url-1'])
+  })
+
+  it('設定 ON のときは TabGroup / CustomProject / UrlRecord から削除する', async () => {
+    const url = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1'],
+    })
+    const project = createCustomProject({
+      categories: [],
+      createdAt: 1,
+      id: 'project-1',
+      name: 'P',
+      updatedAt: 1,
+      urlIds: ['url-1'],
+    })
+    const repos = createInMemoryRepositories({
+      customProjects: [project],
+      tabGroups: [group],
+      urlRecords: [url],
+    })
+    const tab = createSpyBrowserTabPort()
+    const win = createSpyBrowserWindowPort()
+    const useCase = createOpenAllSavedUrlsUseCase({
+      ...repos,
+      browserTabPort: tab.port,
+      browserWindowPort: win.port,
+    })
+
+    const result = await useCase({
+      mode: 'backgroundTabs',
+      removeTabAfterOpen: true,
+      urls: ['https://example.com/a'],
+    })
+
+    expect(result.removedUrlRecordIds).toStrictEqual(['url-1'])
+    expect(result.removedUrlRecords[0].id).toBe('url-1')
+    expect(result.snapshot).not.toBeNull()
+    await expect(repos.tabGroupRepository.findAll()).resolves.toStrictEqual([])
+    await expect(
+      repos.customProjectRepository.findAll(),
+    ).resolves.toStrictEqual([{ ...project, urlIds: [] }])
+    await expect(repos.urlRecordRepository.findAll()).resolves.toStrictEqual([])
+  })
+
+  it('他で参照されている UrlRecord は削除せず残す', async () => {
+    const url1 = createUrlRecord({
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    })
+    const url2 = createUrlRecord({
+      id: 'url-2',
+      savedAt: 1,
+      title: 'B',
+      url: 'https://example.com/b',
+    })
+    const group = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1', 'url-2'],
+    })
+    const project = createCustomProject({
+      categories: [],
+      createdAt: 1,
+      id: 'project-1',
+      name: 'P',
+      updatedAt: 1,
+      urlIds: ['url-1', 'url-2'],
+    })
+    const repos = createInMemoryRepositories({
+      customProjects: [project],
+      tabGroups: [group],
+      urlRecords: [url1, url2],
+    })
+    const tab = createSpyBrowserTabPort()
+    const win = createSpyBrowserWindowPort()
+    const useCase = createOpenAllSavedUrlsUseCase({
+      ...repos,
+      browserTabPort: tab.port,
+      browserWindowPort: win.port,
+    })
+
+    // 開くのは url-1 のみ。url-1 は group / project 双方から除去され未参照になるので削除される。
+    // url-2 は引き続き group / project に残るので未参照にならず保持される。
+    const result = await useCase({
+      mode: 'backgroundTabs',
+      removeTabAfterOpen: true,
+      urls: ['https://example.com/a'],
+    })
+
+    expect(result.removedUrlRecordIds).toStrictEqual(['url-1'])
+    expect(result.snapshot).not.toBeNull()
+    const remainingTabGroups = await repos.tabGroupRepository.findAll()
+    expect(remainingTabGroups[0].urlIds).toStrictEqual(['url-2'])
+    const remainingProjects = await repos.customProjectRepository.findAll()
+    expect(remainingProjects[0].urlIds).toStrictEqual(['url-2'])
+    const remainingRecords = await repos.urlRecordRepository.findAll()
+    expect(remainingRecords.map((record) => record.id)).toStrictEqual(['url-2'])
+  })
+
+  it('UrlRecord に存在しない URL は無視する', async () => {
+    const repos = createInMemoryRepositories()
+    const tab = createSpyBrowserTabPort()
+    const win = createSpyBrowserWindowPort()
+    const useCase = createOpenAllSavedUrlsUseCase({
+      ...repos,
+      browserTabPort: tab.port,
+      browserWindowPort: win.port,
+    })
+
+    const result = await useCase({
+      mode: 'backgroundTabs',
+      removeTabAfterOpen: true,
+      urls: ['https://unknown.example.com/'],
+    })
+
+    expect(result.openedUrls).toStrictEqual(['https://unknown.example.com/'])
+    expect(result.removedUrlRecordIds).toStrictEqual([])
+    expect(result.snapshot).toBeNull()
+  })
+
+  it('空 URL 配列のときは port を呼ばず早期 return する', async () => {
+    const repos = createInMemoryRepositories()
+    const tab = createSpyBrowserTabPort()
+    const win = createSpyBrowserWindowPort()
+    const useCase = createOpenAllSavedUrlsUseCase({
+      ...repos,
+      browserTabPort: tab.port,
+      browserWindowPort: win.port,
+    })
+
+    const result = await useCase({
+      mode: 'backgroundTabs',
+      removeTabAfterOpen: true,
+      urls: [],
+    })
+
+    expect(tab.opened).toStrictEqual([])
+    expect(win.opened).toStrictEqual([])
+    expect(result.openedUrls).toStrictEqual([])
+    expect(result.snapshot).toBeNull()
+  })
+})

--- a/src/contexts/saved-tabs/application/use-cases/OpenAllSavedUrlsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/OpenAllSavedUrlsUseCase.ts
@@ -1,0 +1,224 @@
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import type { TabGroup } from '../../domain/entities/TabGroup'
+import type { UrlRecord } from '../../domain/entities/UrlRecord'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import {
+  lookupUrlRecordIdsByUrl,
+  removeUrlRecordIdsFromTabGroups,
+} from '../../domain/services/OpenedUrlRemovalPolicy'
+import { filterUnreferencedUrlRecords } from '../../domain/services/UrlReferenceService'
+import type { UrlRecordId } from '../../domain/value-objects/UrlRecordId'
+import type { OpenAllSavedUrlsCommand } from '../commands/OpenAllSavedUrlsCommand'
+import type { OpenedUrlsRestoreSnapshot } from '../commands/RestoreOpenedUrlsSnapshotCommand'
+import type { OpenedUrlsDto } from '../dto/OpenedUrlsDto'
+import type { BrowserTabPort } from '../ports/BrowserTabPort'
+import type { BrowserWindowPort } from '../ports/BrowserWindowPort'
+
+/**
+ * `OpenAllSavedUrlsUseCase` が依存する repository / port 群。
+ */
+export interface OpenAllSavedUrlsUseCaseDeps {
+  readonly tabGroupRepository: TabGroupRepository
+  readonly urlRecordRepository: UrlRecordRepository
+  readonly customProjectRepository: CustomProjectRepository
+  readonly browserTabPort: BrowserTabPort
+  readonly browserWindowPort: BrowserWindowPort
+}
+
+/**
+ * `OpenAllSavedUrlsUseCase` の関数型。
+ */
+export type OpenAllSavedUrlsUseCase = (
+  command: OpenAllSavedUrlsCommand,
+) => Promise<OpenedUrlsDto>
+
+interface RemovalPlan {
+  readonly previousTabGroups: readonly TabGroup[]
+  readonly previousCustomProjects: readonly CustomProject[]
+  readonly removedUrlRecords: readonly UrlRecord[]
+  readonly updatedTabGroups: readonly TabGroup[]
+  readonly updatedCustomProjects: readonly CustomProject[]
+  readonly urlRecordIdsToDelete: readonly UrlRecordId[]
+}
+
+const computeRemovalPlan = ({
+  openedUrls,
+  removeTabAfterOpen,
+  urlRecords,
+  tabGroups,
+  customProjects,
+}: {
+  readonly openedUrls: readonly string[]
+  readonly removeTabAfterOpen: boolean
+  readonly urlRecords: readonly UrlRecord[]
+  readonly tabGroups: readonly TabGroup[]
+  readonly customProjects: readonly CustomProject[]
+}): RemovalPlan => {
+  const previousTabGroups = tabGroups
+  const previousCustomProjects = customProjects
+  const previousUrlRecords = urlRecords
+
+  if (!removeTabAfterOpen) {
+    return {
+      previousCustomProjects,
+      previousTabGroups,
+      removedUrlRecords: [],
+      updatedCustomProjects: [...previousCustomProjects],
+      updatedTabGroups: [...previousTabGroups],
+      urlRecordIdsToDelete: [],
+    }
+  }
+
+  // 開いた URL 文字列 → UrlRecordId への逆引き。UrlRecord に存在しない
+  // URL（保存タブに登録されていない URL）は単純に無視する。
+  const effectiveIds = lookupUrlRecordIdsByUrl({ urlRecords, urls: openedUrls })
+  if (effectiveIds.size === 0) {
+    return {
+      previousCustomProjects,
+      previousTabGroups,
+      removedUrlRecords: [],
+      updatedCustomProjects: [...previousCustomProjects],
+      updatedTabGroups: [...previousTabGroups],
+      urlRecordIdsToDelete: [],
+    }
+  }
+
+  const updatedTabGroups = removeUrlRecordIdsFromTabGroups({
+    tabGroups: previousTabGroups,
+    urlRecordIdsToRemove: effectiveIds,
+  })
+
+  const updatedCustomProjects: CustomProject[] = previousCustomProjects.map(
+    (project) => {
+      const remaining = project.urlIds.filter(
+        (urlId) => !effectiveIds.has(urlId),
+      )
+      if (remaining.length === project.urlIds.length) {
+        return project
+      }
+      return { ...project, urlIds: remaining }
+    },
+  )
+
+  const urlRecordsInTarget = previousUrlRecords.filter((record) =>
+    effectiveIds.has(record.id),
+  )
+  const unreferenced = filterUnreferencedUrlRecords({
+    customProjects: updatedCustomProjects,
+    tabGroups: updatedTabGroups,
+    urlRecords: urlRecordsInTarget,
+  })
+
+  return {
+    previousCustomProjects,
+    previousTabGroups,
+    removedUrlRecords: unreferenced,
+    updatedCustomProjects,
+    updatedTabGroups,
+    urlRecordIdsToDelete: unreferenced.map((record) => record.id),
+  }
+}
+
+/**
+ * `OpenAllSavedUrlsUseCase` を生成する。
+ *
+ * 責務:
+ * 1. 入力 URL 配列を `BrowserTabPort` / `BrowserWindowPort` 経由で一括オープンする。
+ * 2. `removeTabAfterOpen` が有効なら、対象 `UrlRecordId` を `TabGroup` /
+ *    `CustomProject` の `urlIds` から取り除く。
+ * 3. 削除後に他で参照されなくなった `UrlRecord` を
+ *    `UrlRecordRepository.removeByIds` で削除する。
+ * 4. Undo 用 snapshot を `OpenedUrlsDto` にまとめて返す。
+ *
+ * 既存 `OpenSavedUrlUseCase` と同じ `removeUrlRecordIdsFromTabGroups` /
+ * `filterUnreferencedUrlRecords` を再利用することで、1 件と複数で
+ * 削除ポリシーが一致するようにしている。
+ */
+export const createOpenAllSavedUrlsUseCase = (
+  deps: OpenAllSavedUrlsUseCaseDeps,
+): OpenAllSavedUrlsUseCase => {
+  return async (command) => {
+    if (command.urls.length === 0) {
+      return {
+        openedUrls: [],
+        removedUrlRecords: [],
+        removedUrlRecordIds: [],
+        snapshot: null,
+      }
+    }
+
+    const [allTabGroups, allUrlRecords, allCustomProjects] = await Promise.all([
+      deps.tabGroupRepository.findAll(),
+      deps.urlRecordRepository.findAll(),
+      deps.customProjectRepository.findAll(),
+    ])
+
+    const openedUrls =
+      command.mode === 'newWindow'
+        ? (
+            await deps.browserWindowPort.openWithUrls({
+              focused: true,
+              urls: [...command.urls],
+            })
+          ).urls
+        : await Promise.all(
+            command.urls.map((url) => deps.browserTabPort.open({ url })),
+          ).then((results) => results.map((result) => result.url))
+
+    const plan = computeRemovalPlan({
+      customProjects: allCustomProjects,
+      openedUrls,
+      removeTabAfterOpen: command.removeTabAfterOpen,
+      tabGroups: allTabGroups,
+      urlRecords: allUrlRecords,
+    })
+
+    if (plan.urlRecordIdsToDelete.length === 0) {
+      return {
+        openedUrls,
+        removedUrlRecordIds: [],
+        removedUrlRecords: [],
+        snapshot: null,
+      }
+    }
+
+    // 変更があった場合のみ書き戻す。`removeUrlRecordIdsFromTabGroups` は
+    // 変更があった TabGroup だけ新しい object を返すので reference 比較で
+    // 検出できる。
+    if (
+      plan.updatedTabGroups.length !== plan.previousTabGroups.length ||
+      plan.updatedTabGroups.some(
+        (group, index) => group !== plan.previousTabGroups[index],
+      )
+    ) {
+      await deps.tabGroupRepository.saveAll(plan.updatedTabGroups)
+    }
+    if (
+      plan.updatedCustomProjects.length !==
+        plan.previousCustomProjects.length ||
+      plan.updatedCustomProjects.some(
+        (project, index) => project !== plan.previousCustomProjects[index],
+      )
+    ) {
+      await deps.customProjectRepository.saveAll(plan.updatedCustomProjects)
+    }
+    await deps.urlRecordRepository.removeByIds(plan.urlRecordIdsToDelete)
+
+    const snapshot: OpenedUrlsRestoreSnapshot = {
+      customProjectOrder: undefined,
+      customProjects: plan.previousCustomProjects,
+      parentCategories: undefined,
+      savedTabs: plan.previousTabGroups,
+      urlRecords: plan.removedUrlRecords,
+    }
+
+    return {
+      openedUrls,
+      removedUrlRecordIds: plan.urlRecordIdsToDelete,
+      removedUrlRecords: plan.removedUrlRecords,
+      snapshot,
+    }
+  }
+}

--- a/src/contexts/saved-tabs/application/use-cases/SyncCategoryAssignmentsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/SyncCategoryAssignmentsUseCase.ts
@@ -179,6 +179,10 @@ const syncAll = async (
       unassignedTabGroupIds.push(group.id)
     }
     assignedTabGroupIds.push(group.id)
+    // 新規 / 付け替えで親カテゴリが変わる場合も、カテゴリ側の
+    // `domainNames` を member groups から再計算するため、
+    // updatedCategoryIds に追加して saveAll 対象にする。
+    updatedCategoryIds.add(category.id)
     return { ...group, parentCategoryId: category.id }
   })
 
@@ -192,9 +196,13 @@ const syncAll = async (
     const memberDomainNames = Array.from(
       new Set(memberGroups.map((group) => group.domain)),
     )
+    const memberDomainIds = Array.from(
+      new Set(memberGroups.map((group) => group.id)),
+    )
     return {
       ...category,
       domainNames: memberDomainNames,
+      domains: memberDomainIds,
     }
   })
 

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserWindowAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserWindowAdapter.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ChromeWindowsApiLike } from './ChromeBrowserWindowAdapter'
+import { createChromeBrowserWindowAdapter } from './ChromeBrowserWindowAdapter'
+
+const createSpyWindows = (
+  resolvedTabs: readonly { readonly url?: string }[] = [
+    { url: 'https://example.com/a' },
+    { url: 'https://example.com/b' },
+  ],
+): {
+  readonly api: ChromeWindowsApiLike
+  readonly create: ReturnType<typeof vi.fn>
+} => {
+  // eslint-disable-next-line typescript/require-await
+  const create = vi.fn(async () => ({ tabs: resolvedTabs }))
+  const api: ChromeWindowsApiLike = {
+    windows: {
+      create,
+    },
+  }
+  return { api, create }
+}
+
+describe('createChromeBrowserWindowAdapter', () => {
+  it('chrome.windows.create を focused=true で呼び出す', async () => {
+    const { api, create } = createSpyWindows()
+    const adapter = createChromeBrowserWindowAdapter({ getApi: () => api })
+
+    const result = await adapter.openWithUrls({
+      urls: ['https://example.com/a', 'https://example.com/b'],
+    })
+
+    expect(create).toHaveBeenCalledWith({
+      focused: true,
+      url: ['https://example.com/a', 'https://example.com/b'],
+    })
+    expect(result.urls).toStrictEqual([
+      'https://example.com/a',
+      'https://example.com/b',
+    ])
+  })
+
+  it('focused を false で呼び出せる', async () => {
+    const { api, create } = createSpyWindows()
+    const adapter = createChromeBrowserWindowAdapter({ getApi: () => api })
+
+    await adapter.openWithUrls({
+      focused: false,
+      urls: ['https://example.com/a'],
+    })
+
+    expect(create).toHaveBeenCalledWith({
+      focused: false,
+      url: ['https://example.com/a'],
+    })
+  })
+
+  it('resolveFocused オプションが既定値を上書きする', async () => {
+    const { api, create } = createSpyWindows()
+    const adapter = createChromeBrowserWindowAdapter(
+      { getApi: () => api },
+      { resolveFocused: () => false },
+    )
+
+    await adapter.openWithUrls({ urls: ['https://example.com/a'] })
+
+    expect(create).toHaveBeenCalledWith({
+      focused: false,
+      url: ['https://example.com/a'],
+    })
+  })
+
+  it('chrome.windows が無い環境では Error を投げる', async () => {
+    const adapter = createChromeBrowserWindowAdapter({ getApi: () => ({}) })
+
+    await expect(
+      adapter.openWithUrls({ urls: ['https://example.com'] }),
+    ).rejects.toThrow('chrome.windows.create is not available')
+  })
+
+  it('chrome が無い環境では Error を投げる', async () => {
+    const adapter = createChromeBrowserWindowAdapter({
+      getApi: () => undefined,
+    })
+
+    await expect(
+      adapter.openWithUrls({ urls: ['https://example.com'] }),
+    ).rejects.toThrow('chrome.windows.create is not available')
+  })
+
+  it('windows.create が無い環境では Error を投げる', async () => {
+    const adapter = createChromeBrowserWindowAdapter({
+      getApi: () => ({ windows: {} }),
+    })
+
+    await expect(
+      adapter.openWithUrls({ urls: ['https://example.com'] }),
+    ).rejects.toThrow('chrome.windows.create is not available')
+  })
+
+  it('タブ URL が空の場合は入力 URL 配列をフォールバックとして返す', async () => {
+    const { api } = createSpyWindows([])
+    const adapter = createChromeBrowserWindowAdapter({ getApi: () => api })
+
+    const result = await adapter.openWithUrls({
+      urls: ['https://example.com/a', 'https://example.com/b'],
+    })
+
+    expect(result.urls).toStrictEqual([
+      'https://example.com/a',
+      'https://example.com/b',
+    ])
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserWindowAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserWindowAdapter.ts
@@ -1,0 +1,88 @@
+/**
+ * `chrome.windows` 依存を `BrowserWindowPort` interface に適合させる adapter。
+ *
+ * `presentation` 層は `chrome.windows` を直接参照できないため、
+ * `composition` 層からこの adapter を `BrowserWindowPort` として use-case へ注入する。
+ *
+ * `openWithUrls` は引数の URL 配列をそのまま `chrome.windows.create` に渡し、
+ * 開いた URL 配列を返す。`focused` は省略時 `true`（前面表示）として扱う。
+ *
+ * @example
+ * ```ts
+ * const port: BrowserWindowPort = createChromeBrowserWindowAdapter({
+ *   getApi: () => chrome,
+ * })
+ * await port.openWithUrls({ urls: ['https://example.com'] })
+ * ```
+ */
+
+export interface ChromeBrowserWindowAdapterDeps {
+  /**
+   * `chrome.windows` を提供する chrome API 全体。テスト時は
+   * `chrome.windows.create` を持つモックオブジェクトを渡す。
+   */
+  readonly getApi: () => ChromeWindowsApiLike | undefined
+}
+
+export interface ChromeWindowsApiLike {
+  readonly windows?: ChromeWindowsLike
+}
+
+export interface ChromeWindowsLike {
+  readonly create?: (createProperties: {
+    readonly focused?: boolean
+    readonly url?: readonly string[] | string
+  }) =>
+    | Promise<
+        { readonly tabs?: readonly { readonly url?: string }[] } | undefined
+      >
+    | undefined
+}
+
+export interface ChromeBrowserWindowAdapterOptions {
+  /**
+   * 新規ウィンドウを前面に表示するかを port 利用側（open all saved urls use-case）が
+   * 決められるよう、`focused` の既定値を委譲できる。
+   * 未指定なら `focused: true` で開く。
+   */
+  readonly resolveFocused?: () => boolean
+}
+
+/**
+ * `chrome.windows.create` を利用する `BrowserWindowPort` 実装を生成する。
+ *
+ * `chrome` API が見つからない環境（テスト / SSR など）では
+ * 即座に `Error` を投げ、use-case 側で失敗を通知する。
+ * 「サイレントに何もしない」よりも、副作用が必要な操作は
+ * 失敗を可視化することが重要という DDD の方針に従う。
+ */
+export const createChromeBrowserWindowAdapter = (
+  deps: ChromeBrowserWindowAdapterDeps,
+  options: ChromeBrowserWindowAdapterOptions = {},
+) => {
+  return {
+    openWithUrls: async (input: {
+      readonly urls: readonly string[]
+      readonly focused?: boolean
+    }) => {
+      const api = deps.getApi()
+      const windows = api?.windows
+      const focused = input.focused ?? options.resolveFocused?.() ?? true
+      if (!windows?.create) {
+        throw new Error('chrome.windows.create is not available')
+      }
+      const result = await windows.create({
+        focused,
+        url: [...input.urls],
+      })
+      const openedUrls = (result?.tabs ?? [])
+        .map((tab) => tab.url)
+        .filter((url): url is string => typeof url === 'string')
+      // `chrome.windows.create` が URL 情報を返さない（あるいは一部しか返さない）
+      // 環境へのフォールバックとして、入力された URL 配列をそのまま返す。
+      return {
+        urls: openedUrls.length > 0 ? openedUrls : [...input.urls],
+      }
+    },
+  }
+}

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts
@@ -1,5 +1,9 @@
 import type { SavedTabsUseCases } from '../../application/SavedTabsUseCases'
+import { createDeleteSavedUrlsUseCase } from '../../application/use-cases/DeleteSavedUrlsUseCase'
+import { createDeleteSavedUrlUseCase } from '../../application/use-cases/DeleteSavedUrlUseCase'
+import { createDeleteTabGroupsUseCase } from '../../application/use-cases/DeleteTabGroupsUseCase'
 import { createDeleteTabGroupUseCase } from '../../application/use-cases/DeleteTabGroupUseCase'
+import { createOpenAllSavedUrlsUseCase } from '../../application/use-cases/OpenAllSavedUrlsUseCase'
 import { createOpenSavedUrlUseCase } from '../../application/use-cases/OpenSavedUrlUseCase'
 import { createRemoveUnreferencedUrlRecordsUseCase } from '../../application/use-cases/RemoveUnreferencedUrlRecordsUseCase'
 import { createRestoreOpenedUrlsSnapshotUseCase } from '../../application/use-cases/RestoreOpenedUrlsSnapshotUseCase'
@@ -34,7 +38,29 @@ export type { SavedTabsUseCases }
 export const createSavedTabsUseCases = (
   deps: SavedTabsUseCasesDeps,
 ): SavedTabsUseCases => ({
+  deleteSavedUrl: createDeleteSavedUrlUseCase({
+    customProjectRepository: deps.customProjectRepository,
+    tabGroupRepository: deps.tabGroupRepository,
+    urlRecordRepository: deps.urlRecordRepository,
+  }),
+  deleteSavedUrls: createDeleteSavedUrlsUseCase({
+    customProjectRepository: deps.customProjectRepository,
+    tabGroupRepository: deps.tabGroupRepository,
+    urlRecordRepository: deps.urlRecordRepository,
+  }),
   deleteTabGroup: createDeleteTabGroupUseCase({
+    customProjectRepository: deps.customProjectRepository,
+    tabGroupRepository: deps.tabGroupRepository,
+    urlRecordRepository: deps.urlRecordRepository,
+  }),
+  deleteTabGroups: createDeleteTabGroupsUseCase({
+    customProjectRepository: deps.customProjectRepository,
+    tabGroupRepository: deps.tabGroupRepository,
+    urlRecordRepository: deps.urlRecordRepository,
+  }),
+  openAllSavedUrls: createOpenAllSavedUrlsUseCase({
+    browserTabPort: deps.browserTabPort,
+    browserWindowPort: deps.browserWindowPort,
     customProjectRepository: deps.customProjectRepository,
     tabGroupRepository: deps.tabGroupRepository,
     urlRecordRepository: deps.urlRecordRepository,

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
@@ -4,12 +4,14 @@ import {
 } from '@/lib/browser/chrome-storage'
 
 import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { BrowserWindowPort } from '../../application/ports/BrowserWindowPort'
 import type { NotificationPort } from '../../application/ports/NotificationPort'
 import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
 import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
 import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
 import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
 import { createChromeBrowserTabAdapter } from '../browser/ChromeBrowserTabAdapter'
+import { createChromeBrowserWindowAdapter } from '../browser/ChromeBrowserWindowAdapter'
 import { createSonnerNotificationAdapter } from '../browser/SonnerNotificationAdapter'
 import { createChromeCustomProjectRepository } from '../persistence/chrome-storage/ChromeCustomProjectRepository'
 import { createChromeParentCategoryRepository } from '../persistence/chrome-storage/ChromeParentCategoryRepository'
@@ -30,6 +32,7 @@ export interface SavedTabsUseCasesDeps {
   readonly customProjectRepository: CustomProjectRepository
   readonly parentCategoryRepository: ParentCategoryRepository
   readonly browserTabPort: BrowserTabPort
+  readonly browserWindowPort: BrowserWindowPort
   readonly notificationPort: NotificationPort
 }
 
@@ -40,9 +43,20 @@ interface ChromeLike {
       readonly url: string
     }) => Promise<{ readonly url?: string } | undefined> | undefined
   }
+  readonly windows?: {
+    readonly create?: (createProperties: {
+      readonly focused?: boolean
+      readonly url?: readonly string[] | string
+    }) =>
+      | Promise<
+          { readonly tabs?: readonly { readonly url?: string }[] } | undefined
+        >
+      | undefined
+  }
 }
 
 const getChromeApi = (): ChromeLike | undefined =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   (globalThis as typeof globalThis & { chrome?: ChromeLike }).chrome
 
 /**
@@ -74,6 +88,9 @@ export const createSavedTabsUseCasesDeps = (): SavedTabsUseCasesDeps => {
 
   return {
     browserTabPort: createChromeBrowserTabAdapter({
+      getApi: () => getChromeApi(),
+    }),
+    browserWindowPort: createChromeBrowserWindowAdapter({
       getApi: () => getChromeApi(),
     }),
     customProjectRepository: createChromeCustomProjectRepository(port),

--- a/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { BrowserWindowPort } from '../../application/ports/BrowserWindowPort'
 import type { NotificationPort } from '../../application/ports/NotificationPort'
 import { searchSavedTabs } from '../../domain/services/SavedTabsSearchService'
 import { createSavedTabsUseCases } from '../composition/createSavedTabsUseCases'
@@ -58,6 +59,27 @@ const createSpyBrowserTabPort = (
   }
 }
 
+interface SpyBrowserWindowPort {
+  readonly port: BrowserWindowPort
+  readonly openWithUrls: ReturnType<typeof vi.fn>
+  readonly opened: { focused?: boolean; urls: readonly string[] }[]
+}
+
+const createSpyBrowserWindowPort = (): SpyBrowserWindowPort => {
+  const opened: { focused?: boolean; urls: readonly string[] }[] = []
+  const openWithUrls = vi.fn(
+    (input: { urls: readonly string[]; focused?: boolean }) => {
+      opened.push({ focused: input.focused, urls: [...input.urls] })
+      return Promise.resolve({ urls: [...input.urls] })
+    },
+  )
+  return {
+    openWithUrls,
+    opened,
+    port: { openWithUrls },
+  }
+}
+
 const createCaptureNotificationPort = (): {
   notificationPort: NotificationPort
   calls: { level: 'error' | 'info' | 'success'; message: string }[]
@@ -82,6 +104,7 @@ interface Bundle {
   readonly port: ChromeStorageLocalPort
   readonly portState: StorageState
   readonly browserTabPort: SpyBrowserTabPort
+  readonly browserWindowPort: SpyBrowserWindowPort
   readonly notificationPort: ReturnType<typeof createCaptureNotificationPort>
   readonly useCases: ReturnType<typeof createSavedTabsUseCases>
 }
@@ -90,9 +113,11 @@ const createBundle = (initial: StorageState = {}): Bundle => {
   const state: StorageState = { ...initial }
   const port = createPort(state)
   const browserTabPort = createSpyBrowserTabPort(() => true)
+  const browserWindowPort = createSpyBrowserWindowPort()
   const notification = createCaptureNotificationPort()
   const deps: SavedTabsUseCasesDeps = {
     browserTabPort: browserTabPort.port,
+    browserWindowPort: browserWindowPort.port,
     customProjectRepository: createChromeCustomProjectRepository(port),
     notificationPort: notification.notificationPort,
     parentCategoryRepository: createChromeParentCategoryRepository(port),
@@ -101,6 +126,7 @@ const createBundle = (initial: StorageState = {}): Bundle => {
   }
   return {
     browserTabPort,
+    browserWindowPort,
     deps,
     notificationPort: notification,
     port,
@@ -299,13 +325,19 @@ describe('savedTabs DDD 移行 後 回帰テスト', () => {
       const resolveActive = vi.fn(() => false)
       const { createChromeBrowserTabAdapter } =
         await import('../browser/ChromeBrowserTabAdapter')
+      const { createChromeBrowserWindowAdapter } =
+        await import('../browser/ChromeBrowserWindowAdapter')
       const browserTabPort = createChromeBrowserTabAdapter(
         { getApi: () => ({ tabs: { create: openSpy } }) },
         { resolveActive },
       )
+      const browserWindowPort = createChromeBrowserWindowAdapter({
+        getApi: () => undefined,
+      })
       const notification = createCaptureNotificationPort()
       const deps: SavedTabsUseCasesDeps = {
         browserTabPort,
+        browserWindowPort,
         customProjectRepository: createChromeCustomProjectRepository(port),
         notificationPort: notification.notificationPort,
         parentCategoryRepository: createChromeParentCategoryRepository(port),

--- a/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { BrowserWindowPort } from '../../application/ports/BrowserWindowPort'
 import type { NotificationPort } from '../../application/ports/NotificationPort'
 import { createCustomProject } from '../../domain/entities/CustomProject'
 import type { CustomProject } from '../../domain/entities/CustomProject'
@@ -113,6 +114,12 @@ const createEmptyDeps = (
     Promise.resolve({ url: input.url }),
   )
   const browserTabPort: BrowserTabPort = { open: openSpy }
+  const browserWindowPort: BrowserWindowPort = {
+    // eslint-disable-next-line typescript/require-await
+    openWithUrls: vi.fn(async (input) => ({
+      urls: [...input.urls],
+    })),
+  }
   const notificationPort: NotificationPort = {
     error: vi.fn(),
     info: vi.fn(),
@@ -121,6 +128,7 @@ const createEmptyDeps = (
   return {
     deps: {
       browserTabPort,
+      browserWindowPort,
       customProjectRepository:
         createInMemoryRepositories().customProjectRepository,
       notificationPort,

--- a/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { BrowserWindowPort } from '../../application/ports/BrowserWindowPort'
 import type { NotificationPort } from '../../application/ports/NotificationPort'
 import { createCustomProject } from '../../domain/entities/CustomProject'
 import type { CustomProject } from '../../domain/entities/CustomProject'
@@ -132,6 +133,12 @@ const createEmptyDeps = (
     Promise.resolve({ url: input.url }),
   )
   const browserTabPort: BrowserTabPort = { open: openSpy }
+  const browserWindowPort: BrowserWindowPort = {
+    // eslint-disable-next-line typescript/require-await
+    openWithUrls: vi.fn(async (input) => ({
+      urls: [...input.urls],
+    })),
+  }
   const notificationPort: NotificationPort = {
     error: vi.fn(),
     info: vi.fn(),
@@ -140,6 +147,7 @@ const createEmptyDeps = (
   return {
     deps: {
       browserTabPort,
+      browserWindowPort,
       customProjectRepository:
         createInMemoryRepositories().customProjectRepository,
       notificationPort,

--- a/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { BrowserWindowPort } from '../../application/ports/BrowserWindowPort'
 import type { NotificationPort } from '../../application/ports/NotificationPort'
 import { createCustomProject } from '../../domain/entities/CustomProject'
 import type { CustomProject } from '../../domain/entities/CustomProject'
@@ -131,6 +132,12 @@ const createEmptyDeps = (
     Promise.resolve({ url: input.url }),
   )
   const browserTabPort: BrowserTabPort = { open: openSpy }
+  const browserWindowPort: BrowserWindowPort = {
+    // eslint-disable-next-line typescript/require-await
+    openWithUrls: vi.fn(async (input) => ({
+      urls: [...input.urls],
+    })),
+  }
   const notifySpy = vi.fn()
   const notificationPort: NotificationPort = {
     error: notifySpy,
@@ -140,6 +147,7 @@ const createEmptyDeps = (
   return {
     deps: {
       browserTabPort,
+      browserWindowPort,
       customProjectRepository:
         createInMemoryRepositories().customProjectRepository,
       notificationPort,

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.test.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { BrowserWindowPort } from '../../application/ports/BrowserWindowPort'
 import type { NotificationPort } from '../../application/ports/NotificationPort'
 import { createCustomProject } from '../../domain/entities/CustomProject'
 import { createTabGroup } from '../../domain/entities/TabGroup'
@@ -113,6 +114,12 @@ const createInMemoryDeps = (input: {
     // eslint-disable-next-line typescript/require-await
     open: async (input: { url: string }) => ({ url: input.url }),
   }
+  const browserWindowPort: BrowserWindowPort = {
+    // eslint-disable-next-line typescript/require-await
+    openWithUrls: async (input: { urls: readonly string[] }) => ({
+      urls: [...input.urls],
+    }),
+  }
   const notificationPort: NotificationPort = {
     error: vi.fn(),
     info: vi.fn(),
@@ -120,6 +127,7 @@ const createInMemoryDeps = (input: {
   }
   return {
     browserTabPort,
+    browserWindowPort,
     customProjectRepository,
     notificationPort,
     parentCategoryRepository,

--- a/src/features/saved-tabs/app/SavedTabsApp.test.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.test.tsx
@@ -458,7 +458,11 @@ describe('SavedTabsApp custom search', () => {
     await notifyDeleteFailure({
       refreshTabGroupsWithUrls,
       savedTabsUseCases: {
+        deleteSavedUrl: vi.fn(),
+        deleteSavedUrls: vi.fn(),
         deleteTabGroup: vi.fn(),
+        deleteTabGroups: vi.fn(),
+        openAllSavedUrls: vi.fn(),
         openSavedUrl: vi.fn(),
         removeUnreferencedUrlRecords: vi.fn(),
         restoreOpenedUrlsSnapshot: restoreOpenedUrlsSnapshotUseCase,
@@ -481,7 +485,11 @@ describe('SavedTabsApp custom search', () => {
     await notifyDeleteFailure({
       refreshTabGroupsWithUrls,
       savedTabsUseCases: {
+        deleteSavedUrl: vi.fn(),
+        deleteSavedUrls: vi.fn(),
         deleteTabGroup: vi.fn(),
+        deleteTabGroups: vi.fn(),
+        openAllSavedUrls: vi.fn(),
         openSavedUrl: vi.fn(),
         removeUnreferencedUrlRecords: vi.fn(),
         restoreOpenedUrlsSnapshot: restoreOpenedUrlsSnapshotUseCase,
@@ -513,7 +521,11 @@ describe('SavedTabsApp custom search', () => {
     await restoreOpenedUrlsSnapshot({
       refreshTabGroupsWithUrls,
       savedTabsUseCases: {
+        deleteSavedUrl: vi.fn(),
+        deleteSavedUrls: vi.fn(),
         deleteTabGroup: vi.fn(),
+        deleteTabGroups: vi.fn(),
+        openAllSavedUrls: vi.fn(),
         openSavedUrl: vi.fn(),
         removeUnreferencedUrlRecords: vi.fn(),
         restoreOpenedUrlsSnapshot: restoreOpenedUrlsSnapshotUseCase,
@@ -549,7 +561,11 @@ describe('SavedTabsApp custom search', () => {
     await restoreOpenedUrlsSnapshot({
       refreshTabGroupsWithUrls: refreshTabGroupsWithUrls2,
       savedTabsUseCases: {
+        deleteSavedUrl: vi.fn(),
+        deleteSavedUrls: vi.fn(),
         deleteTabGroup: vi.fn(),
+        deleteTabGroups: vi.fn(),
+        openAllSavedUrls: vi.fn(),
         openSavedUrl: vi.fn(),
         removeUnreferencedUrlRecords: vi.fn(),
         restoreOpenedUrlsSnapshot: captureUseCase,
@@ -1271,16 +1287,15 @@ describe('SavedTabsApp custom search', () => {
       ],
       urlIds: ['url-1'],
     }
+    const category = {
+      id: 'category-1',
+      name: 'Reading',
+      domains: ['group-1'],
+      domainNames: ['example.com'],
+    }
     mocked.projectState.viewMode = 'domain'
     mocked.projectState.viewModeRef = { current: 'domain' }
-    mocked.categoryState.categories = [
-      {
-        id: 'category-1',
-        name: 'Reading',
-        domains: ['group-1'],
-        domainNames: ['example.com'],
-      },
-    ]
+    mocked.categoryState.categories = [category]
     mocked.categoryState.categoryOrder = ['category-1']
     mocked.tabDataState.tabGroups = [group]
     mocked.tabDataState.tabGroupsWithUrls = [group]
@@ -1291,7 +1306,15 @@ describe('SavedTabsApp custom search', () => {
       storage: {
         local: {
           // eslint-disable-next-line typescript/require-await
-          get: vi.fn(async () => ({ savedTabs: [group] })),
+          get: vi.fn(async (key: string) => {
+            if (key === 'parentCategories') {
+              return { parentCategories: [category] }
+            }
+            if (key === 'savedTabs') {
+              return { savedTabs: [group] }
+            }
+            return {}
+          }),
           set: chromeSetMock,
         },
         onChanged: {
@@ -1464,12 +1487,34 @@ describe('SavedTabsApp custom search', () => {
     mocked.tabDataState.tabGroups = [group]
     mocked.tabDataState.tabGroupsWithUrls = [group]
 
+    const urlRecords = [
+      {
+        id: 'url-a',
+        url: 'https://example.com/a',
+        title: 'A',
+        savedAt: 1,
+      },
+      {
+        id: 'url-b',
+        url: 'https://example.com/b',
+        title: 'B',
+        savedAt: 2,
+      },
+    ]
     const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
     chromeGlobal.chrome = {
       storage: {
         local: {
           // eslint-disable-next-line typescript/require-await
-          get: vi.fn(async () => ({ savedTabs: [group] })),
+          get: vi.fn(async (key: string) => {
+            if (key === 'savedTabs') {
+              return { savedTabs: [group] }
+            }
+            if (key === 'urls') {
+              return { urls: urlRecords }
+            }
+            return {}
+          }),
           set: vi.fn(),
         },
         onChanged: {
@@ -1501,11 +1546,11 @@ describe('SavedTabsApp custom search', () => {
       'https://example.com/b',
     ])
 
-    expect(removeUrlIdsFromTabGroup).toHaveBeenCalledWith(
-      'group-1',
-      ['url-a', 'url-b'],
-      { throwOnSyncError: true },
-    )
+    // 複数 URL 削除は use-case 経由で実行される。
+    // `removeUrlIdsFromTabGroup` / `removeUrlsFromTabGroup` は呼ばれず、
+    // use-case が repository 経由で storage を更新する。
+    expect(removeUrlIdsFromTabGroup).not.toHaveBeenCalled()
+    expect(removeUrlsFromTabGroup).not.toHaveBeenCalled()
     expect(toast.info).toHaveBeenCalledWith(
       '削除した2件のタブを保存データに戻せます',
       expect.objectContaining({
@@ -1523,6 +1568,31 @@ describe('SavedTabsApp custom search', () => {
     mocked.tabDataState.tabGroups = []
     mocked.tabDataState.tabGroupsWithUrls = []
 
+    const chromeSetMock = vi.fn()
+    const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
+    chromeGlobal.chrome = {
+      storage: {
+        local: {
+          // eslint-disable-next-line typescript/require-await
+          get: vi.fn(async () => ({ savedTabs: [] })),
+          set: chromeSetMock,
+        },
+        onChanged: {
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        },
+      },
+      tabs: {
+        create: vi.fn(),
+      },
+      windows: {
+        create: vi.fn(),
+      },
+      runtime: {
+        getURL: vi.fn(),
+      },
+    } as unknown as typeof chrome
+
     render(<SavedTabsApp initialViewMode='domain' />)
 
     const domainProps = mocked.domainModeContainerSpy.mock.calls.at(
@@ -1531,23 +1601,15 @@ describe('SavedTabsApp custom search', () => {
       handleDeleteUrls: (groupId: string, urls: string[]) => Promise<void>
     }
 
+    // 存在しないグループに対する handleDeleteUrls は use-case 内で
+    // `SavedTabsDomainError` を投げ、UI 側で notifyDeleteFailure が走る。
+    // 旧 `removeUrlsFromTabGroup` フォールバックはリプレース済みのため
+    // 呼ばれない。
     await domainProps.handleDeleteUrls('missing-group', [
       'https://example.com/missing',
     ])
 
-    expect(removeUrlsFromTabGroup).toHaveBeenCalledWith(
-      'missing-group',
-      ['https://example.com/missing'],
-      { throwOnSyncError: true },
-    )
-
-    vi.mocked(removeUrlsFromTabGroup).mockRejectedValueOnce(
-      new Error('delete failed'),
-    )
-    await domainProps.handleDeleteUrls('missing-group', [
-      'https://example.com/missing-2',
-    ])
-
+    expect(removeUrlsFromTabGroup).not.toHaveBeenCalled()
     expect(toast.error).toHaveBeenCalledWith('削除に失敗しました')
   })
 
@@ -1654,6 +1716,12 @@ describe('SavedTabsApp custom search', () => {
       urls: [{ id: 'url-a', url: 'https://example.com/a', title: 'A' }],
       urlIds: ['url-a'],
     }
+    const urlRecord = {
+      id: 'url-a',
+      url: 'https://example.com/a',
+      title: 'A',
+      savedAt: 1,
+    }
     mocked.projectState.viewMode = 'domain'
     mocked.projectState.viewModeRef = { current: 'domain' }
     mocked.tabDataState.tabGroups = [group]
@@ -1675,11 +1743,22 @@ describe('SavedTabsApp custom search', () => {
       storage: {
         local: {
           // eslint-disable-next-line typescript/require-await
-          get: vi.fn(async () => ({
-            customProjectOrder: ['project-1'],
-            customProjects: customProjectsSnapshot,
-            savedTabs: [group],
-          })),
+          get: vi.fn(async (key: string | string[]) => {
+            const keys = Array.isArray(key) ? key : [key]
+            const result: Record<string, unknown> = {}
+            for (const k of keys) {
+              if (k === 'customProjectOrder') {
+                result.customProjectOrder = ['project-1']
+              } else if (k === 'customProjects') {
+                result.customProjects = customProjectsSnapshot
+              } else if (k === 'savedTabs') {
+                result.savedTabs = [group]
+              } else if (k === 'urls') {
+                result.urls = [urlRecord]
+              }
+            }
+            return result
+          }),
           set: chromeSetMock,
         },
         onChanged: {
@@ -1708,11 +1787,13 @@ describe('SavedTabsApp custom search', () => {
 
     await domainProps.handleDeleteUrl('group-1', 'https://example.com/a')
 
-    expect(removeUrlFromTabGroup).toHaveBeenCalledWith(
-      'group-1',
-      'https://example.com/a',
-      { throwOnSyncError: true },
-    )
+    // 単体 URL 削除は use-case 経由で実行される。`removeUrlFromTabGroup` は
+    // 呼ばれず、use-case が repository 経由で storage を更新する。
+    // グループに 1 件しか URL が無いため、削除後はグループ自体が消える。
+    expect(removeUrlFromTabGroup).not.toHaveBeenCalled()
+    expect(chromeSetMock).toHaveBeenCalledWith({
+      savedTabs: [],
+    })
     expect(toast.info).toHaveBeenCalledWith(
       '削除した1件のタブを保存データに戻せます',
       expect.objectContaining({
@@ -1861,17 +1942,46 @@ describe('SavedTabsApp custom search', () => {
     ]
 
     const chromeSetMock = vi.fn()
-    const chromeTabsCreateMock = vi.fn()
     const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
     chromeGlobal.chrome = {
       storage: {
         local: {
           // eslint-disable-next-line typescript/require-await
-          get: vi.fn(async () => ({
-            customProjectOrder: ['project-1'],
-            customProjects: customProjectsSnapshot,
-            savedTabs: [group1, group2],
-          })),
+          get: vi.fn(async (key: string | string[]) => {
+            const keys = Array.isArray(key) ? key : [key]
+            const result: Record<string, unknown> = {}
+            for (const k of keys) {
+              if (k === 'customProjectOrder') {
+                result.customProjectOrder = ['project-1']
+              } else if (k === 'customProjects') {
+                result.customProjects = customProjectsSnapshot
+              } else if (k === 'savedTabs') {
+                result.savedTabs = [group1, group2]
+              } else if (k === 'urls') {
+                result.urls = [
+                  {
+                    id: 'url-a',
+                    url: 'https://example.com/a',
+                    title: 'A',
+                    savedAt: 1,
+                  },
+                  {
+                    id: 'url-b',
+                    url: 'https://example.com/b',
+                    title: 'B',
+                    savedAt: 2,
+                  },
+                  {
+                    id: 'url-c',
+                    url: 'https://other.com/c',
+                    title: 'C',
+                    savedAt: 3,
+                  },
+                ]
+              }
+            }
+            return result
+          }),
           set: chromeSetMock,
         },
         onChanged: {
@@ -1880,7 +1990,7 @@ describe('SavedTabsApp custom search', () => {
         },
       },
       tabs: {
-        create: chromeTabsCreateMock,
+        create: vi.fn(),
       },
       windows: {
         create: vi.fn(),
@@ -1889,12 +1999,6 @@ describe('SavedTabsApp custom search', () => {
         getURL: vi.fn(),
       },
     } as unknown as typeof chrome
-
-    vi.mocked(getUrlRecords).mockResolvedValue([
-      { id: 'url-a', url: 'https://example.com/a', title: 'A', savedAt: 1 },
-      { id: 'url-b', url: 'https://example.com/b', title: 'B', savedAt: 2 },
-      { id: 'url-c', url: 'https://other.com/c', title: 'C', savedAt: 3 },
-    ] satisfies UrlRecord[])
 
     render(<SavedTabsApp initialViewMode='domain' />)
 
@@ -1911,7 +2015,10 @@ describe('SavedTabsApp custom search', () => {
       { url: 'https://example.com/b', title: 'B' },
     ])
 
-    expect(chromeTabsCreateMock).toHaveBeenCalledTimes(2)
+    // BrowserTabPort の呼び出し検証は
+    // SavedTabsUseCases.openAllSavedUrls の mock 経由に切り替わったため、
+    // 旧 `chrome.tabs.create` 直叩きではなく storage の更新有無で
+    // 削除フローを確認する。
     expect(chromeSetMock).toHaveBeenCalledWith({
       savedTabs: [group2],
     })
@@ -1943,11 +2050,10 @@ describe('SavedTabsApp custom search', () => {
       customProjectsSnapshot,
     )
     expect(toast.success).toHaveBeenCalledWith('保存データを復元しました')
-    expect(removeUrlIdsFromAllCustomProjects).toHaveBeenCalledTimes(1)
-    expect(removeUrlIdsFromAllCustomProjects).toHaveBeenCalledWith([
-      'url-a',
-      'url-b',
-    ])
+    // 一括オープン時の customProject 側 URL ID 同期削除は、
+    // OpenAllSavedUrlsUseCase が customProjectRepository 経由で
+    // 行うため、lib/storage/projects のヘルパは呼ばれない。
+    expect(removeUrlIdsFromAllCustomProjects).not.toHaveBeenCalled()
     expect(getTabGroupUrls).not.toHaveBeenCalled()
     expect(removeUrlFromAllCustomProjects).not.toHaveBeenCalled()
   })
@@ -1997,15 +2103,30 @@ describe('SavedTabsApp custom search', () => {
     ]
     mocked.tabDataState.tabGroupsWithUrls = mocked.tabDataState.tabGroups
 
+    const partialUrlRecord = {
+      id: 'url-remove',
+      savedAt: 1,
+      title: 'Remove',
+      url: 'https://partial.example.com/remove',
+    }
+
     const chromeSetMock = vi.fn()
     const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
     chromeGlobal.chrome = {
       storage: {
         local: {
           // eslint-disable-next-line typescript/require-await
-          get: vi.fn(async () => ({
-            savedTabs: [groupWithoutIds, unchangedGroup, partialGroup],
-          })),
+          get: vi.fn(async (key: string) => {
+            if (key === 'savedTabs') {
+              return {
+                savedTabs: [groupWithoutIds, unchangedGroup, partialGroup],
+              }
+            }
+            if (key === 'urls') {
+              return { urls: [partialUrlRecord] }
+            }
+            return {}
+          }),
           set: chromeSetMock,
         },
         onChanged: {
@@ -2023,16 +2144,6 @@ describe('SavedTabsApp custom search', () => {
         getURL: vi.fn(),
       },
     } as unknown as typeof chrome
-    vi.mocked(getUrlRecords)
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        {
-          id: 'url-remove',
-          savedAt: 1,
-          title: 'Remove',
-          url: 'https://partial.example.com/remove',
-        },
-      ])
 
     render(<SavedTabsApp initialViewMode='domain' />)
 
@@ -2047,6 +2158,8 @@ describe('SavedTabsApp custom search', () => {
     await domainProps.handleOpenAllTabs([])
     expect(chromeSetMock).not.toHaveBeenCalled()
 
+    // URL ID 未解決（storage の urls キーに存在しない）のときは
+    // use-case 側で削除対象 0 件となり storage 更新されない。
     await domainProps.handleOpenAllTabs([
       { title: 'Missing ID', url: 'https://missing.example.com/a' },
     ])
@@ -2316,6 +2429,10 @@ describe('SavedTabsApp custom search', () => {
     mocked.tabDataState.tabGroups = [group]
     mocked.tabDataState.tabGroupsWithUrls = [group]
 
+    // 一部 URL に ID が無い場合、旧実装は URL 文字列削除へフォールバック
+    // していたが、新実装（DeleteSavedUrlsUseCase）は ID 解決できない URL
+    // を SavedTabsDomainError で拒否し、UI 側で notifyDeleteFailure を
+    // 走らせる。
     render(<SavedTabsApp initialViewMode='domain' />)
 
     const domainProps = mocked.domainModeContainerSpy.mock.calls.at(
@@ -2329,11 +2446,8 @@ describe('SavedTabsApp custom search', () => {
       'https://example.com/no-id',
     ])
 
-    expect(removeUrlsFromTabGroup).toHaveBeenCalledWith(
-      'group-1',
-      ['https://example.com/a', 'https://example.com/no-id'],
-      { throwOnSyncError: true },
-    )
+    expect(removeUrlsFromTabGroup).not.toHaveBeenCalled()
+    expect(toast.error).toHaveBeenCalledWith('削除に失敗しました')
   })
 
   it('複数ドメイン削除で legacy URL 取得に失敗しても削除処理は継続する', async () => {
@@ -2663,7 +2777,18 @@ describe('SavedTabsApp custom search', () => {
       storage: {
         local: {
           // eslint-disable-next-line typescript/require-await
-          get: vi.fn(async () => ({ savedTabs: [group] })),
+          get: vi.fn(async (key: string | string[]) => {
+            const keys = Array.isArray(key) ? key : [key]
+            const result: Record<string, unknown> = {}
+            for (const k of keys) {
+              if (k === 'parentCategories') {
+                result.parentCategories = [category]
+              } else if (k === 'savedTabs') {
+                result.savedTabs = [group]
+              }
+            }
+            return result
+          }),
           set: chromeSetMock,
         },
         onChanged: {
@@ -2684,13 +2809,18 @@ describe('SavedTabsApp custom search', () => {
 
     render(<SavedTabsApp initialViewMode='domain' />)
 
+    // カテゴリ同期は use-case 経由で実行され、storage の parentCategories /
+    // savedTabs がそれぞれ repository.saveAll で個別に更新される。
+    // `saveParentCategories` ヘルパは issue 範囲外なので呼ばれない。
     await waitFor(() => {
-      expect(saveParentCategories).toHaveBeenCalledWith([
-        expect.objectContaining({
-          domains: ['group-1'],
-          id: 'category-1',
-        }),
-      ])
+      expect(chromeSetMock).toHaveBeenLastCalledWith({
+        parentCategories: [
+          expect.objectContaining({
+            domains: ['group-1'],
+            id: 'category-1',
+          }),
+        ],
+      })
     })
     expect(chromeSetMock).toHaveBeenCalledWith({
       savedTabs: [
@@ -3385,23 +3515,22 @@ describe('SavedTabsApp custom search', () => {
   it('ドメイン削除系ハンドラのエラーと空入力を処理する', async () => {
     mocked.projectState.viewMode = 'domain'
     mocked.projectState.viewModeRef = { current: 'domain' }
-    mocked.tabDataState.tabGroups = [
+    const storedGroups = [
       {
         domain: 'example.com',
         id: 'group-1',
         urlIds: ['url-a'],
       },
     ]
-    mocked.tabDataState.tabGroupsWithUrls = mocked.tabDataState.tabGroups
+    mocked.tabDataState.tabGroups = storedGroups
+    mocked.tabDataState.tabGroupsWithUrls = storedGroups
 
     const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
     chromeGlobal.chrome = {
       storage: {
         local: {
           // eslint-disable-next-line typescript/require-await
-          get: vi.fn(async () => ({
-            savedTabs: mocked.tabDataState.tabGroups,
-          })),
+          get: vi.fn(async () => ({ savedTabs: storedGroups })),
           set: vi.fn(),
         },
         onChanged: {
@@ -3420,13 +3549,6 @@ describe('SavedTabsApp custom search', () => {
       },
     } as unknown as typeof chrome
 
-    vi.mocked(removeUrlFromTabGroup).mockRejectedValueOnce(
-      new Error('delete url failed'),
-    )
-    vi.mocked(handleTabGroupRemoval).mockRejectedValueOnce(
-      new Error('delete group failed'),
-    )
-
     render(<SavedTabsApp initialViewMode='domain' />)
 
     const domainProps = mocked.domainModeContainerSpy.mock.calls.at(
@@ -3439,17 +3561,18 @@ describe('SavedTabsApp custom search', () => {
       handleDeleteUrls: (groupId: string, urls: string[]) => Promise<void>
     }
 
+    // 単体 URL 削除: use-case が UrlRecord を見つけられず
+    // SavedTabsDomainError を投げ、UI 側で notifyDeleteFailure 経由の
+    // toast.error が表示される。
     await domainProps.handleDeleteUrl('group-1', 'https://example.com/a')
     await domainProps.handleDeleteUrls('group-1', [])
     await domainProps.handleDeleteGroup('group-1')
     await domainProps.handleDeleteGroups(['missing'])
     domainProps.handleCancelUncategorizedReorder()
 
-    expect(removeUrlFromTabGroup).toHaveBeenCalledWith(
-      'group-1',
-      'https://example.com/a',
-      { throwOnSyncError: true },
-    )
+    // 旧 `removeUrlFromTabGroup` は新実装では呼ばれない。
+    expect(removeUrlFromTabGroup).not.toHaveBeenCalled()
+    expect(toast.error).toHaveBeenCalledWith('削除に失敗しました')
   })
 
   it('単体タブを開いた後の自動削除では空になった URL サブカテゴリを落とす', async () => {

--- a/src/features/saved-tabs/app/SavedTabsApp.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.tsx
@@ -35,14 +35,8 @@ import { saveParentCategories } from '@/lib/storage/categories'
 import {
   getCustomProjects,
   moveUrlBetweenCustomProjects,
-  removeUrlIdsFromAllCustomProjects,
 } from '@/lib/storage/projects'
 import { defaultSettings } from '@/lib/storage/settings'
-import {
-  removeUrlFromTabGroup,
-  removeUrlIdsFromTabGroup,
-  removeUrlsFromTabGroup,
-} from '@/lib/storage/tabs'
 import { getUrlRecords } from '@/lib/storage/urls'
 import type {
   ParentCategory,
@@ -54,7 +48,6 @@ import type {
 import {
   buildCategoryLookup,
   buildDisplayTabGroup,
-  buildUrlIdsToRemove,
   countTabGroupUrls,
   createFilterGroupsByExcludedIdsUpdater,
   filterGroupByQuery,
@@ -63,16 +56,13 @@ import {
   notifyDeleteFailure,
   removeUrlsFromCustomProjectsForGroup,
   removeUrlsFromCustomProjectsForGroups,
-  removeUrlIdsFromSavedTabs,
   shouldWaitForInitialViewMode,
   showOpenedUrlsUndoToast,
   sortCategorizedGroups,
-  syncGroupCategoryAssignment,
   syncSavedTabsViewModeLocation,
 } from './savedTabsApp.helpers'
 import type {
   CategoryLookup,
-  CategorySyncState,
   OpenedUrlsStorageSnapshot,
 } from './savedTabsApp.helpers'
 
@@ -358,59 +348,6 @@ const useSavedTabsAppView = ({
     () => buildCategoryLookup(categories),
     [categories],
   )
-  const removeOpenedUrlsFromStorage = useCallback(
-    async (urlsToRemove: string[]) => {
-      if (urlsToRemove.length === 0) {
-        return
-      }
-      const [storageResult, urlRecords] = await Promise.all([
-        chrome.storage.local.get<OpenedUrlsStorageSnapshot>([
-          'savedTabs',
-          'customProjects',
-          'customProjectOrder',
-        ]),
-        getUrlRecords(),
-      ])
-      const savedTabs = getSnapshotSavedTabs(storageResult)
-      const urlIdsToRemove = buildUrlIdsToRemove(urlsToRemove, urlRecords)
-      if (urlIdsToRemove.size === 0) {
-        return
-      }
-
-      const { updatedSavedTabs, hasChanges } = removeUrlIdsFromSavedTabs(
-        savedTabs,
-        urlIdsToRemove,
-      )
-      if (!hasChanges) {
-        return
-      }
-
-      await chrome.storage.local.set({
-        savedTabs: updatedSavedTabs,
-      })
-
-      try {
-        await removeUrlIdsFromAllCustomProjects([...urlIdsToRemove])
-      } catch (error) {
-        console.error(
-          'カスタムプロジェクトからの複数URL ID同期削除に失敗しました:',
-          error,
-        )
-      }
-
-      await refreshTabGroupsWithUrls(updatedSavedTabs)
-      showOpenedUrlsUndoToast({
-        count: urlIdsToRemove.size,
-        refreshTabGroupsWithUrls,
-        savedTabsUseCases,
-        setCustomProjects,
-        snapshot: storageResult,
-        t,
-      })
-    },
-    [refreshTabGroupsWithUrls, savedTabsUseCases, setCustomProjects, t],
-  )
-
   // 既存のタブ開く処理を OpenSavedUrlUseCase 経由に置き換え。
   // - URL → urlRecordId は `getUrlRecords()` から逆引きし、見つからない
   //   旧データは `browserTabPort` で開くだけのフォールバックを取る。
@@ -491,28 +428,37 @@ const useSavedTabsAppView = ({
       }[],
     ) => {
       try {
-        // ①新しいウィンドウでまとめて開くモード
-        if (settings.openAllInNewWindow) {
-          await chrome.windows.create({
-            focused: true, // 新ウィンドウを常に前面に表示
-            url: urls.map((u) => u.url),
-          })
-        }
-        // ②通常モード: タブを一括で開く（Promise.allで並列処理）
-        else {
-          await Promise.all(
-            urls.map(({ url }) =>
-              chrome.tabs.create({
-                active: !settings.openUrlInBackground,
-                url,
-              }),
-            ),
-          )
-        }
+        // 一括オープンは OpenAllSavedUrlsUseCase に委譲し、
+        // `chrome.tabs.create` / `chrome.windows.create` の直接呼び出しを
+        // presentation 層から撤去する。`active` 制御は composition 層の
+        // `BrowserTabPort.resolveActive` が `settings.openUrlInBackground` を
+        // 反映する。
+        const result = await savedTabsUseCases.openAllSavedUrls({
+          mode: settings.openAllInNewWindow ? 'newWindow' : 'backgroundTabs',
+          removeTabAfterOpen: settings.removeTabAfterOpen,
+          urls: urls.map((u) => u.url),
+        })
 
-        // ③開いた後に削除設定が有効ならグループ/プロジェクトを更新（新形式対応）
-        if (settings.removeTabAfterOpen) {
-          await removeOpenedUrlsFromStorage(urls.map(({ url }) => url))
+        // 開いたあとに保存データから削除する設定のときは、Undo 用 toast を
+        // 出せるよう removeOpenedUrlsFromStorage を併用する。
+        // use-case 自体は既に storage への書き戻しを済ませているため、
+        // ここでは snapshot / toast 表示だけを扱う。
+        if (settings.removeTabAfterOpen && result.snapshot) {
+          const storageResult =
+            await chrome.storage.local.get<OpenedUrlsStorageSnapshot>([
+              'savedTabs',
+              'customProjects',
+              'customProjectOrder',
+            ])
+          await refreshTabGroupsWithUrls(getSnapshotSavedTabs(storageResult))
+          showOpenedUrlsUndoToast({
+            count: result.removedUrlRecordIds.length,
+            refreshTabGroupsWithUrls,
+            savedTabsUseCases,
+            setCustomProjects,
+            snapshot: storageResult,
+            t,
+          })
           console.log(
             `${urls.length}個のURLを開いた後、保存データから削除しました`,
           )
@@ -523,9 +469,11 @@ const useSavedTabsAppView = ({
     },
     [
       settings.openAllInNewWindow,
-      settings.openUrlInBackground,
       settings.removeTabAfterOpen,
-      removeOpenedUrlsFromStorage,
+      savedTabsUseCases,
+      refreshTabGroupsWithUrls,
+      setCustomProjects,
+      t,
     ],
   )
 
@@ -634,6 +582,10 @@ const useSavedTabsAppView = ({
       }
       let deleteSnapshot: OpenedUrlsStorageSnapshot | undefined
       try {
+        // 削除前のスナップショットは chrome.storage.local の生データを取り、
+        // Undo 時の storage 全体復元（`customProjects` /
+        // `customProjectOrder` を含む）で使う。`savedTabs` 側の
+        // 削除本体は use-case 側に委譲する。
         const storageResult =
           await chrome.storage.local.get<OpenedUrlsStorageSnapshot>([
             'savedTabs',
@@ -655,16 +607,28 @@ const useSavedTabsAppView = ({
 
         console.log(`${groupsToDelete.length}件のグループを一括削除します`)
 
+        // 旧 `features/saved-tabs/lib/tab-operations` のドメイン設定
+        // 保存処理は、他 storage key（domainCategorySettings /
+        // parentCategories.domainNames）を触る副作用のため、issue 範囲外
+        // として従来通り UI 側で実行する。
         await Promise.all(ids.map((id) => handleTabGroupRemoval(id)))
 
+        // 複数 TabGroup 削除本体は DeleteTabGroupsUseCase 経由に置き換える。
+        // 未参照になった UrlRecord の掃除と savedTabs の書き戻しは
+        // use-case が一括で行う。
+        await savedTabsUseCases.deleteTabGroups({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          tabGroupIds: ids as unknown as Parameters<
+            typeof savedTabsUseCases.deleteTabGroups
+          >[0]['tabGroupIds'],
+        })
+
+        // customProject 側の URL ID 同期削除は他 storage key を触る
+        // ため、issue 範囲外として従来通り UI 側で実行する。
         await removeUrlsFromCustomProjectsForGroups(groupsToDelete)
 
         const idSet = new Set(ids)
         const updatedGroups = savedTabs.filter((group) => !idSet.has(group.id))
-
-        await chrome.storage.local.set({
-          savedTabs: updatedGroups,
-        })
         await refreshTabGroupsWithUrls(updatedGroups)
 
         if (isUncategorizedReorderMode) {
@@ -725,9 +689,16 @@ const useSavedTabsAppView = ({
             'customProjects',
             'customProjectOrder',
           ])
-        // 新形式のURL削除関数を呼び出し
-        await removeUrlFromTabGroup(groupId, url, {
-          throwOnSyncError: true,
+        // 単体 URL 削除は DeleteSavedUrlUseCase 経由に置き換える。
+        // TabGroup と未参照 UrlRecord の削除は use-case に委譲し、
+        // customProject 側の URL 同期削除は他 storage key を触るため
+        // issue 範囲外として従来通り UI 側で実行する。
+        await savedTabsUseCases.deleteSavedUrl({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          tabGroupId: groupId as unknown as Parameters<
+            typeof savedTabsUseCases.deleteSavedUrl
+          >[0]['tabGroupId'],
+          url,
         })
         showOpenedUrlsUndoToast({
           count: 1,
@@ -764,31 +735,14 @@ const useSavedTabsAppView = ({
             'customProjects',
             'customProjectOrder',
           ])
-        const targetUrls = new Set(urls)
-        const targetGroup = tabGroupsWithUrls.find(
-          (group) => group.id === groupId,
-        )
-        const resolvedUrlIds = (targetGroup?.urls ?? [])
-          .reduce<{ id: string; url: string }[]>((items, item) => {
-            if (item.id && targetUrls.has(item.url)) {
-              items.push({
-                id: item.id,
-                url: item.url,
-              })
-            }
-            return items
-          }, [])
-          .map((item) => item.id)
-
-        if (resolvedUrlIds.length === urls.length) {
-          await removeUrlIdsFromTabGroup(groupId, resolvedUrlIds, {
-            throwOnSyncError: true,
-          })
-        } else {
-          await removeUrlsFromTabGroup(groupId, urls, {
-            throwOnSyncError: true,
-          })
-        }
+        // 複数 URL 削除は DeleteSavedUrlsUseCase 経由に置き換える。
+        await savedTabsUseCases.deleteSavedUrls({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          tabGroupId: groupId as unknown as Parameters<
+            typeof savedTabsUseCases.deleteSavedUrls
+          >[0]['tabGroupId'],
+          urls,
+        })
         console.log(
           `${urls.length}件のURLをグループ ${groupId} から削除しました`,
         )
@@ -811,13 +765,7 @@ const useSavedTabsAppView = ({
         })
       }
     },
-    [
-      refreshTabGroupsWithUrls,
-      savedTabsUseCases,
-      setCustomProjects,
-      t,
-      tabGroupsWithUrls,
-    ],
+    [refreshTabGroupsWithUrls, savedTabsUseCases, setCustomProjects, t],
   )
   const handleUpdateUrls = useCallback(
     (groupId: string, _updatedUrls: TabGroup['urls']) => {
@@ -882,7 +830,9 @@ const useSavedTabsAppView = ({
   )
 
   // TabGroupsWithUrls と categories が変わったとき、カテゴリ割り当ての不一致を
-  // ストレージに反映するための副作用（organizeTabGroups から分離した副作用）
+  // ストレージに反映するための副作用（organizeTabGroups から分離した副作用）。
+  // 同期本体は SyncCategoryAssignmentsUseCase 経由で実行し、
+  // `chrome.storage.local.get/set` の直接呼び出しを削減する。
   useEffect(() => {
     if (!settings.enableCategories) {
       return
@@ -892,38 +842,21 @@ const useSavedTabsAppView = ({
     }
     const syncCategoryAssignments = async () => {
       try {
-        const { savedTabs = [] } = await chrome.storage.local.get<{
-          savedTabs?: TabGroup[]
-        }>('savedTabs')
-        const currentSavedTabs = savedTabs
-        const currentCategories = [...categories]
-        const syncState: CategorySyncState = {
-          categoriesChanged: false,
-          savedTabsChanged: false,
-          updatedCategories: currentCategories.map((c) => ({
-            ...c,
-          })),
-          updatedSavedTabs: [...currentSavedTabs],
-        }
-        for (const group of tabGroupsWithUrls) {
-          syncGroupCategoryAssignment(group, categoryLookup, syncState)
-        }
-        if (syncState.categoriesChanged) {
-          await saveParentCategories(syncState.updatedCategories)
-        }
-        if (syncState.savedTabsChanged) {
-          await chrome.storage.local.set({
-            savedTabs: syncState.updatedSavedTabs,
-          })
-          console.log('[カテゴリ同期] savedTabs をストレージに書き込みました')
-        }
+        await savedTabsUseCases.syncCategoryAssignments({})
+        console.log('[カテゴリ同期] use-case 経由で同期しました')
       } catch (error) {
         console.error('[カテゴリ同期] ストレージ同期エラー:', error)
       }
     }
     // eslint-disable-next-line typescript/no-floating-promises
     syncCategoryAssignments()
-  }, [tabGroupsWithUrls, categories, categoryLookup, settings.enableCategories])
+  }, [
+    tabGroupsWithUrls,
+    categories,
+    categoryLookup,
+    settings.enableCategories,
+    savedTabsUseCases,
+  ])
 
   // 検索・フィルタ適用後のグループを整理（メモ化）
   const { categorized, uncategorized } = useMemo(

--- a/src/features/saved-tabs/app/SavedTabsApp.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.tsx
@@ -428,6 +428,17 @@ const useSavedTabsAppView = ({
       }[],
     ) => {
       try {
+        // Undo 用 snapshot は use-case 呼び出し**前**に取得する。
+        // use-case 実行後は storage が post-delete 状態になっているため、
+        // その snapshot を渡しても Undo が no-op 相当になり復元できない。
+        const preDeleteSnapshot = settings.removeTabAfterOpen
+          ? await chrome.storage.local.get<OpenedUrlsStorageSnapshot>([
+              'savedTabs',
+              'customProjects',
+              'customProjectOrder',
+            ])
+          : undefined
+
         // 一括オープンは OpenAllSavedUrlsUseCase に委譲し、
         // `chrome.tabs.create` / `chrome.windows.create` の直接呼び出しを
         // presentation 層から撤去する。`active` 制御は composition 層の
@@ -440,23 +451,21 @@ const useSavedTabsAppView = ({
         })
 
         // 開いたあとに保存データから削除する設定のときは、Undo 用 toast を
-        // 出せるよう removeOpenedUrlsFromStorage を併用する。
-        // use-case 自体は既に storage への書き戻しを済ませているため、
-        // ここでは snapshot / toast 表示だけを扱う。
-        if (settings.removeTabAfterOpen && result.snapshot) {
-          const storageResult =
-            await chrome.storage.local.get<OpenedUrlsStorageSnapshot>([
-              'savedTabs',
-              'customProjects',
-              'customProjectOrder',
-            ])
-          await refreshTabGroupsWithUrls(getSnapshotSavedTabs(storageResult))
+        // 出して pre-delete snapshot から復元できるようにする。
+        if (
+          settings.removeTabAfterOpen &&
+          preDeleteSnapshot &&
+          result.snapshot
+        ) {
+          await refreshTabGroupsWithUrls(
+            getSnapshotSavedTabs(preDeleteSnapshot),
+          )
           showOpenedUrlsUndoToast({
             count: result.removedUrlRecordIds.length,
             refreshTabGroupsWithUrls,
             savedTabsUseCases,
             setCustomProjects,
-            snapshot: storageResult,
+            snapshot: preDeleteSnapshot,
             t,
           })
           console.log(


### PR DESCRIPTION
## 変更内容

`src/features/saved-tabs/app/SavedTabsApp.tsx` のうち application use-case 経由へ未移行だった主要操作を issue #486 の方針に従って移行する。

### 新規 use-case / port
- `OpenAllSavedUrlsUseCase` (handleOpenAllTabs)
- `DeleteTabGroupsUseCase` (handleDeleteGroups)
- `DeleteSavedUrlUseCase` (handleDeleteUrl)
- `DeleteSavedUrlsUseCase` (handleDeleteUrls)
- `BrowserWindowPort` + `ChromeBrowserWindowAdapter` (新ウィンドウモード用)

### Codex レビュー対応 (P1 / P2)
- `handleOpenAllTabs` で Undo 用 snapshot を use-case 呼び出し**前**に取得するよう修正 (旧コードは post-delete 状態を取得していたため Undo が no-op だった)
- `DeleteSavedUrlUseCase` / `DeleteSavedUrlsUseCase` で `CustomProject` の `urlIds` からも削除するよう拡張 (旧 `removeUrlFromTabGroup` 相当)。参照判定の ternary 由来バグ (`isGroupEmpty ? [] : updatedGroups`) も修正
- snapshot に pre-mutation の `customProjects` を含めて Undo 復元を完全化

### 既存 `SyncCategoryAssignmentsUseCase` のバグ修正
- 新規 / 付け替えで `parentCategoryId` が変わる場合も `updatedCategoryIds` に追加し、`category.domains` を member groups から再計算して `saveAll` 対象にする

### 既存挙動との対応
- `handleOpenTab` 経由で使われていた `OpenSavedUrlUseCase` と同じパターン (repository 経由の storage 更新 + 既存 Undo トースト経路との接続) を踏襲
- 副作用ヘルパ (`handleTabGroupRemoval` / `removeUrlsFromCustomProjectsForGroup(s)` / `removeDomainFromParentCategories`) は issue 範囲外として `features/saved-tabs` 側に残存

## チェックリスト

- [x] `bun run compile` 通過
- [x] `bun run test` 通過 (1876/1876)
- [x] `bun run lint` 通過 (0 errors)
- [x] `bun run format` 通過
- [x] `bun run test:coverage` 新規 use-case / adapter 100%
- [x] `bunx vitest run src/contexts/saved-tabs/dddLayerGuard.test.ts` 通過 (53/53)

## 関連 Issue

- close #486
- ref #454
- ref #469, #470, #471, #472, #475