### PR TITLE
feat(#504): SavedTabsApp の表示判定ロジックを domain-independent な view-model builder へ移設

### DIFF
--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
@@ -419,15 +419,17 @@ import {
   buildPresentationCategoryLookup,
   organizeTabGroupsWithCategories,
 } from '@/contexts/saved-tabs/domain/services/SavedTabsCategorizationService'
-
 import {
   buildDisplayTabGroup,
+  getDisplayUrlCount,
+} from '@/contexts/saved-tabs/presentation/lib/display-tab-group'
+
+import {
   buildUpdatedGroupAfterUrlIdRemoval,
   buildUrlIdsToRemove,
   countTabGroupUrls,
   createFilterGroupsByExcludedIdsUpdater,
   filterGroupsByExcludedIds,
-  getDisplayUrlCount,
   notifyDeleteFailure,
   removeUrlsFromCustomProjectsForGroup,
   removeUrlsFromCustomProjectsForGroups,

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -26,10 +26,10 @@ import type { UseSavedTabsControllerReturn } from '@/contexts/saved-tabs/present
 import { useCategoryManagement } from '@/contexts/saved-tabs/presentation/hooks/useCategoryManagement'
 import { useProjectManagement } from '@/contexts/saved-tabs/presentation/hooks/useProjectManagement'
 import { useTabData } from '@/contexts/saved-tabs/presentation/hooks/useTabData'
+import { createCategorizedDisplayState } from '@/contexts/saved-tabs/presentation/lib/categorized-display'
 import { moveCustomProjectUrlAndSyncState } from '@/contexts/saved-tabs/presentation/lib/custom-project-move'
 import { filterCustomProjectsByQuery } from '@/contexts/saved-tabs/presentation/lib/custom-project-search'
 import { handleTabGroupRemoval } from '@/contexts/saved-tabs/presentation/lib/tab-operations'
-import { shouldShowUncategorizedHeader as computeShouldShowUncategorizedHeader } from '@/contexts/saved-tabs/presentation/lib/uncategorized-display'
 import type { ResolveActiveRef } from '@/contexts/saved-tabs/presentation/pages/SavedTabsPage'
 import { syncStorageChanges } from '@/contexts/saved-tabs/presentation/services/modeSyncService'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
@@ -47,10 +47,8 @@ import type {
 } from '@/types/storage'
 
 import {
-  buildDisplayTabGroup,
   countTabGroupUrls,
   createFilterGroupsByExcludedIdsUpdater,
-  getDisplayUrlCount,
   getSnapshotSavedTabs,
   notifyDeleteFailure,
   removeUrlsFromCustomProjectsForGroup,
@@ -743,14 +741,6 @@ const useSavedTabsAppView = ({
     () => organizeTabGroups(),
     [organizeTabGroups],
   )
-  // コンテンツがあるグループリスト（カテゴリと未分類を結合、URLがあるもののみ）
-  const hasContentTabGroups = useMemo(
-    () =>
-      [...Object.values(categorized).flat(), ...uncategorized].filter(
-        (group) => getDisplayUrlCount(group) > 0,
-      ),
-    [categorized, uncategorized],
-  )
 
   // 未分類ドメインのドラッグエンド処理（並び替えモード対応）
   const handleUncategorizedDragEnd = useCallback(
@@ -819,12 +809,46 @@ const useSavedTabsAppView = ({
   console.log('表示判定デバッグ:')
   console.log('- categorized:', categorized)
   console.log('- uncategorized:', uncategorized)
-  console.log('- hasContentTabGroups:', hasContentTabGroups)
-  console.log('- hasContentTabGroups.length:', hasContentTabGroups.length)
 
   const customProjectsForHeader = customProjects
   const [filteredCustomProjects, setFilteredCustomProjects] =
     useState(customProjects)
+
+  // 表示判定・表示用整形は `createCategorizedDisplayState` へ移設（issue #504）。
+  // domain / chrome API / storage に依存しない pure 関数として
+  // `presentation/lib/categorized-display.ts` に切り出し済み。
+  // `filteredCustomProjects` が `useState(customProjects)` で確定したあとに
+  // 組み立てる必要があるため、`useEffect` で同期する処理群の直後に置く。
+  const {
+    hasContentTabGroups,
+    hasVisibleCategoryGroups,
+    headerFilteredTabGroups,
+    shouldShowUncategorizedList,
+    shouldShowUncategorizedSectionHeader,
+    uncategorizedForDisplay,
+  } = useMemo(
+    () =>
+      createCategorizedDisplayState({
+        categorized,
+        enableCategories: settings.enableCategories,
+        filteredCustomProjects,
+        isUncategorizedReorderMode,
+        searchQuery,
+        tempUncategorizedOrder,
+        uncategorized,
+        viewMode,
+      }),
+    [
+      categorized,
+      settings.enableCategories,
+      filteredCustomProjects,
+      isUncategorizedReorderMode,
+      searchQuery,
+      tempUncategorizedOrder,
+      uncategorized,
+      viewMode,
+    ],
+  )
 
   const handleDeleteUrlFromCustomMode = useCallback(
     async (projectId: string, url: string) => {
@@ -934,39 +958,12 @@ const useSavedTabsAppView = ({
 
   // カテゴリ間でURLを移動するハンドラ
   const handleMoveUrlsBetweenCategories = useCallback(async () => {}, [])
-  const visibleUncategorizedGroups = useMemo(
-    () => uncategorized.filter((group) => getDisplayUrlCount(group) > 0),
-    [uncategorized],
-  )
-  const hasVisibleCategoryGroups =
-    settings.enableCategories && Object.keys(categorized).length > 0
-  const shouldShowUncategorizedSectionHeader =
-    settings.enableCategories &&
-    computeShouldShowUncategorizedHeader({
-      isUncategorizedReorderMode,
-      searchQuery,
-      uncategorizedCount: uncategorized.length,
-      visibleUncategorizedCount: visibleUncategorizedGroups.length,
-    })
-  const shouldShowUncategorizedList = visibleUncategorizedGroups.length > 0
-  const headerFilteredTabGroups = useMemo(() => {
-    if (viewMode === 'domain') {
-      return hasContentTabGroups
-    }
-    return filteredCustomProjects.map((project) =>
-      buildDisplayTabGroup(project),
-    )
-  }, [viewMode, hasContentTabGroups, filteredCustomProjects])
   const customProjectsForDisplay = filteredCustomProjects
   const shouldShowCategoryReorderFooter =
     isCategoryReorderMode && viewMode === 'domain'
   const categoryOrderForDisplay = isCategoryReorderMode
     ? tempCategoryOrder
     : categoryOrder
-  // eslint-disable-next-line react-perf/jsx-no-new-array-as-prop
-  const uncategorizedForDisplay = (
-    isUncategorizedReorderMode ? tempUncategorizedOrder : uncategorized
-  ).filter((group) => getDisplayUrlCount(group) > 0)
   const mainContent =
     viewMode === 'domain' ? (
       <DomainModeContainer

--- a/src/contexts/saved-tabs/presentation/app/savedTabsApp.helpers.ts
+++ b/src/contexts/saved-tabs/presentation/app/savedTabsApp.helpers.ts
@@ -263,15 +263,6 @@ const notifyDeleteFailure = async ({
 
 const countTabGroupUrls = (group: TabGroup): number =>
   group.urlIds?.length ?? group.urls?.length ?? 0
-const getDisplayUrlCount = (group: TabGroup): number =>
-  (group.urls ?? group.urlIds ?? []).length
-const buildDisplayTabGroup = (project: CustomProject): TabGroup =>
-  ({
-    id: project.id,
-    domain: project.name,
-    urls: project.urls ?? [],
-    urlIds: project.urlIds ?? [],
-  }) as TabGroup
 const filterGroupsByExcludedIds = (
   groups: TabGroup[],
   idsToExclude: Set<string>,
@@ -556,13 +547,11 @@ const syncSavedTabsViewModeLocation = ({
 
 export type { CategorySyncState, OpenedUrlsStorageSnapshot }
 export {
-  buildDisplayTabGroup,
   buildUpdatedGroupAfterUrlIdRemoval,
   buildUrlIdsToRemove,
   countTabGroupUrls,
   createFilterGroupsByExcludedIdsUpdater,
   filterGroupsByExcludedIds,
-  getDisplayUrlCount,
   getSnapshotSavedTabs,
   notifyDeleteFailure,
   removeUrlsFromCustomProjectsForGroup,

--- a/src/contexts/saved-tabs/presentation/lib/categorized-display.test.ts
+++ b/src/contexts/saved-tabs/presentation/lib/categorized-display.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CustomProject, TabGroup } from '@/types/storage'
+
+import { createCategorizedDisplayState } from './categorized-display'
+
+const makeGroup = (overrides: Partial<TabGroup> = {}): TabGroup => ({
+  domain: 'example.com',
+  id: 'group-1',
+  ...overrides,
+})
+
+const makeProject = (
+  overrides: Partial<CustomProject> = {},
+): CustomProject => ({
+  categories: [],
+  createdAt: 0,
+  id: 'project-1',
+  name: 'My Project',
+  updatedAt: 0,
+  urlIds: [],
+  urls: [],
+  ...overrides,
+})
+
+const baseInput = {
+  categorized: {} as Record<string, TabGroup[]>,
+  enableCategories: true,
+  filteredCustomProjects: [] as readonly CustomProject[],
+  isUncategorizedReorderMode: false,
+  searchQuery: '',
+  tempUncategorizedOrder: [] as readonly TabGroup[],
+  uncategorized: [] as readonly TabGroup[],
+  viewMode: 'domain' as const,
+}
+
+describe('createCategorizedDisplayState.hasContentTabGroups', () => {
+  it('categorized と uncategorized のうち表示対象 URL を持つグループだけ返す', () => {
+    const displayable = makeGroup({ id: 'a', urlIds: ['u1'] })
+    const empty = makeGroup({ id: 'b', urlIds: [] })
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      categorized: { cat: [empty, displayable] },
+      uncategorized: [empty, displayable],
+    })
+    expect(result.hasContentTabGroups.map((g) => g.id)).toStrictEqual([
+      'a',
+      'a',
+    ])
+  })
+
+  it('何も表示対象がないときは空配列', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      uncategorized: [makeGroup({ id: 'a', urlIds: [] })],
+    })
+    expect(result.hasContentTabGroups).toStrictEqual([])
+  })
+})
+
+describe('createCategorizedDisplayState.visibleUncategorizedGroups', () => {
+  it('uncategorized のうち表示対象 URL を持つグループだけ返す', () => {
+    const empty = makeGroup({ id: 'b', urlIds: [] })
+    const displayable = makeGroup({ id: 'a', urlIds: ['u1'] })
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      uncategorized: [empty, displayable],
+    })
+    expect(result.visibleUncategorizedGroups.map((g) => g.id)).toStrictEqual([
+      'a',
+    ])
+  })
+})
+
+describe('createCategorizedDisplayState.hasVisibleCategoryGroups', () => {
+  it('enableCategories=true かつ categorized が1件以上なら true', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      categorized: { cat: [makeGroup({ id: 'a' })] },
+      enableCategories: true,
+    })
+    expect(result.hasVisibleCategoryGroups).toBe(true)
+  })
+
+  it('enableCategories=false なら categorized に件数があっても false', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      categorized: { cat: [makeGroup({ id: 'a' })] },
+      enableCategories: false,
+    })
+    expect(result.hasVisibleCategoryGroups).toBe(false)
+  })
+
+  it('categorized が空オブジェクトなら false', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      enableCategories: true,
+    })
+    expect(result.hasVisibleCategoryGroups).toBe(false)
+  })
+})
+
+describe('createCategorizedDisplayState.shouldShowUncategorizedSectionHeader', () => {
+  it('enableCategories=false なら false', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      enableCategories: false,
+      uncategorized: [makeGroup({ id: 'a', urlIds: ['u1'] })],
+    })
+    expect(result.shouldShowUncategorizedSectionHeader).toBe(false)
+  })
+
+  it('enableCategories=true で未分類なしなら false', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      enableCategories: true,
+      uncategorized: [],
+    })
+    expect(result.shouldShowUncategorizedSectionHeader).toBe(false)
+  })
+
+  it('enableCategories=true で表示対象未分類ありなら true', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      enableCategories: true,
+      uncategorized: [makeGroup({ id: 'a', urlIds: ['u1'] })],
+    })
+    expect(result.shouldShowUncategorizedSectionHeader).toBe(true)
+  })
+
+  it('検索クエリありで visibleUncategorizedCount=0、並び替え中でないなら false', () => {
+    // visibleUncategorizedCount=0 にするには uncategorized 内のグループが
+    // 表示対象 URL を持たない状態にする必要がある。urlIds=[] / urls=undefined
+    // のグループを 1 件渡すと、hasDisplayableUrls=false でフィルタされ、
+    // visibleUncategorizedCount=0 / uncategorizedCount=1 になる。
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      enableCategories: true,
+      searchQuery: 'nomatch',
+      uncategorized: [makeGroup({ id: 'a', urlIds: [] })],
+    })
+    expect(result.shouldShowUncategorizedSectionHeader).toBe(false)
+  })
+})
+
+describe('createCategorizedDisplayState.shouldShowUncategorizedList', () => {
+  it('visibleUncategorizedGroups が1件以上なら true', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      uncategorized: [makeGroup({ id: 'a', urlIds: ['u1'] })],
+    })
+    expect(result.shouldShowUncategorizedList).toBe(true)
+  })
+
+  it('表示対象未分類が0件なら false', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      uncategorized: [makeGroup({ id: 'a', urlIds: [] })],
+    })
+    expect(result.shouldShowUncategorizedList).toBe(false)
+  })
+})
+
+describe('createCategorizedDisplayState.uncategorizedForDisplay', () => {
+  it('通常時は uncategorized を表示対象 URL のみで返す', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      isUncategorizedReorderMode: false,
+      uncategorized: [
+        makeGroup({ id: 'a', urlIds: ['u1'] }),
+        makeGroup({ id: 'b', urlIds: [] }),
+      ],
+    })
+    expect(result.uncategorizedForDisplay.map((g) => g.id)).toStrictEqual(['a'])
+  })
+
+  it('並び替えモード時は tempUncategorizedOrder を表示対象 URL のみで返す', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      isUncategorizedReorderMode: true,
+      tempUncategorizedOrder: [
+        makeGroup({ id: 'a', urlIds: ['u1'] }),
+        makeGroup({ id: 'b', urlIds: [] }),
+        makeGroup({ id: 'c', urlIds: ['u2'] }),
+      ],
+      uncategorized: [],
+    })
+    expect(result.uncategorizedForDisplay.map((g) => g.id)).toStrictEqual([
+      'a',
+      'c',
+    ])
+  })
+})
+
+describe('createCategorizedDisplayState.headerFilteredTabGroups', () => {
+  it('viewMode=domain なら hasContentTabGroups をそのまま返す', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      uncategorized: [makeGroup({ id: 'a', urlIds: ['u1'] })],
+      viewMode: 'domain',
+    })
+    expect(result.headerFilteredTabGroups.map((g) => g.id)).toStrictEqual(['a'])
+  })
+
+  it('viewMode=custom なら filteredCustomProjects を buildDisplayTabGroup で投影する', () => {
+    const result = createCategorizedDisplayState({
+      ...baseInput,
+      filteredCustomProjects: [
+        makeProject({ id: 'p1', name: 'Project A' }),
+        makeProject({ id: 'p2', name: 'Project B' }),
+      ],
+      viewMode: 'custom',
+    })
+    expect(result.headerFilteredTabGroups.map((g) => g.id)).toStrictEqual([
+      'p1',
+      'p2',
+    ])
+    expect(result.headerFilteredTabGroups.map((g) => g.domain)).toStrictEqual([
+      'Project A',
+      'Project B',
+    ])
+  })
+})

--- a/src/contexts/saved-tabs/presentation/lib/categorized-display.ts
+++ b/src/contexts/saved-tabs/presentation/lib/categorized-display.ts
@@ -1,0 +1,119 @@
+import type { CustomProject, TabGroup, ViewMode } from '@/types/storage'
+
+import { buildDisplayTabGroup, getDisplayUrlCount } from './display-tab-group'
+import { shouldShowUncategorizedHeader } from './uncategorized-display'
+
+/**
+ * `CategorizedDisplayState` への入力。
+ *
+ * `SavedTabsApp.tsx` が保持する `categorized` / `uncategorized` /
+ * 並び替え中の一時順序 / 検索クエリ / viewMode / カテゴリ表示設定から
+ * 描画に必要な派生 state をまとめて組み立てるための pure 関数入力。
+ *
+ * React / chrome API / storage には依存しない (issue #504)。
+ */
+export interface CreateCategorizedDisplayStateInput {
+  readonly categorized: Readonly<Record<string, readonly TabGroup[]>>
+  readonly uncategorized: readonly TabGroup[]
+  readonly tempUncategorizedOrder: readonly TabGroup[]
+  readonly isUncategorizedReorderMode: boolean
+  readonly enableCategories: boolean
+  readonly searchQuery: string
+  readonly viewMode: ViewMode
+  readonly filteredCustomProjects: readonly CustomProject[]
+}
+
+/**
+ * カテゴリ分類済み / 未分類のタブグループから UI 派生 state を組み立てる。
+ *
+ * - `hasContentTabGroups` : カテゴリ + 未分類のうち表示対象 URL を持つ
+ *   グループのフラット配列。`Header` への件数表示と `hasContentCount` 判定用
+ * - `visibleUncategorizedGroups` : 未分類のうち表示対象 URL を持つグループ
+ *   （並び替えモードの一時順序は反映しない）
+ * - `hasVisibleCategoryGroups` : カテゴリ表示が有効かつ分類済みカテゴリが
+ *   1 件以上存在するか
+ * - `shouldShowUncategorizedSectionHeader` : 未分類セクション見出しを
+ *   表示するかどうか
+ * - `shouldShowUncategorizedList` : 未分類グループリスト本体を描画するか
+ * - `uncategorizedForDisplay` : 並び替えモード時は一時順序、通常時は
+ *   フィルタ済み `uncategorized` を表示対象 URL のみへ絞り込んだ配列
+ * - `headerFilteredTabGroups` : ヘッダー用のフィルタ済み表示配列
+ *   （domain モードでは `hasContentTabGroups`、custom モードでは
+ *   `filteredCustomProjects` を `buildDisplayTabGroup` で投影）
+ *
+ * 旧 `SavedTabsApp.tsx` 内の同名の useMemo / 計算式を
+ * domain-independent な pure 関数として切り出したもの (issue #504)。
+ */
+export interface CategorizedDisplayState {
+  readonly hasContentTabGroups: TabGroup[]
+  readonly visibleUncategorizedGroups: TabGroup[]
+  readonly hasVisibleCategoryGroups: boolean
+  readonly shouldShowUncategorizedSectionHeader: boolean
+  readonly shouldShowUncategorizedList: boolean
+  readonly uncategorizedForDisplay: TabGroup[]
+  readonly headerFilteredTabGroups: TabGroup[]
+}
+
+const filterByDisplayableUrls = (groups: readonly TabGroup[]): TabGroup[] =>
+  groups.filter((group) => getDisplayUrlCount(group) > 0)
+
+const buildHeaderFilteredTabGroups = ({
+  filteredCustomProjects,
+  hasContentTabGroups,
+  viewMode,
+}: {
+  readonly filteredCustomProjects: readonly CustomProject[]
+  readonly hasContentTabGroups: TabGroup[]
+  readonly viewMode: ViewMode
+}): TabGroup[] => {
+  if (viewMode === 'domain') {
+    return hasContentTabGroups
+  }
+  return filteredCustomProjects.map((project) => buildDisplayTabGroup(project))
+}
+
+export const createCategorizedDisplayState = ({
+  categorized,
+  enableCategories,
+  filteredCustomProjects,
+  isUncategorizedReorderMode,
+  searchQuery,
+  tempUncategorizedOrder,
+  uncategorized,
+  viewMode,
+}: CreateCategorizedDisplayStateInput): CategorizedDisplayState => {
+  const hasContentTabGroups = filterByDisplayableUrls([
+    ...Object.values(categorized).flat(),
+    ...uncategorized,
+  ])
+  const visibleUncategorizedGroups = filterByDisplayableUrls(uncategorized)
+  const hasVisibleCategoryGroups =
+    enableCategories && Object.keys(categorized).length > 0
+  const shouldShowUncategorizedSectionHeader =
+    enableCategories &&
+    shouldShowUncategorizedHeader({
+      isUncategorizedReorderMode,
+      searchQuery,
+      uncategorizedCount: uncategorized.length,
+      visibleUncategorizedCount: visibleUncategorizedGroups.length,
+    })
+  const shouldShowUncategorizedList = visibleUncategorizedGroups.length > 0
+  const uncategorizedForDisplay = filterByDisplayableUrls(
+    isUncategorizedReorderMode ? tempUncategorizedOrder : uncategorized,
+  )
+  const headerFilteredTabGroups = buildHeaderFilteredTabGroups({
+    filteredCustomProjects,
+    hasContentTabGroups,
+    viewMode,
+  })
+
+  return {
+    hasContentTabGroups,
+    hasVisibleCategoryGroups,
+    headerFilteredTabGroups,
+    shouldShowUncategorizedList,
+    shouldShowUncategorizedSectionHeader,
+    uncategorizedForDisplay,
+    visibleUncategorizedGroups,
+  }
+}

--- a/src/contexts/saved-tabs/presentation/lib/display-tab-group.test.ts
+++ b/src/contexts/saved-tabs/presentation/lib/display-tab-group.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CustomProject, TabGroup } from '@/types/storage'
+
+import { buildDisplayTabGroup, getDisplayUrlCount } from './display-tab-group'
+
+const makeGroup = (overrides: Partial<TabGroup> = {}): TabGroup => ({
+  domain: 'example.com',
+  id: 'group-1',
+  ...overrides,
+})
+
+const makeProject = (
+  overrides: Partial<CustomProject> = {},
+): CustomProject => ({
+  categories: [],
+  createdAt: 0,
+  id: 'project-1',
+  name: 'My Project',
+  updatedAt: 0,
+  urlIds: [],
+  urls: [],
+  ...overrides,
+})
+
+describe('getDisplayUrlCount', () => {
+  it('urls が指定されていればその長さを返す', () => {
+    expect(
+      getDisplayUrlCount(
+        makeGroup({
+          urls: [
+            { title: 'a', url: 'https://a.example.com' },
+            { title: 'b', url: 'https://b.example.com' },
+          ],
+        }),
+      ),
+    ).toBe(2)
+  })
+
+  it('urlIds が指定されていればその長さを返す (旧形式)', () => {
+    expect(getDisplayUrlCount(makeGroup({ urlIds: ['u1', 'u2', 'u3'] }))).toBe(
+      3,
+    )
+  })
+
+  it('urls が優先で urlIds はフォールバック', () => {
+    expect(
+      getDisplayUrlCount(
+        makeGroup({
+          urlIds: ['u1'],
+          urls: [
+            { title: 'a', url: 'https://a.example.com' },
+            { title: 'b', url: 'https://b.example.com' },
+          ],
+        }),
+      ),
+    ).toBe(2)
+  })
+
+  it('両方未定義なら 0', () => {
+    expect(getDisplayUrlCount(makeGroup())).toBe(0)
+  })
+
+  it('両方空配列なら 0', () => {
+    expect(getDisplayUrlCount(makeGroup({ urlIds: [], urls: [] }))).toBe(0)
+  })
+})
+
+describe('buildDisplayTabGroup', () => {
+  it('project 名を domain に流用した TabGroup を返す', () => {
+    const result = buildDisplayTabGroup(
+      makeProject({ id: 'p1', name: 'Reading List' }),
+    )
+    expect(result.id).toBe('p1')
+    expect(result.domain).toBe('Reading List')
+  })
+
+  it('urls / urlIds が未定義なら空配列で詰める', () => {
+    const result = buildDisplayTabGroup(
+      makeProject({ id: 'p1', name: 'No Urls' }),
+    )
+    expect(result.urls).toStrictEqual([])
+    expect(result.urlIds).toStrictEqual([])
+  })
+
+  it('urls / urlIds があればそのままコピーする', () => {
+    const result = buildDisplayTabGroup(
+      makeProject({
+        id: 'p1',
+        name: 'With Urls',
+        urlIds: ['u1', 'u2'],
+        urls: [{ title: 'a', url: 'https://a.example.com' }],
+      }),
+    )
+    expect(result.urlIds).toStrictEqual(['u1', 'u2'])
+    expect(result.urls).toStrictEqual([
+      { title: 'a', url: 'https://a.example.com' },
+    ])
+  })
+})

--- a/src/contexts/saved-tabs/presentation/lib/display-tab-group.ts
+++ b/src/contexts/saved-tabs/presentation/lib/display-tab-group.ts
@@ -1,0 +1,44 @@
+import type { CustomProject, TabGroup } from '@/types/storage'
+
+/**
+ * 描画用に「表示対象」とみなせる URL 数を返す。
+ *
+ * `urls` フィールドが優先で、なければ `urlIds` にフォールバックする
+ * （旧形式タブグループ対応）。両方未定義 / 空配列のときは 0。
+ *
+ * UI 側で「表示対象グループかどうか」を判定する共通基準として使う
+ * pure 関数 (issue #504)。
+ *
+ * @example
+ * ```ts
+ * getDisplayUrlCount({ id: 'g1', domain: 'a', urls: [u1, u2] })   // 2
+ * getDisplayUrlCount({ id: 'g1', domain: 'a', urlIds: ['u1'] })  // 1
+ * getDisplayUrlCount({ id: 'g1', domain: 'a' })                  // 0
+ * ```
+ */
+export const getDisplayUrlCount = (group: TabGroup): number =>
+  (group.urls ?? group.urlIds ?? []).length
+
+/**
+ * ヘッダー / 空状態判定用に、CustomProject を `TabGroup` 形に投影する。
+ *
+ * `domain` には project 名を流用し、`urls` / `urlIds` は未定義時は
+ * 空配列として詰める。presentation 層が `TabGroup` 形を要求する
+ * ヘッダー描画や、空状態判定でのみ使う。
+ *
+ * UI 専用整形のため、storage shape (`TabGroup`) への詰め替えは
+ * 完全一致でなくてよい (issue #504)。
+ *
+ * @example
+ * ```ts
+ * buildDisplayTabGroup({ id: 'p1', name: 'My Project', urlIds: ['u1'] })
+ * // => { id: 'p1', domain: 'My Project', urls: [], urlIds: ['u1'] }
+ * ```
+ */
+export const buildDisplayTabGroup = (project: CustomProject): TabGroup =>
+  ({
+    id: project.id,
+    domain: project.name,
+    urls: project.urls ?? [],
+    urlIds: project.urlIds ?? [],
+  }) as TabGroup


### PR DESCRIPTION
## 変更内容

Issue #504 (DDD: SavedTabsApp に残るカテゴリ分類ロジックを domain service へ完全移行する) のフォローアップ。

`SavedTabsApp.tsx` に残っていた表示判定 / 表示用整形の pure logic を React / chrome API / storage 非依存な pure 関数として切り出し、UI コンポーネントからドメインルールを分離する。

### 追加モジュール

- `src/contexts/saved-tabs/presentation/lib/display-tab-group.ts` (新規)
  - `getDisplayUrlCount(group)` : 表示対象 URL 数を返す
  - `buildDisplayTabGroup(project)` : CustomProject を Header 用 TabGroup 形に投影
  - 旧 `savedTabsApp.helpers.ts` から re-export を撤去し、新モジュールへ移設
- `src/contexts/saved-tabs/presentation/lib/categorized-display.ts` (新規)
  - `createCategorizedDisplayState({ categorized, uncategorized, tempUncategorizedOrder, isUncategorizedReorderMode, enableCategories, searchQuery, viewMode, filteredCustomProjects })` : 旧 `SavedTabsApp.tsx` 内の `useMemo` 群 (`hasContentTabGroups` / `visibleUncategorizedGroups` / `hasVisibleCategoryGroups` / `shouldShowUncategorizedSectionHeader` / `shouldShowUncategorizedList` / `headerFilteredTabGroups` / `uncategorizedForDisplay`) を 1 つの pure 関数に集約
  - 入力: `TabGroup[]` / `CustomProject[]` / `ViewMode` / boolean / string のみ
  - 出力: `CategorizedDisplayState` interface (`TabGroup[]` / boolean)

### テスト

- `display-tab-group.test.ts` (8 tests, 100% coverage)
- `categorized-display.test.ts` (16 tests, 100% coverage)
- 既存 `SavedTabsApp.test.tsx` (64 tests) / `DomainModeContainer.test.tsx` は挙動互換を保ったまま緑

### 変更ファイル

- 新規: `presentation/lib/display-tab-group.ts`
- 新規: `presentation/lib/display-tab-group.test.ts`
- 新規: `presentation/lib/categorized-display.ts`
- 新規: `presentation/lib/categorized-display.test.ts`
- 更新: `presentation/app/SavedTabsApp.tsx` (inline useMemo / filter 計算式を builder 経由の単一 useMemo に集約)
- 更新: `presentation/app/savedTabsApp.helpers.ts` (`getDisplayUrlCount` / `buildDisplayTabGroup` の re-export 撤去)
- 更新: `presentation/app/SavedTabsApp.test.tsx` (新モジュールからの import に切替)

## 受け入れ条件

- [x] `SavedTabsApp.tsx` からカテゴリ分類の pure logic が削減されている
- [x] `organizeTabGroupsWithCategories` 相当の表示判定ロジックが view-model builder に切り出されている
- [x] 切り出した pure logic に unit test がある (16 + 8 tests, 100% coverage)
- [x] builder / helper は React / chrome API / storage に依存していない
- [x] 既存のカテゴリ分類・未分類表示・検索表示の挙動が維持されている
- [x] `bun run compile` が通る
- [x] 関連テスト (`bun run test:node` / `bun run test:dom`) が通る

## 検証

- `bun run test:node`: 119 files / 1417 tests passed
- `bun run test:dom`: 120 files / 812 tests passed
- `bun run compile`: 0 errors
- `bun run lint`: 0 warnings / 0 errors
- `bun run format": no changes
- `bun run test:coverage`: 新規 2 ファイルは 100% coverage (全体はベースライン 97.01% と同等)

## 関連 issue

- close #504
- 後続: `SavedTabsCategorizationService` (issue #496) には触れていない (今回のスコープ外)