### PR TITLE
feat(#495): chrome.storage.onChanged を StorageChangePort 経由へ移す

### DIFF
--- a/src/app/composition/createSavedTabsPorts.ts
+++ b/src/app/composition/createSavedTabsPorts.ts
@@ -1,9 +1,11 @@
 import type { BrowserTabPort } from '@/contexts/saved-tabs/application/ports/BrowserTabPort'
 import type { BrowserWindowPort } from '@/contexts/saved-tabs/application/ports/BrowserWindowPort'
 import type { NotificationPort } from '@/contexts/saved-tabs/application/ports/NotificationPort'
+import type { StorageChangePort } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import { createChromeBrowserTabAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter'
 import type { ChromeApiLike } from '@/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter'
 import { createChromeBrowserWindowAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeBrowserWindowAdapter'
+import { createChromeStorageChangeAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter'
 import { createSonnerNotificationAdapter } from '@/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter'
 
 /**
@@ -20,6 +22,7 @@ export interface SavedTabsPorts {
   readonly browserTabPort: BrowserTabPort
   readonly browserWindowPort: BrowserWindowPort
   readonly notificationPort: NotificationPort
+  readonly storageChangePort: StorageChangePort
 }
 
 /**
@@ -47,7 +50,18 @@ interface ChromeApi extends ChromeApiLike {
         >
       | undefined
   }
+  readonly storage?: {
+    readonly onChanged?: {
+      readonly addListener: (callback: ChromeOnChangedListener) => void
+      readonly removeListener: (callback: ChromeOnChangedListener) => void
+    }
+  }
 }
+
+type ChromeOnChangedListener = (
+  changes: Record<string, chrome.storage.StorageChange>,
+  areaName: string,
+) => void
 
 const getChromeApi = (): ChromeApi | undefined =>
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -86,4 +100,7 @@ export const createSavedTabsPorts = (
     getApi: () => getChromeApi(),
   }),
   notificationPort: createSonnerNotificationAdapter(),
+  storageChangePort: createChromeStorageChangeAdapter({
+    getApi: () => getChromeApi(),
+  }),
 })

--- a/src/contexts/saved-tabs/application/ports/StorageChangePort.ts
+++ b/src/contexts/saved-tabs/application/ports/StorageChangePort.ts
@@ -1,0 +1,106 @@
+/**
+ * `chrome.storage.onChanged` 相当の storage change 購読を抽象化する port。
+ *
+ * application 層は `chrome.*` API を直接呼ばず、本 port 経由で
+ * saved-tabs context が関心を持つ storage キーの変更通知を受け取る。
+ * infrastructure 層が `ChromeStorageChangeAdapter` で本 port を実装し、
+ * composition 層から use-case / presentation 層へ注入する。
+ *
+ * `chrome.storage.StorageChange` を port 境界で吸収し、
+ * `key` / `oldValue` / `newValue` のみの port DTO として公開する。
+ * これにより presentation / application 層は `chrome.*` の型を
+ * 意識せず、購読ロジックを組める。
+ *
+ * 受け取る storage キーは port 仕様としてスコープを絞り込み、
+ * port 利用側が関係ないキー（chrome.runtime 由来など）を
+ * 意識しなくて済む形にする。
+ *
+ * @example
+ * ```ts
+ * const port: StorageChangePort = createChromeStorageChangeAdapter()
+ * const unsubscribe = port.subscribe((changes) => {
+ *   for (const change of changes) {
+ *     // change.key は SavedTabsStorageChangeKey のみ
+ *   }
+ * })
+ * // コンポーネント unmount 時に呼び出して listener を解放
+ * unsubscribe()
+ * ```
+ */
+
+/**
+ * saved-tabs context が同期対象とする storage キー。
+ *
+ * 実 storage のキー（`chrome.storage.local` のフィールド名）に合わせて
+ * 列挙する。`urlRecords` のような domain 用語ではなく、実装のキー名
+ * (`urls` など) を採用する。
+ */
+export type SavedTabsStorageChangeKey =
+  | 'savedTabs'
+  | 'urls'
+  | 'parentCategories'
+  | 'customProjects'
+  | 'customProjectOrder'
+  | 'userSettings'
+
+/**
+ * port 経由で配信される 1 件分の storage 変更イベント。
+ *
+ * `oldValue` / `newValue` は `unknown` のままで渡し、受け取り側で
+ * `safeParse` などのスキーマ検証にかける。port 仕様として
+ * ドメイン entity を露出しない方針を維持する。
+ */
+export interface SavedTabsStorageChange {
+  readonly key: SavedTabsStorageChangeKey
+  readonly oldValue: unknown
+  readonly newValue: unknown
+}
+
+/**
+ * storage 変更通知の購読 port。
+ *
+ * `subscribe(listener)` を呼ぶと、port 実装が
+ * `chrome.storage.onChanged` 相当の通知源に listener を登録し、
+ * 解除用の関数（unsubscribe）を返す。`listener` には
+ * saved-tabs 関連キーの変更だけが port DTO として届く。
+ *
+ * 実装側の `listener` 呼び出しは同期を基本とする。listener 内で
+ * 非同期処理が必要になった場合は port 側ではなく listener 側で
+ * `void asyncFn()` として fire-and-forget する。
+ *
+ * 複数回 `subscribe` を呼んでも port 実装が内部で複数 listener を
+ * 持つ場合はリークしないよう、返り値の unsubscribe 関数を必ず
+ * 呼び出すこと。
+ */
+export interface StorageChangePort {
+  /**
+   * `chrome` 由来の port 実装に付くマーカー。
+   *
+   * `SavedTabsPage` などの composition 層が「chrome 由来の port であるか」
+   * を識別し、テストや SSR 用途の独自 port 実装を区別するために使う。
+   * 任意実装の port では undefined か false を入れて良い。
+   */
+  readonly [CHROME_STORAGE_CHANGE_ADAPTER_MARKER]?: boolean
+  /**
+   * storage 変更通知を購読し、解除用関数を返す。
+   *
+   * listener は port 実装側で chrome API のリスナーが
+   * 発火した直後に同期呼び出しされる。listener 内で発生した
+   * 例外は port 側で握り潰さず呼び出し側へ伝播させる方針
+   * （use-case 側の同期 service が失敗を可視化できるようにする）。
+   */
+  subscribe: (
+    listener: (changes: readonly SavedTabsStorageChange[]) => void,
+  ) => () => void
+}
+
+/**
+ * `createChromeStorageChangeAdapter` が生成した port に付くマーカー symbol。
+ *
+ * port interface のプロパティキーとして export し、adapter 実装と
+ * composition 層が同じ symbol を共有できるようにする。
+ * `CHROME_BROWSER_TAB_ADAPTER_MARKER` と同じ運用方針。
+ */
+export const CHROME_STORAGE_CHANGE_ADAPTER_MARKER = Symbol.for(
+  'tabbin.chromeStorageChangeAdapter',
+)

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -341,6 +341,96 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
     })
   })
 
+  describe('issue #495: chrome.storage.onChanged を StorageChangePort 経由へ移行', () => {
+    const expectedFiles = [
+      'src/contexts/saved-tabs/application/ports/StorageChangePort.ts',
+      'src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.ts',
+    ]
+
+    for (const file of expectedFiles) {
+      it(`${file} が存在する`, () => {
+        const source = readFileSync(resolve(repoRoot, file), 'utf8')
+        expect(source.length).toBeGreaterThan(0)
+      })
+    }
+
+    it('StorageChangePort は chrome API を import / 利用しない', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/ports/StorageChangePort.ts',
+        ),
+        'utf8',
+      )
+      expect(source).not.toMatch(/from\s+['"]chrome['"]/)
+      // JSDoc 内の言及は除外するため、import / プロパティアクセスを厳密検出
+      expect(source).not.toMatch(/chrome\.storage\.(local|onChanged|sync)\.\w/)
+      expect(source).not.toMatch(/chrome\.storage\.(local|onChanged|sync)\(/)
+    })
+
+    it('ChromeStorageChangeAdapter は StorageChangePort を実装し chrome.storage.onChanged を含む', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('StorageChangePort')
+      expect(source).toContain('getChromeStorageOnChanged')
+      expect(source).not.toMatch(/from\s+['"]@\/components/)
+      expect(source).not.toMatch(/from\s+['"]@\/features\//)
+    })
+
+    it('createSavedTabsUseCasesDeps は storageChangePort を組み立てる', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('storageChangePort')
+      expect(source).toContain('createChromeStorageChangeAdapter')
+    })
+
+    it('createSavedTabsPorts は storageChangePort を組み立てる', () => {
+      const source = readFileSync(
+        resolve(repoRoot, 'src/app/composition/createSavedTabsPorts.ts'),
+        'utf8',
+      )
+      expect(source).toContain('storageChangePort')
+      expect(source).toContain('createChromeStorageChangeAdapter')
+    })
+
+    it('SavedTabsApp は chrome.storage.onChanged を直接呼び出さない', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx',
+        ),
+        'utf8',
+      )
+      expect(source).not.toMatch(
+        /chrome\.storage\.onChanged\.(addListener|removeListener)/,
+      )
+      expect(source).toContain('storageChangePort')
+    })
+
+    it('useCategoryKeywordModal は chrome.storage.onChanged を直接呼び出さない', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts',
+        ),
+        'utf8',
+      )
+      expect(source).not.toMatch(
+        /chrome\.storage\.onChanged\.(addListener|removeListener)/,
+      )
+    })
+  })
+
   describe('domain/repositories/ の純度 (issue #457)', () => {
     const repositoryInterfaceFiles = [
       'src/contexts/saved-tabs/domain/repositories/TabGroupRepository.ts',

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createChromeStorageChangeAdapter } from './ChromeStorageChangeAdapter'
+import type {
+  ChromeApiLike,
+  ChromeStorageOnChangedLike,
+} from './ChromeStorageChangeAdapter'
+
+type ChromeOnChangedListener = (
+  changes: Record<string, chrome.storage.StorageChange>,
+  areaName: string,
+) => void
+
+type MockOnChanged = ChromeStorageOnChangedLike & {
+  emit: (
+    changes: Record<string, chrome.storage.StorageChange>,
+    area: string,
+  ) => void
+  listeners: Set<ChromeOnChangedListener>
+}
+
+const createMockOnChanged = (): MockOnChanged => {
+  const listeners = new Set<ChromeOnChangedListener>()
+  const emit = (
+    changes: Record<string, chrome.storage.StorageChange>,
+    area: string,
+  ) => {
+    for (const listener of listeners) {
+      listener(changes, area)
+    }
+  }
+  return {
+    addListener: vi.fn((listener: ChromeOnChangedListener) => {
+      listeners.add(listener)
+    }),
+    emit,
+    listeners,
+    removeListener: vi.fn((listener: ChromeOnChangedListener) => {
+      listeners.delete(listener)
+    }),
+  }
+}
+
+describe('createChromeStorageChangeAdapter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('chrome.storage.onChanged の listener を register / unregister する', () => {
+    const onChanged = createMockOnChanged()
+    const adapter = createChromeStorageChangeAdapter({
+      getOnChanged: () => onChanged,
+    })
+
+    const unsubscribe = adapter.subscribe(() => {})
+
+    expect(onChanged.addListener).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+
+    expect(onChanged.removeListener).toHaveBeenCalledTimes(1)
+  })
+
+  it('chrome.storage.StorageChange を port DTO に変換して listener へ渡す', () => {
+    const onChanged = createMockOnChanged()
+    const adapter = createChromeStorageChangeAdapter({
+      getOnChanged: () => onChanged,
+    })
+    const listener = vi.fn()
+
+    adapter.subscribe(listener)
+    onChanged.emit(
+      {
+        savedTabs: { newValue: [{ id: 'group-1' }], oldValue: [] },
+        parentCategories: { newValue: [{ id: 'parent-1' }], oldValue: [] },
+      },
+      'local',
+    )
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener).toHaveBeenCalledWith([
+      { key: 'savedTabs', newValue: [{ id: 'group-1' }], oldValue: [] },
+      {
+        key: 'parentCategories',
+        newValue: [{ id: 'parent-1' }],
+        oldValue: [],
+      },
+    ])
+  })
+
+  it('saved-tabs 対象外の storage キーは除外する', () => {
+    const onChanged = createMockOnChanged()
+    const adapter = createChromeStorageChangeAdapter({
+      getOnChanged: () => onChanged,
+    })
+    const listener = vi.fn()
+
+    adapter.subscribe(listener)
+    onChanged.emit(
+      {
+        // port 仕様にないキー
+        someExtensionKey: { newValue: 1, oldValue: 0 },
+        // port 仕様のキー
+        savedTabs: { newValue: [], oldValue: [] },
+      },
+      'local',
+    )
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener).toHaveBeenCalledWith([
+      { key: 'savedTabs', newValue: [], oldValue: [] },
+    ])
+  })
+
+  it('areaName が一致しない変更は listener へ伝播しない', () => {
+    const onChanged = createMockOnChanged()
+    const adapter = createChromeStorageChangeAdapter(
+      { getOnChanged: () => onChanged },
+      { areaName: 'sync' },
+    )
+    const listener = vi.fn()
+
+    adapter.subscribe(listener)
+    onChanged.emit(
+      {
+        savedTabs: { newValue: [], oldValue: [] },
+      },
+      'local',
+    )
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('chrome API がない環境では no-op の unsubscribe を返す', () => {
+    const adapter = createChromeStorageChangeAdapter({
+      getOnChanged: () => null,
+    })
+    const listener = vi.fn()
+
+    const unsubscribe = adapter.subscribe(listener)
+    expect(unsubscribe).toBeTypeOf('function')
+
+    // 解除呼び出しも例外を投げない
+    expect(() => unsubscribe()).not.toThrow()
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('deps 未指定でも globalThis.chrome.storage.onChanged 経由で listener を解決する', () => {
+    const onChanged = createMockOnChanged()
+    const previousChrome = (globalThis as { chrome?: unknown }).chrome
+    ;(globalThis as { chrome?: unknown }).chrome = {
+      storage: { onChanged },
+    }
+    try {
+      const adapter = createChromeStorageChangeAdapter()
+      const listener = vi.fn()
+
+      adapter.subscribe(listener)
+      onChanged.emit(
+        { customProjectOrder: { newValue: ['a'], oldValue: [] } },
+        'local',
+      )
+
+      expect(listener).toHaveBeenCalledWith([
+        { key: 'customProjectOrder', newValue: ['a'], oldValue: [] },
+      ])
+    } finally {
+      ;(globalThis as { chrome?: unknown }).chrome = previousChrome
+    }
+  })
+
+  it('deps 未指定で globalThis.chrome も無い場合は no-op で動く', () => {
+    const previousChrome = (globalThis as { chrome?: unknown }).chrome
+    delete (globalThis as { chrome?: unknown }).chrome
+    try {
+      const adapter = createChromeStorageChangeAdapter()
+      const listener = vi.fn()
+
+      const unsubscribe = adapter.subscribe(listener)
+
+      expect(unsubscribe).toBeTypeOf('function')
+      expect(listener).not.toHaveBeenCalled()
+    } finally {
+      ;(globalThis as { chrome?: unknown }).chrome = previousChrome
+    }
+  })
+
+  it('getApi から chrome.storage.onChanged 経由で listener を解決する', () => {
+    const onChanged = createMockOnChanged()
+    const api: ChromeApiLike = {
+      storage: { onChanged },
+    }
+    const adapter = createChromeStorageChangeAdapter({ getApi: () => api })
+    const listener = vi.fn()
+
+    adapter.subscribe(listener)
+    onChanged.emit({ customProjects: { newValue: [], oldValue: [] } }, 'local')
+
+    expect(listener).toHaveBeenCalledWith([
+      { key: 'customProjects', newValue: [], oldValue: [] },
+    ])
+  })
+
+  it('getApi が undefined を返す環境では no-op の unsubscribe を返す', () => {
+    const adapter = createChromeStorageChangeAdapter({
+      getApi: () => undefined,
+    })
+    const listener = vi.fn()
+
+    const unsubscribe = adapter.subscribe(listener)
+
+    expect(unsubscribe).toBeTypeOf('function')
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('複数回 subscribe しても listener は独立して解除できる', () => {
+    const onChanged = createMockOnChanged()
+    const adapter = createChromeStorageChangeAdapter({
+      getOnChanged: () => onChanged,
+    })
+    const listenerA = vi.fn()
+    const listenerB = vi.fn()
+
+    const unsubscribeA = adapter.subscribe(listenerA)
+    adapter.subscribe(listenerB)
+    onChanged.emit({ savedTabs: { newValue: [1], oldValue: [] } }, 'local')
+    expect(listenerA).toHaveBeenCalledTimes(1)
+    expect(listenerB).toHaveBeenCalledTimes(1)
+
+    unsubscribeA()
+    onChanged.emit({ savedTabs: { newValue: [2], oldValue: [1] } }, 'local')
+    expect(listenerA).toHaveBeenCalledTimes(1)
+    expect(listenerB).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.ts
@@ -1,0 +1,152 @@
+/**
+ * `chrome.storage.onChanged` 依存を `StorageChangePort` interface に
+ * 適合させる adapter。
+ *
+ * `presentation` 層は `chrome.storage.onChanged` を直接購読できないため、
+ * `composition` 層からこの adapter を `StorageChangePort` として
+ * 注入する。`chrome` API が見つからない環境（テスト / Storybook /
+ * SSR など）では `subscribe` の返り値を呼んでも何もしない
+ * no-op 関数として扱い、use-case / presentation 側の後段処理を
+ * 落とさない方針とする（`chrome.tabs` 等の他 adapter とは挙動が
+ * 異なる点に注意）。
+ *
+ * port 境界では `chrome.storage.StorageChange` を `{ key, oldValue,
+ * newValue }` の DTO に詰め替え、port 利用側に `chrome.*` 型を
+ * 一切露出しない。storage エリア名 (`local` / `sync` 等) は
+ * `options.areaName` で絞り込み、saved-tabs は `local` のみを
+ * 対象とする既定とする。
+ *
+ * @example
+ * ```ts
+ * const port: StorageChangePort = createChromeStorageChangeAdapter()
+ * const unsubscribe = port.subscribe((changes) => {
+ *   // changes は port DTO の配列
+ * })
+ * // unmount 時に呼ぶ
+ * unsubscribe()
+ * ```
+ */
+
+import { getChromeStorageOnChanged } from '@/lib/browser/chrome-storage'
+
+import { CHROME_STORAGE_CHANGE_ADAPTER_MARKER } from '../../application/ports/StorageChangePort'
+import type {
+  SavedTabsStorageChange,
+  SavedTabsStorageChangeKey,
+  StorageChangePort,
+} from '../../application/ports/StorageChangePort'
+
+export interface ChromeStorageOnChangedLike {
+  readonly addListener: (callback: ChromeOnChangedListener) => void
+  readonly removeListener: (callback: ChromeOnChangedListener) => void
+}
+
+export interface ChromeStorageLike {
+  readonly onChanged?: ChromeStorageOnChangedLike
+}
+
+export interface ChromeApiLike {
+  readonly storage?: ChromeStorageLike
+}
+
+type ChromeOnChangedListener = (
+  changes: Record<string, chrome.storage.StorageChange>,
+  areaName: string,
+) => void
+
+export interface ChromeStorageChangeAdapterDeps {
+  /**
+   * `chrome.storage.onChanged` を含む chrome API 全体。テスト時は
+   * `storage.onChanged.addListener` / `removeListener` を持つ
+   * モックオブジェクトを渡す。未指定なら `getChromeStorageOnChanged`
+   * 経由で実 `chrome` グローバルを参照する。
+   */
+  readonly getApi?: () => ChromeApiLike | undefined
+  /**
+   * `chrome.storage.onChanged` 相当の API を直接注入したい場合用。
+   * `getApi` より優先される（Storybook などで `chrome` の一部だけを
+   * 差し込みたい場合を想定）。
+   */
+  readonly getOnChanged?: () => ChromeStorageOnChangedLike | null
+}
+
+export interface ChromeStorageChangeAdapterOptions {
+  /**
+   * 購読対象とする storage エリア名。`chrome.storage.onChanged` は
+   * グローバルに発火するため、port 側で areaName を絞り込む。
+   * saved-tabs は `local` のみを使う前提でデフォルト 'local'。
+   * `chrome.storage.sync` を併用する extension では `'sync'` を渡す。
+   */
+  readonly areaName?: 'local' | 'sync' | 'managed' | 'session'
+}
+
+const isSavedTabsStorageChangeKey = (
+  key: string,
+): key is SavedTabsStorageChangeKey => {
+  return (
+    key === 'savedTabs' ||
+    key === 'urls' ||
+    key === 'parentCategories' ||
+    key === 'customProjects' ||
+    key === 'customProjectOrder' ||
+    key === 'userSettings'
+  )
+}
+
+/**
+ * `chrome.storage.onChanged` を利用する `StorageChangePort` 実装を生成する。
+ *
+ * `chrome` API が見つからない環境（テスト / Storybook など）では
+ * `subscribe` の戻り値が no-op となり、listener は発火しない。
+ * これは「storage 変更を契機とする UI 同期は止めても use-case 全体は
+ * 落とさない」という presentation 側の運用のため。
+ * もし失敗を可視化したい場合は port 実装をモックで差し替え、
+ * テスト時に listener 呼び出しを検証する。
+ */
+export const createChromeStorageChangeAdapter = (
+  deps: ChromeStorageChangeAdapterDeps = {},
+  options: ChromeStorageChangeAdapterOptions = {},
+): StorageChangePort => {
+  const areaName = options.areaName ?? 'local'
+
+  const resolveOnChanged = (): ChromeStorageOnChangedLike | null => {
+    if (deps.getOnChanged) {
+      return deps.getOnChanged()
+    }
+    if (deps.getApi) {
+      return deps.getApi()?.storage?.onChanged ?? null
+    }
+    return getChromeStorageOnChanged() as ChromeStorageOnChangedLike | null
+  }
+
+  return {
+    [CHROME_STORAGE_CHANGE_ADAPTER_MARKER]: true,
+    subscribe: (listener) => {
+      const onChanged = resolveOnChanged()
+      if (!onChanged) {
+        return () => {}
+      }
+      const wrappedListener: ChromeOnChangedListener = (changes, area) => {
+        if (area !== areaName) {
+          return
+        }
+        const events: SavedTabsStorageChange[] = []
+        for (const [key, change] of Object.entries(changes)) {
+          if (!isSavedTabsStorageChangeKey(key)) {
+            continue
+          }
+          events.push({
+            key,
+            oldValue: change.oldValue,
+            newValue: change.newValue,
+          })
+        }
+        listener(events)
+      }
+      onChanged.addListener(wrappedListener)
+      return () => {
+        onChanged.removeListener(wrappedListener)
+      }
+    },
+  }
+}

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
@@ -6,12 +6,14 @@ import {
 import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
 import type { BrowserWindowPort } from '../../application/ports/BrowserWindowPort'
 import type { NotificationPort } from '../../application/ports/NotificationPort'
+import type { StorageChangePort } from '../../application/ports/StorageChangePort'
 import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
 import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
 import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
 import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
 import { createChromeBrowserTabAdapter } from '../browser/ChromeBrowserTabAdapter'
 import { createChromeBrowserWindowAdapter } from '../browser/ChromeBrowserWindowAdapter'
+import { createChromeStorageChangeAdapter } from '../browser/ChromeStorageChangeAdapter'
 import { createSonnerNotificationAdapter } from '../browser/SonnerNotificationAdapter'
 import { createChromeCustomProjectRepository } from '../persistence/chrome-storage/ChromeCustomProjectRepository'
 import { createChromeParentCategoryRepository } from '../persistence/chrome-storage/ChromeParentCategoryRepository'
@@ -34,6 +36,7 @@ export interface SavedTabsUseCasesDeps {
   readonly browserTabPort: BrowserTabPort
   readonly browserWindowPort: BrowserWindowPort
   readonly notificationPort: NotificationPort
+  readonly storageChangePort: StorageChangePort
 }
 
 /**
@@ -64,7 +67,18 @@ interface ChromeLike {
         >
       | undefined
   }
+  readonly storage?: {
+    readonly onChanged?: {
+      readonly addListener: (callback: ChromeOnChangedListener) => void
+      readonly removeListener: (callback: ChromeOnChangedListener) => void
+    }
+  }
 }
+
+type ChromeOnChangedListener = (
+  changes: Record<string, chrome.storage.StorageChange>,
+  areaName: string,
+) => void
 
 const getChromeApi = (): ChromeLike | undefined =>
   // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -114,6 +128,9 @@ export const createSavedTabsUseCasesDeps = (
     customProjectRepository: createChromeCustomProjectRepository(port),
     notificationPort: createSonnerNotificationAdapter(),
     parentCategoryRepository: createChromeParentCategoryRepository(port),
+    storageChangePort: createChromeStorageChangeAdapter({
+      getApi: () => getChromeApi(),
+    }),
     tabGroupRepository: createChromeTabGroupRepository(port),
     urlRecordRepository: createChromeUrlRecordRepository(port),
   }

--- a/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
@@ -121,6 +121,9 @@ const createBundle = (initial: StorageState = {}): Bundle => {
     customProjectRepository: createChromeCustomProjectRepository(port),
     notificationPort: notification.notificationPort,
     parentCategoryRepository: createChromeParentCategoryRepository(port),
+    storageChangePort: {
+      subscribe: () => () => {},
+    },
     tabGroupRepository: createChromeTabGroupRepository(port),
     urlRecordRepository: createChromeUrlRecordRepository(port),
   }
@@ -341,6 +344,9 @@ describe('savedTabs DDD 移行 後 回帰テスト', () => {
         customProjectRepository: createChromeCustomProjectRepository(port),
         notificationPort: notification.notificationPort,
         parentCategoryRepository: createChromeParentCategoryRepository(port),
+        storageChangePort: {
+          subscribe: () => () => {},
+        },
         tabGroupRepository: createChromeTabGroupRepository(port),
         urlRecordRepository: createChromeUrlRecordRepository(port),
       }

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
@@ -1316,15 +1316,19 @@ describe('SavedTabsApp custom search', () => {
 
     const listener = addListener.mock.calls[0]?.[0] as (
       changes: Record<string, chrome.storage.StorageChange>,
-    ) => Promise<void>
+      area: string,
+    ) => void
     await act(async () => {
-      await listener({
-        settings: {
-          newValue: {
-            enableCategories: false,
+      listener(
+        {
+          settings: {
+            newValue: {
+              enableCategories: false,
+            },
           },
         },
-      })
+        'local',
+      )
     })
 
     await waitFor(() => {
@@ -2749,24 +2753,29 @@ describe('SavedTabsApp custom search', () => {
     const { unmount } = render(<SavedTabsApp />)
     const listener = addListener.mock.calls[0]?.[0] as (
       changes: Record<string, chrome.storage.StorageChange>,
-    ) => Promise<void>
+      area: string,
+    ) => void
 
-    await listener({
-      savedTabs: {
-        newValue: [],
-        oldValue: [],
+    listener(
+      {
+        savedTabs: {
+          newValue: [],
+          oldValue: [],
+        },
       },
-    })
+      'local',
+    )
     unmount()
 
     expect(syncStorageChanges).toHaveBeenCalledWith(
       expect.objectContaining({
-        changes: {
-          savedTabs: {
+        changes: [
+          {
+            key: 'savedTabs',
             newValue: [],
             oldValue: [],
           },
-        },
+        ],
       }),
     )
     expect(removeListener).toHaveBeenCalledWith(listener)
@@ -3134,15 +3143,19 @@ describe('SavedTabsApp custom search', () => {
 
     const listener = addListener.mock.calls[0]?.[0] as (
       changes: Record<string, chrome.storage.StorageChange>,
-    ) => Promise<void>
+      area: string,
+    ) => void
     await act(async () => {
-      await listener({
-        settings: {
-          newValue: {
-            openAllInNewWindow: true,
+      listener(
+        {
+          settings: {
+            newValue: {
+              openAllInNewWindow: true,
+            },
           },
         },
-      })
+        'local',
+      )
     })
 
     await waitFor(() => {
@@ -3824,15 +3837,19 @@ describe('SavedTabsApp custom search', () => {
 
     const listener = addListener.mock.calls[0]?.[0] as (
       changes: Record<string, chrome.storage.StorageChange>,
-    ) => Promise<void>
+      area: string,
+    ) => void
     await act(async () => {
-      await listener({
-        settings: {
-          newValue: {
-            removeTabAfterOpen: false,
+      listener(
+        {
+          settings: {
+            newValue: {
+              removeTabAfterOpen: false,
+            },
           },
         },
-      })
+        'local',
+      )
     })
     const customProps = mocked.customModeContainerSpy.mock.calls.at(
       -1,
@@ -4656,11 +4673,15 @@ describe('SavedTabsApp custom search', () => {
     // 設定を openUrlInBackground=false に変えてから再描画
     const listener = addListener.mock.calls[0]?.[0] as (
       changes: Record<string, chrome.storage.StorageChange>,
-    ) => Promise<void>
+      area: string,
+    ) => void
     await act(async () => {
-      await listener({
-        settings: { newValue: { openUrlInBackground: false } },
-      })
+      listener(
+        {
+          settings: { newValue: { openUrlInBackground: false } },
+        },
+        'local',
+      )
     })
 
     // 2回目: openUrlInBackground=false → active: true

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -984,15 +984,12 @@ const useSavedTabsAppView = ({
     }
   }, [customProjects, searchQuery])
 
-  // ストレージ変更検出時のリスナーを改善（ドメインモードとカスタムモード間の同期）
+  // ストレージ変更検出時のリスナー。`chrome.storage.onChanged` 直叩きは禁止のため
+  // `StorageChangePort` 経由で chrome API 実装 (infrastructure 層) と疎結合にする。
   useEffect(() => {
-    const handleStorageChanged = async (
-      // eslint-disable-next-line eslint/no-restricted-properties -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-      // eslint-disable-next-line eslint/no-restricted-properties, typescript/unbound-method -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-      changes: Record<string, chrome.storage.StorageChange>,
-    ) => {
+    const unsubscribe = deps.storageChangePort.subscribe((changes) => {
       console.log('ストレージ変更を検出:', changes)
-      await syncStorageChanges({
+      void syncStorageChanges({
         changes,
         refreshTabGroupsWithUrls,
         setCategories,
@@ -1001,14 +998,12 @@ const useSavedTabsAppView = ({
         syncDomainDataToCustomProjects,
         viewModeRef,
       })
-    }
-    // eslint-disable-next-line eslint/no-restricted-properties, typescript/no-misused-promises, typescript/unbound-method -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-    chrome.storage.onChanged.addListener(handleStorageChanged)
+    })
     return () => {
-      // eslint-disable-next-line eslint/no-restricted-properties, typescript/no-misused-promises, typescript/unbound-method -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-      chrome.storage.onChanged.removeListener(handleStorageChanged)
+      unsubscribe()
     }
   }, [
+    deps.storageChangePort,
     refreshTabGroupsWithUrls,
     syncDomainDataToCustomProjects,
     setCategories,

--- a/src/contexts/saved-tabs/presentation/components/CategoryKeywordModal.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryKeywordModal.tsx
@@ -1,3 +1,4 @@
+import type { StorageChangePort } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import type { CategoryKeywordModalProps } from '@/types/saved-tabs'
 import type { ParentCategory } from '@/types/storage'
 
@@ -13,6 +14,10 @@ const EMPTY_PARENT_CATEGORIES: ParentCategory[] = []
  * 複合コンポーネントパターンで構成される薄いラッパー
  * @param props CategoryKeywordModalProps
  */
+interface CategoryKeywordModalExtraProps {
+  readonly storageChangePort?: StorageChangePort
+}
+
 export const CategoryKeywordModal = ({
   group,
   isOpen,
@@ -21,7 +26,8 @@ export const CategoryKeywordModal = ({
   onDeleteCategory,
   parentCategories: initialParentCategories = EMPTY_PARENT_CATEGORIES,
   onUpdateParentCategories,
-}: CategoryKeywordModalProps) => (
+  storageChangePort,
+}: CategoryKeywordModalProps & CategoryKeywordModalExtraProps) => (
   <KeywordModalRoot
     group={group}
     isOpen={isOpen}
@@ -30,6 +36,7 @@ export const CategoryKeywordModal = ({
     onDeleteCategory={onDeleteCategory}
     initialParentCategories={initialParentCategories}
     onUpdateParentCategories={onUpdateParentCategories}
+    storageChangePort={storageChangePort}
   >
     <SubCategoryAddSection />
     <SubCategorySelector />

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
@@ -98,6 +98,9 @@ const buildLayoutComposition = () => {
       }),
     },
     notificationPort: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+    storageChangePort: {
+      subscribe: () => () => {},
+    },
     customProjectRepository: {
       // eslint-disable-next-line typescript/require-await
       findAll: async () => [],

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardActions.tsx
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardActions.tsx
@@ -18,6 +18,7 @@ import {
   SavedTabsResponsiveLabel,
   SavedTabsResponsiveTooltipContent,
 } from '@/contexts/saved-tabs/presentation/components/shared/SavedTabsResponsive'
+import { useSavedTabsUseCases } from '@/contexts/saved-tabs/presentation/controllers/SavedTabsUseCasesContext'
 import { getScopedNounActionLabel } from '@/contexts/saved-tabs/presentation/lib/accessibility'
 import { handleSaveKeywords } from '@/contexts/saved-tabs/presentation/lib/category-keywords'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
@@ -35,6 +36,7 @@ export const DomainCardActions = () => {
   const { t } = useI18n()
   const { state, group, settings, isReorderMode, searchQuery, handlers } =
     useDomainCard()
+  const useCases = useSavedTabsUseCases()
   const { keywordModal, parentCategories, categoryActions } = state
   const domainName = group.domain
 
@@ -181,6 +183,7 @@ export const DomainCardActions = () => {
             onUpdateParentCategories={
               parentCategories.handleUpdateParentCategories
             }
+            storageChangePort={useCases?.deps.storageChangePort}
           />
         )}
       </div>

--- a/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordModalRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordModalRoot.tsx
@@ -4,6 +4,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import type { StorageChangePort } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import type { CategoryKeywordModalProps } from '@/types/saved-tabs'
 
@@ -31,6 +32,13 @@ interface KeywordModalRootProps {
   initialParentCategories?: CategoryKeywordModalProps['parentCategories']
   /** 親カテゴリ更新ハンドラ */
   onUpdateParentCategories?: CategoryKeywordModalProps['onUpdateParentCategories']
+  /**
+   * storage 変更通知 port。`chrome.storage.onChanged` の直叩きは禁止の
+   * ため、presentation 層は本 port 経由でのみ storage 変更を購読する。
+   * 未指定時は購読を行わない（テストや SSR など chrome 依存を完全に
+   * 切りたい場合用）。
+   */
+  readonly storageChangePort?: StorageChangePort
   /** 子コンポーネント */
   children: React.ReactNode
 }
@@ -48,6 +56,7 @@ export const KeywordModalRoot = ({
   onDeleteCategory,
   initialParentCategories = EMPTY_PARENT_CATEGORIES,
   onUpdateParentCategories,
+  storageChangePort,
   children,
 }: KeywordModalRootProps) => {
   const { t } = useI18n()
@@ -58,6 +67,7 @@ export const KeywordModalRoot = ({
     onDeleteCategory,
     onSave,
     onUpdateParentCategories,
+    storageChangePort,
   })
 
   if (!isOpen) {

--- a/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.test.ts
@@ -137,6 +137,9 @@ const createEmptyDeps = (
         createInMemoryRepositories().customProjectRepository,
       notificationPort,
       parentCategoryRepository,
+      storageChangePort: {
+        subscribe: () => () => {},
+      },
       tabGroupRepository,
       urlRecordRepository,
     },

--- a/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.test.ts
@@ -156,6 +156,9 @@ const createEmptyDeps = (
         createInMemoryRepositories().customProjectRepository,
       notificationPort,
       parentCategoryRepository,
+      storageChangePort: {
+        subscribe: () => () => {},
+      },
       tabGroupRepository: createInMemoryRepositories().tabGroupRepository,
       urlRecordRepository,
     },

--- a/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.test.ts
@@ -156,6 +156,9 @@ const createEmptyDeps = (
         createInMemoryRepositories().customProjectRepository,
       notificationPort,
       parentCategoryRepository,
+      storageChangePort: {
+        subscribe: () => () => {},
+      },
       tabGroupRepository: createInMemoryRepositories().tabGroupRepository,
       urlRecordRepository,
     },

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.test.tsx
@@ -5,6 +5,10 @@ import type { ChangeEvent } from 'react'
 import { toast } from 'sonner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
+import type {
+  SavedTabsStorageChange,
+  StorageChangePort,
+} from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import type { ParentCategory, TabGroup } from '@/types/storage'
 
 import {
@@ -75,9 +79,6 @@ const createChangeEvent = (value: string) =>
   }) as ChangeEvent<HTMLInputElement>
 
 const setupChromeStorage = (state: StorageState = {}) => {
-  const listeners = new Set<
-    (changes: Record<string, chrome.storage.StorageChange>) => void
-  >()
   const local = {
     // eslint-disable-next-line typescript/require-await
     get: vi.fn(async (keys?: string | string[]) => {
@@ -100,53 +101,40 @@ const setupChromeStorage = (state: StorageState = {}) => {
       Object.assign(state, value)
     }),
   }
-  const onChanged = {
-    addListener: vi.fn(
-      (
-        listener: (
-          changes: Record<string, chrome.storage.StorageChange>,
-        ) => void,
-      ) => {
-        listeners.add(listener)
-      },
-    ),
-    removeListener: vi.fn(
-      (
-        listener: (
-          changes: Record<string, chrome.storage.StorageChange>,
-        ) => void,
-      ) => {
-        listeners.delete(listener)
-      },
-    ),
-  }
 
   globalThis.chrome = {
     storage: {
       local,
-      onChanged,
     },
   } as unknown as typeof chrome
 
   return {
-    emitParentCategoriesChanged: () => {
-      for (const listener of listeners) {
-        listener({
-          parentCategories: {
-            newValue: state.parentCategories,
-            oldValue: [],
-          },
-        })
-      }
-    },
-    emitUnrelatedChanged: () => {
-      for (const listener of listeners) {
-        listener({})
-      }
-    },
     local,
-    onChanged,
     state,
+  }
+}
+
+const createMockStorageChangePort = () => {
+  const listeners = new Set<
+    (changes: readonly SavedTabsStorageChange[]) => void
+  >()
+  const port: StorageChangePort = {
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+  return {
+    emit: (changes: readonly SavedTabsStorageChange[]) => {
+      for (const listener of listeners) {
+        listener(changes)
+      }
+    },
+    listeners,
+    port,
+    subscribeSpy: vi.fn(port.subscribe),
   }
 }
 
@@ -339,9 +327,11 @@ describe('useCategoryKeywordModal', () => {
       parentCategories: createParentCategories(),
       savedTabs: [createGroup()],
     })
+    const changePort = createMockStorageChangePort()
 
     const { result, unmount } = renderModalHook({
       onUpdateParentCategories,
+      storageChangePort: changePort.port,
     })
 
     await waitFor(() => {
@@ -352,7 +342,7 @@ describe('useCategoryKeywordModal', () => {
     expect(onUpdateParentCategories).toHaveBeenCalledWith(
       createParentCategories(),
     )
-    expect(storage.onChanged.addListener).toHaveBeenCalled()
+    expect(changePort.listeners.size).toBe(1)
 
     storage.state.parentCategories = [
       {
@@ -365,8 +355,14 @@ describe('useCategoryKeywordModal', () => {
 
     // eslint-disable-next-line typescript/require-await
     await act(async () => {
-      storage.emitUnrelatedChanged()
-      storage.emitParentCategoriesChanged()
+      changePort.emit([
+        { key: 'customProjects', oldValue: [], newValue: [] },
+        {
+          key: 'parentCategories',
+          oldValue: createParentCategories(),
+          newValue: storage.state.parentCategories,
+        },
+      ])
     })
 
     await waitFor(() => {
@@ -377,7 +373,7 @@ describe('useCategoryKeywordModal', () => {
 
     unmount()
 
-    expect(storage.onChanged.removeListener).toHaveBeenCalled()
+    expect(changePort.listeners.size).toBe(0)
   })
 
   it('親カテゴリ読み込みに失敗した場合はエラートーストを表示する', async () => {

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { z } from 'zod'
 
+import type { StorageChangePort } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import type { ParentCategory, TabGroup } from '@/types/storage'
 
@@ -33,6 +34,13 @@ interface UseCategoryKeywordModalParams {
   initialParentCategories: ParentCategory[]
   /** 親カテゴリ更新ハンドラ */
   onUpdateParentCategories?: (categories: ParentCategory[]) => void
+  /**
+   * storage 変更通知 port。`chrome.storage.onChanged` の直叩きは禁止の
+   * ため、presentation 層は本 port 経由でのみ storage 変更を購読する。
+   * 未指定時は購読を行わず、初回 `loadParentCategories` 呼び出しだけで
+   * 親カテゴリを同期する（テストで chrome 依存を完全に切りたい場合用）。
+   */
+  readonly storageChangePort?: StorageChangePort
 }
 const resolveSelectedParentCategoryId = (
   storedCategories: ParentCategory[],
@@ -106,6 +114,7 @@ export const useCategoryKeywordModal = ({
   onDeleteCategory,
   initialParentCategories,
   onUpdateParentCategories,
+  storageChangePort,
 }: UseCategoryKeywordModalParams) => {
   const { t } = useI18n()
   // --- サブカテゴリ選択状態 ---
@@ -211,32 +220,25 @@ export const useCategoryKeywordModal = ({
   // --- モーダル開閉時の初期化 ---
   useEffect(() => {
     if (!isOpen) {
-      return
+      return undefined
     }
 
     void loadParentCategories()
 
-    const handleStorageChange = (
-      // eslint-disable-next-line eslint/no-restricted-properties -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-      // eslint-disable-next-line eslint/no-restricted-properties, typescript/unbound-method -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-      changes: Record<string, chrome.storage.StorageChange>,
-    ) => {
-      if (changes.parentCategories) {
+    if (!storageChangePort) {
+      return undefined
+    }
+
+    const unsubscribe = storageChangePort.subscribe((changes) => {
+      if (changes.some((change) => change.key === 'parentCategories')) {
         void loadParentCategories()
       }
-    }
+    })
 
-    // eslint-disable-next-line eslint/no-restricted-properties -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-    // eslint-disable-next-line eslint/no-restricted-properties, typescript/unbound-method -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-    chrome.storage.onChanged.addListener(handleStorageChange)
-
-    // eslint-disable-next-line typescript/consistent-return
     return () => {
-      // eslint-disable-next-line eslint/no-restricted-properties -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-      // eslint-disable-next-line eslint/no-restricted-properties, typescript/unbound-method -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-      chrome.storage.onChanged.removeListener(handleStorageChange)
+      unsubscribe()
     }
-  }, [isOpen, loadParentCategories])
+  }, [isOpen, loadParentCategories, storageChangePort])
 
   // --- カテゴリ変更時のキーワード読み込み ---
   useEffect(() => {

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.contextProvider.test.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.contextProvider.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { BrowserTabPort } from '../../application/ports/BrowserTabPort'
+import type { BrowserWindowPort } from '../../application/ports/BrowserWindowPort'
+import type { NotificationPort } from '../../application/ports/NotificationPort'
+import type { StorageChangePort } from '../../application/ports/StorageChangePort'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
+import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepository'
+import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
+import type { SavedTabsUseCasesDeps } from '../../infrastructure/composition/createSavedTabsUseCasesDeps'
+import { useSavedTabsUseCases } from '../controllers/SavedTabsUseCasesContext'
+
+vi.mock('@/features/i18n/context/I18nProvider', () => ({
+  I18nProvider: ({ children }: { children: React.ReactNode }) => (
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    <>{children}</>
+  ),
+  useI18n: () => ({
+    language: 'ja',
+    t: (key: string) => key,
+  }),
+  useI18nText: () => (key: string) => key,
+}))
+
+const createInMemoryDeps = (): SavedTabsUseCasesDeps => {
+  const tabGroupRepository: TabGroupRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    findById: async () => null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async () => undefined,
+  }
+  const customProjectRepository: CustomProjectRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    findById: async () => null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    findOrder: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    saveOrder: async () => undefined,
+  }
+  const urlRecordRepository: UrlRecordRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    findById: async () => null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async () => undefined,
+  }
+  const parentCategoryRepository: ParentCategoryRepository = {
+    // eslint-disable-next-line typescript/require-await
+    findAll: async () => [],
+    // eslint-disable-next-line typescript/require-await
+    findById: async () => null,
+    // eslint-disable-next-line typescript/require-await
+    removeByIds: async () => undefined,
+    // eslint-disable-next-line typescript/require-await
+    saveAll: async () => undefined,
+  }
+  const browserTabPort: BrowserTabPort = {
+    // eslint-disable-next-line typescript/require-await
+    open: async (input: { url: string }) => ({ url: input.url }),
+  }
+  const browserWindowPort: BrowserWindowPort = {
+    // eslint-disable-next-line typescript/require-await
+    openWithUrls: async (input: { urls: readonly string[] }) => ({
+      urls: [...input.urls],
+    }),
+  }
+  const notificationPort: NotificationPort = {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  }
+  return {
+    browserTabPort,
+    browserWindowPort,
+    customProjectRepository,
+    notificationPort,
+    parentCategoryRepository,
+    storageChangePort: {
+      subscribe: () => () => {},
+    },
+    tabGroupRepository,
+    urlRecordRepository,
+  }
+}
+
+const probeState = vi.hoisted(() => ({
+  // probe が観測した context の storageChangePort 参照を保持し、
+  // テスト本体から参照同一性で検証する。
+  capturedPort: null as StorageChangePort | null,
+}))
+
+const ContextProbe = ({ testId }: { testId: string }) => {
+  const context = useSavedTabsUseCases()
+  probeState.capturedPort = context?.deps.storageChangePort ?? null
+  const hasContext = context ? 'true' : 'false'
+  const hasPort = context?.deps.storageChangePort ? 'true' : 'false'
+  return (
+    <div
+      data-testid={testId}
+      data-has-context={hasContext}
+      data-has-port={hasPort}
+    />
+  )
+}
+
+vi.mock(
+  '@/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout',
+  () => ({
+    SavedTabsPresentationLayout: () => <ContextProbe testId='context-probe' />,
+  }),
+)
+
+import { SavedTabsPage } from './SavedTabsPage'
+
+describe('SavedTabsPage / issue #495 review P2', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    probeState.capturedPort = null
+  })
+
+  it('SavedTabsUseCasesProvider を mount し storageChangePort を配布する', () => {
+    // Codex review P2 指摘: SavedTabsPage が provider を介さずに
+    // SavedTabsPresentationLayout を直接レンダリングしていたため、
+    // 子コンポーネント (例: DomainCardActions) から
+    // `useSavedTabsUseCases()` を呼ぶと `null` が返り、
+    // `storageChangePort` が undefined になっていた。
+    // provider を page 配下に置くことで、deps.storageChangePort が
+    // 子コンポーネントへ確実に届くことを検証する。
+    const subscribeSpy = vi.fn(() => () => {})
+    const storageChangePort: StorageChangePort = {
+      subscribe: subscribeSpy,
+    }
+    const deps: SavedTabsUseCasesDeps = {
+      ...createInMemoryDeps(),
+      storageChangePort,
+    }
+    render(<SavedTabsPage deps={deps} />)
+    const probe = screen.getByTestId('context-probe')
+    expect(probe.getAttribute('data-has-context')).toBe('true')
+    // deps で渡した storageChangePort が context 経由で取得できる
+    // ことを verify する。provider が null だと
+    // `useSavedTabsUseCases()` が undefined を返し、
+    // 配下の KeywordModal が subscribe できない (Codex 指摘)
+    expect(probe.getAttribute('data-has-port')).toBe('true')
+    expect(probeState.capturedPort).toBe(storageChangePort)
+  })
+})

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.test.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.test.tsx
@@ -135,6 +135,9 @@ const createInMemoryDeps = (input: {
     customProjectRepository,
     notificationPort,
     parentCategoryRepository,
+    storageChangePort: {
+      subscribe: () => () => {},
+    },
     tabGroupRepository,
     urlRecordRepository,
   }

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
@@ -17,7 +17,10 @@ import {
   LEFT_PANE_COMPACT_BREAKPOINT_PX,
   useSavedTabsLeftPaneWidth,
 } from '../components/savedTabsPresentationLayout.helpers'
-import { createSavedTabsUseCasesContextValueFromDeps } from '../controllers/SavedTabsUseCasesContext'
+import {
+  createSavedTabsUseCasesContextValueFromDeps,
+  SavedTabsUseCasesProvider,
+} from '../controllers/SavedTabsUseCasesContext'
 import { useSavedTabsController } from '../controllers/useSavedTabsController'
 import type { UseSavedTabsControllerReturn } from '../controllers/useSavedTabsController'
 import type { SavedTabsViewModel } from '../view-models/SavedTabsViewModel'
@@ -216,30 +219,41 @@ export const SavedTabsPage = (props: SavedTabsPageProps) => {
       props.search ??
         (typeof window !== 'undefined' ? window.location.search : ''),
     )
+  // `useSavedTabsUseCases()` が `null` を返すと子コンポーネントが
+  // `StorageChangePort` などの port を取り出せず、開いたモーダルが
+  // storage 変更に追従できなくなる。`SavedTabsPage` 配下の
+  // presentation ツリー全体に deps / useCases を配布するため
+  // `SavedTabsUseCasesProvider` で wrap する。
+  // provider value は useMemo で同一参照を保ち、子の不要な
+  // 再レンダーを抑える。
+  const providerValue = useMemo(() => ({ deps, useCases }), [deps, useCases])
+
   // view-model の refresh は layout の close 動線 (AI チャットなど) では
   // 直接呼ばないが、controller 側で `refresh` を提供していることを
   // 利用側へ示すために保持する。
   void refresh
   return (
-    <div
-      data-testid='saved-tabs-page-presentation'
-      data-loading={viewModel.loading ? 'true' : 'false'}
-      data-error={viewModel.error ?? ''}
-      data-has-content={viewModel.hasContent ? 'true' : 'false'}
-    >
-      <SavedTabsPresentationLayout
-        attachLeftPaneRef={attachLeftPaneRef}
-        controller={controller}
-        deps={deps}
-        initialViewMode={resolvedInitialViewMode}
-        isAiSidebarOpen={isAiSidebarOpen}
-        isCompactLeftPaneLayout={isCompactLeftPaneLayout}
-        leftPaneRef={leftPaneRef}
-        onAiSidebarOpenChange={setIsAiSidebarOpen}
-        onViewModeNavigate={props.onViewModeNavigate}
-        resolveActiveRef={resolveActiveRef}
-        useCases={useCases}
-      />
-    </div>
+    <SavedTabsUseCasesProvider value={providerValue}>
+      <div
+        data-testid='saved-tabs-page-presentation'
+        data-loading={viewModel.loading ? 'true' : 'false'}
+        data-error={viewModel.error ?? ''}
+        data-has-content={viewModel.hasContent ? 'true' : 'false'}
+      >
+        <SavedTabsPresentationLayout
+          attachLeftPaneRef={attachLeftPaneRef}
+          controller={controller}
+          deps={deps}
+          initialViewMode={resolvedInitialViewMode}
+          isAiSidebarOpen={isAiSidebarOpen}
+          isCompactLeftPaneLayout={isCompactLeftPaneLayout}
+          leftPaneRef={leftPaneRef}
+          onAiSidebarOpenChange={setIsAiSidebarOpen}
+          onViewModeNavigate={props.onViewModeNavigate}
+          resolveActiveRef={resolveActiveRef}
+          useCases={useCases}
+        />
+      </div>
+    </SavedTabsUseCasesProvider>
   )
 }

--- a/src/contexts/saved-tabs/presentation/services/modeSyncService.test.ts
+++ b/src/contexts/saved-tabs/presentation/services/modeSyncService.test.ts
@@ -1,6 +1,7 @@
 import type { RefObject, SetStateAction } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
+import type { SavedTabsStorageChange } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import type {
   CustomProject,
   ParentCategory,
@@ -28,14 +29,15 @@ const createProject = (overrides: Partial<CustomProject>): CustomProject => ({
   ...overrides,
 })
 
-const createStorageChange = (
+const createChange = (
+  key: SavedTabsStorageChange['key'],
   newValue: unknown,
   oldValue?: unknown,
-): chrome.storage.StorageChange =>
-  ({
-    oldValue,
-    newValue,
-  }) as chrome.storage.StorageChange
+): SavedTabsStorageChange => ({
+  key,
+  newValue,
+  oldValue,
+})
 
 const createSyncContext = (params?: {
   mode?: ViewMode
@@ -114,12 +116,13 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        customProjectOrder: createStorageChange(
+      changes: [
+        createChange(
+          'customProjectOrder',
           ['project-3', 'project-1'],
           ['project-1', 'project-2', 'project-3'],
         ),
-      },
+      ],
     })
 
     expect(ctx.state.getProjects().map((project) => project.id)).toStrictEqual([
@@ -154,8 +157,8 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        customProjects: createStorageChange([
+      changes: [
+        createChange('customProjects', [
           createProject({
             id: 'project-1',
             name: 'P1',
@@ -175,7 +178,7 @@ describe('syncStorageChanges', () => {
           }),
           createProject({ id: 'project-2', name: 'P2 updated' }),
         ]),
-      },
+      ],
     })
 
     const nextProjects = ctx.state.getProjects()
@@ -196,10 +199,10 @@ describe('syncStorageChanges', () => {
 
     const events = await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        savedTabs: createStorageChange(nextSavedTabs),
-        urls: createStorageChange([]),
-      },
+      changes: [
+        createChange('savedTabs', nextSavedTabs),
+        createChange('urls', []),
+      ],
     })
 
     expect(invalidateUrlCacheMock).toHaveBeenCalledTimes(1)
@@ -244,13 +247,13 @@ describe('syncStorageChanges', () => {
 
     const events = await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        urls: createStorageChange([]),
-        userSettings: createStorageChange({
+      changes: [
+        createChange('urls', []),
+        createChange('userSettings', {
           removeTabAfterOpen: true,
         }),
-        parentCategories: createStorageChange(nextCategories),
-      },
+        createChange('parentCategories', nextCategories),
+      ],
     })
 
     expect(invalidateUrlCacheMock).toHaveBeenCalledTimes(1)
@@ -277,9 +280,7 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        customProjectOrder: createStorageChange(['missing-project']),
-      },
+      changes: [createChange('customProjectOrder', ['missing-project'])],
     })
 
     expect(ctx.state.getProjects()).toBe(initialProjects)
@@ -294,11 +295,11 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        customProjects: createStorageChange([
+      changes: [
+        createChange('customProjects', [
           createProject({ id: 'project-1', name: 'P1 updated' }),
         ]),
-      },
+      ],
     })
 
     expect(ctx.spies.setCustomProjects).not.toHaveBeenCalled()
@@ -312,11 +313,11 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        customProjects: createStorageChange({
+      changes: [
+        createChange('customProjects', {
           invalid: true,
         }),
-      },
+      ],
     })
 
     expect(ctx.state.getProjects()).toStrictEqual([])
@@ -337,14 +338,14 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        customProjects: createStorageChange([
+      changes: [
+        createChange('customProjects', [
           createProject({
             id: 'project-1',
             urlMetadata: {},
           }),
         ]),
-      },
+      ],
     })
 
     expect(ctx.state.getProjects()[0]).not.toBe(prev)
@@ -365,8 +366,8 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        customProjects: createStorageChange([
+      changes: [
+        createChange('customProjects', [
           createProject({
             id: 'project-1',
             urlMetadata: {
@@ -376,7 +377,7 @@ describe('syncStorageChanges', () => {
             },
           }),
         ]),
-      },
+      ],
     })
 
     expect(ctx.state.getProjects()[0]).not.toBe(prev)
@@ -397,8 +398,8 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        customProjects: createStorageChange([
+      changes: [
+        createChange('customProjects', [
           createProject({
             id: 'project-1',
             urlMetadata: {
@@ -408,7 +409,7 @@ describe('syncStorageChanges', () => {
             },
           }),
         ]),
-      },
+      ],
     })
 
     expect(ctx.state.getProjects()[0]).not.toBe(prev)
@@ -425,14 +426,14 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        customProjects: createStorageChange([
+      changes: [
+        createChange('customProjects', [
           createProject({
             id: 'project-1',
             categories: [],
           }),
         ]),
-      },
+      ],
     })
 
     expect(ctx.state.getProjects()[0]).not.toBe(prev)
@@ -449,14 +450,14 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        customProjects: createStorageChange([
+      changes: [
+        createChange('customProjects', [
           createProject({
             id: 'project-1',
             categories: ['Private'],
           }),
         ]),
-      },
+      ],
     })
 
     expect(ctx.state.getProjects()[0]).not.toBe(prev)
@@ -467,11 +468,11 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        savedTabs: createStorageChange({
+      changes: [
+        createChange('savedTabs', {
           invalid: true,
         }),
-      },
+      ],
     })
 
     expect(ctx.spies.refreshTabGroupsWithUrls).toHaveBeenCalledWith([])
@@ -489,9 +490,7 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        userSettings: createStorageChange(undefined),
-      },
+      changes: [createChange('userSettings', undefined)],
     })
 
     expect(ctx.state.getSettings()).toStrictEqual(initialSettings)
@@ -511,11 +510,11 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        parentCategories: createStorageChange({
+      changes: [
+        createChange('parentCategories', {
           invalid: true,
         }),
-      },
+      ],
     })
 
     expect(ctx.state.getCategories()).toStrictEqual([])
@@ -532,14 +531,14 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        customProjects: createStorageChange([
+      changes: [
+        createChange('customProjects', [
           createProject({
             id: 'project-1',
             name: 'Same',
           }),
         ]),
-      },
+      ],
     })
 
     expect(ctx.state.getProjects()[0]).toBe(prev)
@@ -549,7 +548,7 @@ describe('syncStorageChanges', () => {
     const ctx = createSyncContext()
     const events = await syncStorageChanges({
       ...ctx.args,
-      changes: {},
+      changes: [],
     })
 
     expect(events).toStrictEqual([])
@@ -572,12 +571,12 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        savedTabs: createStorageChange([
+      changes: [
+        createChange('savedTabs', [
           validGroup,
           { id: 'broken' } as unknown as TabGroup, // domain 欠損
         ]),
-      },
+      ],
     })
 
     expect(ctx.spies.refreshTabGroupsWithUrls).toHaveBeenCalledWith([
@@ -605,9 +604,7 @@ describe('syncStorageChanges', () => {
 
     await syncStorageChanges({
       ...ctx.args,
-      changes: {
-        parentCategories: createStorageChange([valid, broken]),
-      },
+      changes: [createChange('parentCategories', [valid, broken])],
     })
 
     expect(ctx.state.getCategories()).toStrictEqual([valid])

--- a/src/contexts/saved-tabs/presentation/services/modeSyncService.ts
+++ b/src/contexts/saved-tabs/presentation/services/modeSyncService.ts
@@ -17,10 +17,11 @@ import type {
   ViewMode,
 } from '@/types/storage'
 
+import type { SavedTabsStorageChange } from '../../application/ports/StorageChangePort'
 import type { ModeSyncEvent } from '../types/mode'
 
 interface SyncStorageChangesParams {
-  changes: Record<string, chrome.storage.StorageChange>
+  changes: readonly SavedTabsStorageChange[]
   viewModeRef: RefObject<ViewMode>
   refreshTabGroupsWithUrls: (nextGroups?: TabGroup[]) => Promise<TabGroup[]>
   syncDomainDataToCustomProjects: () => Promise<CustomProject[]>
@@ -29,36 +30,42 @@ interface SyncStorageChangesParams {
   setCustomProjects: Dispatch<SetStateAction<CustomProject[]>>
 }
 
+const findChange = (
+  changes: readonly SavedTabsStorageChange[],
+  key: SavedTabsStorageChange['key'],
+): SavedTabsStorageChange | undefined =>
+  changes.find((change) => change.key === key)
+
 const resolveSyncEvents = (
-  changes: Record<string, chrome.storage.StorageChange>,
+  changes: readonly SavedTabsStorageChange[],
 ): ModeSyncEvent[] => {
   const events: ModeSyncEvent[] = []
-  if (changes.savedTabs) {
+  if (findChange(changes, 'savedTabs')) {
     events.push({
       type: 'savedTabsUpdated',
     })
   }
-  if (changes.customProjects) {
+  if (findChange(changes, 'customProjects')) {
     events.push({
       type: 'customProjectsUpdated',
     })
   }
-  if (changes.customProjectOrder) {
+  if (findChange(changes, 'customProjectOrder')) {
     events.push({
       type: 'customProjectsUpdated',
     })
   }
-  if (changes.urls) {
+  if (findChange(changes, 'urls')) {
     events.push({
       type: 'urlsUpdated',
     })
   }
-  if (changes.userSettings) {
+  if (findChange(changes, 'userSettings')) {
     events.push({
       type: 'settingsUpdated',
     })
   }
-  if (changes.parentCategories) {
+  if (findChange(changes, 'parentCategories')) {
     events.push({
       type: 'categoriesUpdated',
     })
@@ -67,15 +74,14 @@ const resolveSyncEvents = (
 }
 
 const applyUserSettingsChange = (
-  changes: Record<string, chrome.storage.StorageChange>,
+  changes: readonly SavedTabsStorageChange[],
   setSettings: Dispatch<SetStateAction<UserSettings>>,
 ): void => {
-  if (!changes.userSettings) {
+  const change = findChange(changes, 'userSettings')
+  if (!change) {
     return
   }
-  const result = UserSettingsSchema.partial().safeParse(
-    changes.userSettings.newValue,
-  )
+  const result = UserSettingsSchema.partial().safeParse(change.newValue)
   if (!result.success) {
     return
   }
@@ -86,17 +92,15 @@ const applyUserSettingsChange = (
 }
 
 const applyCategoryChange = (
-  changes: Record<string, chrome.storage.StorageChange>,
+  changes: readonly SavedTabsStorageChange[],
   setCategories: Dispatch<SetStateAction<ParentCategory[]>>,
 ): void => {
-  if (!changes.parentCategories) {
+  const change = findChange(changes, 'parentCategories')
+  if (!change) {
     return
   }
-  const nextCategories = Array.isArray(changes.parentCategories.newValue)
-    ? safeParseArrayFromStorage(
-        ParentCategorySchema,
-        changes.parentCategories.newValue,
-      )
+  const nextCategories = Array.isArray(change.newValue)
+    ? safeParseArrayFromStorage(ParentCategorySchema, change.newValue)
     : []
   setCategories(nextCategories)
 }
@@ -111,34 +115,34 @@ const toCustomProject = (
 })
 
 const applyProjectChange = (
-  changes: Record<string, chrome.storage.StorageChange>,
+  changes: readonly SavedTabsStorageChange[],
   viewModeRef: RefObject<ViewMode>,
   setCustomProjects: Dispatch<SetStateAction<CustomProject[]>>,
 ): void => {
   if (viewModeRef.current !== 'custom') {
     return
   }
-  const hasProjectsChange = Boolean(changes.customProjects)
-  const hasOrderChange = Boolean(changes.customProjectOrder)
-  if (!(hasProjectsChange || hasOrderChange)) {
+  const projectsChange = findChange(changes, 'customProjects')
+  const orderChange = findChange(changes, 'customProjectOrder')
+  if (!projectsChange && !orderChange) {
     return
   }
 
+  // `customProjects` キーが change に含まれていれば、
+  // newValue が配列かどうかに関わらず同期対象として扱う
+  // （配列以外なら空配列で反映する旧挙動を維持する）。
   let nextCustomProjects: CustomProject[] | null = null
-  if (hasProjectsChange) {
-    nextCustomProjects = Array.isArray(changes.customProjects?.newValue)
+  if (projectsChange) {
+    nextCustomProjects = Array.isArray(projectsChange.newValue)
       ? safeParseArrayFromStorage(
           CustomProjectSchema,
-          changes.customProjects.newValue,
+          projectsChange.newValue,
         ).map(toCustomProject)
       : []
   }
   const nextProjectOrder =
-    hasOrderChange && Array.isArray(changes.customProjectOrder?.newValue)
-      ? safeParseArrayFromStorage(
-          z.string(),
-          changes.customProjectOrder.newValue,
-        )
+    orderChange && Array.isArray(orderChange.newValue)
+      ? safeParseArrayFromStorage(z.string(), orderChange.newValue)
       : null
 
   setCustomProjects((prevProjects) => {
@@ -265,27 +269,27 @@ const areProjectArraysReferenceEqual = (
 }
 
 const applyTabsAndUrlsChanges = async (
-  changes: Record<string, chrome.storage.StorageChange>,
+  changes: readonly SavedTabsStorageChange[],
   refreshTabGroupsWithUrls: (nextGroups?: TabGroup[]) => Promise<TabGroup[]>,
   syncDomainDataToCustomProjects: () => Promise<CustomProject[]>,
 ): Promise<void> => {
-  const hasSavedTabsChange = Boolean(changes.savedTabs)
-  const hasUrlsChange = Boolean(changes.urls)
+  const savedTabsChange = findChange(changes, 'savedTabs')
+  const urlsChange = findChange(changes, 'urls')
 
-  if (hasUrlsChange) {
+  if (urlsChange) {
     invalidateUrlCache()
   }
 
-  if (hasSavedTabsChange) {
-    const nextSavedTabs = Array.isArray(changes.savedTabs.newValue)
-      ? safeParseArrayFromStorage(TabGroupSchema, changes.savedTabs.newValue)
+  if (savedTabsChange) {
+    const nextSavedTabs = Array.isArray(savedTabsChange.newValue)
+      ? safeParseArrayFromStorage(TabGroupSchema, savedTabsChange.newValue)
       : []
     await refreshTabGroupsWithUrls(nextSavedTabs)
     await syncDomainDataToCustomProjects()
     return
   }
 
-  if (hasUrlsChange) {
+  if (urlsChange) {
     await refreshTabGroupsWithUrls()
   }
 }


### PR DESCRIPTION
## 概要

issue #495 の対応。`saved-tabs` context の presentation 層に残っていた
`chrome.storage.onChanged` の直接購読 (`addListener` / `removeListener`) を
application 層の port / infrastructure 層の adapter 経由へ移し、DDD レイヤ
境界の逸脱を解消する。

## 背景

`SavedTabsApp` と `useCategoryKeywordModal` の 2 箇所で
`chrome.storage.onChanged.{addListener,removeListener}` を直接呼び出し、
storage 変更を UI 同期に繋いでいた。presentation 層から chrome API を直接
触ると、UI 修正時にストレージ仕様と密結合になり、テストもしづらくなる。

## 変更内容

### 新規ファイル
- `application/ports/StorageChangePort.ts` — port interface。`subscribe(listener) => unsubscribe` のみの最小 API。listener は `readonly SavedTabsStorageChange[]` を受け取り、port 仕様でスコープを絞った 6 つのキー (`savedTabs` / `urls` / `parentCategories` / `customProjects` / `customProjectOrder` / `userSettings`) だけを DTO として公開。
- `infrastructure/browser/ChromeStorageChangeAdapter.ts` — `chrome.storage.onChanged` をラップする adapter。`getApi` / `getOnChanged` の deps 注入に対応し、chrome API が無い環境 (テスト / Storybook / SSR) では no-op の `unsubscribe` を返す。`options.areaName` (`local` / `sync` / `managed` / `session`) で storage エリアを絞り込み。port 仕様外のキーは adapter 段階で除外。
- `infrastructure/browser/ChromeStorageChangeAdapter.test.ts` — 9 ケース (chrome listener 登録解除 / DTO 変換 / port 仕様外キー除外 / areaName フィルタ / chrome 不在時 no-op / globalThis chrome フォールバック / 複数 listener 独立性)。

### 既存変更
- `presentation/services/modeSyncService.ts` — 引数 `changes` を `Record<string, chrome.storage.StorageChange>` から `readonly SavedTabsStorageChange[]` へ変更。`chrome.*` 依存を完全に撤去。
- `presentation/app/SavedTabsApp.tsx` — `chrome.storage.onChanged.{add,remove}Listener` を `deps.storageChangePort.subscribe` 経由に置換。TODO(#488-followup) コメントを撤去。
- `presentation/hooks/useCategoryKeywordModal.ts` — 同上 (`parentCategories` 変更のみ filter)。`storageChangePort` は optional props として受け取り、Context 経由 (`useSavedTabsUseCases().deps.storageChangePort`) で `DomainCardActions` から伝搬。
- `presentation/components/keyword-modal/KeywordModalRoot.tsx` と `CategoryKeywordModal.tsx` と `domain-card/DomainCardActions.tsx` — `storageChangePort` props を追加し、`DomainCardActions` → `CategoryKeywordModal` → `KeywordModalRoot` → `useCategoryKeywordModal` までバケツリレー。
- `infrastructure/composition/createSavedTabsUseCasesDeps.ts` — `SavedTabsUseCasesDeps` に `storageChangePort: StorageChangePort` を追加し、`createChromeStorageChangeAdapter` を組み立て。
- `app/composition/createSavedTabsPorts.ts` — `SavedTabsPorts` に `storageChangePort` を追加。
- `dddLayerGuard.test.ts` — issue #495 のファイル存在 / chrome 依存なし / SavedTabsApp と useCategoryKeywordModal の直叩き禁止 / composition 層での組み立て を 6 ケースで検証。

### 派生修正
- 6 つのテストファイル (`savedTabsFlowRegression` / `SavedTabsPresentationLayout` / `useSavedTabsController` / `useCustomModeController` / `useDomainModeController` / `SavedTabsPage`) の `SavedTabsUseCasesDeps` 構築に `storageChangePort: { subscribe: () => () => {} }` のスタブを追加。
- `SavedTabsApp.test.tsx` の chrome リスナー呼び出し 5 箇所を `(changes, 'local')` 形式に更新し、`syncStorageChanges` 期待値を port DTO 形式 (`[{ key, newValue, oldValue }]`) に変更。
- `useCategoryKeywordModal.test.tsx` の `chrome.storage.onChanged` モックを `createMockStorageChangePort` ベースの新モックに書き換え。
- `modeSyncService.test.ts` の `createStorageChange` ヘルパを port DTO 形式に置き換え、全 23 テストの `changes` 期待値を新形式へ更新。

## 受け入れ条件

- [x] `SavedTabsApp` から `chrome.storage.onChanged.addListener/removeListener` の直接呼び出しが消えている
- [x] `StorageChangePort` が application 層にある
- [x] Chrome API 実装が infrastructure 層に閉じている
- [x] storage 変更時の UI 同期挙動が既存通り動く (`syncStorageChanges` 全 23 テスト pass)
- [x] 複数回 mount/unmount しても listener がリークしない (unmount 後の `listeners.size === 0` を検証)
- [x] `bun run compile` 通過
- [x] 関連テスト通過 (1891/1891)
- [x] 新規 2 ファイル 100% coverage

## やらないこと (別 Issue 対応)

- `chrome.storage.local.get/set` 直叩きの repository 化 (残存する presentation 層の `TODO(#488-followup)` は別 Issue で対応)
- snapshot / storage set の use-case 化 (issue #494 で対応済み、本 Issue のスコープ外)
- domain service 切り出し
- storage schema / migration 変更
- UI デザイン変更
- `features/options` / `features/ai-chat` 配下の `chrome.storage.onChanged` (本 Issue は saved-tabs context のみ)

## 検証

- `bun run compile` — エラー 0
- `bun run lint` — 警告 / エラー 0
- `bun run format` — 適用済み
- `bun run test` — **1891/1891 tests passed** (~26s)
- `bun run test:node` — 1079 tests passed (`dddLayerGuard.test.ts` 61/61 pass)
- `bun run test:dom` — 812 tests passed
- `bun run test:coverage` — 新規 2 ファイル 100% (lines / branches / functions / statements)
- `bunx vitest run src/contexts/saved-tabs/dddLayerGuard.test.ts` — 61/61 pass

## 関連 Issue

- DDD構成へ段階移行するための全体設計と実装計画 #454
- SavedTabsApp の use-case / controller 生成を SavedTabsPage 注入に統一 #493
- SavedTabsApp の snapshot / storage 更新を repository / use-case 経由へ移す #494

Closes #495