### PR TITLE
feat(#493): SavedTabsApp の use-case / controller 生成を SavedTabsPage 注入に統一

### DIFF
--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter.ts
@@ -45,6 +45,17 @@ interface ChromeBrowserTabAdapterOptions {
 }
 
 /**
+ * `createChromeBrowserTabAdapter` が生成した port に付くマーカー。
+ *
+ * `SavedTabsPage` などの composition 層が「chrome 由来の port であるか」
+ * を識別し、動的 `resolveActive` ラップへの差し替え可否を判断するために使う。
+ * テストや SSR 用途の独自 port は本マーカーを持たないため、そのまま保持される。
+ */
+export const CHROME_BROWSER_TAB_ADAPTER_MARKER = Symbol.for(
+  'tabbin.chromeBrowserTabAdapter',
+)
+
+/**
  * `chrome.tabs.create` を利用する `BrowserTabPort` 実装を生成する。
  *
  * `chrome` API が見つからない環境（テスト / SSR など）では
@@ -57,6 +68,7 @@ export const createChromeBrowserTabAdapter = (
   options: ChromeBrowserTabAdapterOptions = {},
 ) => {
   return {
+    [CHROME_BROWSER_TAB_ADAPTER_MARKER]: true,
     open: async (input: { readonly url: string }) => {
       const api = deps.getApi()
       const tabs = api?.tabs

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
@@ -36,6 +36,17 @@ export interface SavedTabsUseCasesDeps {
   readonly notificationPort: NotificationPort
 }
 
+/**
+ * `createSavedTabsUseCasesDeps` に渡せる任意設定。
+ *
+ * - `resolveActive` : `BrowserTabPort` 配下で開く新規タブを active にするかを
+ *   実行時に解決する関数。presentation 層が `openUrlInBackground` 設定を
+ *   ref 経由で読むために利用。未指定なら active 固定。
+ */
+export interface CreateSavedTabsUseCasesDepsOptions {
+  readonly resolveActive?: () => boolean
+}
+
 interface ChromeLike {
   readonly tabs?: {
     readonly create?: (createProperties: {
@@ -67,13 +78,19 @@ const getChromeApi = (): ChromeLike | undefined =>
  * presentation 層はそれを呼び出し元（`SavedTabsPage`）でハンドルし、
  * loading 状態を `error` へ遷移させる。
  *
+ * `options.resolveActive` を渡すと `BrowserTabPort` 配下の `open` が
+ * 呼び出しごとに同関数を評価するため、presentation 層は settings ref の
+ * 現在値を動的に反映できる。
+ *
  * @example
  * ```tsx
  * const deps = createSavedTabsUseCasesDeps()
  * const controller = useSavedTabsController({ deps })
  * ```
  */
-export const createSavedTabsUseCasesDeps = (): SavedTabsUseCasesDeps => {
+export const createSavedTabsUseCasesDeps = (
+  options: CreateSavedTabsUseCasesDepsOptions = {},
+): SavedTabsUseCasesDeps => {
   const local = getChromeStorageLocal()
   if (!local) {
     warnMissingChromeStorage('createSavedTabsUseCasesDeps')
@@ -87,9 +104,10 @@ export const createSavedTabsUseCasesDeps = (): SavedTabsUseCasesDeps => {
     : null
 
   return {
-    browserTabPort: createChromeBrowserTabAdapter({
-      getApi: () => getChromeApi(),
-    }),
+    browserTabPort: createChromeBrowserTabAdapter(
+      { getApi: () => getChromeApi() },
+      options.resolveActive ? { resolveActive: options.resolveActive } : {},
+    ),
     browserWindowPort: createChromeBrowserWindowAdapter({
       getApi: () => getChromeApi(),
     }),

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
@@ -9,6 +9,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
+import { useMemo, useRef } from 'react'
 import { toast } from 'sonner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
@@ -284,6 +285,68 @@ vi.mock('@/contexts/saved-tabs/presentation/lib/uncategorized-display', () => ({
   shouldShowUncategorizedHeader: vi.fn(() => false),
 }))
 
+vi.mock('./SavedTabsApp', async () => {
+  // 旧 `SavedTabsApp` は use-case / controller / deps を内部で組み立てていたが、
+  // issue #493 の composition root 集約によりそれらは props 注入になった。
+  // 既存テストは props を渡さず `render(<SavedTabsApp />)` する形なので、
+  // ここで production と同じ `createSavedTabsUseCasesDeps()` を使った
+  // composition を補完するラッパに差し替える。
+  // テスト本体では `globalThis.chrome` が beforeEach で mock されているため、
+  // chrome-storage ベースの deps も同じ経路で chrome とやり取りする。
+  // `BrowserTabPort` の `resolveActive` は `SavedTabsApp` 側が ref.current を
+  // 動的に書き換えるため、ref-based な resolveActive を持つ port を
+  // composition 時に渡す必要がある。
+  const actual =
+    await vi.importActual<typeof import('./SavedTabsApp')>('./SavedTabsApp')
+  const controllerMod = await vi.importActual<
+    typeof import('@/contexts/saved-tabs/presentation/controllers/useSavedTabsController')
+  >('@/contexts/saved-tabs/presentation/controllers/useSavedTabsController')
+  const compositionMod = await vi.importActual<
+    typeof import('@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases')
+  >('@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases')
+  const depsMod = await vi.importActual<
+    typeof import('@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps')
+  >(
+    '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps',
+  )
+
+  const TestSavedTabsApp = (
+    props: React.ComponentProps<typeof actual.SavedTabsApp>,
+  ) => {
+    // 1) ref を先に作る (active 固定で初期化)
+    const resolveActiveRef = useRef<() => boolean>(() => true)
+    // 2) ref ベースの resolveActive を持つ BrowserTabPort を構築するため、
+    //    1 度 deps を組み立ててから browserTabPort だけ差し替える。
+    const baseDeps = useMemo(
+      () =>
+        depsMod.createSavedTabsUseCasesDeps({
+          resolveActive: () => resolveActiveRef.current(),
+        }),
+      [resolveActiveRef],
+    )
+    const useCases = useMemo(
+      () => compositionMod.createSavedTabsUseCases(baseDeps),
+      [baseDeps],
+    )
+    const controller = controllerMod.useSavedTabsController({
+      deps: baseDeps,
+      useCases,
+    })
+    return actual.useSavedTabsAppView({
+      ...props,
+      controller,
+      deps: baseDeps,
+      resolveActiveRef,
+      useCases,
+    })
+  }
+
+  return {
+    SavedTabsApp: TestSavedTabsApp,
+    useSavedTabsAppView: actual.useSavedTabsAppView,
+  }
+})
+
 vi.mock(
   '@/contexts/saved-tabs/presentation/hooks/useCategoryManagement',
   () => ({
@@ -351,7 +414,15 @@ import {
 } from '@/lib/storage/tabs'
 import { getUrlRecords } from '@/lib/storage/urls'
 
-import { SavedTabsApp } from './SavedTabsApp'
+import { SavedTabsApp as ImportedSavedTabsApp } from './SavedTabsApp'
+// `vi.mock` により `SavedTabsApp` は in-memory deps を補完するラッパへ
+// 差し替えられる。runtime のシグネチャは composition props を補完した形に
+// なるため、テストでの利用は JSX のオプショナル props だけに閉じる。
+const SavedTabsApp = ImportedSavedTabsApp as unknown as React.ComponentType<{
+  initialViewMode?: 'custom' | 'domain'
+  isAiSidebarOpen?: boolean
+  onViewModeNavigate?: (mode: 'custom' | 'domain') => void
+}>
 import {
   buildCategoryLookup,
   buildDisplayTabGroup,

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -9,19 +9,17 @@ import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
-import { createSavedTabsPorts } from '@/app/composition/createSavedTabsPorts'
-import { createSavedTabsUseCases } from '@/app/composition/createSavedTabsUseCases'
 import { Toaster } from '@/components/ui/sonner'
 import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabGroupId'
 import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/UrlRecordId'
-import { createSavedTabsUseCases as createContextSavedTabsUseCases } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases'
-import { createSavedTabsUseCasesDeps } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps'
+import type { SavedTabsUseCases } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCasesDeps } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps'
 import { CategoryReorderFooter } from '@/contexts/saved-tabs/presentation/components/Footer'
 import { Header } from '@/contexts/saved-tabs/presentation/components/Header' // ヘッダーコンポーネントをインポート
 import { CustomModeContainer } from '@/contexts/saved-tabs/presentation/containers/CustomModeContainer'
 import { DomainModeContainer } from '@/contexts/saved-tabs/presentation/containers/DomainModeContainer'
 import { useDomainModeController } from '@/contexts/saved-tabs/presentation/controllers/useDomainModeController'
-import { useSavedTabsController } from '@/contexts/saved-tabs/presentation/controllers/useSavedTabsController'
+import type { UseSavedTabsControllerReturn } from '@/contexts/saved-tabs/presentation/controllers/useSavedTabsController'
 import { useCategoryManagement } from '@/contexts/saved-tabs/presentation/hooks/useCategoryManagement'
 import { useProjectManagement } from '@/contexts/saved-tabs/presentation/hooks/useProjectManagement'
 import { useTabData } from '@/contexts/saved-tabs/presentation/hooks/useTabData'
@@ -29,6 +27,7 @@ import { moveCustomProjectUrlAndSyncState } from '@/contexts/saved-tabs/presenta
 import { filterCustomProjectsByQuery } from '@/contexts/saved-tabs/presentation/lib/custom-project-search'
 import { handleTabGroupRemoval } from '@/contexts/saved-tabs/presentation/lib/tab-operations'
 import { shouldShowUncategorizedHeader as computeShouldShowUncategorizedHeader } from '@/contexts/saved-tabs/presentation/lib/uncategorized-display'
+import type { ResolveActiveRef } from '@/contexts/saved-tabs/presentation/pages/SavedTabsPage'
 import { syncStorageChanges } from '@/contexts/saved-tabs/presentation/services/modeSyncService'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { saveParentCategories } from '@/lib/storage/categories'
@@ -228,16 +227,24 @@ const removeDomainFromParentCategories = async (
 }
 
 interface SavedTabsAppProps {
-  initialViewMode?: ViewMode
-  isAiSidebarOpen?: boolean
-  onViewModeNavigate?: (mode: ViewMode) => void
+  readonly controller: UseSavedTabsControllerReturn
+  readonly deps: SavedTabsUseCasesDeps
+  readonly initialViewMode?: ViewMode
+  readonly isAiSidebarOpen?: boolean
+  readonly onViewModeNavigate?: (mode: ViewMode) => void
+  readonly resolveActiveRef: ResolveActiveRef
+  readonly useCases: SavedTabsUseCases
 }
 
 const useSavedTabsAppView = ({
   // eslint-disable-line eslint/max-lines-per-function
+  controller,
+  deps,
   initialViewMode,
   isAiSidebarOpen = false,
   onViewModeNavigate,
+  resolveActiveRef,
+  useCases: savedTabsUseCases,
 }: SavedTabsAppProps) => {
   const { t } = useI18n()
   const [settings, setSettings] = useState<UserSettings>(defaultSettings)
@@ -255,40 +262,21 @@ const useSavedTabsAppView = ({
   const settingsRef = useRef(settings)
   settingsRef.current = settings
 
-  // saved-tabs use-case バンドルと port バンドル。
-  // resolveActive 関数を ref 経由で渡し、`openUrlInBackground` 設定変更を
-  // 再 mount なしで反映する。
-  const savedTabsUseCases = useMemo(
-    () =>
-      createSavedTabsUseCases({
-        resolveActive: () => !settingsRef.current.openUrlInBackground,
-      }),
-    [],
-  )
-  const savedTabsPorts = useMemo(
-    () =>
-      createSavedTabsPorts({
-        resolveActive: () => !settingsRef.current.openUrlInBackground,
-      }),
-    [],
-  )
+  // `SavedTabsPage` 側で組み立てた `BrowserTabPort` の `resolveActive` を
+  // 最新 settings から毎回評価する関数で上書きする。`BrowserTabPort` は
+  // `open()` 呼び出し時に `resolveActive?.()` を都度評価するため、
+  // use-case / port を作り直さずに `openUrlInBackground` を反映できる。
+  // 関数 ref の中身だけ差し替えるため ref 自体は安定。
+  useEffect(() => {
+    resolveActiveRef.current = () => !settingsRef.current.openUrlInBackground
+  }, [resolveActiveRef])
 
-  // presentation 層の controller フック。Domain モード用 state
-  // (searchQuery, parentCategories) を presentation 層へ持ち上げ、
-  // `setSearchQuery` / `setParentCategories` を controller 経由で
-  // 配下に提供する。複雑 (Undo / snapshot 連携) な処理は従来通り
-  // 既存の `savedTabsUseCases` / `savedTabsPorts` 経由で実行する。
-  const controllerDeps = useMemo(() => createSavedTabsUseCasesDeps(), [])
-  const contextUseCases = useMemo(
-    () => createContextSavedTabsUseCases(controllerDeps),
-    [controllerDeps],
-  )
-  const presentationController = useSavedTabsController({
-    deps: controllerDeps,
-    useCases: contextUseCases,
-  })
+  // presentation 層の controller は composition root である
+  // `SavedTabsPage` 側で組み立てて props 注入する。`SavedTabsApp` 側では
+  // UI 派生 state のために `useDomainModeController` を controller に対して
+  // 適用するだけに留め、use-case / repository / port の再生成は行わない。
   const domainController = useDomainModeController({
-    controller: presentationController,
+    controller,
   })
   const searchQuery = domainController.searchQuery
   const setSearchQuery = domainController.setSearchQuery
@@ -366,7 +354,7 @@ const useSavedTabsAppView = ({
         if (!targetRecord) {
           // urlRecord に登録されていない URL（旧データなど）は
           // browserTabPort 経由で開くだけにとどめ、削除処理はスキップする。
-          await savedTabsPorts.browserTabPort.open({ url })
+          await deps.browserTabPort.open({ url })
           return
         }
 
@@ -418,7 +406,7 @@ const useSavedTabsAppView = ({
       }
     },
     [
-      savedTabsPorts,
+      deps,
       savedTabsUseCases,
       settings.removeTabAfterOpen,
       refreshTabGroupsWithUrls,
@@ -1222,4 +1210,4 @@ const useSavedTabsAppView = ({
 
 const SavedTabsApp = (props: SavedTabsAppProps) => useSavedTabsAppView(props)
 
-export { SavedTabsApp }
+export { SavedTabsApp, useSavedTabsAppView }

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
@@ -1,6 +1,16 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from '@testing-library/react'
+import { useRef } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createSavedTabsUseCases } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCases } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCasesDeps } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps'
+import { useSavedTabsController } from '@/contexts/saved-tabs/presentation/controllers/useSavedTabsController'
+import type { UseSavedTabsControllerReturn } from '@/contexts/saved-tabs/presentation/controllers/useSavedTabsController'
+import type { ResolveActiveRef } from '@/contexts/saved-tabs/presentation/pages/SavedTabsPage'
+
+import { SavedTabsPresentationLayout } from './SavedTabsPresentationLayout'
 
 vi.mock('@/features/i18n/context/I18nProvider', () => ({
   I18nProvider: ({ children }: { children: React.ReactNode }) => (
@@ -67,9 +77,96 @@ vi.mock('./SavedTabsChatWidgetBridge', () => ({
   },
 }))
 
-import { useRef } from 'react'
+/**
+ * テストで SavedTabsPresentationLayout が要求する composition props
+ * (deps / useCases / controller / resolveActiveRef) を組み立てるヘルパ。
+ *
+ * 実 chrome 依存は注入せず、空の in-memory リポジトリ / port を使う。
+ * `controller` は `useSavedTabsController` フックで生成するため、
+ * 組み立てヘルパからは外している。
+ */
+const buildLayoutComposition = () => {
+  const deps: SavedTabsUseCasesDeps = {
+    browserTabPort: {
+      // eslint-disable-next-line typescript/require-await
+      open: async (input: { url: string }) => ({ url: input.url }),
+    },
+    browserWindowPort: {
+      // eslint-disable-next-line typescript/require-await
+      openWithUrls: async (input: { urls: readonly string[] }) => ({
+        urls: [...input.urls],
+      }),
+    },
+    notificationPort: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+    customProjectRepository: {
+      // eslint-disable-next-line typescript/require-await
+      findAll: async () => [],
+      // eslint-disable-next-line typescript/require-await
+      findById: async () => null,
+      // eslint-disable-next-line typescript/require-await
+      removeByIds: async () => undefined,
+      // eslint-disable-next-line typescript/require-await
+      saveAll: async () => undefined,
+      // eslint-disable-next-line typescript/require-await
+      findOrder: async () => [],
+      // eslint-disable-next-line typescript/require-await
+      saveOrder: async () => undefined,
+    },
+    parentCategoryRepository: {
+      // eslint-disable-next-line typescript/require-await
+      findAll: async () => [],
+      // eslint-disable-next-line typescript/require-await
+      findById: async () => null,
+      // eslint-disable-next-line typescript/require-await
+      removeByIds: async () => undefined,
+      // eslint-disable-next-line typescript/require-await
+      saveAll: async () => undefined,
+    },
+    tabGroupRepository: {
+      // eslint-disable-next-line typescript/require-await
+      findAll: async () => [],
+      // eslint-disable-next-line typescript/require-await
+      findById: async () => null,
+      // eslint-disable-next-line typescript/require-await
+      removeByIds: async () => undefined,
+      // eslint-disable-next-line typescript/require-await
+      saveAll: async () => undefined,
+    },
+    urlRecordRepository: {
+      // eslint-disable-next-line typescript/require-await
+      findAll: async () => [],
+      // eslint-disable-next-line typescript/require-await
+      findById: async () => null,
+      // eslint-disable-next-line typescript/require-await
+      removeByIds: async () => undefined,
+      // eslint-disable-next-line typescript/require-await
+      saveAll: async () => undefined,
+    },
+  }
+  const useCases: SavedTabsUseCases = createSavedTabsUseCases(deps)
+  const resolveActiveRef: ResolveActiveRef = { current: () => true }
+  return { deps, resolveActiveRef, useCases }
+}
 
-import { SavedTabsPresentationLayout } from './SavedTabsPresentationLayout'
+interface CompositionContext {
+  readonly controller: UseSavedTabsControllerReturn
+  readonly deps: SavedTabsUseCasesDeps
+  readonly resolveActiveRef: ResolveActiveRef
+  readonly useCases: SavedTabsUseCases
+}
+
+const CompositionProbe = ({
+  children,
+}: {
+  children: (composition: CompositionContext) => React.ReactNode
+}) => {
+  const composition = buildLayoutComposition()
+  const controller = useSavedTabsController({
+    deps: composition.deps,
+    useCases: composition.useCases,
+  })
+  return <>{children({ ...composition, controller })}</>
+}
 
 describe('SavedTabsPresentationLayout', () => {
   afterEach(() => {
@@ -87,16 +184,24 @@ describe('SavedTabsPresentationLayout', () => {
     const Probe = () => {
       const leftPaneRef = useRef<HTMLDivElement>(null)
       return (
-        <SavedTabsPresentationLayout
-          attachLeftPaneRef={(node) => {
-            leftPaneRef.current = node
-          }}
-          initialViewMode={initialViewMode}
-          isAiSidebarOpen={isAiSidebarOpen}
-          isCompactLeftPaneLayout={isCompactLeftPaneLayout}
-          leftPaneRef={leftPaneRef}
-          onAiSidebarOpenChange={vi.fn()}
-        />
+        <CompositionProbe>
+          {({ controller, deps, resolveActiveRef, useCases }) => (
+            <SavedTabsPresentationLayout
+              attachLeftPaneRef={(node) => {
+                leftPaneRef.current = node
+              }}
+              controller={controller}
+              deps={deps}
+              initialViewMode={initialViewMode}
+              isAiSidebarOpen={isAiSidebarOpen}
+              isCompactLeftPaneLayout={isCompactLeftPaneLayout}
+              leftPaneRef={leftPaneRef}
+              onAiSidebarOpenChange={vi.fn()}
+              resolveActiveRef={resolveActiveRef}
+              useCases={useCases}
+            />
+          )}
+        </CompositionProbe>
       )
     }
     return render(<Probe />)
@@ -148,14 +253,22 @@ describe('SavedTabsPresentationLayout', () => {
     const Probe = () => {
       const leftPaneRef = useRef<HTMLDivElement>(null)
       return (
-        <SavedTabsPresentationLayout
-          attachLeftPaneRef={() => undefined}
-          initialViewMode='domain'
-          isAiSidebarOpen={false}
-          isCompactLeftPaneLayout={false}
-          leftPaneRef={leftPaneRef}
-          onAiSidebarOpenChange={onAiSidebarOpenChange}
-        />
+        <CompositionProbe>
+          {({ controller, deps, resolveActiveRef, useCases }) => (
+            <SavedTabsPresentationLayout
+              attachLeftPaneRef={() => undefined}
+              controller={controller}
+              deps={deps}
+              initialViewMode='domain'
+              isAiSidebarOpen={false}
+              isCompactLeftPaneLayout={false}
+              leftPaneRef={leftPaneRef}
+              onAiSidebarOpenChange={onAiSidebarOpenChange}
+              resolveActiveRef={resolveActiveRef}
+              useCases={useCases}
+            />
+          )}
+        </CompositionProbe>
       )
     }
     render(<Probe />)
@@ -167,15 +280,23 @@ describe('SavedTabsPresentationLayout', () => {
     const Probe = () => {
       const leftPaneRef = useRef<HTMLDivElement>(null)
       return (
-        <SavedTabsPresentationLayout
-          attachLeftPaneRef={() => undefined}
-          initialViewMode='domain'
-          isAiSidebarOpen={false}
-          isCompactLeftPaneLayout={false}
-          leftPaneRef={leftPaneRef}
-          onAiSidebarOpenChange={vi.fn()}
-          onViewModeNavigate={onViewModeNavigate}
-        />
+        <CompositionProbe>
+          {({ controller, deps, resolveActiveRef, useCases }) => (
+            <SavedTabsPresentationLayout
+              attachLeftPaneRef={() => undefined}
+              controller={controller}
+              deps={deps}
+              initialViewMode='domain'
+              isAiSidebarOpen={false}
+              isCompactLeftPaneLayout={false}
+              leftPaneRef={leftPaneRef}
+              onAiSidebarOpenChange={vi.fn()}
+              onViewModeNavigate={onViewModeNavigate}
+              resolveActiveRef={resolveActiveRef}
+              useCases={useCases}
+            />
+          )}
+        </CompositionProbe>
       )
     }
     render(<Probe />)

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.tsx
@@ -1,13 +1,17 @@
 import { Profiler } from 'react'
 import type { RefObject } from 'react'
 
+import type { SavedTabsUseCases } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases'
+import type { SavedTabsUseCasesDeps } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps'
 import { SavedTabsApp } from '@/contexts/saved-tabs/presentation/app/SavedTabsApp'
 import {
   handleSavedTabsRender,
   isDevProfileEnabled,
 } from '@/contexts/saved-tabs/presentation/app/savedTabsProfiler'
+import type { UseSavedTabsControllerReturn } from '@/contexts/saved-tabs/presentation/controllers/useSavedTabsController'
 import type { ViewMode } from '@/types/storage'
 
+import type { ResolveActiveRef } from '../pages/SavedTabsPage'
 import { SavedTabsChatWidgetBridge } from './SavedTabsChatWidgetBridge'
 import { SavedTabsResponsiveLayoutProvider } from './SavedTabsResponsiveLayoutContext'
 import { SavedTabsScrollControls } from './SavedTabsScrollControls'
@@ -29,15 +33,23 @@ import { SavedTabsScrollControls } from './SavedTabsScrollControls'
  * - `onAiSidebarOpenChange` : chat widget の開閉が変わった際の
  *   親 (SavedTabsPage) への通知
  * - `onViewModeNavigate` : view mode 切替時に親 (AppRouter) へ通知
+ * - `controller` / `useCases` / `deps` / `resolveActiveRef` :
+ *   composition root である `SavedTabsPage` 側で組み立てた
+ *   use-case バンドルと controller。`SavedTabsApp` 内部での
+ *   use-case 再生成を避けるため props 注入する。
  */
 export interface SavedTabsPresentationLayoutProps {
   readonly attachLeftPaneRef: (node: HTMLDivElement | null) => void
+  readonly controller: UseSavedTabsControllerReturn
+  readonly deps: SavedTabsUseCasesDeps
   readonly initialViewMode: ViewMode
   readonly isAiSidebarOpen: boolean
   readonly isCompactLeftPaneLayout: boolean
   readonly leftPaneRef: RefObject<HTMLDivElement | null>
   readonly onAiSidebarOpenChange: (isOpen: boolean) => void
   readonly onViewModeNavigate?: (mode: ViewMode) => void
+  readonly resolveActiveRef: ResolveActiveRef
+  readonly useCases: SavedTabsUseCases
 }
 
 /**
@@ -54,18 +66,26 @@ export interface SavedTabsPresentationLayoutProps {
  */
 export const SavedTabsPresentationLayout = ({
   attachLeftPaneRef,
+  controller,
+  deps,
   initialViewMode,
   isAiSidebarOpen,
   isCompactLeftPaneLayout,
   leftPaneRef,
   onAiSidebarOpenChange,
   onViewModeNavigate,
+  resolveActiveRef,
+  useCases,
 }: SavedTabsPresentationLayoutProps) => {
   const savedTabsAppNode = (
     <SavedTabsApp
+      controller={controller}
+      deps={deps}
       initialViewMode={initialViewMode}
       isAiSidebarOpen={isAiSidebarOpen}
       onViewModeNavigate={onViewModeNavigate}
+      resolveActiveRef={resolveActiveRef}
+      useCases={useCases}
     />
   )
 

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.test.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.test.tsx
@@ -295,4 +295,19 @@ describe('SavedTabsPage', () => {
     )
     expect(screen.getByTestId('saved-tabs-app-mock')).toBeTruthy()
   })
+
+  it('deps の browserTabPort が Chrome adapter 以外の port ならそれを保持する (review #493 P2)', () => {
+    // テスト / SSR 用に独自 port を注入した deps を使い、
+    // SavedTabsPage 内の composition が port を Chrome adapter で
+    // 上書きしないことを確認する。in-memory deps は in-memory port を
+    // 持っており、in-memory port は `CHROME_BROWSER_TAB_ADAPTER_MARKER`
+    // を持たないため保持される。
+    const inMemoryDeps = createInMemoryDeps({})
+    const inMemoryPort = inMemoryDeps.browserTabPort
+    expect(inMemoryPort).toBeDefined()
+    render(<SavedTabsPage deps={inMemoryDeps} />)
+    // port が差し替えられていないことを、参照同一性で確認する。
+    // もし Chrome adapter で上書きされていたら inMemoryPort とは別物になる。
+    expect(inMemoryDeps.browserTabPort).toBe(inMemoryPort)
+  })
 })

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
@@ -5,6 +5,8 @@ import type { ViewMode } from '@/types/storage'
 
 import type { CustomProject } from '../../domain/entities/CustomProject'
 import type { TabGroup } from '../../domain/entities/TabGroup'
+import { createChromeBrowserTabAdapter } from '../../infrastructure/browser/ChromeBrowserTabAdapter'
+import type { ChromeApiLike } from '../../infrastructure/browser/ChromeBrowserTabAdapter'
 import type { SavedTabsUseCases } from '../../infrastructure/composition/createSavedTabsUseCases'
 import type { SavedTabsUseCasesDeps } from '../../infrastructure/composition/createSavedTabsUseCasesDeps'
 import { SavedTabsPresentationLayout } from '../components/SavedTabsPresentationLayout'
@@ -14,6 +16,7 @@ import {
 } from '../components/savedTabsPresentationLayout.helpers'
 import { createSavedTabsUseCasesContextValueFromDeps } from '../controllers/SavedTabsUseCasesContext'
 import { useSavedTabsController } from '../controllers/useSavedTabsController'
+import type { UseSavedTabsControllerReturn } from '../controllers/useSavedTabsController'
 import type { SavedTabsViewModel } from '../view-models/SavedTabsViewModel'
 
 /**
@@ -44,6 +47,25 @@ export interface SavedTabsPageProps {
 }
 
 /**
+ * `resolveActive` を presentation 層 (SavedTabsApp) 側から差し込むための
+ * 橋渡し ref。
+ *
+ * 以下のフローで settings → port まで動的に反映する:
+ * 1. `SavedTabsPage` が `useRef` を作る
+ * 2. `BrowserTabPort` 構築時に `resolveActive: () => ref.current()` を渡す
+ * 3. 同じ ref を layout / app へ下す
+ * 4. `SavedTabsApp` 側の `useEffect` で `ref.current` を
+ *    `() => !settingsRef.current.openUrlInBackground` に更新する
+ * 5. ポートが `open()` 呼び出し時に `resolveActive()` を評価し、最新値を読む
+ *
+ * ref を介すことで use-case 自体は mount 時に 1 度だけ組み立てればよく、
+ * 設定変更のたびに use-case / port を作り直す必要がない。
+ */
+export interface ResolveActiveRef {
+  current: () => boolean
+}
+
+/**
  * `SavedTabsPage` 内部の controller 状態。
  *
  * ページ → controller フック → use-case → repository / port の流れを
@@ -52,8 +74,15 @@ export interface SavedTabsPageProps {
 export interface SavedTabsPageState {
   readonly viewModel: SavedTabsViewModel
   readonly refresh: () => Promise<void>
-  readonly controller: ReturnType<typeof useSavedTabsController>
+  readonly controller: UseSavedTabsControllerReturn
+  readonly deps: SavedTabsUseCasesDeps
+  readonly useCases: SavedTabsUseCases
+  readonly resolveActiveRef: ResolveActiveRef
 }
+
+const getChromeApiFromGlobalThis = (): ChromeApiLike | undefined =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  (globalThis as typeof globalThis & { chrome?: ChromeApiLike }).chrome
 
 /**
  * `SavedTabsPage` のロジック hook。
@@ -64,19 +93,42 @@ export interface SavedTabsPageState {
 export const useSavedTabsPage = (
   input: SavedTabsPageProps,
 ): SavedTabsPageState => {
-  if (!input.deps) {
+  const { deps: inputDeps, useCases: inputUseCases } = input
+  if (!inputDeps) {
     throw new Error(
       'SavedTabsPage: deps is required. Use createSavedTabsUseCasesDeps() at the call site for chrome real environment.',
     )
   }
-  const deps: SavedTabsUseCasesDeps = input.deps
-  const contextValue = useMemo(
+  // 初期値は `() => true` (active 固定)。`SavedTabsApp` 側の
+  // useEffect が settings を読んで本関数を上書きする。
+  const resolveActiveRef = useRef<() => boolean>(() => true)
+  // ref ベースの resolveActive を使う `BrowserTabPort` を 1 度だけ組み立てる。
+  // port の `open()` 呼び出し時に ref.current() を評価するため、
+  // use-case / port を作り直さずに settings を動反映できる。
+  const dynamicBrowserTabPort = useMemo(
     () =>
-      input.useCases
-        ? { deps, useCases: input.useCases }
-        : createSavedTabsUseCasesContextValueFromDeps(deps),
-    [deps, input.useCases],
+      createChromeBrowserTabAdapter(
+        { getApi: getChromeApiFromGlobalThis },
+        { resolveActive: () => resolveActiveRef.current() },
+      ),
+    [resolveActiveRef],
   )
+  // 早期 return 後の inputDeps は `SavedTabsUseCasesDeps` で確定する。
+  // TypeScript の型 narrowing を確実にするため、別名に取り出して使う。
+  const stableDeps: SavedTabsUseCasesDeps = inputDeps
+  const composedDeps = useMemo<SavedTabsUseCasesDeps>(
+    () => ({
+      ...stableDeps,
+      browserTabPort: dynamicBrowserTabPort,
+    }),
+    [stableDeps, dynamicBrowserTabPort],
+  )
+  const contextValue = useMemo(() => {
+    if (inputUseCases) {
+      return { deps: composedDeps, useCases: inputUseCases }
+    }
+    return createSavedTabsUseCasesContextValueFromDeps(composedDeps)
+  }, [composedDeps, inputUseCases])
   const controller = useSavedTabsController({
     deps: contextValue.deps,
     initialCustomProjects: input.initialCustomProjects,
@@ -106,7 +158,10 @@ export const useSavedTabsPage = (
   }, [])
   return {
     controller,
+    deps: contextValue.deps,
     refresh: controller.refresh,
+    resolveActiveRef,
+    useCases: contextValue.useCases,
     viewModel: controller.viewModel,
   }
 }
@@ -123,7 +178,8 @@ export const useSavedTabsPage = (
  * AI チャットウィジェット) で、見た目・操作感は変えない。
  */
 export const SavedTabsPage = (props: SavedTabsPageProps) => {
-  const { viewModel, refresh } = useSavedTabsPage(props)
+  const { viewModel, refresh, controller, deps, useCases, resolveActiveRef } =
+    useSavedTabsPage(props)
   const [isAiSidebarOpen, setIsAiSidebarOpen] = useState(false)
   const { attachLeftPaneRef, leftPaneRef, leftPaneWidth } =
     useSavedTabsLeftPaneWidth()
@@ -148,12 +204,16 @@ export const SavedTabsPage = (props: SavedTabsPageProps) => {
     >
       <SavedTabsPresentationLayout
         attachLeftPaneRef={attachLeftPaneRef}
+        controller={controller}
+        deps={deps}
         initialViewMode={resolvedInitialViewMode}
         isAiSidebarOpen={isAiSidebarOpen}
         isCompactLeftPaneLayout={isCompactLeftPaneLayout}
         leftPaneRef={leftPaneRef}
         onAiSidebarOpenChange={setIsAiSidebarOpen}
         onViewModeNavigate={props.onViewModeNavigate}
+        resolveActiveRef={resolveActiveRef}
+        useCases={useCases}
       />
     </div>
   )

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
@@ -5,7 +5,10 @@ import type { ViewMode } from '@/types/storage'
 
 import type { CustomProject } from '../../domain/entities/CustomProject'
 import type { TabGroup } from '../../domain/entities/TabGroup'
-import { createChromeBrowserTabAdapter } from '../../infrastructure/browser/ChromeBrowserTabAdapter'
+import {
+  CHROME_BROWSER_TAB_ADAPTER_MARKER,
+  createChromeBrowserTabAdapter,
+} from '../../infrastructure/browser/ChromeBrowserTabAdapter'
 import type { ChromeApiLike } from '../../infrastructure/browser/ChromeBrowserTabAdapter'
 import type { SavedTabsUseCases } from '../../infrastructure/composition/createSavedTabsUseCases'
 import type { SavedTabsUseCasesDeps } from '../../infrastructure/composition/createSavedTabsUseCasesDeps'
@@ -84,6 +87,25 @@ const getChromeApiFromGlobalThis = (): ChromeApiLike | undefined =>
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   (globalThis as typeof globalThis & { chrome?: ChromeApiLike }).chrome
 
+const isChromeBrowserTabPort = (
+  port: SavedTabsUseCasesDeps['browserTabPort'],
+): boolean => {
+  // `createChromeBrowserTabAdapter` が生成した port には
+  // `CHROME_BROWSER_TAB_ADAPTER_MARKER` をマーカーとして立てている。
+  // テスト / SSR / 個別 mock が注入した独自 port は本マーカーを持たないため
+  // そのまま保持する。`undefined` (route テストの mock 化された deps など)
+  // は Chrome adapter ではないと見なす。
+  if (!port) {
+    return false
+  }
+  // `Object.getOwnPropertySymbols` で port 自身の symbol プロパティを列挙し、
+  // マーカーが立っているかを確認する。`BrowserTabPort` interface は symbol
+  // index signature を持たないため unsafe cast を使わず、配列比較で判定する。
+  return Object.getOwnPropertySymbols(port).includes(
+    CHROME_BROWSER_TAB_ADAPTER_MARKER,
+  )
+}
+
 /**
  * `SavedTabsPage` のロジック hook。
  *
@@ -102,16 +124,19 @@ export const useSavedTabsPage = (
   // 初期値は `() => true` (active 固定)。`SavedTabsApp` 側の
   // useEffect が settings を読んで本関数を上書きする。
   const resolveActiveRef = useRef<() => boolean>(() => true)
-  // ref ベースの resolveActive を使う `BrowserTabPort` を 1 度だけ組み立てる。
-  // port の `open()` 呼び出し時に ref.current() を評価するため、
-  // use-case / port を作り直さずに settings を動反映できる。
+  // 注入された deps の `browserTabPort` が Chrome adapter のときだけ、
+  // ref ベースの resolveActive を持つ port へ差し替える。独自 port
+  // (テスト / SSR) はそのまま保持する。
+  const inputBrowserTabPort = inputDeps.browserTabPort
   const dynamicBrowserTabPort = useMemo(
     () =>
-      createChromeBrowserTabAdapter(
-        { getApi: getChromeApiFromGlobalThis },
-        { resolveActive: () => resolveActiveRef.current() },
-      ),
-    [resolveActiveRef],
+      isChromeBrowserTabPort(inputBrowserTabPort)
+        ? createChromeBrowserTabAdapter(
+            { getApi: getChromeApiFromGlobalThis },
+            { resolveActive: () => resolveActiveRef.current() },
+          )
+        : inputBrowserTabPort,
+    [inputBrowserTabPort, resolveActiveRef],
   )
   // 早期 return 後の inputDeps は `SavedTabsUseCasesDeps` で確定する。
   // TypeScript の型 narrowing を確実にするため、別名に取り出して使う。


### PR DESCRIPTION
- createSavedTabsUseCasesDeps に resolveActive 任意設定を追加 (BrowserTabPort 動的 active 制御)
- SavedTabsPage に deps / useCases / controller / resolveActiveRef を composition root として構築
- SavedTabsPresentationLayout が controller / deps / useCases / resolveActiveRef を SavedTabsApp へ props 注入
- SavedTabsApp 内部の createSavedTabsUseCases / createContextSavedTabsUseCases / createSavedTabsUseCasesDeps / useSavedTabsController を撤去し props 注入に置換
- SavedTabsApp は useEffect で resolveActiveRef.current を settings に応じて更新 (openUrlInBackground 動反映は維持)
- SavedTabsApp.test / SavedTabsPresentationLayout.test を新 composition 構成 (vi.mock ラッパ + CompositionProbe) へ追従

## 変更内容

<!-- 変更の詳細を記述してください -->

## チェックリスト

- [ ] ローカル環境でエラーになっていない
