### PR TITLE
feat(#503): presentation 層から chrome.storage.onChanged の言及を撤廃し layer guard を強化

### DIFF
--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { relative, resolve, sep } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
@@ -117,6 +117,39 @@ const getRestrictedProperties = (
     }
     return []
   })
+}
+
+const collectSourceFiles = (dir: string): string[] => {
+  const result: string[] = []
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return result
+  }
+  for (const entry of entries) {
+    const fullPath = resolve(dir, entry)
+    let stats
+    try {
+      stats = statSync(fullPath)
+    } catch {
+      continue
+    }
+    if (stats.isDirectory()) {
+      result.push(...collectSourceFiles(fullPath))
+      continue
+    }
+    if (!stats.isFile()) {
+      continue
+    }
+    if (entry.endsWith('.test.ts') || entry.endsWith('.test.tsx')) {
+      continue
+    }
+    if (entry.endsWith('.ts') || entry.endsWith('.tsx')) {
+      result.push(fullPath)
+    }
+  }
+  return result
 }
 
 describe('src/contexts/saved-tabs DDD layer guard', () => {
@@ -429,6 +462,39 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
         /chrome\.storage\.onChanged\.(addListener|removeListener)/,
       )
     })
+  })
+
+  describe('issue #503: presentation 配下は chrome.storage.onChanged を直参照しない', () => {
+    const presentationRoot = resolve(
+      repoRoot,
+      'src/contexts/saved-tabs/presentation',
+    )
+    const presentationSourceFiles = collectSourceFiles(presentationRoot)
+
+    it('presentation 配下に .ts / .tsx ソースファイルが存在する', () => {
+      expect(presentationSourceFiles.length).toBeGreaterThan(0)
+    })
+
+    for (const absolutePath of presentationSourceFiles) {
+      const relativePath = relative(repoRoot, absolutePath).split(sep).join('/')
+      it(`${relativePath} は chrome.storage.onChanged 文字列を含まない`, () => {
+        const source = readFileSync(absolutePath, 'utf8')
+        expect(
+          source,
+          `${relativePath} should not reference chrome.storage.onChanged`,
+        ).not.toMatch(/chrome\.storage\.onChanged/)
+      })
+
+      it(`${relativePath} は chrome.storage.onChanged.addListener / removeListener を直接呼び出さない`, () => {
+        const source = readFileSync(absolutePath, 'utf8')
+        expect(
+          source,
+          `${relativePath} should not call chrome.storage.onChanged.addListener/removeListener`,
+        ).not.toMatch(
+          /chrome\.storage\.onChanged\.(addListener|removeListener)/,
+        )
+      })
+    }
   })
 
   describe('domain/repositories/ の純度 (issue #457)', () => {

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -859,8 +859,10 @@ const useSavedTabsAppView = ({
     }
   }, [customProjects, searchQuery])
 
-  // ストレージ変更検出時のリスナー。`chrome.storage.onChanged` 直叩きは禁止のため
-  // `StorageChangePort` 経由で chrome API 実装 (infrastructure 層) と疎結合にする。
+  // ストレージ変更検出時のリスナー。`StorageChangePort` 経由で chrome API 実装
+  // (infrastructure 層) と疎結合にし、port 境界をまたいだ購読 / 解除として
+  // 扱う（issue #503）。React 側は購読開始 / 解除と state 反映のみに責務を絞り、
+  // Chrome ストレージ変更通知の詳細は port 実装側に閉じ込めている。
   useEffect(() => {
     const unsubscribe = deps.storageChangePort.subscribe((changes) => {
       console.log('ストレージ変更を検出:', changes)

--- a/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordModalRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordModalRoot.tsx
@@ -40,10 +40,11 @@ interface KeywordModalRootProps {
     parentCategoryRepository: ParentCategoryRepository
   }
   /**
-   * storage 変更通知 port。`chrome.storage.onChanged` の直叩きは禁止の
-   * ため、presentation 層は本 port 経由でのみ storage 変更を購読する。
-   * 未指定時は購読を行わない（テストや SSR など chrome 依存を完全に
-   * 切りたい場合用）。
+   * storage 変更通知 port。`StorageChangePort` 経由でのみ storage 変更を
+   * 購読する（issue #503）。chrome API の詳細は infrastructure 層の
+   * `ChromeStorageChangeAdapter` に閉じ込めており、presentation 層から
+   * 購読 / 解除を直接行う場合は本 port を使う。未指定時は購読を行わない
+   * （テストや SSR など chrome 依存を完全に切りたい場合用）。
    */
   readonly storageChangePort?: StorageChangePort
   /** 子コンポーネント */

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
@@ -47,10 +47,12 @@ interface UseCategoryKeywordModalParams {
   /** 永続化依存（Repository 群）。`chrome.storage.local` 直叩きを撤去するため必須。 */
   deps: UseCategoryKeywordModalDeps
   /**
-   * storage 変更通知 port。`chrome.storage.onChanged` の直叩きは禁止の
-   * ため、presentation 層は本 port 経由でのみ storage 変更を購読する。
-   * 未指定時は購読を行わず、初回 `loadParentCategories` 呼び出しだけで
-   * 親カテゴリを同期する（テストで chrome 依存を完全に切りたい場合用）。
+   * storage 変更通知 port。`StorageChangePort` 経由でのみ storage 変更を
+   * 購読する（issue #503）。chrome API の詳細は infrastructure 層の
+   * `ChromeStorageChangeAdapter` に閉じ込めており、presentation 層から
+   * 購読 / 解除を直接行う場合は本 port を使う。未指定時は購読を行わず、
+   * 初回 `loadParentCategories` 呼び出しだけで親カテゴリを同期する
+   * （テストで chrome 依存を完全に切りたい場合用）。
    */
   readonly storageChangePort?: StorageChangePort
 }

--- a/src/contexts/saved-tabs/presentation/services/modeSyncService.ts
+++ b/src/contexts/saved-tabs/presentation/services/modeSyncService.ts
@@ -288,9 +288,9 @@ const applyTabsAndUrlsChanges = async (
     // 旧 `invalidateUrlCache()` 相当の処理は DDD 移行で不要。
     // `UrlRecordRepository`（chrome impl）は `findAll` 呼び出しごとに
     // `chrome.storage.local.get` を直接実行するため、cache 無効化は
-    // 必要ない（`chrome.storage.onChanged` 経由の最新値を即時読む）。
+    // 必要ない（`StorageChangePort` 経由の最新値を即時読む）。
     // ここでは `refreshTabGroupsWithUrls()` のみ呼んで urlRecords を
-    // 取り直させれば十分（issue #501）。
+    // 取り直させれば十分（issue #501 / #503）。
     await refreshTabGroupsWithUrls()
   }
 }


### PR DESCRIPTION
## 概要
saved-tabs の presentation 層に残る `chrome.storage.onChanged` の言及を撤廃し、`StorageChangePort` / adapter 経由の購読にコメントレベルから統一する。合わせて `dddLayerGuard.test.ts` を強化し、presentation 配下全体に対する `chrome.storage.onChanged` 静的検査を追加する（#503 / #495 の後続）。

## 背景
- #495 で `chrome.storage.onChanged` の直叩きは port 経由へ移設済みだが、production code のコメントには依然として `chrome.storage.onChanged` の文字列が残っており、grep 結果や AI 実装時に「直叩きがまだ残っている」と誤認される可能性があった。
- 既存の `dddLayerGuard` の `chrome.storage.onChanged` 検査は `SavedTabsApp.tsx` / `useCategoryKeywordModal.ts` の 2 ファイルに限定されており、presentation 配下の他ファイルへの回帰を検知できなかった。

## 変更内容
- `SavedTabsApp.tsx` / `useCategoryKeywordModal.ts` / `KeywordModalRoot.tsx` / `modeSyncService.ts` のコメントを `StorageChangePort` 抽象ベースに書き換え、port 境界の説明と issue #503 への参照を追記。
- `dddLayerGuard.test.ts` に `collectSourceFiles` ヘルパーを追加し、`src/contexts/saved-tabs/presentation/**` 配下の全 `.ts` / `.tsx` ソース（test ファイルは除外）に対して以下を禁止する静的検査を追加。
  - `chrome.storage.onChanged` 文字列の出現
  - `chrome.storage.onChanged.addListener` / `removeListener` の直接呼び出し

## 受け入れ条件
- [x] `src/contexts/saved-tabs/presentation/**` に `chrome.storage.onChanged.addListener` が残っていない
- [x] `src/contexts/saved-tabs/presentation/**` に `chrome.storage.onChanged.removeListener` が残っていない
- [x] storage変更購読は `StorageChangePort` / adapter 経由になっている
- [x] storage変更時の再同期挙動が維持されている
- [x] `bun run compile` が通る
- [x] 関連テストが通る

## 検証
- `tsgo --noEmit` → exit 0
- `bun run test:node` → 117 files / 1389 tests passed
- `bun run test:dom`  → 120 files /  812 tests passed
- `bun run test`      → 237 files / 2201 tests passed
- `bun run lint`      → 0 warnings / 0 errors
- `bun run format:check` → all matched
- 回帰検知テスト: `savedTabsApp.helpers.ts` にダミーで `chrome.storage.onChanged` 文字列を挿入した状態で新テストが `AssertionError` で失敗することを確認し、その後 revert。

## 関連
- close #503
- after #495, #502
- DDD 移行計画 #454