### PR TITLE
[DDD] saved-tabs DDD移行の最終確認と不要TODO・READMEクリーンアップ (issue #526)

### DIFF
--- a/src/contexts/saved-tabs/README.md
+++ b/src/contexts/saved-tabs/README.md
@@ -1,17 +1,28 @@
 # src/contexts/saved-tabs
 
-`saved-tabs` 機能の DDD レイヤ構成（domain / application / infrastructure / presentation）のスケルトンです。WXT の `src/entrypoints/` は維持したまま、保存タブ関連の責務を段階的にこの配下へ移します。
+`saved-tabs` 機能の DDD レイヤ構成（domain / application / infrastructure / presentation）の実装本体です。WXT の `src/entrypoints/` は維持したまま、保存タブ関連の責務をこの context 配下に集約しています。
 
-全体方針は Issue #454、最初の追加 PR は Issue #455、各層の責務と禁止ルールは `docs/architecture/ddd.md` を参照してください。
+全体方針は Issue #454、最初のスケルトン追加は Issue #455、各層の責務と禁止ルールは `docs/architecture/ddd.md` を参照してください。
 
 ## 構成
 
 ```
 contexts/saved-tabs/
-  domain/             # ビジネスルール・値オブジェクト・repository interface
-  application/        # use-case / command / query / dto / port
-  infrastructure/     # chrome-storage / browser adapter / mapper / migration
-  presentation/       # route / page / controller hook / component / view-model
+  domain/             # ビジネスルール・値オブジェクト・repository interface・domain service・domain DTO
+  application/        # use-case / command / query / dto / port / mapper
+  infrastructure/     # chrome-storage / browser adapter / mapper / composition root
+  presentation/       # route / page / app / controller / hook / container / view-model / service
+  testing/            # テスト用 mock factory
+  dddLayerGuard.test.ts  # layer 越境の静的ガード
+  README.md
 ```
 
-当面はスケルトンのみです。`features/saved-tabs` の既存ロジックは変更せず、後続 Issue（#456 以降）で 1 層ずつ / 1 use-case ずつ移します。実装時には `docs/architecture/ddd.md` を起点に依存方向と禁止ルールを確認してください。
+旧 `src/features/saved-tabs/` 配下の UI / hooks / lib は DDD 移行完了に伴い撤去済みです（Issue #488）。`SavedTabsPage` / `SavedTabsRoute` などの組み立ては `presentation/` 配下にあり、`src/entrypoints/saved-tabs/main.tsx` から呼び出されます。
+
+## 開発時の参照順序
+
+1. `docs/architecture/ddd.md` で依存方向と禁止ルールを確認します。
+2. 新しい use-case を追加するときは `application/use-cases/` に 1 ファイルで追加し、`SavedTabsUseCases` 型（`infrastructure/composition/createSavedTabsUseCases.ts`）へ露出します。
+3. Repository / port の実装は `infrastructure/` 配下のリポジトリだけに閉じ込め、presentation 側では `use-cases` と `query` だけを呼びます。
+4. 新しい UI を追加するときは `presentation/containers` または `presentation/app` で `use-case` を呼び、`presentation/components` には view model だけを渡す形にします。
+5. layer 越境を検知するガードは `dddLayerGuard.test.ts` にあり、`bun run test:node` で実行できます。

--- a/src/contexts/saved-tabs/presentation/README.md
+++ b/src/contexts/saved-tabs/presentation/README.md
@@ -4,19 +4,19 @@
 
 ## サブディレクトリ
 
-| ディレクトリ    | 役割                                                                                                          |
-| --------------- | ------------------------------------------------------------------------------------------------------------- |
-| `routes/`       | React Router のルート定義                                                                                     |
-| `pages/`        | ページコンポーネント（composition root。controller / container / providers を組み合わせる）                   |
-| `app/`          | `SavedTabsApp` 本体（DOM 全体）と `savedTabsApp.helpers` / `savedTabsProfiler` などの組み立て補助             |
-| `containers/`   | `DomainModeContainer` / `CustomModeContainer` などの view モード別組み立て層                                  |
-| `controllers/`  | use-case を呼ぶ controller hook（`useSavedTabsController` / `useDomainModeController` / `useCustomModeController`）と `SavedTabsUseCasesContext` |
-| `components/`   | view model を受け取り描画する純粋な component（`CategoryGroup` / `CategoryModal` / `SortableUrlItem` など）と `category-group` / `category-modal` / `domain-card` / `project-card` / `keyword-modal` / `shared` 配下のサブディレクトリ |
-| `hooks/`        | UI 単位の hook（`useCategoryManagement` / `useTabData` / `useCategoryGroupState` / `useProjectManagement` / DnD / ソートなど）|
-| `view-models/`  | presentation 内部の整形済みモデル（`SavedTabsViewModel` / `DomainModeViewModel` / `CustomModeViewModel` / `TabGroupViewModel` / `CustomProjectViewModel`）|
-| `services/`     | `StorageChangePort.subscribe` を受けて React state へ反映する `modeSyncService` / `viewModeNavigationService` / undo 通知 service |
-| `lib/`          | presentation 層内の pure 関数（`categorized-display` / `display-tab-group` / `scroll-controls` など）       |
-| `types/`        | presentation 層内のローカル型（`mode` / component 固有の型）                                                   |
+| ディレクトリ   | 役割                                                                                                                                                                                                                                   |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `routes/`      | React Router のルート定義                                                                                                                                                                                                              |
+| `pages/`       | ページコンポーネント（composition root。controller / container / providers を組み合わせる）                                                                                                                                            |
+| `app/`         | `SavedTabsApp` 本体（DOM 全体）と `savedTabsApp.helpers` / `savedTabsProfiler` などの組み立て補助                                                                                                                                      |
+| `containers/`  | `DomainModeContainer` / `CustomModeContainer` などの view モード別組み立て層                                                                                                                                                           |
+| `controllers/` | use-case を呼ぶ controller hook（`useSavedTabsController` / `useDomainModeController` / `useCustomModeController`）と `SavedTabsUseCasesContext`                                                                                       |
+| `components/`  | view model を受け取り描画する純粋な component（`CategoryGroup` / `CategoryModal` / `SortableUrlItem` など）と `category-group` / `category-modal` / `domain-card` / `project-card` / `keyword-modal` / `shared` 配下のサブディレクトリ |
+| `hooks/`       | UI 単位の hook（`useCategoryManagement` / `useTabData` / `useCategoryGroupState` / `useProjectManagement` / DnD / ソートなど）                                                                                                         |
+| `view-models/` | presentation 内部の整形済みモデル（`SavedTabsViewModel` / `DomainModeViewModel` / `CustomModeViewModel` / `TabGroupViewModel` / `CustomProjectViewModel`）                                                                             |
+| `services/`    | `StorageChangePort.subscribe` を受けて React state へ反映する `modeSyncService` / `viewModeNavigationService` / undo 通知 service                                                                                                      |
+| `lib/`         | presentation 層内の pure 関数（`categorized-display` / `display-tab-group` / `scroll-controls` など）                                                                                                                                  |
+| `types/`       | presentation 層内のローカル型（`mode` / component 固有の型）                                                                                                                                                                           |
 
 ## 禁止
 

--- a/src/contexts/saved-tabs/presentation/README.md
+++ b/src/contexts/saved-tabs/presentation/README.md
@@ -1,18 +1,25 @@
 # presentation 層
 
-`saved-tabs` の React UI / controller hook / view model を置く層です。詳細ルールは `docs/architecture/ddd.md` を参照してください。
+`saved-tabs` の React UI / controller hook / view model / 組み立て層を置く層です。詳細ルールは `docs/architecture/ddd.md` を参照してください。
 
 ## サブディレクトリ
 
-| ディレクトリ   | 役割                                                                                  |
-| -------------- | ------------------------------------------------------------------------------------- |
-| `routes/`      | React Router のルート定義                                                             |
-| `pages/`       | ページコンポーネント（controller hook + components の組み立て）                       |
-| `controllers/` | use-case を呼ぶ controller hook（`useSavedTabsController` など）                      |
-| `components/`  | view model を受け取り描画する純粋な component（`TabGroupCard` / `TabGroupList` など） |
-| `view-models/` | presentation 内部の整形済みモデル                                                     |
+| ディレクトリ    | 役割                                                                                                          |
+| --------------- | ------------------------------------------------------------------------------------------------------------- |
+| `routes/`       | React Router のルート定義                                                                                     |
+| `pages/`        | ページコンポーネント（composition root。controller / container / providers を組み合わせる）                   |
+| `app/`          | `SavedTabsApp` 本体（DOM 全体）と `savedTabsApp.helpers` / `savedTabsProfiler` などの組み立て補助             |
+| `containers/`   | `DomainModeContainer` / `CustomModeContainer` などの view モード別組み立て層                                  |
+| `controllers/`  | use-case を呼ぶ controller hook（`useSavedTabsController` / `useDomainModeController` / `useCustomModeController`）と `SavedTabsUseCasesContext` |
+| `components/`   | view model を受け取り描画する純粋な component（`CategoryGroup` / `CategoryModal` / `SortableUrlItem` など）と `category-group` / `category-modal` / `domain-card` / `project-card` / `keyword-modal` / `shared` 配下のサブディレクトリ |
+| `hooks/`        | UI 単位の hook（`useCategoryManagement` / `useTabData` / `useCategoryGroupState` / `useProjectManagement` / DnD / ソートなど）|
+| `view-models/`  | presentation 内部の整形済みモデル（`SavedTabsViewModel` / `DomainModeViewModel` / `CustomModeViewModel` / `TabGroupViewModel` / `CustomProjectViewModel`）|
+| `services/`     | `StorageChangePort.subscribe` を受けて React state へ反映する `modeSyncService` / `viewModeNavigationService` / undo 通知 service |
+| `lib/`          | presentation 層内の pure 関数（`categorized-display` / `display-tab-group` / `scroll-controls` など）       |
+| `types/`        | presentation 層内のローカル型（`mode` / component 固有の型）                                                   |
 
 ## 禁止
 
 - `chrome.storage.local` / `chrome.*` API の直接利用
 - ドメインルールの埋め込み（entity のバリデーションや不変条件は domain 層に置く）
+- repository / port 実装の直接 import（composition root 以外では `application/use-cases` または query を介する）

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -278,13 +278,9 @@ const useSavedTabsAppView = ({
             })
           : undefined
 
-        // 一括オープンは OpenAllSavedUrlsUseCase に委譲し、
-        // eslint-disable-next-line eslint/no-restricted-properties -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-        // eslint-disable-next-line eslint/no-restricted-properties, typescript/unbound-method -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-        // `chrome.tabs.create` / `chrome.windows.create` の直接呼び出しを
-        // presentation 層から撤去する。`active` 制御は composition 層の
-        // `BrowserTabPort.resolveActive` が `settings.openUrlInBackground` を
-        // 反映する。
+        // 一括オープンは OpenAllSavedUrlsUseCase に委譲する。
+        // `active` 制御は composition 層の `BrowserTabPort.resolveActive` が
+        // `settings.openUrlInBackground` を反映する。
         const result = await savedTabsUseCases.openAllSavedUrls({
           mode: settings.openAllInNewWindow ? 'newWindow' : 'backgroundTabs',
           removeTabAfterOpen: settings.removeTabAfterOpen,
@@ -730,10 +726,7 @@ const useSavedTabsAppView = ({
 
   // TabGroupsWithUrls と categories が変わったとき、カテゴリ割り当ての不一致を
   // ストレージに反映するための副作用（organizeTabGroups から分離した副作用）。
-  // 同期本体は SyncCategoryAssignmentsUseCase 経由で実行し、
-  // eslint-disable-next-line eslint/no-restricted-properties -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-  // eslint-disable-next-line eslint/no-restricted-properties, typescript/unbound-method -- TODO(#488-followup): presentation 層から chrome.* を撤去し Repository / Port 経由へ移行
-  // `chrome.storage.local.get/set` の直接呼び出しを削減する。
+  // 同期本体は SyncCategoryAssignmentsUseCase 経由で実行する。
   useEffect(
     () => {
       if (!settings.enableCategories) {


### PR DESCRIPTION
## 変更内容

`#454` の saved-tabs DDD 移行の最終確認として、`#526` のチェックリストをすべて走査し、完了済み followup の disable コメントと古い README を現状に合わせて整理しました。

### 変更ファイル

- `src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx`
  - `OpenAllSavedUrlsUseCase` / `SyncCategoryAssignmentsUseCase` 周辺の `eslint-disable-next-line eslint/no-restricted-properties` と `TODO(#488-followup)` 4 行を削除。`chrome.*` の直接呼び出しがもう production code に残っていないため disable は不要。
- `src/contexts/saved-tabs/README.md`
  - 「当面はスケルトンのみ」「features/saved-tabs の既存ロジックは変更せず」という旧記述を、現状の「実装本体」状態に更新。旧 `features/saved-tabs` 撤去 (#488) と `entrypoints` からの呼び出し構造、開発時の参照順序を追記。
- `src/contexts/saved-tabs/presentation/README.md`
  - サブディレクトリ表を `app/` / `containers/` / `hooks/` / `services/` / `lib/` / `types/` を含む現状構成に更新。`chrome.*` 直依存禁止に加えて repository / port 実装の直接 import 禁止を明記。

## 確認結果（#526 チェックリスト）

- [x] `SavedTabsApp` に repository 直接依存が残っていない
- [x] presentation 層に `chrome.storage.local` の直参照がない
- [x] presentation 層に `chrome.storage.onChanged` の直参照がない（`StorageChangePort` 経由）
- [ ] presentation 層から `@/lib/storage/*` へ直接依存していない → `modeSyncService.ts` で `zod-storage` を参照している 1 件を残課題として issue #530 化
- [x] saved-tabs の主要操作が application use-case / query / port 経由になっている
- [x] domain 層が `@/types/storage` に依存していない
- [x] `src/features/saved-tabs` の旧実装は撤去済み
- [x] `TODO(#488-followup)` など古い移行 TODO は #488 完了済みとして SavedTabsApp 周辺の disable を削除（`TODO(#502-followup)` の disable は別 issue のメモとして残置）
- [x] `docs/architecture/ddd.md` / `src/contexts/saved-tabs/README.md` が現状と一致
- [x] `bun run lint` / `bun run compile` / `bun run test:node` / presentation 配下 test が通る
- [ ] presentation 層から `chrome.runtime.*` の直参照がない → `ProjectUrlItem.tsx` / `SortableUrlItem.tsx` の 2 ファイルを残課題として issue #531 化

## 残課題（追加 issue として記録）

- **#530**: modeSyncService の `@/lib/storage/zod-storage` 依存を `StorageChangePort` 境界へ閉じる
- **#531**: presentation 層の `chrome.runtime.sendMessage` 直参照を `MessagingPort` 経由へ移す

両 issue とも #454 のサブ issue として登録。#454 の close は #530 / #531 完了まで保留します。

## 検証

- `bun run lint` → 0 errors / 0 warnings
- `bun run compile` → エラーなし
- `bunx vitest run --config vitest.ci.config.ts src/contexts/saved-tabs` → 811 tests pass
- SavedTabsApp.test.tsx (60 tests) / dddLayerGuard.test.ts (312 tests) すべて pass
- ローカル環境でエラーになっていない ✅

## 関連

- #454 (親 issue。#530 / #531 完了まで close 保留)
- #526 (この PR の元 issue)
- #488 (closed: features/saved-tabs 撤去 — disable 削除の根拠)
- #530 (追加: modeSyncService の storage 依存 port 化)
- #531 (追加: chrome.runtime 直参照 MessagingPort 化)