### PR TITLE
[DDD] useCategoryManagement のカテゴリ移動・カテゴリ内ドメイン順序更新を use-case 化する (issue #525)

### DIFF
--- a/src/contexts/saved-tabs/application/SavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/application/SavedTabsUseCases.ts
@@ -15,6 +15,7 @@ import type { FindUrlRecordByUrlUseCase } from './use-cases/FindUrlRecordByUrlUs
 import type { GetProjectUrlsUseCase } from './use-cases/GetProjectUrlsUseCase'
 import type { LoadTabGroupsWithUrlsUseCase } from './use-cases/LoadTabGroupsWithUrlsUseCase'
 import type { LoadTabGroupUrlsUseCase } from './use-cases/LoadTabGroupUrlsUseCase'
+import type { MoveDomainBetweenCategoriesUseCase } from './use-cases/MoveDomainBetweenCategoriesUseCase'
 import type { OpenAllSavedUrlsUseCase } from './use-cases/OpenAllSavedUrlsUseCase'
 import type { OpenSavedUrlUseCase } from './use-cases/OpenSavedUrlUseCase'
 import type { PrepareTabGroupDeletionUseCase } from './use-cases/PrepareTabGroupDeletionUseCase'
@@ -25,6 +26,7 @@ import type { RemoveSubCategoryFromTabGroupsUseCase } from './use-cases/RemoveSu
 import type { RemoveUnreferencedUrlRecordsUseCase } from './use-cases/RemoveUnreferencedUrlRecordsUseCase'
 import type { RemoveUrlsFromCustomProjectsUseCase } from './use-cases/RemoveUrlsFromCustomProjectsUseCase'
 import type { RenameParentCategoryUseCase } from './use-cases/RenameParentCategoryUseCase'
+import type { ReorderDomainsInCategoryUseCase } from './use-cases/ReorderDomainsInCategoryUseCase'
 import type { ReorderParentCategoriesUseCase } from './use-cases/ReorderParentCategoriesUseCase'
 import type { ReorderTabGroupsUseCase } from './use-cases/ReorderTabGroupsUseCase'
 import type { ReorderTabGroupUrlsUseCase } from './use-cases/ReorderTabGroupUrlsUseCase'
@@ -104,6 +106,21 @@ export interface SavedTabsUseCases {
   readonly renameParentCategory: RenameParentCategoryUseCase
   readonly addDomainToParentCategory: AddDomainToParentCategoryUseCase
   readonly removeDomainFromParentCategory: RemoveDomainFromParentCategoryUseCase
+  /**
+   * カテゴリ間のドメイン移動 use-case (issue #525)。
+   * 旧 `useCategoryManagement.handleMoveDomainToCategory` 内の
+   * `tabGroups` 引き当て / `domains` / `domainNames` 移動 /
+   * `reorderParentCategoriesUseCase` 直叩きを 1 つの application
+   * use-case に統合する。
+   */
+  readonly moveDomainBetweenCategories: MoveDomainBetweenCategoriesUseCase
+  /**
+   * カテゴリ内ドメイン順序更新 use-case (issue #525)。
+   * 旧 `useCategoryManagement.handleUpdateDomainsOrder` 内の
+   * 並び替え / `reorderParentCategoriesUseCase` 直叩きを
+   * application use-case へ統合する。
+   */
+  readonly reorderDomainsInCategory: ReorderDomainsInCategoryUseCase
   /**
    * 親カテゴリの `domains` (TabGroupId 配列) から指定 ID を横断削除する
    * use-case (issue #523)。

--- a/src/contexts/saved-tabs/application/commands/MoveDomainBetweenCategoriesCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/MoveDomainBetweenCategoriesCommand.ts
@@ -1,0 +1,45 @@
+import type { TabGroup } from '@/types/storage'
+
+/**
+ * `MoveDomainBetweenCategoriesUseCase` の入力 (issue #525)。
+ *
+ * UI 側の `useCategoryManagement.handleMoveDomainToCategory` から
+ * presentation 層で組み立てて use-case へ渡す。`tabGroups` は
+ * `tabGroupId` -> `TabGroup.domain` の引き当てにだけ使い、ドメイン
+ * 順序更新や `chrome.storage.local` への永続化は use-case 側に閉じる。
+ *
+ * `domainId` は `TabGroup.id` と同じく生文字列で受け付ける。storage
+ * 層の `TabGroup` は branded ではないため、UI 側の string id を
+ * そのまま渡して use-case 内で `TabGroupId` / `DomainName` へ
+ * widening する設計としている。
+ *
+ * @example
+ * ```ts
+ * const command: MoveDomainBetweenCategoriesCommand = {
+ *   domainId: 'tab-1',
+ *   fromCategoryId: 'cat-docs',
+ *   tabGroups: [group1, group2],
+ *   toCategoryId: 'cat-news',
+ * }
+ * ```
+ */
+export interface MoveDomainBetweenCategoriesCommand {
+  /** 移動する `TabGroupId`（生文字列）。 */
+  readonly domainId: string
+  /**
+   * 移動元カテゴリの `ParentCategoryId`。
+   * 未分類（どのカテゴリにも属さない）からの移動は `null`。
+   */
+  readonly fromCategoryId: string | null
+  /**
+   * UI 側が保持する `TabGroup` スナップショット。
+   *
+   * domain service の `moveDomainBetweenCategories` 自体は
+   * `domainId` / `domainName` 確定後の純粋な配列変換のみを担うため、
+   * `tabGroups` は `domainId` 一致で `domainName` を引くためにだけ
+   * 使用する。
+   */
+  readonly tabGroups: readonly TabGroup[]
+  /** 移動先カテゴリの `ParentCategoryId`。 */
+  readonly toCategoryId: string
+}

--- a/src/contexts/saved-tabs/application/commands/ReorderDomainsInCategoryCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/ReorderDomainsInCategoryCommand.ts
@@ -1,0 +1,28 @@
+import type { TabGroup } from '@/types/storage'
+
+/**
+ * `ReorderDomainsInCategoryUseCase` の入力 (issue #525)。
+ *
+ * UI 側の `useCategoryManagement.handleUpdateDomainsOrder` から
+ * presentation 層で組み立てて use-case へ渡す。`domainIds` への
+ * 変換（`TabGroup` -> `TabGroupId`）は use-case 側で行う。
+ *
+ * @example
+ * ```ts
+ * const command: ReorderDomainsInCategoryCommand = {
+ *   categoryId: 'cat-docs',
+ *   updatedDomains: [group2, group1, group3],
+ * }
+ * ```
+ */
+export interface ReorderDomainsInCategoryCommand {
+  /** 並び替え対象カテゴリの `ParentCategoryId`。 */
+  readonly categoryId: string
+  /**
+   * UI 側で並び替えたあとの `TabGroup` 配列。
+   *
+   * `TabGroup.id` (`TabGroupId`) を取り出して `domainIds` へ変換した
+   * 上で domain service へ渡す。
+   */
+  readonly updatedDomains: readonly TabGroup[]
+}

--- a/src/contexts/saved-tabs/application/use-cases/MoveDomainBetweenCategoriesUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/MoveDomainBetweenCategoriesUseCase.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { TabGroup } from '@/types/storage'
+
+import { createParentCategory } from '../../domain/entities/ParentCategory'
+import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
+import { createTabGroupId } from '../../domain/value-objects/TabGroupId'
+import { createMoveDomainBetweenCategoriesUseCase } from './MoveDomainBetweenCategoriesUseCase'
+import type { MoveDomainBetweenCategoriesUseCaseDeps } from './MoveDomainBetweenCategoriesUseCase'
+
+const createInMemoryRepository = (
+  initial: ReturnType<typeof createParentCategory>[] = [],
+): ParentCategoryRepository => {
+  let store: ReturnType<typeof createParentCategory>[] = [...initial]
+  return {
+    // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は ParentCategoryRepository 側で必須
+    findAll: async () => store.map((category) => ({ ...category })),
+    // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は ParentCategoryRepository 側で必須
+    findById: async (id) =>
+      store.find((category) => category.id === id) ?? null,
+    // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は ParentCategoryRepository 側で必須
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids)
+      store = store.filter((category) => !idSet.has(category.id))
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は ParentCategoryRepository 側で必須
+    saveAll: async (categories) => {
+      store = categories.map((category) => ({ ...category }))
+    },
+  }
+}
+
+const createDeps = (
+  repo: ParentCategoryRepository,
+): MoveDomainBetweenCategoriesUseCaseDeps => ({
+  parentCategoryRepository: repo,
+})
+
+const buildTabGroup = (id: string, domain: string): TabGroup =>
+  ({
+    domain,
+    id: createTabGroupId(id),
+    parentCategoryId: null,
+    savedAt: 0,
+    subCategories: [],
+    urls: [],
+  }) as unknown as TabGroup
+
+describe('createMoveDomainBetweenCategoriesUseCase', () => {
+  let repo: ParentCategoryRepository
+
+  beforeEach(() => {
+    repo = createInMemoryRepository([
+      createParentCategory({
+        domainNames: ['example.com', 'docs.com'],
+        domains: ['tab-1', 'tab-2'],
+        id: 'cat-docs',
+        name: 'Docs',
+      }),
+      createParentCategory({
+        domainNames: ['news.com'],
+        domains: ['tab-3'],
+        id: 'cat-news',
+        name: 'News',
+      }),
+    ])
+  })
+
+  it('移動元から取り除き移動先へ追加する', async () => {
+    const useCase = createMoveDomainBetweenCategoriesUseCase(createDeps(repo))
+    const tabGroups = [
+      buildTabGroup('tab-1', 'example.com'),
+      buildTabGroup('tab-3', 'news.com'),
+    ]
+    const result = await useCase({
+      domainId: createTabGroupId('tab-1'),
+      fromCategoryId: 'cat-docs',
+      tabGroups,
+      toCategoryId: 'cat-news',
+    })
+    const docs = result.find((c) => c.id === 'cat-docs')
+    const news = result.find((c) => c.id === 'cat-news')
+    expect(docs?.domains).toStrictEqual(['tab-2'])
+    expect(docs?.domainNames).toStrictEqual(['docs.com'])
+    expect(news?.domains).toStrictEqual(['tab-3', 'tab-1'])
+    expect(news?.domainNames).toStrictEqual(['news.com', 'example.com'])
+  })
+
+  it('domainId が tabGroups 中に存在しない場合は no-op', async () => {
+    const useCase = createMoveDomainBetweenCategoriesUseCase(createDeps(repo))
+    const tabGroups = [buildTabGroup('tab-1', 'example.com')]
+    const result = await useCase({
+      domainId: createTabGroupId('tab-missing'),
+      fromCategoryId: 'cat-docs',
+      tabGroups,
+      toCategoryId: 'cat-news',
+    })
+    expect(result.find((c) => c.id === 'cat-docs')?.domains).toStrictEqual([
+      'tab-1',
+      'tab-2',
+    ])
+    expect(result.find((c) => c.id === 'cat-news')?.domains).toStrictEqual([
+      'tab-3',
+    ])
+  })
+
+  it('fromCategoryId が null の場合は追加のみ行う', async () => {
+    const useCase = createMoveDomainBetweenCategoriesUseCase(createDeps(repo))
+    const tabGroups = [buildTabGroup('tab-99', 'new.com')]
+    const result = await useCase({
+      domainId: createTabGroupId('tab-99'),
+      fromCategoryId: null,
+      tabGroups,
+      toCategoryId: 'cat-docs',
+    })
+    const docs = result.find((c) => c.id === 'cat-docs')
+    expect(docs?.domains).toStrictEqual(['tab-1', 'tab-2', 'tab-99'])
+    expect(docs?.domainNames).toStrictEqual([
+      'example.com',
+      'docs.com',
+      'new.com',
+    ])
+  })
+
+  it('saveAll が更新後の categories で呼ばれる', async () => {
+    const useCase = createMoveDomainBetweenCategoriesUseCase(createDeps(repo))
+    const saveAllSpy = vi.spyOn(repo, 'saveAll')
+    const tabGroups = [
+      buildTabGroup('tab-1', 'example.com'),
+      buildTabGroup('tab-3', 'news.com'),
+    ]
+    await useCase({
+      domainId: createTabGroupId('tab-1'),
+      fromCategoryId: 'cat-docs',
+      tabGroups,
+      toCategoryId: 'cat-news',
+    })
+    expect(saveAllSpy).toHaveBeenCalledTimes(1)
+    const saved = saveAllSpy.mock.calls[0]?.[0]
+    expect(saved).toHaveLength(2)
+  })
+})

--- a/src/contexts/saved-tabs/application/use-cases/MoveDomainBetweenCategoriesUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/MoveDomainBetweenCategoriesUseCase.ts
@@ -1,0 +1,69 @@
+import type { ParentCategory } from '../../domain/entities/ParentCategory'
+import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
+import { moveDomainBetweenCategories } from '../../domain/services/CategoryDomainMoveService'
+import { createDomainName } from '../../domain/value-objects/DomainName'
+import { createTabGroupId } from '../../domain/value-objects/TabGroupId'
+import type { MoveDomainBetweenCategoriesCommand } from '../commands/MoveDomainBetweenCategoriesCommand'
+
+/**
+ * `MoveDomainBetweenCategoriesUseCase` が依存する repository 群。
+ */
+export interface MoveDomainBetweenCategoriesUseCaseDeps {
+  readonly parentCategoryRepository: ParentCategoryRepository
+}
+
+/**
+ * `MoveDomainBetweenCategoriesUseCase` の関数型。
+ *
+ * 成功時は更新後の domain 形 `ParentCategory[]` を返す。
+ * `command.tabGroups` から対象 `domainId` が見つからない場合は
+ * `moved=false` 相当の結果（カテゴリを一切変更しない）を返す（旧
+ * `useCategoryManagement.handleMoveDomainToCategory` の挙動と一致）。
+ */
+export type MoveDomainBetweenCategoriesUseCase = (
+  command: MoveDomainBetweenCategoriesCommand,
+) => Promise<readonly ParentCategory[]>
+
+/**
+ * `MoveDomainBetweenCategoriesUseCase` を生成する。
+ *
+ * 責務 (issue #525):
+ * 1. `command.tabGroups` から `command.domainId` 一致の `TabGroup.domain`
+ *    を引き、`DomainName` 化する。
+ * 2. domain `CategoryDomainMoveService.moveDomainBetweenCategories` で
+ *    カテゴリ配列の `domains` / `domainNames` を更新する。
+ * 3. `parentCategoryRepository.saveAll` で全カテゴリを書き戻す。
+ * 4. 更新後の domain 形 `ParentCategory[]` を presentation 側へ返す。
+ *
+ * 旧
+ * `src/contexts/saved-tabs/presentation/hooks/useCategoryManagement.ts`
+ * の `handleMoveDomainToCategory` 内の
+ * - `tabGroups` 引き当て
+ * - 移動元カテゴリの `domains` / `domainNames` 削除
+ * - 移動先カテゴリの `domains` / `domainNames` 追加
+ * - `reorderParentCategoriesUseCase` 直叩き
+ *
+ * を 1 つの application use-case に統合する。
+ */
+export const createMoveDomainBetweenCategoriesUseCase = (
+  deps: MoveDomainBetweenCategoriesUseCaseDeps,
+): MoveDomainBetweenCategoriesUseCase => {
+  return async (command) => {
+    const allCategories = await deps.parentCategoryRepository.findAll()
+    const domainGroup = command.tabGroups.find(
+      (group) => group.id === command.domainId,
+    )
+    if (!domainGroup) {
+      return allCategories
+    }
+    const { updatedCategories } = moveDomainBetweenCategories({
+      categories: allCategories,
+      domainId: createTabGroupId(command.domainId),
+      domainName: createDomainName(domainGroup.domain),
+      fromCategoryId: command.fromCategoryId,
+      toCategoryId: command.toCategoryId,
+    })
+    await deps.parentCategoryRepository.saveAll(updatedCategories)
+    return updatedCategories
+  }
+}

--- a/src/contexts/saved-tabs/application/use-cases/ReorderDomainsInCategoryUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderDomainsInCategoryUseCase.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { TabGroup } from '@/types/storage'
+
+import { createParentCategory } from '../../domain/entities/ParentCategory'
+import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
+import { createTabGroupId } from '../../domain/value-objects/TabGroupId'
+import { createReorderDomainsInCategoryUseCase } from './ReorderDomainsInCategoryUseCase'
+import type { ReorderDomainsInCategoryUseCaseDeps } from './ReorderDomainsInCategoryUseCase'
+
+const createInMemoryRepository = (
+  initial: ReturnType<typeof createParentCategory>[] = [],
+): ParentCategoryRepository => {
+  let store: ReturnType<typeof createParentCategory>[] = [...initial]
+  return {
+    // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は ParentCategoryRepository 側で必須
+    findAll: async () => store.map((category) => ({ ...category })),
+    // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は ParentCategoryRepository 側で必須
+    findById: async (id) =>
+      store.find((category) => category.id === id) ?? null,
+    // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は ParentCategoryRepository 側で必須
+    removeByIds: async (ids) => {
+      const idSet = new Set(ids)
+      store = store.filter((category) => !idSet.has(category.id))
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は ParentCategoryRepository 側で必須
+    saveAll: async (categories) => {
+      store = categories.map((category) => ({ ...category }))
+    },
+  }
+}
+
+const createDeps = (
+  repo: ParentCategoryRepository,
+): ReorderDomainsInCategoryUseCaseDeps => ({
+  parentCategoryRepository: repo,
+})
+
+const buildTabGroup = (id: string): TabGroup =>
+  ({ id: createTabGroupId(id) }) as unknown as TabGroup
+
+describe('createReorderDomainsInCategoryUseCase', () => {
+  let repo: ParentCategoryRepository
+
+  beforeEach(() => {
+    repo = createInMemoryRepository([
+      createParentCategory({
+        domainNames: ['example.com', 'docs.com', 'extra.com'],
+        domains: ['tab-1', 'tab-2', 'tab-3'],
+        id: 'cat-docs',
+        name: 'Docs',
+      }),
+    ])
+  })
+
+  it('新しい domainIds 順で categories.domains を更新して saveAll する', async () => {
+    const useCase = createReorderDomainsInCategoryUseCase(createDeps(repo))
+    const saveAllSpy = vi.spyOn(repo, 'saveAll')
+    const result = await useCase({
+      categoryId: 'cat-docs',
+      updatedDomains: [
+        buildTabGroup('tab-3'),
+        buildTabGroup('tab-1'),
+        buildTabGroup('tab-2'),
+      ],
+    })
+    const docs = result.find((c) => c.id === 'cat-docs')
+    expect(docs?.domains).toStrictEqual(['tab-3', 'tab-1', 'tab-2'])
+    expect(saveAllSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('updatedDomains が空の場合は no-op として現在値を返す', async () => {
+    const useCase = createReorderDomainsInCategoryUseCase(createDeps(repo))
+    const saveAllSpy = vi.spyOn(repo, 'saveAll')
+    const result = await useCase({
+      categoryId: 'cat-docs',
+      updatedDomains: [],
+    })
+    const docs = result.find((c) => c.id === 'cat-docs')
+    expect(docs?.domains).toStrictEqual(['tab-1', 'tab-2', 'tab-3'])
+    expect(saveAllSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('対象カテゴリが見つからない場合は no-op として現在値を返す', async () => {
+    const useCase = createReorderDomainsInCategoryUseCase(createDeps(repo))
+    const result = await useCase({
+      categoryId: 'cat-missing',
+      updatedDomains: [buildTabGroup('tab-1')],
+    })
+    const docs = result.find((c) => c.id === 'cat-docs')
+    expect(docs?.domains).toStrictEqual(['tab-1', 'tab-2', 'tab-3'])
+  })
+
+  it('domainNames は変更しない (並び替えは domains のみ)', async () => {
+    const useCase = createReorderDomainsInCategoryUseCase(createDeps(repo))
+    const result = await useCase({
+      categoryId: 'cat-docs',
+      updatedDomains: [buildTabGroup('tab-3'), buildTabGroup('tab-1')],
+    })
+    const docs = result.find((c) => c.id === 'cat-docs')
+    expect(docs?.domainNames).toStrictEqual([
+      'example.com',
+      'docs.com',
+      'extra.com',
+    ])
+  })
+})

--- a/src/contexts/saved-tabs/application/use-cases/ReorderDomainsInCategoryUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderDomainsInCategoryUseCase.test.ts
@@ -69,7 +69,7 @@ describe('createReorderDomainsInCategoryUseCase', () => {
     expect(saveAllSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('updatedDomains が空の場合は no-op として現在値を返す', async () => {
+  it('updatedDomains が空の場合、domains も空にして saveAll する (旧挙動と一致)', async () => {
     const useCase = createReorderDomainsInCategoryUseCase(createDeps(repo))
     const saveAllSpy = vi.spyOn(repo, 'saveAll')
     const result = await useCase({
@@ -77,8 +77,22 @@ describe('createReorderDomainsInCategoryUseCase', () => {
       updatedDomains: [],
     })
     const docs = result.find((c) => c.id === 'cat-docs')
-    expect(docs?.domains).toStrictEqual(['tab-1', 'tab-2', 'tab-3'])
+    expect(docs?.domains).toStrictEqual([])
     expect(saveAllSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('domainNames 経由の表示エントリを domains へ昇格させる (Codex レビュー対応 / issue #525)', async () => {
+    // 旧 `handleUpdateDomainsOrder` は `updatedDomains.map((d) => d.id)`
+    // をそのまま保存していたため、 `domainNames` 経由でのみ表示されて
+    // いたエントリも並び替え時に explicit な `domains` へ昇格していた。
+    // 新実装も同じ挙動を保つ。
+    const useCase = createReorderDomainsInCategoryUseCase(createDeps(repo))
+    const result = await useCase({
+      categoryId: 'cat-docs',
+      updatedDomains: [buildTabGroup('tab-extra'), buildTabGroup('tab-1')],
+    })
+    const docs = result.find((c) => c.id === 'cat-docs')
+    expect(docs?.domains).toStrictEqual(['tab-extra', 'tab-1'])
   })
 
   it('対象カテゴリが見つからない場合は no-op として現在値を返す', async () => {

--- a/src/contexts/saved-tabs/application/use-cases/ReorderDomainsInCategoryUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderDomainsInCategoryUseCase.ts
@@ -1,0 +1,60 @@
+import type { ParentCategory } from '../../domain/entities/ParentCategory'
+import type { ParentCategoryRepository } from '../../domain/repositories/ParentCategoryRepository'
+import { reorderDomainsInCategory } from '../../domain/services/CategoryDomainOrderingService'
+import { createTabGroupId } from '../../domain/value-objects/TabGroupId'
+import type { ReorderDomainsInCategoryCommand } from '../commands/ReorderDomainsInCategoryCommand'
+
+/**
+ * `ReorderDomainsInCategoryUseCase` が依存する repository 群。
+ */
+export interface ReorderDomainsInCategoryUseCaseDeps {
+  readonly parentCategoryRepository: ParentCategoryRepository
+}
+
+/**
+ * `ReorderDomainsInCategoryUseCase` の関数型。
+ *
+ * 成功時は更新後の domain 形 `ParentCategory[]` を返す。`categoryId` が
+ * `categories` 中に存在しない場合は no-op として現在値を返す（旧
+ * `useCategoryManagement.handleUpdateDomainsOrder` の挙動と一致）。
+ */
+export type ReorderDomainsInCategoryUseCase = (
+  command: ReorderDomainsInCategoryCommand,
+) => Promise<readonly ParentCategory[]>
+
+/**
+ * `ReorderDomainsInCategoryUseCase` を生成する。
+ *
+ * 責務 (issue #525):
+ * 1. UI 側の `TabGroup[]` を `TabGroupId[]` に変換する。
+ * 2. domain `CategoryDomainOrderingService.reorderDomainsInCategory` で
+ *    対象カテゴリの `domains` 順序を組み替える。
+ * 3. `parentCategoryRepository.saveAll` で全カテゴリを書き戻す。
+ * 4. 更新後の domain 形 `ParentCategory[]` を presentation 側へ返す。
+ *
+ * 旧
+ * `src/contexts/saved-tabs/presentation/hooks/useCategoryManagement.ts`
+ * の `handleUpdateDomainsOrder` 内の
+ * - 対象カテゴリ検索
+ * - `domains` の組み替え
+ * - `reorderParentCategoriesUseCase` 直叩き
+ *
+ * を 1 つの application use-case に統合する。
+ */
+export const createReorderDomainsInCategoryUseCase = (
+  deps: ReorderDomainsInCategoryUseCaseDeps,
+): ReorderDomainsInCategoryUseCase => {
+  return async (command) => {
+    const allCategories = await deps.parentCategoryRepository.findAll()
+    const domainIds = command.updatedDomains.map((domain) =>
+      createTabGroupId(domain.id),
+    )
+    const { updatedCategories } = reorderDomainsInCategory({
+      categories: allCategories,
+      categoryId: command.categoryId,
+      domainIds,
+    })
+    await deps.parentCategoryRepository.saveAll(updatedCategories)
+    return updatedCategories
+  }
+}

--- a/src/contexts/saved-tabs/domain/services/CategoryDomainMoveService.test.ts
+++ b/src/contexts/saved-tabs/domain/services/CategoryDomainMoveService.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+
+import { createParentCategory } from '../entities/ParentCategory'
+import { createDomainName } from '../value-objects/DomainName'
+import { createParentCategoryId } from '../value-objects/ParentCategoryId'
+import { createTabGroupId } from '../value-objects/TabGroupId'
+import { moveDomainBetweenCategories } from './CategoryDomainMoveService'
+
+const buildDocs = () =>
+  createParentCategory({
+    domainNames: ['example.com', 'docs.com'],
+    domains: ['tab-1', 'tab-2'],
+    id: 'cat-docs',
+    name: 'Docs',
+  })
+const buildNews = () =>
+  createParentCategory({
+    domainNames: ['news.com'],
+    domains: ['tab-3'],
+    id: 'cat-news',
+    name: 'News',
+  })
+
+describe('moveDomainBetweenCategories', () => {
+  it('移動元から domainId/domainName を取り除き、移動先へ追加する', () => {
+    const result = moveDomainBetweenCategories({
+      categories: [buildDocs(), buildNews()],
+      domainId: createTabGroupId('tab-1'),
+      domainName: createDomainName('example.com'),
+      fromCategoryId: 'cat-docs',
+      toCategoryId: 'cat-news',
+    })
+    expect(result.moved).toBe(true)
+    const docs = result.updatedCategories.find((c) => c.id === 'cat-docs')
+    const news = result.updatedCategories.find((c) => c.id === 'cat-news')
+    expect(docs?.domains).toStrictEqual(['tab-2'])
+    expect(docs?.domainNames).toStrictEqual(['docs.com'])
+    expect(news?.domains).toStrictEqual(['tab-3', 'tab-1'])
+    expect(news?.domainNames).toStrictEqual(['news.com', 'example.com'])
+  })
+
+  it('fromCategoryId が null の場合は追加のみ行う', () => {
+    const result = moveDomainBetweenCategories({
+      categories: [buildDocs()],
+      domainId: createTabGroupId('tab-99'),
+      domainName: createDomainName('new.com'),
+      fromCategoryId: null,
+      toCategoryId: 'cat-docs',
+    })
+    expect(result.moved).toBe(true)
+    const docs = result.updatedCategories.find((c) => c.id === 'cat-docs')
+    expect(docs?.domains).toStrictEqual(['tab-1', 'tab-2', 'tab-99'])
+    expect(docs?.domainNames).toStrictEqual([
+      'example.com',
+      'docs.com',
+      'new.com',
+    ])
+  })
+
+  it('fromCategoryId が categories 中に存在しない場合は移動先への追加のみ行う', () => {
+    const result = moveDomainBetweenCategories({
+      categories: [buildDocs()],
+      domainId: createTabGroupId('tab-1'),
+      domainName: createDomainName('example.com'),
+      fromCategoryId: 'cat-missing',
+      toCategoryId: 'cat-docs',
+    })
+    // 移動元が categories 中に無いので remove は no-op。
+    // 移動先 cat-docs には既に tab-1 / example.com が含まれているので
+    // add は no-op (重複追加しない)。
+    const docs = result.updatedCategories.find((c) => c.id === 'cat-docs')
+    expect(docs?.domains).toStrictEqual(['tab-1', 'tab-2'])
+    expect(docs?.domainNames).toStrictEqual(['example.com', 'docs.com'])
+  })
+
+  it('toCategoryId が categories 中に存在しない場合は moved=false', () => {
+    const result = moveDomainBetweenCategories({
+      categories: [buildDocs()],
+      domainId: createTabGroupId('tab-1'),
+      domainName: createDomainName('example.com'),
+      fromCategoryId: 'cat-docs',
+      toCategoryId: 'cat-missing',
+    })
+    // 移動先が categories 中に無いので add は no-op。移動元 cat-docs
+    // からは remove で tab-1 が消えるので moved=true になる。
+    expect(result.moved).toBe(true)
+    const docs = result.updatedCategories.find((c) => c.id === 'cat-docs')
+    expect(docs?.domains).toStrictEqual(['tab-2'])
+  })
+
+  it('fromCategoryId === toCategoryId の場合は重複排除のみ行う', () => {
+    const categories = [
+      createParentCategory({
+        domainNames: ['example.com', 'example.com'],
+        domains: ['tab-1', 'tab-1', 'tab-2'],
+        id: 'cat-docs',
+        name: 'Docs',
+      }),
+    ]
+    const result = moveDomainBetweenCategories({
+      categories,
+      domainId: createTabGroupId('tab-1'),
+      domainName: createDomainName('example.com'),
+      fromCategoryId: 'cat-docs',
+      toCategoryId: 'cat-docs',
+    })
+    const docs = result.updatedCategories.find((c) => c.id === 'cat-docs')
+    // 同一カテゴリ内の remove -> add では、重複 tab-1 の 1 つが
+    // filter で消え、続く add は `includes` 判定で「tab-1 を含まない」
+    // 状態と判定されて末尾に再追加される (旧実装と一致)。
+    expect(docs?.domains).toStrictEqual(['tab-2', 'tab-1'])
+    expect(docs?.domainNames).toStrictEqual(['example.com'])
+  })
+
+  it('入力配列を破壊しない', () => {
+    const categories = [buildDocs(), buildNews()]
+    const beforeDocs = categories[0]?.domains.slice()
+    const beforeNews = categories[1]?.domains.slice()
+    moveDomainBetweenCategories({
+      categories,
+      domainId: createTabGroupId('tab-1'),
+      domainName: createDomainName('example.com'),
+      fromCategoryId: 'cat-docs',
+      toCategoryId: 'cat-news',
+    })
+    expect(categories[0]?.domains).toStrictEqual(beforeDocs)
+    expect(categories[1]?.domains).toStrictEqual(beforeNews)
+  })
+
+  it('既存 domain を含まない移動先では末尾に追加される', () => {
+    const result = moveDomainBetweenCategories({
+      categories: [buildDocs(), buildNews()],
+      domainId: createTabGroupId('tab-99'),
+      domainName: createDomainName('extra.com'),
+      fromCategoryId: null,
+      toCategoryId: 'cat-news',
+    })
+    const news = result.updatedCategories.find((c) => c.id === 'cat-news')
+    expect(news?.domains).toStrictEqual(['tab-3', 'tab-99'])
+  })
+
+  it('createParentCategoryId で生成した ID も category.id と一致して処理できる', () => {
+    const docs = buildDocs()
+    const result = moveDomainBetweenCategories({
+      categories: [docs],
+      domainId: createTabGroupId('tab-1'),
+      domainName: createDomainName('example.com'),
+      fromCategoryId: createParentCategoryId('cat-docs'),
+      toCategoryId: createParentCategoryId('cat-docs'),
+    })
+    const moved = result.updatedCategories.find((c) => c.id === docs.id)
+    // 同一カテゴリ内の remove -> add で tab-1 が一度消えてから末尾に
+    // 再追加される (旧実装と一致する挙動)。
+    expect(moved?.domains).toStrictEqual(['tab-2', 'tab-1'])
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/CategoryDomainMoveService.ts
+++ b/src/contexts/saved-tabs/domain/services/CategoryDomainMoveService.ts
@@ -1,0 +1,133 @@
+import type { ParentCategory } from '../entities/ParentCategory'
+import type { DomainName } from '../value-objects/DomainName'
+import type { TabGroupId } from '../value-objects/TabGroupId'
+
+/**
+ * カテゴリ間ドメイン移動の pure domain service (issue #525)。
+ *
+ * 旧
+ * `src/contexts/saved-tabs/presentation/hooks/useCategoryManagement.ts`
+ * の `handleMoveDomainToCategory` 内の
+ * - 移動元カテゴリから `domainId` / `domainName` を取り除く
+ * - 移動先カテゴリに `domainId` / `domainName` を追加する
+ *
+ * ロジックを domain 等価物として抽出したもの。
+ *
+ * UI 側で受け取った `tabGroups`（`TabGroup` 配列）から対象 domain
+ * (`TabGroupId` 一致) を引き、`domainName` を `DomainName` 化するのは
+ * use-case 側の責務。本 service は `domainId` / `domainName` が確定した
+ * 後の純粋な配列変換のみを担う。
+ *
+ * domain 層ガード (React 依存禁止、`chrome.*` 依存禁止、`toast` 依存
+ * 禁止、`@dnd-kit/sortable` 依存禁止) を満たすため、副作用・永続化・
+ * ロギングは含めない。
+ */
+export interface MoveDomainBetweenCategoriesParams {
+  readonly categories: readonly ParentCategory[]
+  readonly domainId: TabGroupId
+  readonly domainName: DomainName
+  /**
+   * 移動元カテゴリの `ParentCategoryId`。
+   * 未分類（どのカテゴリにも属さない）からの移動は `null`。
+   */
+  readonly fromCategoryId: string | null
+  /** 移動先カテゴリの `ParentCategoryId`。 */
+  readonly toCategoryId: string
+}
+
+export interface MoveDomainBetweenCategoriesResult {
+  readonly moved: boolean
+  readonly updatedCategories: readonly ParentCategory[]
+}
+
+const removeDomainFromCategory = (
+  category: ParentCategory,
+  domainId: TabGroupId,
+  domainName: DomainName,
+): ParentCategory => {
+  const filteredDomains = category.domains.includes(domainId)
+    ? category.domains.filter((id) => id !== domainId)
+    : [...category.domains]
+  const filteredDomainNames = category.domainNames.includes(domainName)
+    ? category.domainNames.filter((name) => name !== domainName)
+    : [...category.domainNames]
+  return {
+    ...category,
+    domainNames: filteredDomainNames,
+    domains: filteredDomains,
+  }
+}
+
+const addDomainToCategory = (
+  category: ParentCategory,
+  domainId: TabGroupId,
+  domainName: DomainName,
+): ParentCategory => {
+  const nextDomains = category.domains.includes(domainId)
+    ? [...category.domains]
+    : [...category.domains, domainId]
+  const nextDomainNames = category.domainNames.includes(domainName)
+    ? [...category.domainNames]
+    : [...category.domainNames, domainName]
+  return {
+    ...category,
+    domainNames: nextDomainNames,
+    domains: nextDomains,
+  }
+}
+
+export const moveDomainBetweenCategories = (
+  params: MoveDomainBetweenCategoriesParams,
+): MoveDomainBetweenCategoriesResult => {
+  const { categories, domainId, domainName, fromCategoryId, toCategoryId } =
+    params
+  let moved = false
+  const updatedCategories = categories.map((category) => {
+    // 移動元と移動先が同一カテゴリの場合は remove -> add を順に適用。
+    if (
+      fromCategoryId !== null &&
+      category.id === fromCategoryId &&
+      category.id === toCategoryId
+    ) {
+      const before = category
+      const afterRemove = removeDomainFromCategory(
+        category,
+        domainId,
+        domainName,
+      )
+      const afterAdd = addDomainToCategory(afterRemove, domainId, domainName)
+      if (
+        afterAdd.domains.length !== before.domains.length ||
+        afterAdd.domainNames.length !== before.domainNames.length ||
+        afterRemove.domains.length !== before.domains.length
+      ) {
+        moved = true
+      }
+      return afterAdd
+    }
+    if (fromCategoryId !== null && category.id === fromCategoryId) {
+      const before = category
+      const next = removeDomainFromCategory(category, domainId, domainName)
+      if (
+        next.domains.length !== before.domains.length ||
+        next.domainNames.length !== before.domainNames.length
+      ) {
+        moved = true
+      }
+      return next
+    }
+    if (category.id === toCategoryId) {
+      const before = category
+      const next = addDomainToCategory(category, domainId, domainName)
+      if (
+        next.domains.length !== before.domains.length ||
+        next.domainNames.length !== before.domainNames.length
+      ) {
+        moved = true
+      }
+      return next
+    }
+    return { ...category }
+  })
+  return { moved, updatedCategories }
+}

--- a/src/contexts/saved-tabs/domain/services/CategoryDomainOrderingService.test.ts
+++ b/src/contexts/saved-tabs/domain/services/CategoryDomainOrderingService.test.ts
@@ -20,27 +20,34 @@ describe('reorderDomainsInCategory', () => {
       domainIds: [createTabGroupId('tab-3'), createTabGroupId('tab-1')],
     })
     expect(result.targetFound).toBe(true)
-    expect(result.domainIdOrder).toStrictEqual(['tab-3', 'tab-1', 'tab-2'])
+    expect(result.domainIdOrder).toStrictEqual(['tab-3', 'tab-1'])
     const docs = result.updatedCategories.find((c) => c.id === 'cat-docs')
-    expect(docs?.domains).toStrictEqual(['tab-3', 'tab-1', 'tab-2'])
+    expect(docs?.domains).toStrictEqual(['tab-3', 'tab-1'])
   })
 
-  it('domainIds に存在しない既存 ID は末尾に保持される', () => {
+  it('既存 domainIds にない ID もそのまま保存する (Codex レビュー対応 / issue #525)', () => {
+    // `domainNames` 経由でのみ表示されるエントリが `updatedDomains` に
+    // 含まれているケース。旧 `handleUpdateDomainsOrder` の挙動と一致
+    // させ、 `targetCategory.domains` に存在しない ID も保存する。
     const result = reorderDomainsInCategory({
       categories: [buildDocs()],
       categoryId: 'cat-docs',
       domainIds: [createTabGroupId('tab-3')],
     })
-    expect(result.domainIdOrder).toStrictEqual(['tab-3', 'tab-1', 'tab-2'])
+    expect(result.domainIdOrder).toStrictEqual(['tab-3'])
+    const docs = result.updatedCategories.find((c) => c.id === 'cat-docs')
+    expect(docs?.domains).toStrictEqual(['tab-3'])
   })
 
-  it('domainIds が空の場合、既存順序をそのまま返す', () => {
+  it('domainIds が空の場合、domains も空になる (旧挙動と一致)', () => {
     const result = reorderDomainsInCategory({
       categories: [buildDocs()],
       categoryId: 'cat-docs',
       domainIds: [],
     })
-    expect(result.domainIdOrder).toStrictEqual(['tab-1', 'tab-2', 'tab-3'])
+    expect(result.domainIdOrder).toStrictEqual([])
+    const docs = result.updatedCategories.find((c) => c.id === 'cat-docs')
+    expect(docs?.domains).toStrictEqual([])
   })
 
   it('対象カテゴリが見つからない場合は targetFound=false', () => {

--- a/src/contexts/saved-tabs/domain/services/CategoryDomainOrderingService.test.ts
+++ b/src/contexts/saved-tabs/domain/services/CategoryDomainOrderingService.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { createParentCategory } from '../entities/ParentCategory'
+import { createTabGroupId } from '../value-objects/TabGroupId'
+import { reorderDomainsInCategory } from './CategoryDomainOrderingService'
+
+const buildDocs = () =>
+  createParentCategory({
+    domainNames: ['example.com', 'docs.com', 'extra.com'],
+    domains: ['tab-1', 'tab-2', 'tab-3'],
+    id: 'cat-docs',
+    name: 'Docs',
+  })
+
+describe('reorderDomainsInCategory', () => {
+  it('新しい順序で domains を組み替える', () => {
+    const result = reorderDomainsInCategory({
+      categories: [buildDocs()],
+      categoryId: 'cat-docs',
+      domainIds: [createTabGroupId('tab-3'), createTabGroupId('tab-1')],
+    })
+    expect(result.targetFound).toBe(true)
+    expect(result.domainIdOrder).toStrictEqual(['tab-3', 'tab-1', 'tab-2'])
+    const docs = result.updatedCategories.find((c) => c.id === 'cat-docs')
+    expect(docs?.domains).toStrictEqual(['tab-3', 'tab-1', 'tab-2'])
+  })
+
+  it('domainIds に存在しない既存 ID は末尾に保持される', () => {
+    const result = reorderDomainsInCategory({
+      categories: [buildDocs()],
+      categoryId: 'cat-docs',
+      domainIds: [createTabGroupId('tab-3')],
+    })
+    expect(result.domainIdOrder).toStrictEqual(['tab-3', 'tab-1', 'tab-2'])
+  })
+
+  it('domainIds が空の場合、既存順序をそのまま返す', () => {
+    const result = reorderDomainsInCategory({
+      categories: [buildDocs()],
+      categoryId: 'cat-docs',
+      domainIds: [],
+    })
+    expect(result.domainIdOrder).toStrictEqual(['tab-1', 'tab-2', 'tab-3'])
+  })
+
+  it('対象カテゴリが見つからない場合は targetFound=false', () => {
+    const categories = [buildDocs()]
+    const result = reorderDomainsInCategory({
+      categories,
+      categoryId: 'cat-missing',
+      domainIds: [createTabGroupId('tab-1')],
+    })
+    expect(result.targetFound).toBe(false)
+    expect(result.domainIdOrder).toStrictEqual([])
+    expect(result.updatedCategories[0]?.domains).toStrictEqual([
+      'tab-1',
+      'tab-2',
+      'tab-3',
+    ])
+  })
+
+  it('入力配列を破壊しない', () => {
+    const categories = [buildDocs()]
+    const before = categories[0]?.domains.slice()
+    reorderDomainsInCategory({
+      categories,
+      categoryId: 'cat-docs',
+      domainIds: [createTabGroupId('tab-3')],
+    })
+    expect(categories[0]?.domains).toStrictEqual(before)
+  })
+
+  it('他カテゴリの domains は影響を受けない', () => {
+    const news = createParentCategory({
+      domainNames: ['news.com'],
+      domains: ['tab-99'],
+      id: 'cat-news',
+      name: 'News',
+    })
+    const result = reorderDomainsInCategory({
+      categories: [buildDocs(), news],
+      categoryId: 'cat-docs',
+      domainIds: [createTabGroupId('tab-3'), createTabGroupId('tab-2')],
+    })
+    const updatedNews = result.updatedCategories.find(
+      (c) => c.id === 'cat-news',
+    )
+    expect(updatedNews?.domains).toStrictEqual(['tab-99'])
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/CategoryDomainOrderingService.ts
+++ b/src/contexts/saved-tabs/domain/services/CategoryDomainOrderingService.ts
@@ -1,0 +1,72 @@
+import type { ParentCategory } from '../entities/ParentCategory'
+import type { TabGroupId } from '../value-objects/TabGroupId'
+
+/**
+ * カテゴリ内ドメイン順序更新の pure domain service (issue #525)。
+ *
+ * 旧
+ * `src/contexts/saved-tabs/presentation/hooks/useCategoryManagement.ts`
+ * の `handleUpdateDomainsOrder` 内の
+ * - 対象カテゴリの `domains` を新しい順序へ組み替える
+ *
+ * ロジックを domain 等価物として抽出したもの。
+ *
+ * UI 側は `TabGroup` 配列を受け取るが、domain 層は永続化対象である
+ * `TabGroupId[]` のみを扱う。`TabGroup` -> `TabGroupId` 変換は
+ * use-case 側に閉じる。
+ *
+ * domain 層ガード (React 依存禁止、`chrome.*` 依存禁止、`toast` 依存
+ * 禁止、`@dnd-kit/sortable` 依存禁止) を満たすため、副作用・永続化・
+ * ロギングは含めず、純粋な配列変換のみを公開する。
+ */
+export interface ReorderDomainsInCategoryParams {
+  readonly categories: readonly ParentCategory[]
+  /** 並び替え対象カテゴリの `ParentCategoryId`。 */
+  readonly categoryId: string
+  /**
+   * 新しいドメイン順序（`TabGroupId` の配列）。
+   * UI 側で並び替えたあとの順序をそのまま渡す。既存 `domains` に
+   * 存在しない ID（新規追加されたものなど）は末尾へ保持される。
+   */
+  readonly domainIds: readonly TabGroupId[]
+}
+
+export interface ReorderDomainsInCategoryResult {
+  readonly targetFound: boolean
+  readonly updatedCategories: readonly ParentCategory[]
+  readonly domainIdOrder: readonly TabGroupId[]
+}
+
+export const reorderDomainsInCategory = (
+  params: ReorderDomainsInCategoryParams,
+): ReorderDomainsInCategoryResult => {
+  const { categories, categoryId, domainIds } = params
+  const targetCategory = categories.find(
+    (category) => category.id === categoryId,
+  )
+  if (!targetCategory) {
+    return {
+      domainIdOrder: [],
+      targetFound: false,
+      updatedCategories: categories.map((category) => ({ ...category })),
+    }
+  }
+  const existingDomainIds = new Set<TabGroupId>(targetCategory.domains)
+  const orderedExisting = domainIds.filter((id) => existingDomainIds.has(id))
+  const inputIdSet = new Set<TabGroupId>(domainIds)
+  const trailingIds = targetCategory.domains.filter((id) => !inputIdSet.has(id))
+  const nextDomainIds: readonly TabGroupId[] = [
+    ...orderedExisting,
+    ...trailingIds,
+  ]
+  const updatedCategories = categories.map((category) =>
+    category.id === categoryId
+      ? { ...category, domains: nextDomainIds }
+      : { ...category },
+  )
+  return {
+    domainIdOrder: nextDomainIds,
+    targetFound: true,
+    updatedCategories,
+  }
+}

--- a/src/contexts/saved-tabs/domain/services/CategoryDomainOrderingService.ts
+++ b/src/contexts/saved-tabs/domain/services/CategoryDomainOrderingService.ts
@@ -7,7 +7,7 @@ import type { TabGroupId } from '../value-objects/TabGroupId'
  * 旧
  * `src/contexts/saved-tabs/presentation/hooks/useCategoryManagement.ts`
  * の `handleUpdateDomainsOrder` 内の
- * - 対象カテゴリの `domains` を新しい順序へ組み替える
+ * - 対象カテゴリの `domains` を UI から渡された順序へ組み替える
  *
  * ロジックを domain 等価物として抽出したもの。
  *
@@ -18,6 +18,17 @@ import type { TabGroupId } from '../value-objects/TabGroupId'
  * domain 層ガード (React 依存禁止、`chrome.*` 依存禁止、`toast` 依存
  * 禁止、`@dnd-kit/sortable` 依存禁止) を満たすため、副作用・永続化・
  * ロギングは含めず、純粋な配列変換のみを公開する。
+ *
+ * 旧実装との互換性:
+ * - `updatedDomains` (=`command.domainIds`) の順序をそのまま
+ *   `domains` に保存する（旧 `handleUpdateDomainsOrder` の
+ *   `updatedDomains.map((d) => d.id)` 上書き挙動と一致）。
+ * - `domainNames` 経由でのみ表示されるエントリ（`domains` に
+ *   存在しないが `domainNames` に存在するもの）も `updatedDomains`
+ *   経由で `domains` へ追加される（Codex レビュー対応 / issue #525）。
+ *   これにより、UI 並び替え確定時に「`domainNames` だけ残っていた
+ *   ドメイン」が explicit な `domains` 順序へ昇格する。
+ * - 対象カテゴリが見つからない場合は no-op として現在値を返す。
  */
 export interface ReorderDomainsInCategoryParams {
   readonly categories: readonly ParentCategory[]
@@ -25,8 +36,10 @@ export interface ReorderDomainsInCategoryParams {
   readonly categoryId: string
   /**
    * 新しいドメイン順序（`TabGroupId` の配列）。
-   * UI 側で並び替えたあとの順序をそのまま渡す。既存 `domains` に
-   * 存在しない ID（新規追加されたものなど）は末尾へ保持される。
+   *
+   * UI 側で並び替えたあとの順序をそのまま保存する。既存 `domains` に
+   * 存在しない ID（`domainNames` 経由の表示エントリ等）もそのまま
+   * 順序に組み込まれる。
    */
   readonly domainIds: readonly TabGroupId[]
 }
@@ -51,21 +64,13 @@ export const reorderDomainsInCategory = (
       updatedCategories: categories.map((category) => ({ ...category })),
     }
   }
-  const existingDomainIds = new Set<TabGroupId>(targetCategory.domains)
-  const orderedExisting = domainIds.filter((id) => existingDomainIds.has(id))
-  const inputIdSet = new Set<TabGroupId>(domainIds)
-  const trailingIds = targetCategory.domains.filter((id) => !inputIdSet.has(id))
-  const nextDomainIds: readonly TabGroupId[] = [
-    ...orderedExisting,
-    ...trailingIds,
-  ]
   const updatedCategories = categories.map((category) =>
     category.id === categoryId
-      ? { ...category, domains: nextDomainIds }
+      ? { ...category, domains: domainIds }
       : { ...category },
   )
   return {
-    domainIdOrder: nextDomainIds,
+    domainIdOrder: domainIds,
     targetFound: true,
     updatedCategories,
   }

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts
@@ -16,6 +16,7 @@ import { createFindUrlRecordByUrlUseCase } from '../../application/use-cases/Fin
 import { createGetProjectUrlsUseCase } from '../../application/use-cases/GetProjectUrlsUseCase'
 import { createLoadTabGroupsWithUrlsUseCase } from '../../application/use-cases/LoadTabGroupsWithUrlsUseCase'
 import { createLoadTabGroupUrlsUseCase } from '../../application/use-cases/LoadTabGroupUrlsUseCase'
+import { createMoveDomainBetweenCategoriesUseCase } from '../../application/use-cases/MoveDomainBetweenCategoriesUseCase'
 import { createOpenAllSavedUrlsUseCase } from '../../application/use-cases/OpenAllSavedUrlsUseCase'
 import { createOpenSavedUrlUseCase } from '../../application/use-cases/OpenSavedUrlUseCase'
 import { createPrepareTabGroupDeletionUseCase } from '../../application/use-cases/PrepareTabGroupDeletionUseCase'
@@ -26,6 +27,7 @@ import { createRemoveSubCategoryFromTabGroupsUseCase } from '../../application/u
 import { createRemoveUnreferencedUrlRecordsUseCase } from '../../application/use-cases/RemoveUnreferencedUrlRecordsUseCase'
 import { createRemoveUrlsFromCustomProjectsUseCase } from '../../application/use-cases/RemoveUrlsFromCustomProjectsUseCase'
 import { createRenameParentCategoryUseCase } from '../../application/use-cases/RenameParentCategoryUseCase'
+import { createReorderDomainsInCategoryUseCase } from '../../application/use-cases/ReorderDomainsInCategoryUseCase'
 import { createReorderParentCategoriesUseCase } from '../../application/use-cases/ReorderParentCategoriesUseCase'
 import { createReorderTabGroupsUseCase } from '../../application/use-cases/ReorderTabGroupsUseCase'
 import { createReorderTabGroupUrlsUseCase } from '../../application/use-cases/ReorderTabGroupUrlsUseCase'
@@ -188,6 +190,12 @@ export const createSavedTabsUseCases = (
     }),
   }),
   renameParentCategory: createRenameParentCategoryUseCase({
+    parentCategoryRepository: deps.parentCategoryRepository,
+  }),
+  moveDomainBetweenCategories: createMoveDomainBetweenCategoriesUseCase({
+    parentCategoryRepository: deps.parentCategoryRepository,
+  }),
+  reorderDomainsInCategory: createReorderDomainsInCategoryUseCase({
     parentCategoryRepository: deps.parentCategoryRepository,
   }),
   reorderTabGroupUrls: createReorderTabGroupUrlsUseCase({

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
@@ -663,6 +663,8 @@ describe('SavedTabsApp custom search', () => {
         setCategoryKeywords: vi.fn(),
         syncCategoryAssignments: vi.fn(),
         updateCustomProjectName: vi.fn(),
+        moveDomainBetweenCategories: vi.fn(),
+        reorderDomainsInCategory: vi.fn(),
       },
       setCustomProjects: vi.fn(),
       snapshot: {
@@ -717,6 +719,8 @@ describe('SavedTabsApp custom search', () => {
         setCategoryKeywords: vi.fn(),
         syncCategoryAssignments: vi.fn(),
         updateCustomProjectName: vi.fn(),
+        moveDomainBetweenCategories: vi.fn(),
+        reorderDomainsInCategory: vi.fn(),
       },
       setCustomProjects: vi.fn(),
       t: (key) => key,

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -119,6 +119,9 @@ const useSavedTabsAppView = ({
     reorderParentCategoriesUseCase: savedTabsUseCases.reorderParentCategories,
     removeSubCategoryFromTabGroupsUseCase:
       savedTabsUseCases.removeSubCategoryFromTabGroups,
+    moveDomainBetweenCategoriesUseCase:
+      savedTabsUseCases.moveDomainBetweenCategories,
+    reorderDomainsInCategoryUseCase: savedTabsUseCases.reorderDomainsInCategory,
   })
   const tabDataState = useTabData({
     loadTabGroupsWithUrlsUseCase: savedTabsUseCases.loadTabGroupsWithUrls,

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryManagement.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryManagement.ts
@@ -7,7 +7,10 @@ import { useCallback, useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { toast } from 'sonner'
 
+import { toStorageParentCategory } from '@/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper'
+import type { MoveDomainBetweenCategoriesUseCase } from '@/contexts/saved-tabs/application/use-cases/MoveDomainBetweenCategoriesUseCase'
 import type { RemoveSubCategoryFromTabGroupsUseCase } from '@/contexts/saved-tabs/application/use-cases/RemoveSubCategoryFromTabGroupsUseCase'
+import type { ReorderDomainsInCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/ReorderDomainsInCategoryUseCase'
 import type { ReorderParentCategoriesUseCase } from '@/contexts/saved-tabs/application/use-cases/ReorderParentCategoriesUseCase'
 import { buildReorderedCategoryOrder } from '@/contexts/saved-tabs/domain/services/ParentCategoryReorderService'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
@@ -97,6 +100,21 @@ interface UseCategoryManagementParams {
    * rich フィールドを保持してしまう既存問題に対応)。
    */
   removeSubCategoryFromTabGroupsUseCase: RemoveSubCategoryFromTabGroupsUseCase
+  /**
+   * カテゴリ間ドメイン移動 use-case (issue #525)。
+   * 旧 `useCategoryManagement.handleMoveDomainToCategory` 内の
+   * `tabGroups` 引き当て / `domains` / `domainNames` 移動 /
+   * `reorderParentCategoriesUseCase` 直叩きを 1 つの application
+   * use-case に統合する。
+   */
+  moveDomainBetweenCategoriesUseCase: MoveDomainBetweenCategoriesUseCase
+  /**
+   * カテゴリ内ドメイン順序更新 use-case (issue #525)。
+   * 旧 `useCategoryManagement.handleUpdateDomainsOrder` 内の
+   * 並び替え / `reorderParentCategoriesUseCase` 直叩きを
+   * application use-case へ統合する。
+   */
+  reorderDomainsInCategoryUseCase: ReorderDomainsInCategoryUseCase
 }
 
 /**
@@ -118,6 +136,8 @@ const useCategoryManagement = (
   const {
     reorderParentCategoriesUseCase,
     removeSubCategoryFromTabGroupsUseCase,
+    moveDomainBetweenCategoriesUseCase,
+    reorderDomainsInCategoryUseCase,
   } = params
   const { t } = useI18n()
   const [categories, setCategoriesState] = useState<ParentCategory[]>([])
@@ -253,11 +273,11 @@ const useCategoryManagement = (
   /**
    * カテゴリ内のドメイン順序を更新する。
    *
-   * 並び順検証 / 永続化は use-case 化候補だが、本 issue (#519) の
-   * スコープ外（pure logic 移設対象ではない）ため、 presentation
-   * 側で完結させる。挙動は旧実装と同じ
-   * `categoryAssignmentPort.saveParentCategories` 直叩き相当を
-   * `reorderParentCategoriesUseCase` 経由で保存する形に置き換える。
+   * 並び順検証 / 永続化は `ReorderDomainsInCategoryUseCase` 経由
+   * (issue #525) で実行し、 presentation 層はイベントハンドラと
+   * use-case 呼び出しのオーケストレーションに専念する。
+   * 旧実装と同じく、対象カテゴリが見つからない場合は use-case 側で
+   * no-op として処理される（エラーログは presentation 側で記録）。
    */
   const handleUpdateDomainsOrder = useCallback(
     async (categoryId: string, updatedDomains: TabGroup[]): Promise<void> => {
@@ -267,28 +287,27 @@ const useCategoryManagement = (
           console.error('更新対象のカテゴリが見つかりません:', categoryId)
           return
         }
-        const updatedDomainIds = updatedDomains.map((domain) => domain.id)
-        const updatedCategories = categories.map((category) =>
-          category.id === categoryId
-            ? { ...category, domains: updatedDomainIds }
-            : category,
-        )
-        await reorderParentCategoriesUseCase({ categories: updatedCategories })
-        setCategories(updatedCategories)
+        const updatedDomainCategories = await reorderDomainsInCategoryUseCase({
+          categoryId,
+          updatedDomains,
+        })
+        setCategories(updatedDomainCategories.map(toStorageParentCategory))
       } catch (error) {
         console.error('カテゴリ内ドメイン順序更新エラー:', error)
       }
     },
-    [categories, reorderParentCategoriesUseCase, setCategories],
+    [categories, reorderDomainsInCategoryUseCase, setCategories],
   )
 
   /**
    * ドメインを別のカテゴリに移動する。
    * tabGroups は main.tsx から渡す（useTabData に依存するため引数として受け取る）。
    *
-   * 永続化は本 issue (#519) で導入した `reorderParentCategoriesUseCase`
-   * 経由へ寄せる（旧 `categoryAssignmentPort.saveParentCategories` 直叩き
-   * と同等）。
+   * ドメイン引き当て / 移動元 `domains` / `domainNames` 削除 /
+   * 移動先 `domains` / `domainNames` 追加 / 永続化は
+   * `MoveDomainBetweenCategoriesUseCase` 経由 (issue #525) で実行し、
+   * presentation 層はイベントハンドラと use-case 呼び出しの
+   * オーケストレーションに専念する。
    */
   const handleMoveDomainToCategory = useCallback(
     async (
@@ -302,35 +321,14 @@ const useCategoryManagement = (
         if (!domainGroup) {
           return
         }
-        let updatedCategories = [...categories]
-        if (fromCategoryId) {
-          updatedCategories = updatedCategories.map((cat) =>
-            cat.id === fromCategoryId
-              ? {
-                  ...cat,
-                  domainNames: cat.domainNames
-                    ? cat.domainNames.filter((d) => d !== domainGroup.domain)
-                    : [],
-                  domains: cat.domains.filter((d) => d !== domainId),
-                }
-              : cat,
-          )
-        }
-        updatedCategories = updatedCategories.map((cat) =>
-          cat.id === toCategoryId
-            ? {
-                ...cat,
-                domainNames: cat.domainNames?.includes(domainGroup.domain)
-                  ? cat.domainNames
-                  : [...(cat.domainNames || []), domainGroup.domain],
-                domains: cat.domains.includes(domainId)
-                  ? cat.domains
-                  : [...cat.domains, domainId],
-              }
-            : cat,
-        )
-        await reorderParentCategoriesUseCase({ categories: updatedCategories })
-        setCategories(updatedCategories)
+        const updatedDomainCategories =
+          await moveDomainBetweenCategoriesUseCase({
+            domainId,
+            fromCategoryId,
+            tabGroups,
+            toCategoryId,
+          })
+        setCategories(updatedDomainCategories.map(toStorageParentCategory))
         console.log(
           `ドメイン ${domainGroup.domain} を ${fromCategoryId || '未分類'} から ${toCategoryId} に移動しました`, // eslint-disable-line typescript/prefer-nullish-coalescing -- fromCategoryId could be empty string
         )
@@ -338,7 +336,7 @@ const useCategoryManagement = (
         console.error('カテゴリ間ドメイン移動エラー:', error)
       }
     },
-    [categories, reorderParentCategoriesUseCase, setCategories],
+    [moveDomainBetweenCategoriesUseCase, setCategories],
   )
   return {
     categories,


### PR DESCRIPTION
## 概要

#454 の saved-tabs DDD 移行の最終仕上げとして、 `useCategoryManagement` に残るカテゴリ移動・カテゴリ内ドメイン順序更新ロジックを application use-case / domain service へ移す (issue #525)。

#519 でカテゴリ削除・並び替えの主要処理は整理済みだが、 `handleMoveDomainToCategory` / `handleUpdateDomainsOrder` 内の更新ロジックがまだ残っていた。

## 変更内容

- domain 層 (pure logic) を追加
  - `CategoryDomainMoveService.moveDomainBetweenCategories`
  - `CategoryDomainOrderingService.reorderDomainsInCategory`
- application use-case を追加
  - `MoveDomainBetweenCategoriesUseCase` + `MoveDomainBetweenCategoriesCommand`
  - `ReorderDomainsInCategoryUseCase` + `ReorderDomainsInCategoryCommand`
- `useCategoryManagement.handleMoveDomainToCategory` / `handleUpdateDomainsOrder` を use-case 経由へ置換
  - `tabGroups` 引き当て / `domains` / `domainNames` 移動 / `reorderParentCategoriesUseCase` 直叩きを application 層に統合
  - presentation 層は UI イベントハンドラと use-case 呼び出しのオーケストレーションに専念
- `SavedTabsUseCases` バンドルと composition (`createSavedTabsUseCases`) へ組み込み
- `SavedTabsApp` からの依存注入と `SavedTabsApp.test` のモックを更新
- 各 use-case / domain service に 100% カバレッジの単体テストを追加

## やらないこと

- カテゴリUIの見た目変更
- storage schema / migration の変更
- #523 / #524 の削除処理整理まで同時に広げること

## 検証

- `bun run compile` : pass
- `bun run lint` : 0 errors
- `bun run test` : 257 files / 2338 tests pass
- `bun run test:coverage` : 新規追加ファイルは 100% カバー

## 関連

- #454
- #519
- #523
- #524
- close #525