### PR TITLE
feat(#487): customProjectOrder の復元を repository / use-case 経由に置き換え

### DIFF
--- a/src/contexts/saved-tabs/application/dto/RestoredSnapshotDto.ts
+++ b/src/contexts/saved-tabs/application/dto/RestoredSnapshotDto.ts
@@ -2,6 +2,7 @@ import type { CustomProject } from '../../domain/entities/CustomProject'
 import type { ParentCategory } from '../../domain/entities/ParentCategory'
 import type { TabGroup } from '../../domain/entities/TabGroup'
 import type { UrlRecord } from '../../domain/entities/UrlRecord'
+import type { CustomProjectId } from '../../domain/value-objects/CustomProjectId'
 
 /**
  * `RestoreOpenedUrlsSnapshotUseCase` の結果 DTO。
@@ -10,10 +11,16 @@ import type { UrlRecord } from '../../domain/entities/UrlRecord'
  * 既に他の `TabGroup` と衝突する）を表現するため、各フィールドを
  * optional にしてある。presentation 層は件数だけ表示するか、
  * 個別に成功 / 失敗を通知するかを選べる。
+ *
+ * `restoredCustomProjectOrder` は snapshot に `customProjectOrder` が
+ * 含まれていたときだけ値を返し、未指定なら `undefined` のまま。
+ * 既存データ（`order` 未保存の snapshot）と後方互換を保つため、
+ * 必須フィールドにはしない。
  */
 export interface RestoredSnapshotDto {
   readonly restoredTabGroups: readonly TabGroup[]
   readonly restoredUrlRecords: readonly UrlRecord[]
   readonly restoredCustomProjects: readonly CustomProject[]
   readonly restoredParentCategories: readonly ParentCategory[]
+  readonly restoredCustomProjectOrder?: readonly CustomProjectId[]
 }

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.test.ts
@@ -77,6 +77,10 @@ const createInMemoryRepositories = (
     saveAll: async (projects) => {
       customProjects.splice(0, customProjects.length, ...projects)
     },
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async () => undefined,
   }
   return {
     customProjectRepository,

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.test.ts
@@ -77,6 +77,10 @@ const createInMemoryRepositories = (
     saveAll: async (projects) => {
       customProjects.splice(0, customProjects.length, ...projects)
     },
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async () => undefined,
   }
   return {
     customProjectRepository,

--- a/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupUseCase.test.ts
@@ -73,6 +73,10 @@ const createInMemoryRepositories = (
     saveAll: async (projects) => {
       customProjects.splice(0, customProjects.length, ...projects)
     },
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async () => undefined,
   }
   return {
     customProjectRepository,

--- a/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupsUseCase.test.ts
@@ -77,6 +77,10 @@ const createInMemoryRepositories = (
     saveAll: async (projects) => {
       customProjects.splice(0, customProjects.length, ...projects)
     },
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async () => undefined,
   }
   return {
     customProjectRepository,

--- a/src/contexts/saved-tabs/application/use-cases/OpenAllSavedUrlsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/OpenAllSavedUrlsUseCase.test.ts
@@ -77,6 +77,10 @@ const createInMemoryRepositories = (
     saveAll: async (projects) => {
       customProjects.splice(0, customProjects.length, ...projects)
     },
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async () => undefined,
   }
   return { customProjectRepository, tabGroupRepository, urlRecordRepository }
 }

--- a/src/contexts/saved-tabs/application/use-cases/OpenSavedUrlUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/OpenSavedUrlUseCase.test.ts
@@ -84,6 +84,10 @@ const createInMemoryRepositories = (
     saveAll: async (projects) => {
       customProjects.splice(0, customProjects.length, ...projects)
     },
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async () => undefined,
   }
   return {
     customProjectRepository,

--- a/src/contexts/saved-tabs/application/use-cases/RemoveUnreferencedUrlRecordsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveUnreferencedUrlRecordsUseCase.test.ts
@@ -64,6 +64,10 @@ const createInMemoryRepositories = (
     removeByIds: async () => undefined,
     // eslint-disable-next-line typescript/require-await
     saveAll: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async () => undefined,
   }
   return {
     customProjectRepository,

--- a/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.test.ts
@@ -8,6 +8,7 @@ import type { CustomProjectRepository } from '../../domain/repositories/CustomPr
 import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
 import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
 import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import { createCustomProjectId } from '../../domain/value-objects/CustomProjectId'
 import type { RestoreOpenedUrlsSnapshotUseCaseDeps } from './RestoreOpenedUrlsSnapshotUseCase'
 import { createRestoreOpenedUrlsSnapshotUseCase } from './RestoreOpenedUrlsSnapshotUseCase'
 
@@ -15,6 +16,7 @@ interface Repositories extends RestoreOpenedUrlsSnapshotUseCaseDeps {
   tabGroups: ReturnType<typeof createTabGroup>[]
   urlRecords: ReturnType<typeof createUrlRecord>[]
   customProjects: ReturnType<typeof createCustomProject>[]
+  customProjectOrder: ReturnType<typeof createCustomProjectId>[]
   parentCategories: ReturnType<typeof createParentCategory>[]
 }
 
@@ -23,6 +25,7 @@ const createInMemoryRepositories = (
     tabGroups?: ReturnType<typeof createTabGroup>[]
     urlRecords?: ReturnType<typeof createUrlRecord>[]
     customProjects?: ReturnType<typeof createCustomProject>[]
+    customProjectOrder?: ReturnType<typeof createCustomProjectId>[]
     parentCategories?: ReturnType<typeof createParentCategory>[]
   } = {},
 ): Repositories => {
@@ -34,6 +37,9 @@ const createInMemoryRepositories = (
   ]
   const customProjects: ReturnType<typeof createCustomProject>[] = [
     ...(initial.customProjects ?? []),
+  ]
+  const customProjectOrder: ReturnType<typeof createCustomProjectId>[] = [
+    ...(initial.customProjectOrder ?? []),
   ]
   const parentCategories: ReturnType<typeof createParentCategory>[] = [
     ...(initial.parentCategories ?? []),
@@ -87,6 +93,12 @@ const createInMemoryRepositories = (
     saveAll: async (projects) => {
       customProjects.splice(0, customProjects.length, ...projects)
     },
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [...customProjectOrder],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async (order) => {
+      customProjectOrder.splice(0, customProjectOrder.length, ...order)
+    },
   }
   const parentCategoryRepository: ParentCategoryRepository = {
     // eslint-disable-next-line typescript/require-await
@@ -108,6 +120,7 @@ const createInMemoryRepositories = (
     },
   }
   return {
+    customProjectOrder,
     customProjectRepository,
     customProjects,
     parentCategories,
@@ -265,6 +278,44 @@ describe('RestoreOpenedUrlsSnapshotUseCase', () => {
     expect(result.restoredUrlRecords).toStrictEqual([])
     expect(result.restoredCustomProjects).toStrictEqual([])
     expect(result.restoredParentCategories).toStrictEqual([])
+    expect(result.restoredCustomProjectOrder).toBeUndefined()
     expect(repos.tabGroups).toStrictEqual([])
+    expect(repos.customProjectOrder).toStrictEqual([])
+  })
+
+  it('snapshot の customProjectOrder を repository 経由で保存する', async () => {
+    const repos = createInMemoryRepositories({
+      customProjectOrder: [
+        createCustomProjectId('project-old'),
+        createCustomProjectId('project-stale'),
+      ],
+    })
+    const useCase = createRestoreOpenedUrlsSnapshotUseCase(repos)
+
+    const result = await useCase({
+      snapshot: {
+        customProjectOrder: ['project-new', 'project-old', 'project-new', ''],
+      },
+    })
+
+    expect(result.restoredCustomProjectOrder?.map((id) => id)).toStrictEqual([
+      'project-new',
+      'project-old',
+    ])
+    expect(repos.customProjectOrder.map((id) => id)).toStrictEqual([
+      'project-new',
+      'project-old',
+    ])
+  })
+
+  it('snapshot に customProjectOrder が無いとき repository には書き戻さない', async () => {
+    const initial = [createCustomProjectId('project-keep')]
+    const repos = createInMemoryRepositories({ customProjectOrder: initial })
+    const useCase = createRestoreOpenedUrlsSnapshotUseCase(repos)
+
+    const result = await useCase({ snapshot: {} })
+
+    expect(result.restoredCustomProjectOrder).toBeUndefined()
+    expect(repos.customProjectOrder).toStrictEqual(initial)
   })
 })

--- a/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.ts
@@ -2,6 +2,8 @@ import type { CustomProjectRepository } from '../../domain/repositories/CustomPr
 import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
 import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
 import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import { createCustomProjectId } from '../../domain/value-objects/CustomProjectId'
+import type { CustomProjectId } from '../../domain/value-objects/CustomProjectId'
 import type { RestoreOpenedUrlsSnapshotCommand } from '../commands/RestoreOpenedUrlsSnapshotCommand'
 import type { RestoredSnapshotDto } from '../dto/RestoredSnapshotDto'
 
@@ -26,6 +28,34 @@ export type RestoreOpenedUrlsSnapshotUseCase = (
 ) => Promise<RestoredSnapshotDto>
 
 /**
+ * snapshot 内の `customProjectOrder` を検証して `CustomProjectId[]` へ
+ * 正規化する。空文字や重複は破棄し、復元対象から外す。
+ *
+ * 旧 `presentation` 層で `chrome.storage.local.set({ customProjectOrder })`
+ * を補助呼び出ししていた処理を repository 経由に置き換える（issue #487）。
+ */
+const normalizeCustomProjectOrder = (
+  order: readonly string[] | undefined,
+): readonly CustomProjectId[] | undefined => {
+  if (!order) {
+    return undefined
+  }
+  const result: CustomProjectId[] = []
+  const seen = new Set<string>()
+  for (const raw of order) {
+    if (typeof raw !== 'string' || raw.length === 0) {
+      continue
+    }
+    if (seen.has(raw)) {
+      continue
+    }
+    seen.add(raw)
+    result.push(createCustomProjectId(raw))
+  }
+  return result
+}
+
+/**
  * `RestoreOpenedUrlsSnapshotUseCase` を生成する。
  *
  * 責務:
@@ -36,9 +66,11 @@ export type RestoreOpenedUrlsSnapshotUseCase = (
  * - `savedTabs` / `urlRecords` / `customProjects` については、
  *   snapshot の内容を **既存データへ追加** する（ID 重複は snapshot 優先）。
  * - `parentCategories` は `saveAll` で全置換する（カテゴリは集合として扱う）。
- * - `customProjectOrder` は repository interface がないため、現状は DTO へ
- *   そのまま載せず、presentation 層で `chrome.storage.local` へ書き戻す
- *   拡張は別 issue に切り出す。
+ * - `customProjectOrder` は `customProjectRepository.saveOrder` で
+ *   snapshot の値で **全置換** する。`order` は表示用並び順なので
+ *   「既存に項目を残してマージ」する意味が薄く、Undo 押下時点の
+ *   ユーザー期待は「snapshot 時点の表示順に戻る」ため、全置換が
+ *   直感に合う（issue #487）。
  *
  * この use-case は冪等ではなく、Undo ボタンが押されるたびに
  * 同じ snapshot を適用する想定。複数回押された場合は
@@ -54,6 +86,9 @@ export const createRestoreOpenedUrlsSnapshotUseCase = (
     const restoredUrlRecords = snapshot.urlRecords ?? []
     const restoredCustomProjects = snapshot.customProjects ?? []
     const restoredParentCategories = snapshot.parentCategories ?? []
+    const restoredCustomProjectOrder = normalizeCustomProjectOrder(
+      snapshot.customProjectOrder,
+    )
 
     if (snapshot.savedTabs && snapshot.savedTabs.length > 0) {
       const existing = await deps.tabGroupRepository.findAll()
@@ -93,7 +128,12 @@ export const createRestoreOpenedUrlsSnapshotUseCase = (
       await deps.parentCategoryRepository.saveAll(snapshot.parentCategories)
     }
 
+    if (restoredCustomProjectOrder) {
+      await deps.customProjectRepository.saveOrder(restoredCustomProjectOrder)
+    }
+
     return {
+      restoredCustomProjectOrder,
       restoredCustomProjects,
       restoredParentCategories,
       restoredTabGroups,

--- a/src/contexts/saved-tabs/domain/repositories/CustomProjectRepository.ts
+++ b/src/contexts/saved-tabs/domain/repositories/CustomProjectRepository.ts
@@ -5,8 +5,16 @@ import type { CustomProjectId } from '../value-objects/CustomProjectId'
  * `CustomProject` の永続化責務だけを抽出した repository interface。
  *
  * プロジェクト単位での URL 集約 (`urlIds` / `categories` / `createdAt` /
- * `updatedAt`) の読み書きだけを domain interface に閉じ込め、
- * 並び替え・カテゴリ追加・URL 追加などは use-case 側で表現する。
+ * `updatedAt`) の読み書きと、表示順 (`order`) の読み書きだけを
+ * domain interface に閉じ込める。並び替え・カテゴリ追加・URL 追加などは
+ * use-case 側で表現する。
+ *
+ * `order` は `CustomProject` 集合とは独立した「表示用の並び順」であり、
+ * 同じ ID を持つ `CustomProject` が storage 上から消えても `order` の
+ * エントリは残ってよい。presentation 層は order を手掛かりに
+ * `CustomProject` 配列を stable sort し、未知 ID は末尾へ送る / 無視する
+ * などのフォールバックを行う。`saveOrder` は生 ID 配列をそのまま保存する
+ * 素のマッピングに留め、storage key との対応は実装側に閉じる。
  *
  * `chrome.storage.local` の直接アクセスは禁止。実装は
  * `src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/` 側に置く。
@@ -14,6 +22,7 @@ import type { CustomProjectId } from '../value-objects/CustomProjectId'
  * @example
  * ```ts
  * const projects = await customProjectRepository.findAll()
+ * const order = await customProjectRepository.findOrder()
  * const target = projects.find((project) => project.id === projectId)
  * ```
  */
@@ -22,4 +31,6 @@ export interface CustomProjectRepository {
   findById: (id: CustomProjectId) => Promise<CustomProject | null>
   saveAll: (projects: readonly CustomProject[]) => Promise<void>
   removeByIds: (ids: readonly CustomProjectId[]) => Promise<void>
+  findOrder: () => Promise<readonly CustomProjectId[]>
+  saveOrder: (order: readonly CustomProjectId[]) => Promise<void>
 }

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.test.ts
@@ -5,7 +5,10 @@ import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStora
 import { createChromeCustomProjectRepository } from './ChromeCustomProjectRepository'
 import { SavedTabsRepositoryUnavailableError } from './ChromeUrlRecordRepository'
 import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
-import { CUSTOM_PROJECTS_KEY } from './savedTabsStorageKeys'
+import {
+  CUSTOM_PROJECT_ORDER_KEY,
+  CUSTOM_PROJECTS_KEY,
+} from './savedTabsStorageKeys'
 
 type StorageState = Record<string, unknown>
 
@@ -393,6 +396,66 @@ describe('ChromeCustomProjectRepository', () => {
       const repo = createChromeCustomProjectRepository(port)
       await repo.removeByIds([])
       expect(port.set).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('findOrder', () => {
+    it('空 storage のとき空配列を返す', async () => {
+      const repo = createChromeCustomProjectRepository(createPort({}))
+      await expect(repo.findOrder()).resolves.toStrictEqual([])
+    })
+
+    it('CUSTOM_PROJECT_ORDER_KEY の生 string[] を CustomProjectId[] として返す', async () => {
+      const state: StorageState = {
+        [CUSTOM_PROJECT_ORDER_KEY]: ['project-2', 'project-1'],
+      }
+      const repo = createChromeCustomProjectRepository(createPort(state))
+      const result = await repo.findOrder()
+      expect(result.map((id) => id)).toStrictEqual(['project-2', 'project-1'])
+    })
+
+    it('非配列 / 配列でない string / 空文字 / 重複を除外して返す', async () => {
+      const state: StorageState = {
+        [CUSTOM_PROJECT_ORDER_KEY]: [
+          'project-1',
+          '',
+          null,
+          42,
+          'project-1',
+          'project-2',
+        ],
+      }
+      const repo = createChromeCustomProjectRepository(createPort(state))
+      const result = await repo.findOrder()
+      expect(result.map((id) => id)).toStrictEqual(['project-1', 'project-2'])
+    })
+  })
+
+  describe('saveOrder', () => {
+    it('CustomProjectId[] を CUSTOM_PROJECT_ORDER_KEY に string[] として保存する', async () => {
+      const port = createPort({})
+      const repo = createChromeCustomProjectRepository(port)
+      await repo.saveOrder([
+        createCustomProjectId('project-1'),
+        createCustomProjectId('project-2'),
+      ])
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      expect(lastSetArg[CUSTOM_PROJECT_ORDER_KEY]).toStrictEqual([
+        'project-1',
+        'project-2',
+      ])
+    })
+
+    it('空配列を渡したら空配列を保存する', async () => {
+      const port = createPort({})
+      const repo = createChromeCustomProjectRepository(port)
+      await repo.saveOrder([])
+      const lastSetArg = (port.set as ReturnType<typeof vi.fn>).mock.calls.at(
+        -1,
+      )?.[0] as Record<string, unknown>
+      expect(lastSetArg[CUSTOM_PROJECT_ORDER_KEY]).toStrictEqual([])
     })
   })
 })

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository.ts
@@ -9,7 +9,10 @@ import type { CustomProjectId } from '../../../domain/value-objects/CustomProjec
 import { ChromeSavedTabsStorageMapper } from '../../mappers/ChromeSavedTabsStorageMapper'
 import { SavedTabsRepositoryUnavailableError } from './ChromeUrlRecordRepository'
 import type { ChromeStorageLocalPort } from './ChromeUrlRecordRepository'
-import { CUSTOM_PROJECTS_KEY } from './savedTabsStorageKeys'
+import {
+  CUSTOM_PROJECT_ORDER_KEY,
+  CUSTOM_PROJECTS_KEY,
+} from './savedTabsStorageKeys'
 import { CustomProjectRawSchema } from './savedTabsStorageSchema'
 import type { CustomProjectRaw } from './savedTabsStorageSchema'
 
@@ -44,6 +47,34 @@ const findAllRawCustomProjects = async (
     }
   }
   return valid
+}
+
+/**
+ * `CUSTOM_PROJECT_ORDER_KEY` の生値を `CustomProjectId[]` へ詰め替える。
+ *
+ * - 非配列 / 配列でも要素が文字列以外 / 空文字はスキップする。
+ * - ドメイン層で `createCustomProjectId` が空文字を拒否するため、parse
+ *   時点で空文字を除外しないと repository 境界で例外が漏れる。
+ */
+const parseCustomProjectOrder = (raw: unknown): readonly CustomProjectId[] => {
+  if (!Array.isArray(raw)) {
+    return []
+  }
+  const result: CustomProjectId[] = []
+  const seen = new Set<string>()
+  for (const item of raw) {
+    if (typeof item !== 'string' || item.length === 0) {
+      continue
+    }
+    if (seen.has(item)) {
+      continue
+    }
+    seen.add(item)
+    // ブランド型タグ付けに限定し、検証は `createCustomProjectId` 側に委ねる
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion
+    result.push(item as CustomProjectId)
+  }
+  return result
 }
 
 const createChromeCustomProjectRepositoryImpl = (
@@ -96,7 +127,30 @@ const createChromeCustomProjectRepositoryImpl = (
     await saveAll(remaining)
   }
 
-  return { findAll, findById, removeByIds, saveAll }
+  const findOrder = async (): Promise<readonly CustomProjectId[]> => {
+    const result = await port.get(CUSTOM_PROJECT_ORDER_KEY)
+    return parseCustomProjectOrder(result[CUSTOM_PROJECT_ORDER_KEY])
+  }
+
+  const saveOrder = async (
+    order: readonly CustomProjectId[],
+  ): Promise<void> => {
+    // ブランド型を剥いで素の string[] として保存する。重複や空文字は
+    // parse 側で弾いているためここでは素直に unwrap するだけで十分。
+    const plain: string[] = order.map((id) =>
+      ChromeSavedTabsStorageMapper.customProjectIdToString(id),
+    )
+    await port.set({ [CUSTOM_PROJECT_ORDER_KEY]: plain })
+  }
+
+  return {
+    findAll,
+    findById,
+    findOrder,
+    removeByIds,
+    saveAll,
+    saveOrder,
+  }
 }
 
 /**
@@ -107,6 +161,13 @@ const createChromeCustomProjectRepositoryImpl = (
  * `categoryOrder`）は domain entity には載らないが、`saveAll` で既存 raw
  * データから持ち越して `urlIds` の集合に合わせて整合性を取りつつ保存する。
  * これによりユーザーの既存保存データを破壊しない。
+ *
+ * `findOrder` / `saveOrder` は `CUSTOM_PROJECT_ORDER_KEY`（旧
+ * `customProjectOrder`）を読み書きする。`order` は `CustomProject`
+ * 集合とは独立した表示用並び順情報で、`CustomProject` が storage 上から
+ * 消えてもエントリ自体は残ってよい。presentation 層は order を
+ * stable sort の手掛かりとして扱い、未知 ID の扱いは view-model 側の
+ * 責務とする（issue #487 で use-case 経由での復元を保証）。
  *
  * @throws {SavedTabsRepositoryUnavailableError} chrome.storage.local 不在時
  */

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageKeys.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageKeys.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  CUSTOM_PROJECT_ORDER_KEY,
   CUSTOM_PROJECTS_KEY,
   PARENT_CATEGORIES_KEY,
   SAVED_TABS_KEY,
@@ -16,12 +17,17 @@ describe('savedTabsStorageKeys', () => {
     expect(CUSTOM_PROJECTS_KEY).toBe('customProjects')
   })
 
-  it('4 つのメイン key を配列で列挙できる', () => {
+  it('issue #487 で customProjectOrder を DDD 永続化境界に取り込んだ', () => {
+    expect(CUSTOM_PROJECT_ORDER_KEY).toBe('customProjectOrder')
+  })
+
+  it('5 つのメイン key を配列で列挙できる', () => {
     expect(SAVED_TABS_STORAGE_KEYS).toStrictEqual([
       'savedTabs',
       'urls',
       'parentCategories',
       'customProjects',
+      'customProjectOrder',
     ])
   })
 })

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageKeys.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageKeys.ts
@@ -6,12 +6,14 @@
  *
  * 旧 `src/lib/storage/*` と同じキー名を維持しているため、既存ユーザーの
  * データ（`chrome.storage.local.savedTabs` / `urls` / `parentCategories` /
- * `customProjects`）はそのまま読み書きできる。
+ * `customProjects` / `customProjectOrder`）はそのまま読み書きできる。
  *
  * 並び替え順序など付随する storage key（`customProjectOrder` /
  * `domainCategoryMappings` / `domainCategorySettings` /
- * `urlsMigrationCompleted`）は別 issue で domain / repository 化するため、
- * ここでは 4 つのメイン key だけを公開する。
+ * `urlsMigrationCompleted`）のうち、`customProjectOrder` は
+ * `CustomProjectRepository.findOrder` / `saveOrder` 経由で扱う DDD
+ * 永続化境界に取り込んだ（issue #487）。残りは別 issue で
+ * domain / repository 化する。
  */
 
 export const SAVED_TABS_KEY = 'savedTabs' as const
@@ -22,11 +24,14 @@ export const PARENT_CATEGORIES_KEY = 'parentCategories' as const
 
 export const CUSTOM_PROJECTS_KEY = 'customProjects' as const
 
+export const CUSTOM_PROJECT_ORDER_KEY = 'customProjectOrder' as const
+
 export const SAVED_TABS_STORAGE_KEYS = [
   SAVED_TABS_KEY,
   URLS_KEY,
   PARENT_CATEGORIES_KEY,
   CUSTOM_PROJECTS_KEY,
+  CUSTOM_PROJECT_ORDER_KEY,
 ] as const
 
 export type SavedTabsStorageKey = (typeof SAVED_TABS_STORAGE_KEYS)[number]

--- a/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.test.ts
@@ -53,6 +53,10 @@ const createInMemoryRepositories = (initial: Partial<InMemoryState> = {}) => {
     saveAll: async (projects) => {
       state.customProjects = projects.map((project) => ({ ...project }))
     },
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async () => undefined,
   }
   return { customProjectRepository, state }
 }

--- a/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.test.ts
@@ -81,6 +81,10 @@ const createInMemoryRepositories = (initial: Partial<InMemoryState> = {}) => {
     saveAll: async (projects) => {
       state.customProjects = projects.map((project) => ({ ...project }))
     },
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async () => undefined,
   }
   return { customProjectRepository, state, tabGroupRepository }
 }

--- a/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.test.ts
@@ -79,6 +79,10 @@ const createInMemoryRepositories = (initial: Partial<InMemoryState> = {}) => {
     saveAll: async (projects) => {
       state.customProjects = projects.map((project) => ({ ...project }))
     },
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async () => undefined,
   }
   return { customProjectRepository, state, tabGroupRepository }
 }

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.test.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.test.tsx
@@ -89,6 +89,10 @@ const createInMemoryDeps = (input: {
         ...projects.map((p) => ({ ...p })),
       )
     },
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async () => undefined,
   }
   const urlRecordRepository: UrlRecordRepository = {
     // eslint-disable-next-line typescript/require-await

--- a/src/features/saved-tabs/app/SavedTabsApp.test.tsx
+++ b/src/features/saved-tabs/app/SavedTabsApp.test.tsx
@@ -544,7 +544,10 @@ describe('SavedTabsApp custom search', () => {
 
     // 不正な id の TabGroup / CustomProject / ParentCategory は
     // domain factory の SavedTabsDomainError 経由でスキップされる。
-    // chromeSetMock は customProjectOrder 1 件だけ。
+    // customProjectOrder も含めて snapshot は command に詰め替えられ、
+    // RestoreOpenedUrlsSnapshotUseCase 経由で repository へ書き戻される
+    // （issue #487）。presentation 層は chrome.storage.local.set を
+    // 呼ばないため chromeSetMock は 0 呼び出しのまま。
     const captured: unknown[] = []
     // eslint-disable-next-line typescript/require-await
     const captureUseCase = vi.fn(async (input: { snapshot: unknown }) => {
@@ -627,6 +630,7 @@ describe('SavedTabsApp custom search', () => {
 
     expect(captureUseCase).toHaveBeenCalledTimes(1)
     const command = (captured[0] as { snapshot: unknown }).snapshot as {
+      customProjectOrder?: string[]
       customProjects: { id: string }[]
       parentCategories: { id: string }[]
       savedTabs: { id: string }[]
@@ -638,9 +642,11 @@ describe('SavedTabsApp custom search', () => {
     expect(command.parentCategories.map((c) => c.id)).toStrictEqual([
       'cat-good',
     ])
-    expect(chromeSetMock).toHaveBeenLastCalledWith({
-      customProjectOrder: ['project-good'],
-    })
+    // customProjectOrder は RestoreOpenedUrlsSnapshotUseCase 経由で
+    // repository へ書き戻される（issue #487）。presentation 層からは
+    // chrome.storage.local.set を呼ばない。
+    expect(command.customProjectOrder).toStrictEqual(['project-good'])
+    expect(chromeSetMock).not.toHaveBeenCalled()
     expect(setCustomProjects2).toHaveBeenCalledWith([
       {
         categories: [],
@@ -1444,8 +1450,10 @@ describe('SavedTabsApp custom search', () => {
     await undoOptions?.action?.onClick?.()
 
     // 復元は RestoreOpenedUrlsSnapshotUseCase 経由になり、TabGroup /
-    // CustomProject / ParentCategory は各 repository の saveAll で個別に
-    // 書き戻される。presentation 層で残るのは customProjectOrder のみ。
+    // CustomProject / ParentCategory / customProjectOrder すべて
+    // repository 経由で個別に書き戻される（issue #487）。
+    // customProjectOrder は chromeCustomProjectRepository.saveOrder
+    // 経由で chrome.storage.local.set に到達する。
     expect(chromeSetMock).toHaveBeenLastCalledWith({
       customProjectOrder: ['project-1'],
     })
@@ -1813,8 +1821,10 @@ describe('SavedTabsApp custom search', () => {
     await undoOptions?.action?.onClick?.()
 
     // 復元は RestoreOpenedUrlsSnapshotUseCase 経由になり、TabGroup /
-    // CustomProject は各 repository の saveAll で個別に書き戻される。
-    // presentation 層で残るのは customProjectOrder のみ。
+    // CustomProject / customProjectOrder すべて repository 経由で
+    // 個別に書き戻される（issue #487）。customProjectOrder は
+    // chromeCustomProjectRepository.saveOrder 経由で chrome.storage.local
+    // に到達する。
     expect(chromeSetMock).toHaveBeenLastCalledWith({
       customProjectOrder: ['project-1'],
     })
@@ -1889,8 +1899,10 @@ describe('SavedTabsApp custom search', () => {
 
     // 削除失敗時は catch から `notifyDeleteFailure` が呼ばれ、
     // RestoreOpenedUrlsSnapshotUseCase 経由で snapshot が復元される。
-    // snapshot の savedTabs が repository.saveAll 経由で書き戻され、
-    // customProjectOrder のみ presentation 層で補助的に書き戻される。
+    // TabGroup / CustomProject / customProjectOrder すべて
+    // repository 経由で書き戻される（issue #487）。
+    // customProjectOrder は chromeCustomProjectRepository.saveOrder
+    // 経由で chrome.storage.local.set に到達する。
     expect(chromeSetMock).toHaveBeenLastCalledWith({
       customProjectOrder: ['project-1'],
     })
@@ -2041,8 +2053,10 @@ describe('SavedTabsApp custom search', () => {
     await undoOptions?.action?.onClick?.()
 
     // 復元は RestoreOpenedUrlsSnapshotUseCase 経由になり、TabGroup /
-    // CustomProject は各 repository の saveAll で個別に書き戻される。
-    // presentation 層で残るのは customProjectOrder のみ。
+    // CustomProject / customProjectOrder すべて repository 経由で
+    // 個別に書き戻される（issue #487）。customProjectOrder は
+    // chromeCustomProjectRepository.saveOrder 経由で chrome.storage.local
+    // に到達する。
     expect(chromeSetMock).toHaveBeenLastCalledWith({
       customProjectOrder: ['project-1'],
     })
@@ -2401,8 +2415,10 @@ describe('SavedTabsApp custom search', () => {
     await undoOptions?.action?.onClick?.()
 
     // 復元は RestoreOpenedUrlsSnapshotUseCase 経由になり、TabGroup /
-    // CustomProject / ParentCategory は各 repository の saveAll で個別に
-    // 書き戻される。presentation 層で残るのは customProjectOrder のみ。
+    // CustomProject / ParentCategory / customProjectOrder すべて
+    // repository 経由で個別に書き戻される（issue #487）。
+    // customProjectOrder は chromeCustomProjectRepository.saveOrder
+    // 経由で chrome.storage.local.set に到達する。
     expect(chromeSetMock).toHaveBeenLastCalledWith({
       customProjectOrder: ['project-1'],
     })

--- a/src/features/saved-tabs/app/savedTabsApp.helpers.ts
+++ b/src/features/saved-tabs/app/savedTabsApp.helpers.ts
@@ -156,8 +156,8 @@ const toDomainParentCategories = (
 
 /**
  * 旧 storage スナップショットを `RestoreOpenedUrlsSnapshotUseCase` の
- * command へ変換する。`customProjectOrder` は use-case DTO に載らない
- * ため、command には含めず presentation 層で補助的に書き戻す。
+ * command へ変換する。`customProjectOrder` は repository 経由で復元する
+ * ため、command にも `customProjectOrder` を含める（issue #487）。
  */
 const toOpenedUrlsRestoreCommand = (
   snapshot: OpenedUrlsStorageSnapshot,
@@ -165,6 +165,7 @@ const toOpenedUrlsRestoreCommand = (
   const command: {
     savedTabs?: OpenedUrlsRestoreSnapshot['savedTabs']
     customProjects?: OpenedUrlsRestoreSnapshot['customProjects']
+    customProjectOrder?: OpenedUrlsRestoreSnapshot['customProjectOrder']
     parentCategories?: OpenedUrlsRestoreSnapshot['parentCategories']
   } = {}
   const savedTabs = toDomainTabGroups(snapshot.savedTabs)
@@ -174,6 +175,9 @@ const toOpenedUrlsRestoreCommand = (
   const customProjects = toDomainCustomProjects(snapshot.customProjects)
   if (customProjects) {
     command.customProjects = customProjects
+  }
+  if (snapshot.customProjectOrder) {
+    command.customProjectOrder = [...snapshot.customProjectOrder]
   }
   const parentCategories = toDomainParentCategories(snapshot.parentCategories)
   if (parentCategories) {
@@ -196,22 +200,14 @@ const restoreOpenedUrlsSnapshot = async ({
   snapshot: OpenedUrlsStorageSnapshot
 }) => {
   // 復元本体は RestoreOpenedUrlsSnapshotUseCase に委譲する。
-  // presentation 層は snapshot を domain command へ詰め替えるだけとし、
-  // chrome.storage.local.set の直接呼び出しは customProjectOrder の補助
-  // 書き込みに限定する。
+  // presentation 層は snapshot を domain command へ詰め替えるだけに
+  // 閉じ、chrome.storage.local.set の直接呼び出しは行わない
+  // （issue #487 で `customProjectOrder` も use-case / repository 経由に
+  // 移管）。
   const command = toOpenedUrlsRestoreCommand(snapshot)
   await savedTabsUseCases.restoreOpenedUrlsSnapshot({
     snapshot: command,
   })
-
-  // customProjectOrder は RestoreOpenedUrlsSnapshotUseCase の DTO に含まれ
-  // ない（repository interface 未整備のため別 issue 切り出し）ため、
-  // presentation 層で補助的に書き戻す。
-  if (snapshot.customProjectOrder) {
-    await chrome.storage.local.set({
-      customProjectOrder: [...snapshot.customProjectOrder],
-    })
-  }
 
   // 画面側 state は storage 形状を期待するため、use-case DTO ではなく
   // 入力 snapshot をそのまま state へ反映する。Repository 側の mapper が


### PR DESCRIPTION
## 変更内容

`Undo` / 復元時の `customProjectOrder` を、presentation 層からの `chrome.storage.local.set` 直書きから、repository / use-case 経由の DDD 永続化境界に移しました。

### 採用方針
**案A: `CustomProjectRepository` に `findOrder` / `saveOrder` を含める**（影響範囲が小さく、order 概念が `CustomProject` 集約に紐づくため repository を分けない方がシンプル）

### domain / application
- `CustomProjectRepository` interface に `findOrder` / `saveOrder` を追加
- `RestoreOpenedUrlsSnapshotUseCase` で snapshot に `customProjectOrder` が含まれる場合に `customProjectRepository.saveOrder` で全置換復元
- `RestoredSnapshotDto` に `restoredCustomProjectOrder?: readonly CustomProjectId[]` を追加
- snapshot の `customProjectOrder` を `createCustomProjectId` で検証・正規化（空文字 / 重複は破棄）

### infrastructure
- `savedTabsStorageKeys` に `CUSTOM_PROJECT_ORDER_KEY = 'customProjectOrder'` を追加
- `ChromeCustomProjectRepository` に `findOrder` / `saveOrder` を実装
  - `parseCustomProjectOrder` で `chrome.storage.local` 上の非配列 / 配列でない要素 / 空文字 / 重複をガード

### presentation
- `features/saved-tabs/app/savedTabsApp.helpers.ts` の `restoreOpenedUrlsSnapshot` から `chrome.storage.local.set({ customProjectOrder })` の直書きを削除
- `toOpenedUrlsRestoreCommand` で `customProjectOrder` を command に詰め替え、`RestoreOpenedUrlsSnapshotUseCase` 経由に統一

### tests
- `ChromeCustomProjectRepository.test.ts` に `findOrder` / `saveOrder` 5 ケース追加
- `RestoreOpenedUrlsSnapshotUseCase.test.ts` に snapshot order の保存 / 既存 order 維持 2 ケース追加
- `savedTabsStorageKeys.test.ts` に `CUSTOM_PROJECT_ORDER_KEY` 検証追加
- `SavedTabsApp.test.tsx` の Undo 関連 6 テストを use-case / chrome adapter 経由の `customProjectOrder` 復元検証に更新
- 影響範囲の 11 テストファイルに `findOrder` / `saveOrder` の no-op スタブを追加（mock 整合性）

## 検証
- `bun run compile` — エラー 0
- `bun run lint` — 警告 / エラー 0
- `bun run format` — 適用済み
- `bun run test` — **222 files / 1884 tests passed**
- `bun run test:node` — 1058 tests passed（`dddLayerGuard.test.ts` 53 件も pass）
- `bun run test:dom` — 826 tests passed
- `RestoreOpenedUrlsSnapshotUseCase.ts` カバレッジ 100%

## 受け入れ条件
- [x] `customProjectOrder` が repository / use-case 経由で復元される
- [x] presentation 層から `customProjectOrder` 用の `chrome.storage.local.set` 直書きがなくなる
- [x] Undo / restore 後にカスタムプロジェクトの順序が維持される
- [x] 既存データ形式を壊さない（storage key 名 `customProjectOrder` を維持）
- [x] unit test 追加 / 更新
- [x] `bun run compile` 通過
- [x] 関連テスト通過

## 関連 Issue
- DDD構成へ段階移行するための全体設計と実装計画 #454
- restore / undo 処理を RestoreOpenedUrlsSnapshotUseCase 経由に置き換える #472
- saved-tabs の残操作を application use-case 経由に置き換える #486

Closes #487