### PR TITLE
[DDD] presentation 層の chrome.runtime.sendMessage 直参照を MessagingPort 経由へ移す (issue #531)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -667,6 +667,11 @@
             "object": "chrome",
             "property": "alarms",
             "message": "presentation 層は chrome.alarms を直接利用できません"
+          },
+          {
+            "object": "chrome",
+            "property": "runtime",
+            "message": "presentation 層は chrome.runtime を直接利用できません（MessagingPort 経由）"
           }
         ]
       }

--- a/src/app/composition/createSavedTabsPorts.ts
+++ b/src/app/composition/createSavedTabsPorts.ts
@@ -1,10 +1,13 @@
 import type { BrowserTabPort } from '@/contexts/saved-tabs/application/ports/BrowserTabPort'
 import type { BrowserWindowPort } from '@/contexts/saved-tabs/application/ports/BrowserWindowPort'
+import type { MessagingPort } from '@/contexts/saved-tabs/application/ports/MessagingPort'
 import type { NotificationPort } from '@/contexts/saved-tabs/application/ports/NotificationPort'
 import type { StorageChangePort } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import { createChromeBrowserTabAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter'
 import type { ChromeApiLike } from '@/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter'
 import { createChromeBrowserWindowAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeBrowserWindowAdapter'
+import { createChromeMessagingAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeMessagingAdapter'
+import type { ChromeApiLike as ChromeMessagingApiLike } from '@/contexts/saved-tabs/infrastructure/browser/ChromeMessagingAdapter'
 import { createChromeStorageChangeAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter'
 import { createSonnerNotificationAdapter } from '@/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter'
 
@@ -23,6 +26,13 @@ export interface SavedTabsPorts {
   readonly browserWindowPort: BrowserWindowPort
   readonly notificationPort: NotificationPort
   readonly storageChangePort: StorageChangePort
+  /**
+   * background 通信 port (issue #531)。
+   * presentation 層 (`ProjectUrlItem` / `SortableUrlItem`) の
+   * 外部ウィンドウ D&D 通知を `chrome.runtime.sendMessage` 直叩きせず
+   * port 経由で行うため、ports 経由で配下に注入する。
+   */
+  readonly messagingPort: MessagingPort
 }
 
 /**
@@ -49,6 +59,13 @@ interface ChromeApi extends ChromeApiLike {
           { readonly tabs?: readonly { readonly url?: string }[] } | undefined
         >
       | undefined
+  }
+  readonly runtime?: {
+    readonly sendMessage?: (
+      message: unknown,
+      callback?: (response: unknown) => void,
+    ) => void
+    readonly lastError?: { readonly message?: string } | undefined
   }
   readonly storage?: {
     readonly onChanged?: {
@@ -98,6 +115,17 @@ export const createSavedTabsPorts = (
   ),
   browserWindowPort: createChromeBrowserWindowAdapter({
     getApi: () => getChromeApi(),
+  }),
+  messagingPort: createChromeMessagingAdapter({
+    // `getChromeApi()` の戻り値 `ChromeApi` は `BrowserTabPort` 由来の
+    // `ChromeApiLike` (`{ tabs?: ... }`) に対し `runtime` / `storage` を
+    // 追加で持つ拡張型。`createChromeMessagingAdapter` は
+    // 拡張後の `ChromeApiLike` (`{ runtime?: ... }`) を要求するため、
+    // `ChromeMessagingApiLike` への構造的部分型キャストで境界を超える。
+    getApi: () => {
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      return getChromeApi() as unknown as ChromeMessagingApiLike | undefined
+    },
   }),
   notificationPort: createSonnerNotificationAdapter(),
   storageChangePort: createChromeStorageChangeAdapter({

--- a/src/contexts/saved-tabs/application/ports/MessagingPort.ts
+++ b/src/contexts/saved-tabs/application/ports/MessagingPort.ts
@@ -1,0 +1,121 @@
+/**
+ * `chrome.runtime.sendMessage` 相当の background 通信を抽象化する port。
+ *
+ * presentation / application 層は `chrome.*` API を直接呼ばず、本 port 経由で
+ * `BackgroundMessage` (typed envelope) を background script へ通知する。
+ * infrastructure 層が `ChromeMessagingAdapter` で本 port を実装し、
+ * composition 層 (`createSavedTabsUseCasesDeps`) から use-case および
+ * presentation コンポーネントへ注入する。
+ *
+ * port 境界では `chrome.runtime.sendMessage` の生 payload を
+ * `BackgroundMessage` (issue #531) の DTO に正規化し、port 利用側に
+ * `chrome.*` 型を一切露出しない。これにより presentation 層の
+ * `ProjectUrlItem` / `SortableUrlItem` などの component は
+ * `chrome.runtime.sendMessage` を直叩きせず、port 経由のみで
+ * 外部ウィンドウへのドラッグ&ドロップ通知 (`urlDragStarted` / `urlDropped`)
+ * を行える。
+ *
+ * port 設計は「送る payload は typed envelope、レスポンスは受け取り側で
+ * 関心があるフィールドだけ」の最小 interface に絞り、port 利用者
+ * (UI コンポーネント) が `chrome.runtime.MessageSender` 相当の sender や
+ * 拡張機能固有の概念に依存しない形にする。
+ *
+ * レスポンス (`response`) は `chrome.runtime.sendMessage` と同じく
+ * 任意受け取りで、未指定時は ack を待たない fire-and-forget として扱う。
+ * port 実装側 (`ChromeMessagingAdapter`) は `chrome.runtime.lastError`
+ * などがあれば握り潰し、ログだけ残す方針とする。
+ *
+ * @example
+ * ```ts
+ * const port: MessagingPort = createChromeMessagingAdapter()
+ * port.send({
+ *   action: 'urlDragStarted',
+ *   url: 'https://example.com',
+ *   groupId: 'group-1',
+ * })
+ * ```
+ */
+
+import type {
+  UrlDragStartedMessage,
+  UrlDroppedMessage,
+} from '@/types/background'
+
+/**
+ * port 経由で送れる background メッセージ (typed envelope)。
+ *
+ * issue #531 で対象としている `urlDragStarted` / `urlDropped` を中心に、
+ * 今後 presentation 層から background へ通知したくなるメッセージを
+ * discriminated union として拡張していく。
+ * レスポンス受信を port 利用側が意識しなくて良いよう、各 action は
+ * `UrlDragStartedMessage` / `UrlDroppedMessage` の interface を
+ * そのまま共有する (`action` discriminant で switch 絞り込み可能)。
+ */
+export type ExternalDragMessage = UrlDragStartedMessage | UrlDroppedMessage
+
+/**
+ * port 経由で受け取る background レスポンスの最小 DTO。
+ *
+ * 現状は background handler (`message-handler.ts`) が返す
+ * `StatusResponse` のうち、presentation 層が利用するのは
+ * `status` / `success` 程度だが、port 境界では
+ * `unknown` まで公開せず、型ナローイングできる最小限のフィールドに
+ * 留める。`removedCount` / `error` などを必要になった時点で
+ * discriminated union として拡張する。
+ */
+export interface MessagingPortResponse {
+  readonly status: string
+  readonly success?: boolean
+}
+
+/**
+ * background 通信 port の最小 interface。
+ *
+ * `send` は `chrome.runtime.sendMessage` の fire-and-forget / callback
+ * 受け取りを 1 つの Promise ベース API に正規化したもの。
+ * port 実装 (`ChromeMessagingAdapter`) は `chrome` が見つからない
+ * 環境では no-op として ack を待ち、use-case / presentation 層が
+ * background 未注入環境 (Storybook / SSR / 一部テスト) でも落ちない
+ * ようにする。`getApi` が undefined を返した environment では
+ * 早期 return で `undefined` を返す。
+ */
+export interface MessagingPort {
+  /**
+   * `chrome` 由来の port 実装に付くマーカー。
+   *
+   * `SavedTabsPage` などの composition 層が「chrome 由来の port であるか」
+   * を識別し、テスト / SSR 用途の独自 port 実装を区別するために使う。
+   * 任意実装の port では undefined か false を入れて良い。
+   */
+  readonly [CHROME_MESSAGING_ADAPTER_MARKER]?: boolean
+  /**
+   * background script へ typed envelope を送信する。
+   *
+   * `message` には `ExternalDragMessage` (現状は `urlDragStarted` /
+   * `urlDropped`) のいずれかを渡す。`urlDropped` の `fromExternal`
+   * フラグなど、envelope 内の optional フィールドは port 利用側が
+   * 組み立てる責務 (presentation 層が UI の D&D 状態を見て判断する)。
+   *
+   * 返り値は background handler からのレスポンスを
+   * `MessagingPortResponse` までナローイングした値。
+   * handler が `sendResponse` を呼ばない、または
+   * `chrome.runtime.lastError` が発生した場合は `undefined` を返す。
+   * port 利用側はレスポンス未到着を許容できるよう、await しない
+   * fire-and-forget 呼び出し (`void port.send(...)`) を基本とする。
+   */
+  send: (
+    message: ExternalDragMessage,
+  ) => Promise<MessagingPortResponse | undefined>
+}
+
+/**
+ * `createChromeMessagingAdapter` が生成した port に付くマーカー symbol。
+ *
+ * port interface のプロパティキーとして export し、adapter 実装と
+ * composition 層が同じ symbol を共有できるようにする。
+ * `CHROME_BROWSER_TAB_ADAPTER_MARKER` / `CHROME_STORAGE_CHANGE_ADAPTER_MARKER`
+ * と同じ運用方針。
+ */
+export const CHROME_MESSAGING_ADAPTER_MARKER = Symbol.for(
+  'tabbin.chromeMessagingAdapter',
+)

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -275,12 +275,15 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       expect(override).toBeDefined()
     })
 
-    it('chrome.storage / chrome.tabs / chrome.contextMenus / chrome.alarms の直叩きを禁止している', () => {
+    it('chrome.storage / chrome.tabs / chrome.contextMenus / chrome.alarms / chrome.runtime の直叩きを禁止している', () => {
       const names = getRestrictedProperties(override)
       expect(names).toContain('chrome.storage')
       expect(names).toContain('chrome.tabs')
       expect(names).toContain('chrome.contextMenus')
       expect(names).toContain('chrome.alarms')
+      // issue #531: `chrome.runtime.sendMessage` などの background 通信
+      // 直叩きも presentation 層ガードで再発防止する。
+      expect(names).toContain('chrome.runtime')
     })
   })
 
@@ -543,6 +546,99 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
         ).not.toMatch(/from\s+['"]@\/lib\/storage\//)
       })
     }
+  })
+
+  describe('issue #531: presentation 配下は chrome.runtime.sendMessage を直叩きしない', () => {
+    const presentationRoot = resolve(
+      repoRoot,
+      'src/contexts/saved-tabs/presentation',
+    )
+    const presentationSourceFiles = collectSourceFiles(presentationRoot)
+
+    it('presentation 配下に .ts / .tsx ソースファイルが存在する', () => {
+      expect(presentationSourceFiles.length).toBeGreaterThan(0)
+    })
+
+    for (const absolutePath of presentationSourceFiles) {
+      const relativePath = relative(repoRoot, absolutePath).split(sep).join('/')
+      it(`${relativePath} は chrome.runtime.sendMessage 文字列を含まない`, () => {
+        const source = readFileSync(absolutePath, 'utf8')
+        expect(
+          source,
+          `${relativePath} should not reference chrome.runtime.sendMessage`,
+        ).not.toMatch(/chrome\.runtime\.sendMessage/)
+      })
+
+      it(`${relativePath} は chrome.runtime.* プロパティを直接参照しない`, () => {
+        const source = readFileSync(absolutePath, 'utf8')
+        expect(
+          source,
+          `${relativePath} should not call chrome.runtime.* directly`,
+        ).not.toMatch(/chrome\.runtime\.\w+\(/)
+      })
+    }
+  })
+
+  describe('issue #531: MessagingPort / ChromeMessagingAdapter ファイルが追加されている', () => {
+    const expectedFiles = [
+      'src/contexts/saved-tabs/application/ports/MessagingPort.ts',
+      'src/contexts/saved-tabs/infrastructure/browser/ChromeMessagingAdapter.ts',
+    ]
+
+    for (const file of expectedFiles) {
+      it(`${file} が存在する`, () => {
+        const source = readFileSync(resolve(repoRoot, file), 'utf8')
+        expect(source.length).toBeGreaterThan(0)
+      })
+    }
+
+    it('MessagingPort は chrome API を import / 利用しない', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/ports/MessagingPort.ts',
+        ),
+        'utf8',
+      )
+      expect(source).not.toMatch(/from\s+['"]chrome['"]/)
+      // JSDoc 内の言及は除外するため、import / プロパティアクセスを厳密検出
+      expect(source).not.toMatch(/chrome\.runtime\.\w+\(/)
+    })
+
+    it('ChromeMessagingAdapter は MessagingPort を実装し chrome.runtime.sendMessage を含む', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/infrastructure/browser/ChromeMessagingAdapter.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('MessagingPort')
+      expect(source).toContain('chrome.runtime.sendMessage')
+      expect(source).not.toMatch(/from\s+['"]@\/components/)
+      expect(source).not.toMatch(/from\s+['"]@\/features\//)
+    })
+
+    it('createSavedTabsUseCasesDeps は messagingPort を組み立てる', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('messagingPort')
+      expect(source).toContain('createChromeMessagingAdapter')
+    })
+
+    it('createSavedTabsPorts は messagingPort を組み立てる', () => {
+      const source = readFileSync(
+        resolve(repoRoot, 'src/app/composition/createSavedTabsPorts.ts'),
+        'utf8',
+      )
+      expect(source).toContain('messagingPort')
+      expect(source).toContain('createChromeMessagingAdapter')
+    })
   })
 
   describe('domain/repositories/ の純度 (issue #457)', () => {

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeMessagingAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeMessagingAdapter.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { CHROME_MESSAGING_ADAPTER_MARKER } from '../../application/ports/MessagingPort'
+import type { ExternalDragMessage } from '../../application/ports/MessagingPort'
+import type { ChromeApiLike } from './ChromeMessagingAdapter'
+import { createChromeMessagingAdapter } from './ChromeMessagingAdapter'
+
+const createMockApi = (
+  impl?: (message: ExternalDragMessage) => void,
+  lastError?: { readonly message?: string },
+): ChromeApiLike => ({
+  runtime: {
+    lastError,
+    sendMessage: vi.fn(
+      (
+        message: ExternalDragMessage,
+        callback?: (response: { status: string }) => void,
+      ) => {
+        if (impl) {
+          impl(message)
+        }
+        callback?.({ status: 'ok' })
+      },
+    ),
+  },
+})
+
+describe('createChromeMessagingAdapter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('CHROME_MESSAGING_ADAPTER_MARKER を port に立てる', () => {
+    const adapter = createChromeMessagingAdapter({
+      getApi: () => createMockApi(),
+    })
+    expect(adapter[CHROME_MESSAGING_ADAPTER_MARKER]).toBe(true)
+  })
+
+  it('chrome.runtime.sendMessage 経由で urlDragStarted を送信する', async () => {
+    const sendMessage = vi.fn(
+      (
+        message: ExternalDragMessage,
+        callback?: (response: { status: string }) => void,
+      ) => {
+        expect(message).toStrictEqual({
+          action: 'urlDragStarted',
+          groupId: 'group-1',
+          url: 'https://example.com',
+        })
+        callback?.({ status: 'ok' })
+      },
+    )
+    const api: ChromeApiLike = { runtime: { sendMessage } }
+    const adapter = createChromeMessagingAdapter({ getApi: () => api })
+    const response = await adapter.send({
+      action: 'urlDragStarted',
+      groupId: 'group-1',
+      url: 'https://example.com',
+    })
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+    expect(response).toStrictEqual({ status: 'ok' })
+  })
+
+  it('chrome.runtime.sendMessage 経由で fromExternal 付き urlDropped を送信する', async () => {
+    const sendMessage = vi.fn(
+      (
+        message: ExternalDragMessage,
+        callback?: (response: { status: string }) => void,
+      ) => {
+        expect(message).toStrictEqual({
+          action: 'urlDropped',
+          fromExternal: true,
+          groupId: 'group-1',
+          url: 'https://example.com',
+        })
+        callback?.({ status: 'removed' })
+      },
+    )
+    const api: ChromeApiLike = { runtime: { sendMessage } }
+    const adapter = createChromeMessagingAdapter({ getApi: () => api })
+    const response = await adapter.send({
+      action: 'urlDropped',
+      fromExternal: true,
+      groupId: 'group-1',
+      url: 'https://example.com',
+    })
+    expect(response).toStrictEqual({ status: 'removed' })
+  })
+
+  it('chrome.runtime.lastError があるときは undefined を返す', async () => {
+    // chrome.runtime.sendMessage が lastError を報告する経路では
+    // adapter が warn ログを出す。setup-console.ts が `console.warn` を
+    // 検知してテスト失敗にするため、本ケースだけスタブする。
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const sendMessage = vi.fn(
+      (
+        _message: ExternalDragMessage,
+        callback?: (response: { status: string }) => void,
+      ) => {
+        callback?.({ status: 'ok' })
+      },
+    )
+    const api: ChromeApiLike = {
+      runtime: {
+        lastError: { message: 'Receiving end does not exist' },
+        sendMessage,
+      },
+    }
+    const adapter = createChromeMessagingAdapter({ getApi: () => api })
+    const response = await adapter.send({
+      action: 'urlDragStarted',
+      groupId: 'group-1',
+      url: 'https://example.com',
+    })
+    expect(response).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('chrome API がない環境では undefined を返し reject しない', async () => {
+    const adapter = createChromeMessagingAdapter({ getApi: () => undefined })
+    const response = await adapter.send({
+      action: 'urlDragStarted',
+      groupId: 'group-1',
+      url: 'https://example.com',
+    })
+    expect(response).toBeUndefined()
+  })
+
+  it('chrome.runtime.sendMessage がない環境では undefined を返す', async () => {
+    const api: ChromeApiLike = { runtime: {} }
+    const adapter = createChromeMessagingAdapter({ getApi: () => api })
+    const response = await adapter.send({
+      action: 'urlDragStarted',
+      groupId: 'group-1',
+      url: 'https://example.com',
+    })
+    expect(response).toBeUndefined()
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeMessagingAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeMessagingAdapter.ts
@@ -1,0 +1,111 @@
+/**
+ * `chrome.runtime.sendMessage` 依存を `MessagingPort` interface に
+ * 適合させる adapter。
+ *
+ * `presentation` 層は `chrome.runtime.sendMessage` を直接参照できないため、
+ * `composition` 層からこの adapter を `MessagingPort` として
+ * presentation コンポーネント (issue #531 で対象としている
+ * `ProjectUrlItem` / `SortableUrlItem`) へ注入する。
+ *
+ * port 境界では `chrome.runtime.sendMessage` の生 callback 受け取りを
+ * `Promise<MessagingPortResponse | undefined>` に正規化し、port 利用側に
+ * `chrome.*` 型を一切露出しない。`chrome` API が見つからない環境
+ * (テスト / Storybook / SSR など) では `send` は即座に `undefined` を
+ * 返し、UI 側の fire-and-forget 呼び出しが落とされないように no-op 化する。
+ *
+ * 内部では `chrome.runtime.lastError` を確認し、失敗時に握り潰して
+ * `undefined` を返す。`MessagingPort` 仕様は「失敗を throw しない」
+ * 方針のため、background 未起動や runtime エラーで use-case /
+ * presentation 全体が落ちないようにする。
+ *
+ * @example
+ * ```ts
+ * const port: MessagingPort = createChromeMessagingAdapter()
+ * await port.send({
+ *   action: 'urlDragStarted',
+ *   url: 'https://example.com',
+ *   groupId: 'group-1',
+ * })
+ * ```
+ */
+
+import { CHROME_MESSAGING_ADAPTER_MARKER } from '../../application/ports/MessagingPort'
+import type {
+  ExternalDragMessage,
+  MessagingPort,
+  MessagingPortResponse,
+} from '../../application/ports/MessagingPort'
+
+export interface ChromeRuntimeSendMessageLike {
+  /**
+   * `chrome.runtime.sendMessage` 互換の最小 API。
+   * callback 受け取りは port 側で `Promise` 化する。
+   */
+  readonly sendMessage?: (
+    message: ExternalDragMessage,
+    callback?: (response: MessagingPortResponse | undefined) => void,
+  ) => void
+}
+
+export interface ChromeRuntimeLike {
+  readonly sendMessage?: ChromeRuntimeSendMessageLike['sendMessage']
+  readonly lastError?: { readonly message?: string } | undefined
+}
+
+export interface ChromeApiLike {
+  readonly runtime?: ChromeRuntimeLike
+}
+
+export interface ChromeMessagingAdapterDeps {
+  /**
+   * `chrome.runtime` を含む chrome API 全体。テスト時は
+   * `runtime.sendMessage` を持つモックオブジェクトを渡す。
+   * 未指定なら `globalThis.chrome` を直接参照する。
+   */
+  readonly getApi?: () => ChromeApiLike | undefined
+}
+
+/**
+ * `chrome.runtime.sendMessage` を利用する `MessagingPort` 実装を生成する。
+ *
+ * `chrome` API が見つからない環境 (テスト / Storybook / SSR など) では
+ * `send` は即座に `undefined` を返し、port 利用側 (UI コンポーネント) の
+ * fire-and-forget 呼び出しが落とされないようにする。
+ * もし背景通信の失敗を可視化したい場合は port 実装をモックで差し替え、
+ * テスト時に `send` 呼び出しを検証する。
+ */
+export const createChromeMessagingAdapter = (
+  deps: ChromeMessagingAdapterDeps = {},
+): MessagingPort => {
+  const resolveApi = (): ChromeApiLike | undefined => {
+    if (deps.getApi) {
+      return deps.getApi()
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return (globalThis as typeof globalThis & { chrome?: ChromeApiLike }).chrome
+  }
+  return {
+    [CHROME_MESSAGING_ADAPTER_MARKER]: true,
+    send: (message) => {
+      const api = resolveApi()
+      const sendMessage = api?.runtime?.sendMessage
+      if (!sendMessage) {
+        return Promise.resolve(undefined)
+      }
+      return new Promise<MessagingPortResponse | undefined>((resolve) => {
+        sendMessage(message, (response) => {
+          const lastError = api?.runtime?.lastError
+          if (lastError) {
+            console.warn(
+              '[messaging] chrome.runtime.sendMessage でエラー:',
+              lastError.message,
+            )
+            resolve(undefined)
+            return
+          }
+          resolve(response)
+        })
+      })
+    },
+  }
+}

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
@@ -8,6 +8,7 @@ import type { BrowserWindowPort } from '../../application/ports/BrowserWindowPor
 import type { CategoriesCommandService } from '../../application/ports/CategoriesCommandService'
 import type { CategoryAssignmentPort } from '../../application/ports/CategoryAssignmentPort'
 import type { CustomProjectsCommandService } from '../../application/ports/CustomProjectsCommandService'
+import type { MessagingPort } from '../../application/ports/MessagingPort'
 import type { MigrationPort } from '../../application/ports/MigrationPort'
 import type { NotificationPort } from '../../application/ports/NotificationPort'
 import type { RemoveSubCategoryFromTabGroupPort } from '../../application/ports/RemoveSubCategoryFromTabGroupPort'
@@ -21,7 +22,10 @@ import type { TabGroupRepository } from '../../domain/repositories/TabGroupRepos
 import type { UrlRecordRepository } from '../../domain/repositories/UrlRecordRepository'
 import type { UserSettingsRepository } from '../../domain/repositories/UserSettingsRepository'
 import { createChromeBrowserTabAdapter } from '../browser/ChromeBrowserTabAdapter'
+import type { ChromeApiLike as ChromeApiLikeBase } from '../browser/ChromeBrowserTabAdapter'
 import { createChromeBrowserWindowAdapter } from '../browser/ChromeBrowserWindowAdapter'
+import { createChromeMessagingAdapter } from '../browser/ChromeMessagingAdapter'
+import type { ChromeApiLike as ChromeMessagingApiLike } from '../browser/ChromeMessagingAdapter'
 import { createChromeStorageChangeAdapter } from '../browser/ChromeStorageChangeAdapter'
 import { createSonnerNotificationAdapter } from '../browser/SonnerNotificationAdapter'
 import { createChromeCustomProjectRepository } from '../persistence/chrome-storage/ChromeCustomProjectRepository'
@@ -59,6 +63,13 @@ export interface SavedTabsUseCasesDeps {
   readonly browserWindowPort: BrowserWindowPort
   readonly notificationPort: NotificationPort
   readonly storageChangePort: StorageChangePort
+  /**
+   * background 通信 port (issue #531)。
+   * presentation 層 (`ProjectUrlItem` / `SortableUrlItem`) の
+   * 外部ウィンドウ D&D 通知を `chrome.runtime.sendMessage` 直叩きせず
+   * port 経由で行うため、deps 経由で配下に注入する。
+   */
+  readonly messagingPort: MessagingPort
   readonly migrationPort: MigrationPort
   readonly categoriesCommandService: CategoriesCommandService
   readonly customProjectsCommandService: CustomProjectsCommandService
@@ -83,7 +94,7 @@ export interface CreateSavedTabsUseCasesDepsOptions {
   readonly resolveActive?: () => boolean
 }
 
-interface ChromeLike {
+interface ChromeLike extends ChromeApiLikeBase {
   readonly tabs?: {
     readonly create?: (createProperties: {
       readonly active?: boolean
@@ -99,6 +110,13 @@ interface ChromeLike {
           { readonly tabs?: readonly { readonly url?: string }[] } | undefined
         >
       | undefined
+  }
+  readonly runtime?: {
+    readonly sendMessage?: (
+      message: unknown,
+      callback?: (response: unknown) => void,
+    ) => void
+    readonly lastError?: { readonly message?: string } | undefined
   }
   readonly storage?: {
     readonly onChanged?: {
@@ -170,6 +188,17 @@ export const createSavedTabsUseCasesDeps = (
     domainCategorySettingsRepository:
       createChromeDomainCategorySettingsRepository(port),
     migrationPort: createChromeMigrationAdapter(),
+    messagingPort: createChromeMessagingAdapter({
+      // `ChromeLike` は `BrowserTabPort` 由来の `ChromeApiLike` に対し
+      // `runtime` / `storage` を追加で持つ拡張型。
+      // `createChromeMessagingAdapter` は `runtime` を持つ別系統の
+      // `ChromeApiLike` を要求するため、構造的部分型の境界を
+      // unsafe cast で超える。
+      getApi: () => {
+        // eslint-disable-next-line typescript/no-unsafe-type-assertion
+        return getChromeApi() as unknown as ChromeMessagingApiLike | undefined
+      },
+    }),
     notificationPort: createSonnerNotificationAdapter(),
     parentCategoryRepository: createChromeParentCategoryRepository(port),
     removeSubCategoryFromTabGroupPort:

--- a/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
@@ -164,6 +164,9 @@ const createBundle = (initial: StorageState = {}): Bundle => {
     storageChangePort: {
       subscribe: () => () => {},
     },
+    messagingPort: {
+      send: vi.fn().mockResolvedValue(undefined),
+    },
     tabGroupRepository: createChromeTabGroupRepository(port),
     urlRecordRepository: createChromeUrlRecordRepository(port),
     userSettingsRepository: createChromeUserSettingsRepository(port),
@@ -424,6 +427,9 @@ describe('savedTabs DDD 移行 後 回帰テスト', () => {
         setCategoryKeywordsPort: createLibSetCategoryKeywordsAdapter(),
         storageChangePort: {
           subscribe: () => () => {},
+        },
+        messagingPort: {
+          send: vi.fn().mockResolvedValue(undefined),
         },
         tabGroupRepository: createChromeTabGroupRepository(port),
         urlRecordRepository: createChromeUrlRecordRepository(port),

--- a/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.additional.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.additional.test.tsx
@@ -2,6 +2,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
+import type { MessagingPort } from '@/contexts/saved-tabs/application/ports/MessagingPort'
 import type { UserSettingsDto as UserSettings } from '@/contexts/saved-tabs/domain/dto/UserSettingsDto'
 
 import type { ProjectUrlItemProps } from './ProjectUrlItem'
@@ -51,6 +52,7 @@ vi.mock('@/features/i18n/context/I18nProvider', async () => {
   }
 })
 
+import { SavedTabsUseCasesProvider } from '../controllers/SavedTabsUseCasesContext'
 import { ProjectUrlItem } from './ProjectUrlItem'
 
 const defaultSettings: UserSettings = {
@@ -80,21 +82,64 @@ const createProps = (): ProjectUrlItemProps => ({
   settings: defaultSettings,
 })
 
+const renderWithMessagingPort = (
+  ui: React.ReactElement,
+  messagingPort?: MessagingPort,
+) => {
+  if (!messagingPort) {
+    return render(ui)
+  }
+  const deps = {
+    browserTabPort: { open: vi.fn() },
+    browserWindowPort: { openWithUrls: vi.fn() },
+    categoryAssignmentPort: {
+      saveParentCategories: vi.fn(),
+      saveTabGroups: vi.fn(),
+    },
+    categoriesCommandService: { updateDomainCategorySettings: vi.fn() },
+    customProjectsCommandService: {
+      addCategoryToProject: vi.fn(),
+      addUrlToCustomProject: vi.fn(),
+      moveUrlBetweenCustomProjects: vi.fn(),
+      removeCategoryFromProject: vi.fn(),
+      removeUrlFromCustomProject: vi.fn(),
+      removeUrlIdsFromAllCustomProjects: vi.fn(),
+      removeUrlsFromAllCustomProjects: vi.fn(),
+      removeUrlsFromCustomProject: vi.fn(),
+      renameCategoryInProject: vi.fn(),
+      reorderProjectUrls: vi.fn(),
+      setUrlCategory: vi.fn(),
+      updateCategoryOrder: vi.fn(),
+      updateProjectKeywords: vi.fn(),
+    },
+    customProjectRepository: {} as never,
+    domainCategoryMappingRepository: {} as never,
+    domainCategorySettingsRepository: {} as never,
+    migrationPort: {} as never,
+    messagingPort,
+    notificationPort: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+    parentCategoryRepository: {} as never,
+    removeSubCategoryFromTabGroupPort: {
+      removeSubCategoryFromTabGroup: vi.fn(),
+    },
+    setCategoryKeywordsPort: { setCategoryKeywords: vi.fn() },
+    storageChangePort: { subscribe: () => () => {} },
+    tabGroupRepository: {} as never,
+    urlRecordRepository: {} as never,
+    userSettingsRepository: {} as never,
+  } as never
+  return render(
+    <SavedTabsUseCasesProvider value={{ deps, useCases: {} as never }}>
+      {ui}
+    </SavedTabsUseCasesProvider>,
+  )
+}
+
 describe('ProjectUrlItem additional', () => {
   const sendMessageMock = vi.fn()
 
   beforeEach(() => {
-    sendMessageMock.mockImplementation(
-      (_message: unknown, callback?: (response: { ok: boolean }) => void) => {
-        callback?.({ ok: true })
-      },
-    )
-    const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
-    chromeGlobal.chrome = {
-      runtime: {
-        sendMessage: sendMessageMock,
-      },
-    } as unknown as typeof chrome
+    sendMessageMock.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -102,8 +147,10 @@ describe('ProjectUrlItem additional', () => {
     vi.clearAllMocks()
   })
 
-  it('window 内 drop 済みなら urlDropped を送らない', () => {
-    render(<ProjectUrlItem {...createProps()} />)
+  it('window 内 drop 済みなら MessagingPort.send を urlDropped で呼ばない', () => {
+    renderWithMessagingPort(<ProjectUrlItem {...createProps()} />, {
+      send: sendMessageMock,
+    })
 
     const link = screen.getByRole('button', { name: 'Doc' })
     const dataTransfer = {
@@ -119,7 +166,6 @@ describe('ProjectUrlItem additional', () => {
       expect.objectContaining({
         action: 'urlDropped',
       }),
-      expect.any(Function),
     )
   })
 })

--- a/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.test.tsx
@@ -2,6 +2,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
+import type { MessagingPort } from '@/contexts/saved-tabs/application/ports/MessagingPort'
 import type { UserSettingsDto as UserSettings } from '@/contexts/saved-tabs/domain/dto/UserSettingsDto'
 
 import type { ProjectUrlItemProps } from './ProjectUrlItem'
@@ -48,6 +49,7 @@ vi.mock('@/features/i18n/context/I18nProvider', async () => {
   }
 })
 
+import { SavedTabsUseCasesProvider } from '../controllers/SavedTabsUseCasesContext'
 import { ProjectUrlItem } from './ProjectUrlItem'
 import { getCategoryDisplayName } from './projectUrlItemHelpers'
 
@@ -88,21 +90,69 @@ const createProps = (
   ...overrides,
 })
 
+/**
+ * `ProjectUrlItem` は `useSavedTabsUseCases()` 経由で `messagingPort` を
+ * 取り出す (issue #531)。テストではモック port を context 経由で注入する。
+ * 渡さない (provider なし) のときは messagingPort が undefined になり、
+ * 内部で `void port.send(...)` を呼ぶ経路が no-op になる。
+ */
+const renderWithMessagingPort = (
+  ui: React.ReactElement,
+  messagingPort?: MessagingPort,
+) => {
+  if (!messagingPort) {
+    return render(ui)
+  }
+  const deps = {
+    browserTabPort: { open: vi.fn() },
+    browserWindowPort: { openWithUrls: vi.fn() },
+    categoryAssignmentPort: {
+      saveParentCategories: vi.fn(),
+      saveTabGroups: vi.fn(),
+    },
+    categoriesCommandService: { updateDomainCategorySettings: vi.fn() },
+    customProjectsCommandService: {
+      addCategoryToProject: vi.fn(),
+      addUrlToCustomProject: vi.fn(),
+      moveUrlBetweenCustomProjects: vi.fn(),
+      removeCategoryFromProject: vi.fn(),
+      removeUrlFromCustomProject: vi.fn(),
+      removeUrlIdsFromAllCustomProjects: vi.fn(),
+      removeUrlsFromAllCustomProjects: vi.fn(),
+      removeUrlsFromCustomProject: vi.fn(),
+      renameCategoryInProject: vi.fn(),
+      reorderProjectUrls: vi.fn(),
+      setUrlCategory: vi.fn(),
+      updateCategoryOrder: vi.fn(),
+      updateProjectKeywords: vi.fn(),
+    },
+    customProjectRepository: {} as never,
+    domainCategoryMappingRepository: {} as never,
+    domainCategorySettingsRepository: {} as never,
+    migrationPort: {} as never,
+    messagingPort,
+    notificationPort: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+    parentCategoryRepository: {} as never,
+    removeSubCategoryFromTabGroupPort: {
+      removeSubCategoryFromTabGroup: vi.fn(),
+    },
+    setCategoryKeywordsPort: { setCategoryKeywords: vi.fn() },
+    storageChangePort: { subscribe: () => () => {} },
+    tabGroupRepository: {} as never,
+    urlRecordRepository: {} as never,
+    userSettingsRepository: {} as never,
+  } as never
+  return render(
+    <SavedTabsUseCasesProvider value={{ deps, useCases: {} as never }}>
+      {ui}
+    </SavedTabsUseCasesProvider>,
+  )
+}
+
 describe('ProjectUrlItem', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    sendMessageMock.mockImplementation(
-      (_message: unknown, callback?: (response: { ok: boolean }) => void) => {
-        callback?.({ ok: true })
-      },
-    )
-    const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
-    chromeGlobal.chrome = {
-      runtime: {
-        sendMessage: sendMessageMock,
-      },
-    } as unknown as typeof chrome
-
+    sendMessageMock.mockResolvedValue(undefined)
     useSortableMock.mockReturnValue({
       attributes: {},
       listeners: {},
@@ -127,7 +177,7 @@ describe('ProjectUrlItem', () => {
       notes: 'memo',
     }
 
-    render(
+    renderWithMessagingPort(
       <ProjectUrlItem
         {...createProps({
           item,
@@ -206,7 +256,7 @@ describe('ProjectUrlItem', () => {
       category: 'Parent/Child',
     }
 
-    render(
+    renderWithMessagingPort(
       <ProjectUrlItem
         {...createProps({
           item,
@@ -256,7 +306,7 @@ describe('ProjectUrlItem', () => {
     expect(getCategoryDisplayName()).toBe('')
   })
 
-  it('外部D&D成立時にurlDroppedメッセージを送る', () => {
+  it('外部D&D成立時に MessagingPort.send を urlDropped メッセージで呼ぶ', () => {
     using addEventListenerSpy = vi.spyOn(window, 'addEventListener')
     const item = {
       url: 'https://example.com/doc',
@@ -264,7 +314,9 @@ describe('ProjectUrlItem', () => {
       category: undefined,
     }
 
-    render(<ProjectUrlItem {...createProps({ item })} />)
+    renderWithMessagingPort(<ProjectUrlItem {...createProps({ item })} />, {
+      send: sendMessageMock,
+    })
 
     const link = screen.getByRole('button', { name: 'Doc' })
     const dataTransfer = {
@@ -289,11 +341,10 @@ describe('ProjectUrlItem', () => {
         groupId: 'project-1',
         fromExternal: true,
       }),
-      expect.any(Function),
     )
   })
 
-  it('dropEffectがlink以外ならurlDroppedメッセージを送らない', () => {
+  it('dropEffectがlink以外なら MessagingPort.send を urlDropped で呼ばない', () => {
     using addEventListenerSpy = vi.spyOn(window, 'addEventListener')
     const item = {
       url: 'https://example.com/doc',
@@ -301,7 +352,9 @@ describe('ProjectUrlItem', () => {
       category: undefined,
     }
 
-    render(<ProjectUrlItem {...createProps({ item })} />)
+    renderWithMessagingPort(<ProjectUrlItem {...createProps({ item })} />, {
+      send: sendMessageMock,
+    })
 
     const link = screen.getByRole('button', { name: 'Doc' })
     const dataTransfer = {
@@ -321,11 +374,10 @@ describe('ProjectUrlItem', () => {
 
     expect(sendMessageMock).not.toHaveBeenCalledWith(
       expect.objectContaining({ action: 'urlDropped' }),
-      expect.any(Function),
     )
   })
 
-  it('ドラッグ終了後にblurが発生してもurlDroppedメッセージを送らない', () => {
+  it('ドラッグ終了後にblurが発生しても MessagingPort.send を urlDropped で呼ばない', () => {
     using addEventListenerSpy = vi.spyOn(window, 'addEventListener')
     const item = {
       url: 'https://example.com/doc',
@@ -333,7 +385,9 @@ describe('ProjectUrlItem', () => {
       category: undefined,
     }
 
-    render(<ProjectUrlItem {...createProps({ item })} />)
+    renderWithMessagingPort(<ProjectUrlItem {...createProps({ item })} />, {
+      send: sendMessageMock,
+    })
 
     const link = screen.getByRole('button', { name: 'Doc' })
     const dataTransfer = {
@@ -353,18 +407,19 @@ describe('ProjectUrlItem', () => {
 
     expect(sendMessageMock).not.toHaveBeenCalledWith(
       expect.objectContaining({ action: 'urlDropped' }),
-      expect.any(Function),
     )
   })
 
-  it('dropEffectがcopyならblurなしでもurlDroppedメッセージを送る', () => {
+  it('dropEffectがcopyならblurなしでも MessagingPort.send を urlDropped で呼ぶ', () => {
     const item = {
       url: 'https://example.com/doc',
       title: 'Doc',
       category: undefined,
     }
 
-    render(<ProjectUrlItem {...createProps({ item })} />)
+    renderWithMessagingPort(<ProjectUrlItem {...createProps({ item })} />, {
+      send: sendMessageMock,
+    })
 
     const link = screen.getByRole('button', { name: 'Doc' })
     const dataTransfer = {
@@ -382,7 +437,34 @@ describe('ProjectUrlItem', () => {
         groupId: 'project-1',
         fromExternal: true,
       }),
-      expect.any(Function),
+    )
+  })
+
+  it('dragStart で MessagingPort.send を urlDragStarted メッセージで呼ぶ', () => {
+    const item = {
+      url: 'https://example.com/doc',
+      title: 'Doc',
+      category: undefined,
+    }
+
+    renderWithMessagingPort(<ProjectUrlItem {...createProps({ item })} />, {
+      send: sendMessageMock,
+    })
+
+    const link = screen.getByRole('button', { name: 'Doc' })
+    const dataTransfer = {
+      setData: vi.fn(),
+      dropEffect: 'none',
+    }
+
+    fireEvent.dragStart(link, { dataTransfer })
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'urlDragStarted',
+        url: item.url,
+        groupId: 'project-1',
+      }),
     )
   })
 })

--- a/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx
@@ -9,6 +9,7 @@ import type { UserSettingsDto } from '@/contexts/saved-tabs/domain/dto/UserSetti
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import type { CustomProject } from '@/types/storage'
 
+import { useSavedTabsUseCases } from '../controllers/SavedTabsUseCasesContext'
 import {
   getCategoryDisplayName,
   getCategoryLevel,
@@ -60,6 +61,13 @@ const ProjectUrlItemComponent = ({
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
   const isDraggingRef = useRef(false)
   const windowBlurredDuringDragRef = useRef(false)
+  // 外部ウィンドウへの D&D 通知に使う `MessagingPort` (issue #531)。
+  // `SavedTabsPage` 配下では `SavedTabsUseCasesProvider` が
+  // `useCases.deps.messagingPort` を提供するため、`useSavedTabsUseCases()`
+  // から取り出してそのまま使う。Provider 外 (Storybook / 一部テスト) では
+  // `null` になるので、その場合は通知を no-op とする。
+  const savedTabsUseCases = useSavedTabsUseCases()
+  const messagingPort = savedTabsUseCases?.deps.messagingPort
 
   // ドラッグアンドドロップの設定を強化
   const {
@@ -99,18 +107,16 @@ const ProjectUrlItemComponent = ({
   }
 
   const handleExternalDrop = useCallback(() => {
-    chrome.runtime.sendMessage(
-      {
-        action: 'urlDropped',
-        fromExternal: true,
-        groupId: projectId,
-        url: originalUrl,
-      },
-      (response) => {
-        console.log('外部ドロップ後の応答:', response)
-      },
-    )
-  }, [originalUrl, projectId])
+    if (!messagingPort) {
+      return
+    }
+    void messagingPort.send({
+      action: 'urlDropped',
+      fromExternal: true,
+      groupId: projectId,
+      url: originalUrl,
+    })
+  }, [messagingPort, originalUrl, projectId])
 
   const handleWindowBlur = useCallback(() => {
     if (isDraggingRef.current) {
@@ -128,16 +134,13 @@ const ProjectUrlItemComponent = ({
     e.dataTransfer.setData('text/uri-list', originalUrl)
     window.addEventListener('blur', handleWindowBlur)
 
-    chrome.runtime.sendMessage(
-      {
+    if (messagingPort) {
+      void messagingPort.send({
         action: 'urlDragStarted',
         groupId: projectId,
         url: originalUrl,
-      },
-      (response) => {
-        console.log('ドラッグ開始通知の応答:', response)
-      },
-    )
+      })
+    }
   }
 
   const handleDragEnd = useCallback(

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
@@ -104,6 +104,9 @@ const buildLayoutComposition = () => {
     storageChangePort: {
       subscribe: () => () => {},
     },
+    messagingPort: {
+      send: vi.fn().mockResolvedValue(undefined),
+    },
     customProjectRepository: {
       // eslint-disable-next-line typescript/require-await
       findAll: async () => [],

--- a/src/contexts/saved-tabs/presentation/components/SortableUrlItem.additional.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableUrlItem.additional.test.tsx
@@ -2,6 +2,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
+import type { MessagingPort } from '@/contexts/saved-tabs/application/ports/MessagingPort'
 import type { UserSettingsDto as UserSettings } from '@/contexts/saved-tabs/domain/dto/UserSettingsDto'
 import type { SortableUrlItemProps } from '@/types/saved-tabs'
 
@@ -59,6 +60,7 @@ vi.mock('@/features/i18n/context/I18nProvider', async () => {
   }
 })
 
+import { SavedTabsUseCasesProvider } from '../controllers/SavedTabsUseCasesContext'
 import { SortableUrlItem } from './SortableUrlItem'
 
 const defaultSettings: UserSettings = {
@@ -88,21 +90,64 @@ const createProps = (): SortableUrlItemProps => ({
   settings: defaultSettings,
 })
 
+const renderWithMessagingPort = (
+  ui: React.ReactElement,
+  messagingPort?: MessagingPort,
+) => {
+  if (!messagingPort) {
+    return render(ui)
+  }
+  const deps = {
+    browserTabPort: { open: vi.fn() },
+    browserWindowPort: { openWithUrls: vi.fn() },
+    categoryAssignmentPort: {
+      saveParentCategories: vi.fn(),
+      saveTabGroups: vi.fn(),
+    },
+    categoriesCommandService: { updateDomainCategorySettings: vi.fn() },
+    customProjectsCommandService: {
+      addCategoryToProject: vi.fn(),
+      addUrlToCustomProject: vi.fn(),
+      moveUrlBetweenCustomProjects: vi.fn(),
+      removeCategoryFromProject: vi.fn(),
+      removeUrlFromCustomProject: vi.fn(),
+      removeUrlIdsFromAllCustomProjects: vi.fn(),
+      removeUrlsFromAllCustomProjects: vi.fn(),
+      removeUrlsFromCustomProject: vi.fn(),
+      renameCategoryInProject: vi.fn(),
+      reorderProjectUrls: vi.fn(),
+      setUrlCategory: vi.fn(),
+      updateCategoryOrder: vi.fn(),
+      updateProjectKeywords: vi.fn(),
+    },
+    customProjectRepository: {} as never,
+    domainCategoryMappingRepository: {} as never,
+    domainCategorySettingsRepository: {} as never,
+    migrationPort: {} as never,
+    messagingPort,
+    notificationPort: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+    parentCategoryRepository: {} as never,
+    removeSubCategoryFromTabGroupPort: {
+      removeSubCategoryFromTabGroup: vi.fn(),
+    },
+    setCategoryKeywordsPort: { setCategoryKeywords: vi.fn() },
+    storageChangePort: { subscribe: () => () => {} },
+    tabGroupRepository: {} as never,
+    urlRecordRepository: {} as never,
+    userSettingsRepository: {} as never,
+  } as never
+  return render(
+    <SavedTabsUseCasesProvider value={{ deps, useCases: {} as never }}>
+      {ui}
+    </SavedTabsUseCasesProvider>,
+  )
+}
+
 describe('SortableUrlItem additional', () => {
   const sendMessageMock = vi.fn()
 
   beforeEach(() => {
-    sendMessageMock.mockImplementation(
-      (_message: unknown, callback?: (response: { ok: boolean }) => void) => {
-        callback?.({ ok: true })
-      },
-    )
-    const chromeGlobal = globalThis as unknown as { chrome: typeof chrome }
-    chromeGlobal.chrome = {
-      runtime: {
-        sendMessage: sendMessageMock,
-      },
-    } as unknown as typeof chrome
+    sendMessageMock.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -112,7 +157,9 @@ describe('SortableUrlItem additional', () => {
   })
 
   it('window 内 drop 済みなら外部ドロップ扱いしない', () => {
-    render(<SortableUrlItem {...createProps()} />)
+    renderWithMessagingPort(<SortableUrlItem {...createProps()} />, {
+      send: sendMessageMock,
+    })
 
     const link = screen.getByRole('button', { name: 'Example Tab' })
     const dataTransfer = {
@@ -128,7 +175,6 @@ describe('SortableUrlItem additional', () => {
       expect.objectContaining({
         action: 'urlDropped',
       }),
-      expect.any(Function),
     )
   })
 })

--- a/src/contexts/saved-tabs/presentation/components/SortableUrlItem.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableUrlItem.tsx
@@ -9,6 +9,7 @@ import type { SortableUrlItemProps } from '@/types/saved-tabs'
 import { TimeRemaining } from '@/utils/datetime'
 import { formatFixedDatetime as formatDatetime } from '@/utils/localDateTime'
 
+import { useSavedTabsUseCases } from '../controllers/SavedTabsUseCasesContext'
 import { DeleteUrlConfirmDialog } from './shared/DeleteUrlConfirmDialog'
 
 // グローバルのドロップ状態を追跡（ウィンドウ内でのドロップか外部へのドロップかを判定するため）
@@ -44,6 +45,13 @@ export const SortableUrlItem = ({
   const isDraggingRef = useRef(false)
   const windowBlurredDuringDragRef = useRef(false)
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false)
+  // 外部ウィンドウへの D&D 通知に使う `MessagingPort` (issue #531)。
+  // `SavedTabsPage` 配下では `SavedTabsUseCasesProvider` が
+  // `useCases.deps.messagingPort` を提供するため、`useSavedTabsUseCases()`
+  // から取り出してそのまま使う。Provider 外 (Storybook / 一部テスト) では
+  // `null` になるので、その場合は通知を no-op とする。
+  const savedTabsUseCases = useSavedTabsUseCases()
+  const messagingPort = savedTabsUseCases?.deps.messagingPort
 
   const handleWindowBlur = useCallback(() => {
     if (isDraggingRef.current) {
@@ -61,39 +69,32 @@ export const SortableUrlItem = ({
     // URI-listとしても設定（多くのブラウザやアプリがこのフォーマットを認識）
     e.dataTransfer.setData('text/uri-list', url)
 
-    console.log('ドラッグ開始:', url)
-
     // 外部ブラウザへのドラッグ判定のため、ウィンドウのblurを監視
     window.addEventListener('blur', handleWindowBlur)
 
     // ドラッグ開始をバックグラウンドに通知
-    chrome.runtime.sendMessage(
-      {
+    if (messagingPort) {
+      void messagingPort.send({
         action: 'urlDragStarted',
         groupId,
         url,
-      },
-      (response) => {
-        console.log('ドラッグ開始通知の応答:', response)
-      },
-    )
+      })
+    }
   }
 
   // 外部ウィンドウへのドロップ処理
   const handleExternalDrop = useCallback(() => {
+    if (!messagingPort) {
+      return
+    }
     // 外部へのドロップ時にタブを削除するよう通知
-    chrome.runtime.sendMessage(
-      {
-        action: 'urlDropped',
-        fromExternal: true,
-        groupId,
-        url,
-      },
-      (response) => {
-        console.log('外部ドロップ後の応答:', response)
-      },
-    )
-  }, [url, groupId])
+    void messagingPort.send({
+      action: 'urlDropped',
+      fromExternal: true,
+      groupId,
+      url,
+    })
+  }, [messagingPort, url, groupId])
 
   // eslint-disable-next-line react-perf/jsx-no-new-function-as-prop
   const handleDragEnd = (e: React.DragEvent<HTMLElement>) => {
@@ -113,7 +114,6 @@ export const SortableUrlItem = ({
 
     isDraggingRef.current = false
     windowBlurredDuringDragRef.current = false
-    console.log('ドラッグ終了:', e.dataTransfer.dropEffect)
   }
 
   // コンポーネントのアンマウント時にクリーンアップ

--- a/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.test.ts
@@ -192,6 +192,9 @@ const createEmptyDeps = (
       storageChangePort: {
         subscribe: () => () => {},
       },
+      messagingPort: {
+        send: vi.fn().mockResolvedValue(undefined),
+      },
       tabGroupRepository,
       urlRecordRepository,
       userSettingsRepository: {

--- a/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.test.ts
@@ -211,6 +211,9 @@ const createEmptyDeps = (
       storageChangePort: {
         subscribe: () => () => {},
       },
+      messagingPort: {
+        send: vi.fn().mockResolvedValue(undefined),
+      },
       tabGroupRepository: createInMemoryRepositories().tabGroupRepository,
       urlRecordRepository,
       userSettingsRepository: {

--- a/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.test.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.test.ts
@@ -211,6 +211,9 @@ const createEmptyDeps = (
       storageChangePort: {
         subscribe: () => () => {},
       },
+      messagingPort: {
+        send: vi.fn().mockResolvedValue(undefined),
+      },
       tabGroupRepository: createInMemoryRepositories().tabGroupRepository,
       urlRecordRepository,
       userSettingsRepository: {

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.contextProvider.test.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.contextProvider.test.tsx
@@ -144,6 +144,9 @@ const createInMemoryDeps = (): SavedTabsUseCasesDeps => {
     storageChangePort: {
       subscribe: () => () => {},
     },
+    messagingPort: {
+      send: vi.fn().mockResolvedValue(undefined),
+    },
     tabGroupRepository,
     urlRecordRepository,
     userSettingsRepository: {

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.test.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.test.tsx
@@ -188,6 +188,9 @@ const createInMemoryDeps = (input: {
     storageChangePort: {
       subscribe: () => () => {},
     },
+    messagingPort: {
+      send: vi.fn().mockResolvedValue(undefined),
+    },
     tabGroupRepository,
     urlRecordRepository,
     userSettingsRepository: {

--- a/src/types/background.ts
+++ b/src/types/background.ts
@@ -50,10 +50,25 @@ export interface BaseMessage {
 
 /**
  * URLドラッグ開始メッセージ
+ *
+ * 旧 `ProjectUrlItem` / `SortableUrlItem` からは `groupId` (savedTabs の
+ * グループ id) も同時に送られていたが、background handler
+ * (`message-handler.ts` の `handleUrlDragStarted`) は現状 `url` だけを
+ * 利用し、`groupId` は log 用途に留めていた。presentation 層との
+ * typed envelope 整合のため `groupId` も必須フィールドとして公開し、
+ * 既存 background handler はそのまま optional 扱いする方針
+ * (issue #531)。
  */
 export interface UrlDragStartedMessage extends BaseMessage {
   action: 'urlDragStarted'
   url: string
+  /**
+   * ドラッグされた URL が属する savedTabs グループ id。
+   * 旧 presentation 実装 (`ProjectUrlItem` / `SortableUrlItem`) と
+   * 同じ形を維持するため optional とし、background handler 側でも
+   * 未指定でも動作する。
+   */
+  readonly groupId?: string
 }
 
 /**
@@ -63,6 +78,12 @@ export interface UrlDroppedMessage extends BaseMessage {
   action: 'urlDropped'
   url: string
   fromExternal?: boolean
+  /**
+   * ドロップされた URL が属する savedTabs グループ id。
+   * 旧 presentation 実装 (`ProjectUrlItem` / `SortableUrlItem`) と
+   * 同じ形を維持するため optional。
+   */
+  readonly groupId?: string
 }
 
 /**


### PR DESCRIPTION
## 概要

#454 / #526 の saved-tabs DDD 移行の最終確認 (issue #526) で残っていた
`presentation` 層から `chrome.runtime.sendMessage` を直叩きしていた
2 ファイル (`ProjectUrlItem.tsx` / `SortableUrlItem.tsx`) を
`MessagingPort` 経由へ移設する (issue #531)。

## 変更点

- `application/ports/MessagingPort.ts` を新規追加し、
  `chrome.runtime.sendMessage` 相当の background 通信を
  `urlDragStarted` / `urlDropped` typed envelope で抽象化する port を定義。
- `infrastructure/browser/ChromeMessagingAdapter.ts` を新規追加し、
  `chrome.runtime.sendMessage` を `Promise<MessagingPortResponse | undefined>`
  に正規化する adapter を実装。
- `SavedTabsUseCasesDeps` および `SavedTabsPorts` (app/composition) に
  `messagingPort` を追加し、composition 層 (`createSavedTabsUseCasesDeps` /
  `createSavedTabsPorts`) で `ChromeMessagingAdapter` を組み立てる。
- `ProjectUrlItem` / `SortableUrlItem` の `chrome.runtime.sendMessage` を
  `useSavedTabsUseCases()` 経由で取り出した `messagingPort.send(...)` に
  置換。未注入環境 (Storybook / 一部テスト) では no-op として扱う。
- `types/background.ts` の `UrlDragStartedMessage` / `UrlDroppedMessage` に
  旧 presentation 実装と同一の `groupId` optional フィールドを追加し、
  port 境界の typed envelope と presentation 層 D&D 通知を一致させる。
- `.oxlintrc.json` の presentation 層 override に `chrome.runtime` を
  `no-restricted-properties` 対象として追加し、ガードに抜け穴が残らない
  ようにする。
- `dddLayerGuard.test.ts` に presentation 層が
  `chrome.runtime.sendMessage` / `chrome.runtime.*` を直参照しないこと
  を確認するスイート、および `MessagingPort` / `ChromeMessagingAdapter`
  のファイル存在と composition 接続を検証するスイートを追加。
- 関連コンポーネント / page / controller / `SavedTabsUseCasesDeps` 組み立て
  系の test に `messagingPort: { send: vi.fn() }` モックを追加。

## 受け入れ条件

- [x] `src/contexts/saved-tabs/presentation/**` から `chrome.runtime.*` への
  production code 直参照が 0 件になる (`dddLayerGuard.test.ts` で機械的に検証)。
- [x] 外部ウィンドウへの D&D 時の background 通知
  (`urlDragStarted` / `urlDropped`) が以前と同様に動作する
  (`MessagingPort` 注入経路で payload 互換を維持)。
- [x] `.oxlintrc.json` override 6 に `chrome.runtime` が追加され、
  presentation 層ガードで再発を防げる。
- [x] `bun run lint` / `bun run compile` / `bun run test:node` /
  `bun run test:dom` がすべて成功する (2732 / 810 tests passed)。

## 関連

- 親 issue: #454
- 発見契機: #526
- 類似 closed issue (storage 編): #502 / #503
- 後続で `chrome.runtime` 直叩きが残るファイルがあれば同パターンで
  MessagingPort 経由へ移設可能。

## ローカル検証

- `bun run lint` ✅
- `bun run compile` ✅
- `bun run test:node` ✅ (1922 tests passed)
- `bun run test:dom` ✅ (810 tests passed)
- `bun run test` (全テスト) ✅ (2732 tests passed)