### PR TITLE
feat(#496): SavedTabsApp の分類・表示判定ロジックを domain service へ移設

### DIFF
--- a/.apm/hooks/claude-quality-hooks.json
+++ b/.apm/hooks/claude-quality-hooks.json
@@ -29,6 +29,16 @@
             "type": "command"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit|apply_patch",
+        "hooks": [
+          {
+            "command": "./scripts/format-check-on-edit.sh",
+            "timeout": 60,
+            "type": "command"
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/.apm/hooks/scripts/format-check-on-edit.sh
+++ b/.apm/hooks/scripts/format-check-on-edit.sh
@@ -1,0 +1,162 @@
+#!/bin/sh
+set -eu
+
+project_dir="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$project_dir"
+
+hook_input="$(mktemp "${TMPDIR:-/tmp}/apm-format-check.XXXXXX")"
+trap 'rm -f "$hook_input"' EXIT HUP INT TERM
+cat >"$hook_input" || true
+
+node - "$hook_input" "$project_dir" <<'NODE'
+const fs = require('fs')
+const path = require('path')
+const { execFileSync } = require('child_process')
+
+const [, , inputPath, projectDir] = process.argv
+
+const relevantExtensions = new Set([
+  '.cjs',
+  '.cts',
+  '.css',
+  '.js',
+  '.jsx',
+  '.json',
+  '.jsonc',
+  '.md',
+  '.mjs',
+  '.mts',
+  '.ts',
+  '.tsx',
+  '.yaml',
+  '.yml',
+])
+
+function collectPaths(value, paths = []) {
+  if (!value || typeof value !== 'object') {
+    return paths
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectPaths(item, paths)
+    }
+    return paths
+  }
+  for (const [key, item] of Object.entries(value)) {
+    if (
+      typeof item === 'string' &&
+      (key === 'file_path' || key === 'path') &&
+      !item.includes('\n')
+    ) {
+      paths.push(item)
+    } else {
+      collectPaths(item, paths)
+    }
+  }
+  return paths
+}
+
+function collectApplyPatchPaths(text, paths = []) {
+  if (typeof text !== 'string' || !text.includes('*** Begin Patch')) {
+    return paths
+  }
+  for (const line of text.split(/\r?\n/)) {
+    for (const prefix of [
+      '*** Update File: ',
+      '*** Add File: ',
+      '*** Delete File: ',
+      '*** Move to: ',
+    ]) {
+      if (line.startsWith(prefix)) {
+        paths.push(line.slice(prefix.length).trim())
+      }
+    }
+  }
+  return paths
+}
+
+function collectTouchedPaths(value, paths = []) {
+  if (!value || typeof value !== 'object') {
+    return paths
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectTouchedPaths(item, paths)
+    }
+    return paths
+  }
+  collectPaths(value, paths)
+  for (const item of Object.values(value)) {
+    if (typeof item === 'string') {
+      collectApplyPatchPaths(item, paths)
+    } else {
+      collectTouchedPaths(item, paths)
+    }
+  }
+  return paths
+}
+
+function normalizeProjectPath(candidate) {
+  const absolutePath = path.isAbsolute(candidate)
+    ? path.normalize(candidate)
+    : path.resolve(projectDir, candidate)
+  const relativePath = path.relative(projectDir, absolutePath)
+  if (
+    relativePath === '' ||
+    relativePath.startsWith('..') ||
+    path.isAbsolute(relativePath)
+  ) {
+    return null
+  }
+  return relativePath.split(path.sep).join('/')
+}
+
+try {
+  const raw = fs.readFileSync(inputPath, 'utf8').trim()
+  if (!raw) {
+    process.exit(0)
+  }
+  const payload = JSON.parse(raw)
+
+  const touchedPaths = [
+    ...new Set(
+      collectTouchedPaths(payload)
+        .map(normalizeProjectPath)
+        .filter(Boolean),
+    ),
+  ]
+    .filter((rel) => relevantExtensions.has(path.extname(rel)))
+    .filter((rel) => fs.existsSync(path.resolve(projectDir, rel)))
+
+  if (touchedPaths.length === 0) {
+    process.exit(0)
+  }
+
+  const failed = []
+  for (const rel of touchedPaths) {
+    const abs = path.resolve(projectDir, rel)
+    try {
+      execFileSync('bunx', ['oxfmt', '--check', abs], {
+        cwd: projectDir,
+        stdio: 'pipe',
+      })
+    } catch (error) {
+      failed.push(rel)
+    }
+  }
+
+  if (failed.length > 0) {
+    console.error(
+      'APM format check: 以下のファイルに oxfmt 違反があります。`bun run format` で自動修正してください。',
+    )
+    for (const rel of failed) {
+      console.error(`  - ${rel}`)
+    }
+    // PostToolUse で exit 2 = hook error 扱いでブロック可能なことを示す。
+    // Edit/Write/MultiEdit/apply_patch の戻り値としては surfaced される。
+    process.exit(2)
+  }
+} catch (error) {
+  console.error(`APM format check warning: ${error.message}`)
+}
+NODE

--- a/src/contexts/saved-tabs/domain/services/SavedTabsCategorizationService.test.ts
+++ b/src/contexts/saved-tabs/domain/services/SavedTabsCategorizationService.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ParentCategory, TabGroup } from '@/types/storage'
+
+import {
+  buildPresentationCategoryLookup,
+  organizeTabGroupsWithCategories,
+} from './SavedTabsCategorizationService'
+
+const docsCategory: ParentCategory = {
+  domainNames: ['docs.example.com'],
+  domains: ['group-docs-1', 'group-docs-2'],
+  id: 'docs',
+  name: 'Docs',
+}
+const newsCategory: ParentCategory = {
+  domainNames: ['news.example.com'],
+  domains: [],
+  id: 'news',
+  name: 'News',
+}
+
+const makeGroup = (overrides: Partial<TabGroup> = {}): TabGroup => ({
+  domain: 'example.com',
+  id: 'group-1',
+  urlIds: ['url-1'],
+  ...overrides,
+})
+
+describe('SavedTabsCategorizationService.buildPresentationCategoryLookup', () => {
+  it('byId / byGroupId / byDomainName の各キーで引ける', () => {
+    const lookup = buildPresentationCategoryLookup([docsCategory, newsCategory])
+    expect(lookup.byId.get('docs')).toStrictEqual(docsCategory)
+    expect(lookup.byGroupId.get('group-docs-1')).toStrictEqual(docsCategory)
+    expect(lookup.byDomainName.get('news.example.com')).toStrictEqual(
+      newsCategory,
+    )
+  })
+
+  it('同一 id / domainName を複数カテゴリが宣言したら先勝ちで保持する', () => {
+    const conflicting: ParentCategory = {
+      domainNames: ['docs.example.com'],
+      domains: ['group-docs-1'],
+      id: 'docs-conflict',
+      name: 'Docs Conflict',
+    }
+    const lookup = buildPresentationCategoryLookup([docsCategory, conflicting])
+    expect(lookup.byGroupId.get('group-docs-1')?.id).toBe('docs')
+    expect(lookup.byDomainName.get('docs.example.com')?.id).toBe('docs')
+  })
+
+  it('空配列を渡しても例外を出さない', () => {
+    const lookup = buildPresentationCategoryLookup([])
+    expect(lookup.byId.size).toBe(0)
+    expect(lookup.byGroupId.size).toBe(0)
+    expect(lookup.byDomainName.size).toBe(0)
+  })
+})
+
+describe('SavedTabsCategorizationService.organizeTabGroupsWithCategories', () => {
+  const lookup = buildPresentationCategoryLookup([docsCategory, newsCategory])
+
+  it('ID 一致でカテゴリ分類される (parentCategoryId 単独では分類されない既存挙動)', () => {
+    // 旧 `organizeTabGroupsWithCategories` では `tryCategorizeById` /
+    // `tryCategorizeByDomainName` の判定で `parentCategoryId` を直接使わず、
+    // `byGroupId` / `byDomainName` の lookup ヒットのみで分類する。
+    // parentCategoryId がカテゴリ ID と一致していても、lookup に登録が無ければ
+    // 未分類になる既存挙動を保つ (issue #496: 既存表示を変えない)。
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [
+        makeGroup({
+          domain: 'docs1.example.com',
+          id: 'group-docs-1',
+        }),
+        makeGroup({
+          domain: 'other.example.com',
+          id: 'group-other',
+          parentCategoryId: 'docs',
+        }),
+      ],
+    })
+    expect(result.categorized.docs?.map((g) => g.id)).toStrictEqual([
+      'group-docs-1',
+    ])
+    expect(result.uncategorized.map((g) => g.id)).toStrictEqual(['group-other'])
+  })
+
+  it('lookup.byGroupId で見つかるグループはドメイン名より優先される', () => {
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [
+        makeGroup({
+          domain: 'news.example.com',
+          id: 'group-docs-1',
+        }),
+      ],
+    })
+    // docs カテゴリに group-docs-1 が登録されているため、docs に分類される
+    expect(result.categorized.docs?.map((g) => g.id)).toStrictEqual([
+      'group-docs-1',
+    ])
+    expect(result.categorized.news).toBeUndefined()
+  })
+
+  it('ドメイン名一致でカテゴリ分類される', () => {
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [
+        makeGroup({ domain: 'news.example.com', id: 'group-news' }),
+      ],
+    })
+    expect(result.categorized.news?.map((g) => g.id)).toStrictEqual([
+      'group-news',
+    ])
+  })
+
+  it('該当カテゴリがないものは未分類へ入る', () => {
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [
+        makeGroup({ domain: 'misc.example.com', id: 'group-misc' }),
+      ],
+    })
+    expect(result.uncategorized.map((g) => g.id)).toStrictEqual(['group-misc'])
+    expect(Object.keys(result.categorized)).toHaveLength(0)
+  })
+
+  it('表示可能 URL がないグループは表示対象から除外される', () => {
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [
+        makeGroup({
+          domain: 'news.example.com',
+          id: 'group-empty',
+          urlIds: [],
+        }),
+        makeGroup({ domain: 'news.example.com', id: 'group-news' }),
+      ],
+    })
+    expect(result.categorized.news?.map((g) => g.id)).toStrictEqual([
+      'group-news',
+    ])
+    expect(result.uncategorized).toHaveLength(0)
+  })
+
+  it('enableCategories=false なら categorized は空、uncategorized は入力のまま', () => {
+    const groups = [
+      makeGroup({ domain: 'news.example.com', id: 'group-news' }),
+      makeGroup({ domain: 'misc.example.com', id: 'group-misc' }),
+    ]
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: false,
+      tabGroupsWithUrls: groups,
+    })
+    expect(result.categorized).toStrictEqual({})
+    expect(result.uncategorized).toStrictEqual(groups)
+  })
+
+  it('カテゴリ内の groups は ParentCategory.domains 順で並ぶ', () => {
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [
+        makeGroup({ domain: 'docs2.example.com', id: 'group-docs-2' }),
+        makeGroup({ domain: 'docs1.example.com', id: 'group-docs-1' }),
+      ],
+    })
+    expect(result.categorized.docs?.map((g) => g.id)).toStrictEqual([
+      'group-docs-1',
+      'group-docs-2',
+    ])
+  })
+
+  it('domains に登録された id は domains 順に並ぶ (登録外 id は未分類へ)', () => {
+    // 旧 `sortCategorizedGroups` では `domains` に含まれない id は
+    // 末尾へ送られるが、その id が `byDomainName` で他カテゴリに解決
+    // されない場合は categorized から外れて uncategorized へ落ちる
+    // 既存挙動を保持する (issue #496: 既存表示を変えない)。
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [
+        makeGroup({ domain: 'docs1.example.com', id: 'group-docs-1' }),
+        makeGroup({ domain: 'docs-extra.example.com', id: 'group-extra' }),
+        makeGroup({ domain: 'docs2.example.com', id: 'group-docs-2' }),
+      ],
+    })
+    expect(result.categorized.docs?.map((g) => g.id)).toStrictEqual([
+      'group-docs-1',
+      'group-docs-2',
+    ])
+    expect(result.uncategorized.map((g) => g.id)).toStrictEqual(['group-extra'])
+  })
+
+  it('searchQuery が指定されたときは urls を持つグループの URL を絞り込んでカテゴリ分類する', () => {
+    // 旧 `filterGroupByQuery` と同じく urls フィールドが無いグループは
+    // 絞り込めない既存挙動を保つ。urlIds のみでも hasDisplayableUrls は
+    // true のままだが、urls が空配列になったグループは categorizing される
+    // (urlIds 側の存在で displayable と判定される既存挙動を保持)。
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: true,
+      searchQuery: 'react',
+      tabGroupsWithUrls: [
+        makeGroup({
+          domain: 'docs1.example.com',
+          id: 'group-docs-1',
+          urls: [
+            { title: 'React 入門', url: 'https://docs.example.com/react' },
+            { title: 'Vue 入門', url: 'https://docs.example.com/vue' },
+          ],
+        }),
+        makeGroup({
+          domain: 'docs2.example.com',
+          id: 'group-docs-2',
+          urls: [{ title: 'Angular 入門', url: 'https://docs.example.com/ng' }],
+        }),
+      ],
+    })
+    expect(result.categorized.docs).toHaveLength(2)
+    const group1 = result.categorized.docs?.find((g) => g.id === 'group-docs-1')
+    const group2 = result.categorized.docs?.find((g) => g.id === 'group-docs-2')
+    expect(group1?.urls).toHaveLength(1)
+    expect(group1?.urls?.[0]?.title).toBe('React 入門')
+    // group-docs-2 は urls が全件フィルタで消えるが urlIds があり
+    // hasDisplayableUrls=true なので categorized に残る (既存挙動)。
+    expect(group2?.urls).toHaveLength(0)
+  })
+
+  it('searchQuery が何にもマッチしない urls を持つグループは categorizing から除外される', () => {
+    // urls を持つグループで `currentUrls.length === 0` の early-return は
+    // 適用されないので、`filterGroupByQuery` が全件を削り `urls` が空に
+    // なる。urlIds を持たないグループは urls が空になる = displayable false
+    // となり categorizing から除外される (既存挙動)。
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: true,
+      searchQuery: 'nomatch',
+      tabGroupsWithUrls: [
+        makeGroup({
+          domain: 'news.example.com',
+          id: 'group-news',
+          urlIds: [],
+          urls: [{ title: 'Other', url: 'https://other.example.com' }],
+        }),
+      ],
+    })
+    expect(result.categorized.news).toBeUndefined()
+    expect(result.uncategorized).toHaveLength(0)
+  })
+
+  it('空配列を渡しても例外を出さない', () => {
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [],
+    })
+    expect(result.categorized).toStrictEqual({})
+    expect(result.uncategorized).toStrictEqual([])
+  })
+
+  it('空 categories を渡しても全グループが未分類になる', () => {
+    const emptyLookup = buildPresentationCategoryLookup([])
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: emptyLookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [
+        makeGroup({ domain: 'news.example.com', id: 'group-news' }),
+      ],
+    })
+    expect(result.uncategorized.map((g) => g.id)).toStrictEqual(['group-news'])
+    expect(Object.keys(result.categorized)).toHaveLength(0)
+  })
+
+  it('ドメイン名一致で分類された結果は parentCategoryId が categoryId に上書きされる', () => {
+    // 旧 `pushGroupToCategory`: `group.parentCategoryId === categoryId`
+    // なら group をそのまま、そうでなければ parentCategoryId を
+    // categoryId に上書きした group を push する。
+    // 入力 group の parentCategoryId と lookup 解決 categoryId が一致
+    // する場合は元の parentCategoryId が維持される既存挙動。
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [
+        makeGroup({
+          domain: 'news.example.com',
+          id: 'group-other',
+          parentCategoryId: 'news',
+        }),
+      ],
+    })
+    expect(result.categorized.news?.[0]?.parentCategoryId).toBe('news')
+  })
+
+  it('URL 件数やカテゴリ件数が既存表示と同じになる (混合パターン)', () => {
+    const result = organizeTabGroupsWithCategories({
+      categoryLookup: lookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [
+        makeGroup({ domain: 'docs1.example.com', id: 'group-docs-1' }),
+        makeGroup({ domain: 'docs2.example.com', id: 'group-docs-2' }),
+        makeGroup({ domain: 'news.example.com', id: 'group-news' }),
+        makeGroup({ domain: 'misc.example.com', id: 'group-misc' }),
+        makeGroup({
+          domain: 'empty.example.com',
+          id: 'group-empty',
+          urlIds: [],
+        }),
+      ],
+    })
+    const totalCategorized = Object.values(result.categorized).reduce(
+      (sum, groups) => sum + groups.length,
+      0,
+    )
+    expect(totalCategorized + result.uncategorized.length).toBe(4)
+    expect(totalCategorized).toBe(3)
+    expect(result.uncategorized.map((g) => g.id)).toStrictEqual(['group-misc'])
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/SavedTabsCategorizationService.ts
+++ b/src/contexts/saved-tabs/domain/services/SavedTabsCategorizationService.ts
@@ -1,0 +1,278 @@
+import type { ParentCategory, TabGroup } from '@/types/storage'
+
+/**
+ * 親カテゴリの高速検索用マップ (presentation 形 / unbranded ID ベース)。
+ *
+ * `CategoryAssignmentPolicy.CategoryLookup` (branded types ベース) とは
+ * キー型が branded か `string` かのみが異なる。`SavedTabsApp` 既存挙動
+ * (string ID ベース) と完全互換の lookup を domain 側でも提供するための型
+ * (issue #496)。
+ *
+ * - `byId`: `ParentCategory.id` から `ParentCategory` を引く (O(1))
+ * - `byGroupId`: `TabGroup.id` から所属カテゴリを引く (O(1))
+ * - `byDomainName`: `TabGroup.domain` から所属カテゴリを引く (O(1))
+ *
+ * 同じ `TabGroupId` / `DomainName` を複数カテゴリが宣言している場合は
+ * 最初に出現したカテゴリを優先する（先勝ち）。
+ */
+export interface PresentationCategoryLookup {
+  readonly byId: ReadonlyMap<string, ParentCategory>
+  readonly byGroupId: ReadonlyMap<string, ParentCategory>
+  readonly byDomainName: ReadonlyMap<string, ParentCategory>
+}
+
+/**
+ * `ParentCategory[]` から `PresentationCategoryLookup` を構築する。
+ *
+ * `SavedTabsApp.tsx` の `buildCategoryLookup` (presentation 形) を
+ * domain 等価物に置き換えるための pure 関数 (issue #496)。
+ *
+ * @example
+ * ```ts
+ * const lookup = buildPresentationCategoryLookup([docs, news])
+ * lookup.byGroupId.get(group.id)
+ * ```
+ */
+export const buildPresentationCategoryLookup = (
+  categories: readonly ParentCategory[],
+): PresentationCategoryLookup => {
+  const byId = new Map<string, ParentCategory>()
+  const byGroupId = new Map<string, ParentCategory>()
+  const byDomainName = new Map<string, ParentCategory>()
+  for (const category of categories) {
+    byId.set(category.id, category)
+    for (const tabGroupId of category.domains) {
+      if (!byGroupId.has(tabGroupId)) {
+        byGroupId.set(tabGroupId, category)
+      }
+    }
+    for (const domainName of category.domainNames) {
+      if (!byDomainName.has(domainName)) {
+        byDomainName.set(domainName, category)
+      }
+    }
+  }
+  return { byId, byGroupId, byDomainName }
+}
+
+const hasDisplayableUrls = (group: TabGroup): boolean => {
+  const hasNewUrls = Boolean(group.urlIds && group.urlIds.length > 0)
+  const hasOldUrls = Boolean(group.urls && group.urls.length > 0)
+  return hasNewUrls || hasOldUrls
+}
+
+const pushGroupToCategory = (
+  categorizedGroups: Record<string, TabGroup[]>,
+  categoryId: string,
+  group: TabGroup,
+): void => {
+  if (!categorizedGroups[categoryId]) {
+    categorizedGroups[categoryId] = []
+  }
+  const categorizedGroup =
+    group.parentCategoryId === categoryId
+      ? group
+      : {
+          ...group,
+          parentCategoryId: categoryId,
+        }
+  categorizedGroups[categoryId].push(categorizedGroup)
+}
+
+const tryCategorizeById = (
+  group: TabGroup,
+  categoryLookup: PresentationCategoryLookup,
+  categorizedGroups: Record<string, TabGroup[]>,
+): boolean => {
+  const category = categoryLookup.byGroupId.get(group.id)
+  if (!category) {
+    return false
+  }
+  pushGroupToCategory(categorizedGroups, category.id, group)
+  return true
+}
+
+const tryCategorizeByDomainName = (
+  group: TabGroup,
+  categoryLookup: PresentationCategoryLookup,
+  categorizedGroups: Record<string, TabGroup[]>,
+): boolean => {
+  const category = categoryLookup.byDomainName.get(group.domain)
+  if (!category) {
+    return false
+  }
+  pushGroupToCategory(categorizedGroups, category.id, group)
+  return true
+}
+
+const matchesParentCategoryQuery = (
+  group: TabGroup,
+  categoryLookup: PresentationCategoryLookup,
+  normalizedQuery: string,
+): boolean => {
+  if (group.parentCategoryId) {
+    const parentCategory = categoryLookup.byId.get(group.parentCategoryId)
+    if (parentCategory) {
+      return parentCategory.name.toLowerCase().includes(normalizedQuery)
+    }
+  }
+  const fallbackCategory =
+    // `||` needed: Map.get() could return empty string
+    // eslint-disable-next-line typescript/prefer-nullish-coalescing
+    categoryLookup.byGroupId.get(group.id) ||
+    categoryLookup.byDomainName.get(group.domain)
+  if (fallbackCategory) {
+    return fallbackCategory.name.toLowerCase().includes(normalizedQuery)
+  }
+  return false
+}
+
+const filterGroupByQuery = (
+  group: TabGroup,
+  normalizedQuery: string,
+  categoryLookup: PresentationCategoryLookup,
+): TabGroup => {
+  const currentUrls = group.urls ?? []
+  if (currentUrls.length === 0) {
+    return group
+  }
+  const parentCategoryMatched = matchesParentCategoryQuery(
+    group,
+    categoryLookup,
+    normalizedQuery,
+  )
+  const filteredUrls = currentUrls.filter((item) => {
+    const matchesBasicFields =
+      item.title.toLowerCase().includes(normalizedQuery) ||
+      item.url.toLowerCase().includes(normalizedQuery) ||
+      group.domain.toLowerCase().includes(normalizedQuery)
+    const matchesSubCategory = item.subCategory
+      ?.toLowerCase()
+      .includes(normalizedQuery)
+    // eslint-disable-next-line typescript/prefer-nullish-coalescing -- boolean values; false should not fall through
+    return matchesBasicFields || matchesSubCategory || parentCategoryMatched
+  })
+  if (filteredUrls.length === currentUrls.length) {
+    return group
+  }
+  return {
+    ...group,
+    urls: filteredUrls,
+  }
+}
+
+const sortCategorizedGroups = (
+  categorizedGroups: Record<string, TabGroup[]>,
+  categoryLookup: PresentationCategoryLookup,
+): void => {
+  for (const categoryId of Object.keys(categorizedGroups)) {
+    const category = categoryLookup.byId.get(categoryId)
+    const domains = category?.domains
+    if (!(domains && domains.length > 0)) {
+      continue
+    }
+    const domainOrder = new Map(domains.map((domain, index) => [domain, index]))
+    categorizedGroups[categoryId].sort((a, b) => {
+      const indexA = domainOrder.get(a.id) ?? -1
+      const indexB = domainOrder.get(b.id) ?? -1
+      if (indexA === -1) {
+        return 1
+      }
+      if (indexB === -1) {
+        return -1
+      }
+      return indexA - indexB
+    })
+  }
+}
+
+/**
+ * `TabGroup` 配列を `ParentCategory` 配列と `PresentationCategoryLookup` を
+ * 使ってカテゴリ別に振り分ける pure 関数。
+ *
+ * `SavedTabsApp.tsx` の `organizeTabGroupsWithCategories` を domain 側へ
+ * 純粋関数として移設したもの (issue #496)。React / chrome API / toast /
+ * router / console には依存しない。
+ *
+ * - `enableCategories=false` のときは全グループを `uncategorized` に置く
+ * - `searchQuery` が指定された場合は URL / title / subCategory / カテゴリ名で
+ *   フィルタしたうえで分類する
+ * - 戻り値の `categorized` は `Record<categoryId, TabGroup[]>` で、
+ *   各カテゴリ配列は `ParentCategory.domains` 順でソートされる
+ *   (順序に存在しない TabGroup は末尾、相対順序維持)
+ * - `uncategorized` はどのカテゴリにも該当しなかったグループ
+ *
+ * 旧 `SavedTabsApp.tsx` の `organizeTabGroupsWithCategories` と挙動互換。
+ * `console.log` デバッグ出力は省略している。
+ *
+ * @example
+ * ```ts
+ * const result = organizeTabGroupsWithCategories({
+ *   enableCategories: true,
+ *   categoryLookup,
+ *   tabGroupsWithUrls,
+ * })
+ * // result.categorized: { 'cat-1': [group1, group2], 'cat-2': [group3] }
+ * // result.uncategorized: [group4]
+ * ```
+ */
+export const organizeTabGroupsWithCategories = ({
+  enableCategories,
+  tabGroupsWithUrls,
+  categoryLookup,
+  searchQuery,
+}: {
+  readonly enableCategories: boolean
+  readonly tabGroupsWithUrls: readonly TabGroup[]
+  readonly categoryLookup: PresentationCategoryLookup
+  readonly searchQuery?: string
+}): {
+  readonly categorized: Record<string, TabGroup[]>
+  readonly uncategorized: TabGroup[]
+} => {
+  if (!enableCategories) {
+    return {
+      categorized: {},
+      uncategorized: [...tabGroupsWithUrls],
+    }
+  }
+  const categorizedGroups: Record<string, TabGroup[]> = {}
+  const uncategorizedGroups: TabGroup[] = []
+  const normalizedQuery = searchQuery?.trim().toLowerCase() ?? ''
+  const hasSearchQuery = normalizedQuery.length > 0
+  const groupsToOrganize = tabGroupsWithUrls.reduce<TabGroup[]>(
+    (groups, group) => {
+      const nextGroup = hasSearchQuery
+        ? filterGroupByQuery(group, normalizedQuery, categoryLookup)
+        : group
+      if (hasDisplayableUrls(nextGroup)) {
+        groups.push(nextGroup)
+      }
+      return groups
+    },
+    [],
+  )
+  for (const group of groupsToOrganize) {
+    const categorizedById = tryCategorizeById(
+      group,
+      categoryLookup,
+      categorizedGroups,
+    )
+    if (categorizedById) {
+      continue
+    }
+    const categorizedByDomainName = tryCategorizeByDomainName(
+      group,
+      categoryLookup,
+      categorizedGroups,
+    )
+    if (!categorizedByDomainName) {
+      uncategorizedGroups.push(group)
+    }
+  }
+  sortCategorizedGroups(categorizedGroups, categoryLookup)
+  return {
+    categorized: categorizedGroups,
+    uncategorized: uncategorizedGroups,
+  }
+}

--- a/src/contexts/saved-tabs/domain/services/SavedTabsDisplayPolicy.test.ts
+++ b/src/contexts/saved-tabs/domain/services/SavedTabsDisplayPolicy.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import type { TabGroup } from '@/types/storage'
+
+import { hasDisplayableUrls } from './SavedTabsDisplayPolicy'
+
+const makeGroup = (overrides: Partial<TabGroup> = {}): TabGroup => ({
+  domain: 'example.com',
+  id: 'group-1',
+  ...overrides,
+})
+
+describe('SavedTabsDisplayPolicy.hasDisplayableUrls', () => {
+  it('新形式 urlIds が 1 件以上あれば true を返す', () => {
+    expect(hasDisplayableUrls(makeGroup({ urlIds: ['url-1'] }))).toBe(true)
+  })
+
+  it('旧形式 urls が 1 件以上あれば true を返す', () => {
+    expect(
+      hasDisplayableUrls(
+        makeGroup({
+          urls: [{ title: 'A', url: 'https://example.com' }],
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('新形式旧形式両方の URL を持っていても true を返す', () => {
+    expect(
+      hasDisplayableUrls(
+        makeGroup({
+          urlIds: ['url-1'],
+          urls: [{ title: 'A', url: 'https://example.com' }],
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('新形式旧形式ともに空配列なら false を返す', () => {
+    expect(hasDisplayableUrls(makeGroup({ urlIds: [], urls: [] }))).toBe(false)
+  })
+
+  it('フィールド自体が無いグループは false を返す', () => {
+    expect(hasDisplayableUrls(makeGroup())).toBe(false)
+  })
+
+  it('空 urlIds (undefined) と 1 件 urls を持つグループは true を返す', () => {
+    expect(
+      hasDisplayableUrls(
+        makeGroup({
+          urls: [{ title: 'A', url: 'https://example.com' }],
+        }),
+      ),
+    ).toBe(true)
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/SavedTabsDisplayPolicy.ts
+++ b/src/contexts/saved-tabs/domain/services/SavedTabsDisplayPolicy.ts
@@ -1,0 +1,24 @@
+import type { TabGroup } from '@/types/storage'
+
+/**
+ * `SavedTabsApp` 内の pure な表示判定ロジックを domain 側へ集約した
+ * ポリシー (issue #496)。
+ *
+ * UI 表示上「ノードとして数えられる URL を保持するグループ」かを判定する。
+ * 新形式 (`urlIds`) と旧形式 (`urls`) の両方を考慮し、`SavedTabsApp` 内の
+ * 旧 `hasDisplayableUrls` と同じ判定結果を返す。
+ *
+ * 旧実装にあった `console.log` デバッグ出力は domain 層では省略している
+ * （純粋関数としてのシグナル/ノイズ比を改善し、テスト時のログ汚染を防ぐため）。
+ *
+ * @example
+ * ```ts
+ * hasDisplayableUrls({ id: 'g1', domain: 'example.com', urlIds: ['u1'] }) // true
+ * hasDisplayableUrls({ id: 'g1', domain: 'example.com' })                 // false
+ * ```
+ */
+export const hasDisplayableUrls = (group: TabGroup): boolean => {
+  const hasNewUrls = Boolean(group.urlIds && group.urlIds.length > 0)
+  const hasOldUrls = Boolean(group.urls && group.urls.length > 0)
+  return hasNewUrls || hasOldUrls
+}

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
@@ -424,20 +424,22 @@ const SavedTabsApp = ImportedSavedTabsApp as unknown as React.ComponentType<{
   onViewModeNavigate?: (mode: 'custom' | 'domain') => void
 }>
 import {
-  buildCategoryLookup,
+  buildPresentationCategoryLookup,
+  organizeTabGroupsWithCategories,
+} from '@/contexts/saved-tabs/domain/services/SavedTabsCategorizationService'
+
+import {
   buildDisplayTabGroup,
   buildUpdatedGroupAfterUrlIdRemoval,
   buildUrlIdsToRemove,
   countTabGroupUrls,
   createFilterGroupsByExcludedIdsUpdater,
-  filterGroupByQuery,
   filterGroupsByExcludedIds,
   getDisplayUrlCount,
   notifyDeleteFailure,
   removeUrlsFromCustomProjectsForGroup,
   removeUrlsFromCustomProjectsForGroups,
   restoreOpenedUrlsSnapshot,
-  sortCategorizedGroups,
   syncGroupCategoryAssignment,
 } from './savedTabsApp.helpers'
 
@@ -499,7 +501,7 @@ describe('SavedTabsApp custom search', () => {
       ),
     ).toStrictEqual(new Set(['url-a']))
 
-    const categoryLookup = buildCategoryLookup([
+    const categoryLookup = buildPresentationCategoryLookup([
       {
         domainNames: ['extra.example.com'],
         domains: ['group-ordered'],
@@ -507,8 +509,10 @@ describe('SavedTabsApp custom search', () => {
         name: 'Ordered',
       },
     ])
-    const categorized = {
-      'category-1': [
+    const sortedResult = organizeTabGroupsWithCategories({
+      categoryLookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [
         { domain: 'extra.example.com', id: 'group-extra', urlIds: ['url-b'] },
         {
           domain: 'ordered.example.com',
@@ -516,14 +520,11 @@ describe('SavedTabsApp custom search', () => {
           urlIds: ['url-a'],
         },
       ],
-    }
+    })
 
-    sortCategorizedGroups(categorized, categoryLookup)
-
-    expect(categorized['category-1']).toStrictEqual([
-      expect.objectContaining({ id: 'group-ordered' }),
-      expect.objectContaining({ id: 'group-extra' }),
-    ])
+    expect(
+      sortedResult.categorized['category-1']?.map((group) => group.id),
+    ).toStrictEqual(['group-ordered', 'group-extra'])
 
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     // eslint-disable-next-line typescript/require-await
@@ -736,11 +737,18 @@ describe('SavedTabsApp custom search', () => {
       domain: 'empty.example.com',
       id: 'group-empty',
     }
-    expect(
-      filterGroupByQuery(groupWithoutUrls, 'reading', buildCategoryLookup([])),
-    ).toBe(groupWithoutUrls)
+    // searchQuery 指定で URLs 空のグループは表示対象から除外される
+    // (issue #496: domain service の organizeTabGroupsWithCategories 経由で確認)。
+    const filteredEmpty = organizeTabGroupsWithCategories({
+      categoryLookup: buildPresentationCategoryLookup([]),
+      enableCategories: true,
+      searchQuery: 'reading',
+      tabGroupsWithUrls: [groupWithoutUrls],
+    })
+    expect(filteredEmpty.categorized).toStrictEqual({})
+    expect(filteredEmpty.uncategorized).toStrictEqual([])
 
-    const duplicateLookup = buildCategoryLookup([
+    const duplicateLookup = buildPresentationCategoryLookup([
       {
         domainNames: ['duplicate.example.com'],
         domains: ['duplicate-group'],
@@ -760,22 +768,23 @@ describe('SavedTabsApp custom search', () => {
     expect(duplicateLookup.byDomainName.get('duplicate.example.com')?.id).toBe(
       'category-a',
     )
-    expect(
-      filterGroupByQuery(
+    // 'nomatch' でマッチしない URL は検索結果から除外される
+    // (issue #496: domain service の organizeTabGroupsWithCategories 経由で確認)。
+    const filteredNoMatch = organizeTabGroupsWithCategories({
+      categoryLookup: duplicateLookup,
+      enableCategories: true,
+      searchQuery: 'nomatch',
+      tabGroupsWithUrls: [
         {
           domain: 'other.example.com',
           id: 'duplicate-group',
           parentCategoryId: 'category-a',
           urls: [{ title: 'Other', url: 'https://other.example.com' }],
         },
-        'nomatch',
-        duplicateLookup,
-      ),
-    ).toStrictEqual(
-      expect.objectContaining({
-        urls: [],
-      }),
-    )
+      ],
+    })
+    expect(filteredNoMatch.categorized).toStrictEqual({})
+    expect(filteredNoMatch.uncategorized).toStrictEqual([])
 
     expect(
       countTabGroupUrls({ domain: 'ids.example.com', id: 'ids', urlIds: [] }),
@@ -899,7 +908,7 @@ describe('SavedTabsApp custom search', () => {
         domain: 'example.com',
         id: 'group-1',
       },
-      buildCategoryLookup(state.updatedCategories),
+      buildPresentationCategoryLookup(state.updatedCategories),
       state,
     )
 
@@ -980,53 +989,45 @@ describe('SavedTabsApp custom search', () => {
     expect(removeUrlsFromAllCustomProjects).not.toHaveBeenCalled()
   })
 
-  it('helper はカテゴリ順序にない先頭グループを末尾へ送る', () => {
-    const categoryLookup = buildCategoryLookup([
+  it('helper はカテゴリ順序に合わせてグループを並べる', () => {
+    // 旧 `sortCategorizedGroups` の挙動確認 (categorized 内の sort) は
+    // domain 側の `organizeTabGroupsWithCategories` 経由で同等確認する。
+    // 入力は domains に登録された id のみとし、categorized に push される
+    // 状態を作る (issue #496: sortCategorizedGroups は domain へ移設)。
+    const categoryLookup = buildPresentationCategoryLookup([
       {
         domainNames: [],
-        domains: ['group-a', 'group-b'],
+        domains: ['group-a', 'group-b', 'group-c'],
         id: 'category-1',
         name: 'Ordered',
       },
     ])
-    const categorized = {
-      'category-1': [
-        { domain: 'unknown.example.com', id: 'group-unknown', urlIds: ['u'] },
+    const sortedResult = organizeTabGroupsWithCategories({
+      categoryLookup,
+      enableCategories: true,
+      tabGroupsWithUrls: [
+        { domain: 'c.example.com', id: 'group-c', urlIds: ['c'] },
         { domain: 'b.example.com', id: 'group-b', urlIds: ['b'] },
         { domain: 'a.example.com', id: 'group-a', urlIds: ['a'] },
       ],
-    }
-
-    sortCategorizedGroups(categorized, categoryLookup)
-
-    expect(categorized['category-1'].map((group) => group.id)).toStrictEqual([
+    })
+    const sortedGroups = sortedResult.categorized['category-1'] ?? []
+    expect(sortedGroups.map((group) => group.id)).toStrictEqual([
       'group-a',
       'group-b',
-      'group-unknown',
+      'group-c',
     ])
 
-    const categorizedWithUnknownLast = {
-      'category-1': [
-        { domain: 'a.example.com', id: 'group-a', urlIds: ['a'] },
-        { domain: 'unknown.example.com', id: 'group-unknown', urlIds: ['u'] },
-      ],
-    }
-    sortCategorizedGroups(categorizedWithUnknownLast, categoryLookup)
     expect(
-      categorizedWithUnknownLast['category-1'].map((group) => group.id),
-    ).toStrictEqual(['group-a', 'group-unknown'])
-
-    expect(
-      filterGroupsByExcludedIds(
-        categorized['category-1'],
-        new Set(['group-b']),
-      ).map((group) => group.id),
-    ).toStrictEqual(['group-a', 'group-unknown'])
+      filterGroupsByExcludedIds(sortedGroups, new Set(['group-b'])).map(
+        (group) => group.id,
+      ),
+    ).toStrictEqual(['group-a', 'group-c'])
     expect(
       createFilterGroupsByExcludedIdsUpdater(new Set(['group-a']))(
-        categorized['category-1'],
+        sortedGroups,
       ).map((group) => group.id),
-    ).toStrictEqual(['group-b', 'group-unknown'])
+    ).toStrictEqual(['group-b', 'group-c'])
   })
 
   it('プロジェクト名一致で対象プロジェクトだけを表示する', async () => {

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -10,6 +10,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 import { Toaster } from '@/components/ui/sonner'
+import {
+  buildPresentationCategoryLookup,
+  organizeTabGroupsWithCategories,
+} from '@/contexts/saved-tabs/domain/services/SavedTabsCategorizationService'
 import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabGroupId'
 import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/UrlRecordId'
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases'
@@ -45,11 +49,9 @@ import type {
 } from '@/types/storage'
 
 import {
-  buildCategoryLookup,
   buildDisplayTabGroup,
   countTabGroupUrls,
   createFilterGroupsByExcludedIdsUpdater,
-  filterGroupByQuery,
   getDisplayUrlCount,
   getSnapshotSavedTabs,
   notifyDeleteFailure,
@@ -57,153 +59,14 @@ import {
   removeUrlsFromCustomProjectsForGroups,
   shouldWaitForInitialViewMode,
   showOpenedUrlsUndoToast,
-  sortCategorizedGroups,
   syncSavedTabsViewModeLocation,
   toDomainParentCategories,
   toDomainTabGroupsForReorder,
 } from './savedTabsApp.helpers'
-import type {
-  CategoryLookup,
-  OpenedUrlsStorageSnapshot,
-} from './savedTabsApp.helpers'
+import type { OpenedUrlsStorageSnapshot } from './savedTabsApp.helpers'
 
 // eslint-disable-next-line import/no-unassigned-import
 import '@/assets/global.css'
-
-const hasDisplayableUrls = (group: TabGroup): boolean => {
-  const hasNewUrls = Boolean(group.urlIds && group.urlIds.length > 0)
-  const hasOldUrls = Boolean(group.urls && group.urls.length > 0)
-  console.log(
-    `フィルタチェック ${group.domain}: urlIds=${group.urlIds?.length ?? 0}, urls=${group.urls?.length ?? 0}, 表示=${hasNewUrls || hasOldUrls}`, // eslint-disable-line typescript/prefer-nullish-coalescing -- `||` needed: boolean values; false should not be treated as "not set"
-  )
-  return hasNewUrls || hasOldUrls
-}
-const pushGroupToCategory = (
-  categorizedGroups: Record<string, TabGroup[]>,
-  categoryId: string,
-  group: TabGroup,
-): void => {
-  if (!categorizedGroups[categoryId]) {
-    categorizedGroups[categoryId] = []
-  }
-  const categorizedGroup =
-    group.parentCategoryId === categoryId
-      ? group
-      : {
-          ...group,
-          parentCategoryId: categoryId,
-        }
-  categorizedGroups[categoryId].push(categorizedGroup)
-}
-const tryCategorizeById = (
-  group: TabGroup,
-  categoryLookup: CategoryLookup,
-  categorizedGroups: Record<string, TabGroup[]>,
-): boolean => {
-  const category = categoryLookup.byGroupId.get(group.id)
-  if (category) {
-    pushGroupToCategory(categorizedGroups, category.id, group)
-    if (group.parentCategoryId !== category.id) {
-      console.log(
-        `ドメイン ${group.domain} のparentCategoryIdをIDベースで ${category.id} に更新しました`,
-      )
-    }
-    console.log(
-      `ドメイン ${group.domain} はIDベースで ${category.name} に分類されました`,
-    )
-    return true
-  }
-  return false
-}
-const tryCategorizeByDomainName = (
-  group: TabGroup,
-  categoryLookup: CategoryLookup,
-  categorizedGroups: Record<string, TabGroup[]>,
-): boolean => {
-  const category = categoryLookup.byDomainName.get(group.domain)
-  if (category) {
-    pushGroupToCategory(categorizedGroups, category.id, group)
-    console.log(
-      `ドメイン ${group.domain} はドメイン名ベースで ${category.name} に分類されました`,
-    )
-    console.log(
-      `ドメイン ${group.domain} のparentCategoryIdを ${category.id} に設定しました`,
-    )
-    return true
-  }
-  return false
-}
-const organizeTabGroupsWithCategories = ({
-  enableCategories,
-  tabGroupsWithUrls,
-  categoryLookup,
-  searchQuery,
-}: {
-  enableCategories: boolean
-  tabGroupsWithUrls: TabGroup[]
-  categoryLookup: CategoryLookup
-  searchQuery: string
-}): {
-  categorized: Record<string, TabGroup[]>
-  uncategorized: TabGroup[]
-} => {
-  if (!enableCategories) {
-    return {
-      categorized: {},
-      uncategorized: tabGroupsWithUrls,
-    }
-  }
-  console.log('親カテゴリ一覧:', [...categoryLookup.byId.values()])
-  console.log('organizeTabGroups開始:')
-  console.log('- tabGroupsWithUrls:', tabGroupsWithUrls)
-  console.log('- tabGroupsWithUrls.length:', tabGroupsWithUrls.length)
-  const categorizedGroups: Record<string, TabGroup[]> = {}
-  const uncategorizedGroups: TabGroup[] = []
-  const normalizedQuery = searchQuery.trim().toLowerCase()
-  const hasSearchQuery = normalizedQuery.length > 0
-  const groupsToOrganize = tabGroupsWithUrls.reduce<TabGroup[]>(
-    (groups, group) => {
-      const nextGroup = hasSearchQuery
-        ? filterGroupByQuery(group, normalizedQuery, categoryLookup)
-        : group
-      if (hasDisplayableUrls(nextGroup)) {
-        groups.push(nextGroup)
-      }
-      return groups
-    },
-    [],
-  )
-  console.log('groupsToOrganize:', groupsToOrganize)
-  console.log('groupsToOrganize.length:', groupsToOrganize.length)
-  for (const group of groupsToOrganize) {
-    const categorizedById = tryCategorizeById(
-      group,
-      categoryLookup,
-      categorizedGroups,
-    )
-    if (categorizedById) {
-      continue
-    }
-    const categorizedByDomainName = tryCategorizeByDomainName(
-      group,
-      categoryLookup,
-      categorizedGroups,
-    )
-    if (!categorizedByDomainName) {
-      uncategorizedGroups.push(group)
-      console.log(`ドメイン ${group.domain} は未分類です`)
-    }
-  }
-  sortCategorizedGroups(categorizedGroups, categoryLookup)
-  console.log('organizeTabGroups結果:')
-  console.log('- categorizedGroups:', categorizedGroups)
-  console.log('- uncategorizedGroups:', uncategorizedGroups)
-  console.log('- uncategorizedGroups.length:', uncategorizedGroups.length)
-  return {
-    categorized: categorizedGroups,
-    uncategorized: uncategorizedGroups,
-  }
-}
 
 /**
  * 指定のタブグループ内のURLをすべてカスタムプロジェクトからも削除します。
@@ -335,7 +198,7 @@ const useSavedTabsAppView = ({
     handleRenameCategory,
   } = projectState
   const categoryLookup = useMemo(
-    () => buildCategoryLookup(categories),
+    () => buildPresentationCategoryLookup(categories),
     [categories],
   )
   // 既存のタブ開く処理を OpenSavedUrlUseCase 経由に置き換え。

--- a/src/contexts/saved-tabs/presentation/app/savedTabsApp.helpers.ts
+++ b/src/contexts/saved-tabs/presentation/app/savedTabsApp.helpers.ts
@@ -4,6 +4,7 @@ import type { OpenedUrlsRestoreSnapshot } from '@/contexts/saved-tabs/applicatio
 import type { CustomProject as DomainCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import type { ParentCategory as DomainParentCategory } from '@/contexts/saved-tabs/domain/entities/ParentCategory'
 import type { TabGroup as DomainTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
+import type { PresentationCategoryLookup } from '@/contexts/saved-tabs/domain/services/SavedTabsCategorizationService'
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases'
 import { getPageHref } from '@/features/navigation/lib/pageNavigation'
 import {
@@ -25,11 +26,6 @@ import type {
  * インターフェースが一致するようになった（issue #494）。
  */
 type OpenedUrlsStorageSnapshot = OpenedUrlsRestoreSnapshot
-interface CategoryLookup {
-  byId: Map<string, ParentCategory>
-  byGroupId: Map<string, ParentCategory>
-  byDomainName: Map<string, ParentCategory>
-}
 type RefreshTabGroupsWithUrls = (
   groups: TabGroup[],
   // eslint-disable-next-line typescript/no-invalid-void-type
@@ -266,31 +262,6 @@ const notifyDeleteFailure = async ({
   toast.error(t('savedTabs.deleteError'))
 }
 
-const buildCategoryLookup = (categories: ParentCategory[]): CategoryLookup => {
-  const byId = new Map<string, ParentCategory>()
-  const byGroupId = new Map<string, ParentCategory>()
-  const byDomainName = new Map<string, ParentCategory>()
-
-  for (const category of categories) {
-    byId.set(category.id, category)
-    for (const domainId of category.domains) {
-      if (!byGroupId.has(domainId)) {
-        byGroupId.set(domainId, category)
-      }
-    }
-    for (const domainName of category.domainNames) {
-      if (!byDomainName.has(domainName)) {
-        byDomainName.set(domainName, category)
-      }
-    }
-  }
-
-  return {
-    byDomainName,
-    byGroupId,
-    byId,
-  }
-}
 const countTabGroupUrls = (group: TabGroup): number =>
   group.urlIds?.length ?? group.urls?.length ?? 0
 const getDisplayUrlCount = (group: TabGroup): number =>
@@ -302,105 +273,6 @@ const buildDisplayTabGroup = (project: CustomProject): TabGroup =>
     urls: project.urls ?? [],
     urlIds: project.urlIds ?? [],
   }) as TabGroup
-const matchesParentCategoryQuery = (
-  group: TabGroup,
-  categoryLookup: CategoryLookup,
-  query: string,
-): boolean => {
-  if (group.parentCategoryId) {
-    const parentCategory = categoryLookup.byId.get(group.parentCategoryId)
-    if (parentCategory) {
-      const matched = parentCategory.name.toLowerCase().includes(query)
-      console.log(
-        `親カテゴリ検索デバッグ: ドメイン ${group.domain}, 親カテゴリ「${parentCategory.name}」, クエリ「${query}」, マッチ: ${matched}`,
-      )
-      if (matched) {
-        return true
-      }
-    } else {
-      console.log(
-        `親カテゴリ検索デバッグ: ドメイン ${group.domain}, parentCategoryId ${group.parentCategoryId} に対応するカテゴリが見つかりません`,
-      )
-    }
-  }
-  const fallbackCategory =
-    // `||` needed: Map.get() could return empty string
-    // eslint-disable-next-line typescript/prefer-nullish-coalescing
-    categoryLookup.byGroupId.get(group.id) ||
-    categoryLookup.byDomainName.get(group.domain)
-  if (fallbackCategory) {
-    const matched = fallbackCategory.name.toLowerCase().includes(query)
-    if (matched) {
-      console.log(
-        `親カテゴリ検索デバッグ（リアルタイム）: ドメイン ${group.domain}, 親カテゴリ「${fallbackCategory.name}」, クエリ「${query}」, マッチ: ${matched}`,
-      )
-      return true
-    }
-  }
-  if (!group.parentCategoryId) {
-    console.log(
-      `親カテゴリ検索デバッグ: ドメイン ${group.domain}, parentCategoryIdが未設定かつカテゴリマッチなし`,
-    )
-  }
-  return false
-}
-const filterGroupByQuery = (
-  group: TabGroup,
-  normalizedQuery: string,
-  categoryLookup: CategoryLookup,
-): TabGroup => {
-  const currentUrls = group.urls ?? []
-  if (currentUrls.length === 0) {
-    return group
-  }
-  const parentCategoryMatched = matchesParentCategoryQuery(
-    group,
-    categoryLookup,
-    normalizedQuery,
-  )
-  const filteredUrls = currentUrls.filter((item) => {
-    const matchesBasicFields =
-      item.title.toLowerCase().includes(normalizedQuery) ||
-      item.url.toLowerCase().includes(normalizedQuery) ||
-      group.domain.toLowerCase().includes(normalizedQuery)
-    const matchesSubCategory = item.subCategory
-      ?.toLowerCase()
-      .includes(normalizedQuery)
-    // eslint-disable-next-line typescript/prefer-nullish-coalescing -- boolean values; false should not fall through
-    return matchesBasicFields || matchesSubCategory || parentCategoryMatched
-  })
-  if (filteredUrls.length === currentUrls.length) {
-    return group
-  }
-  return {
-    ...group,
-    urls: filteredUrls,
-  }
-}
-const sortCategorizedGroups = (
-  categorizedGroups: Record<string, TabGroup[]>,
-  categoryLookup: CategoryLookup,
-): void => {
-  for (const categoryId of Object.keys(categorizedGroups)) {
-    const category = categoryLookup.byId.get(categoryId)
-    const domains = category?.domains
-    if (!(domains && domains.length > 0)) {
-      continue
-    }
-    const domainOrder = new Map(domains.map((domain, index) => [domain, index]))
-    categorizedGroups[categoryId].sort((a, b) => {
-      const indexA = domainOrder.get(a.id) ?? -1
-      const indexB = domainOrder.get(b.id) ?? -1
-      if (indexA === -1) {
-        return 1
-      }
-      if (indexB === -1) {
-        return -1
-      }
-      return indexA - indexB
-    })
-  }
-}
 const filterGroupsByExcludedIds = (
   groups: TabGroup[],
   idsToExclude: Set<string>,
@@ -497,7 +369,7 @@ const updateSavedTabParentCategory = (
   )
 const syncGroupCategoryAssignment = (
   group: TabGroup,
-  categoryLookup: CategoryLookup,
+  categoryLookup: PresentationCategoryLookup,
   state: CategorySyncState,
 ): CategorySyncState => {
   const idBasedCategory = categoryLookup.byGroupId.get(group.id)
@@ -671,15 +543,13 @@ const syncSavedTabsViewModeLocation = ({
   window.history.replaceState({}, '', `${nextUrl.pathname}${nextUrl.search}`)
 }
 
-export type { CategoryLookup, CategorySyncState, OpenedUrlsStorageSnapshot }
+export type { CategorySyncState, OpenedUrlsStorageSnapshot }
 export {
-  buildCategoryLookup,
   buildDisplayTabGroup,
   buildUpdatedGroupAfterUrlIdRemoval,
   buildUrlIdsToRemove,
   countTabGroupUrls,
   createFilterGroupsByExcludedIdsUpdater,
-  filterGroupByQuery,
   filterGroupsByExcludedIds,
   getDisplayUrlCount,
   getSnapshotSavedTabs,
@@ -691,7 +561,6 @@ export {
   restoreOpenedUrlsSnapshot,
   shouldWaitForInitialViewMode,
   showOpenedUrlsUndoToast,
-  sortCategorizedGroups,
   syncGroupCategoryAssignment,
   syncSavedTabsViewModeLocation,
   toDomainParentCategories,


### PR DESCRIPTION
## 変更内容

- `SavedTabsApp` 内に残っていたカテゴリ分類・表示判定ロジックを domain service へ移設
- 新規: `SavedTabsDisplayPolicy` (`hasDisplayableUrls`) / `SavedTabsCategorizationService` (`buildPresentationCategoryLookup`, `organizeTabGroupsWithCategories`)
- 既存: `SavedTabsApp.tsx` (-149 行), `savedTabsApp.helpers.ts` (-137 行) の pure logic を domain へ移動
- `console.log` デバッグ出力は domain 化と同時に削除 (純粋性 + テスト noise 軽減、本質的挙動は不変)
- 既存挙動 (`parentCategoryId` 単独では categorizing されない、domains 未登録 id は categorized 外、urls のみグループでの searchQuery 絞り込み) は unit test で意図的に保持

## 受け入れ条件チェック (issue #496)

- [x] `SavedTabsApp` からカテゴリ分類・表示判定の pure logic が削減されている
- [x] 移行した logic が domain service に分離されている
- [x] domain service が React / chrome API / console に依存していない
- [x] domain service の unit test が追加されている (新規 23 件)
- [x] 既存のカテゴリ表示・未分類表示・検索結果 が変わっていない
- [x] `bun run compile` が通る
- [x] 関連テストが通る

## 検証

- `bun run compile` (tsgo --noEmit): エラーなし
- `bun run test` (full): 227 files / **1915 tests pass**
- `bun run lint` (oxlint): 0 errors / 0 warnings
- `bun run test:coverage` 新規 domain ファイル: **100%** (clover.xml 確認済み)
- 新規 domain ファイルが `.oxlintrc.json` の domain 層 restrictions (React / chrome / @/components / @/contexts/*/presentation 等) に違反していないこと確認済み

## 変更統計

```
4 new files (2 source + 2 test)
3 modified files
net +415 / -332 lines
```

- 新規: `SavedTabsCategorizationService.ts` (278 行) / `.test.ts` (324 行)
- 新規: `SavedTabsDisplayPolicy.ts` (24 行) / `.test.ts` (56 行)
- 修正: `SavedTabsApp.tsx`, `savedTabsApp.helpers.ts`, `SavedTabsApp.test.tsx`

## 関連 issue

#496