### PR TITLE
[DDD] customProjects の rich フィールド保持と DeleteCustomProjectUseCase の urlMetadata 永続化 (issue #535)

### DIFF
--- a/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createCustomProject } from '../../domain/entities/CustomProject'
 import type { CustomProject } from '../../domain/entities/CustomProject'
@@ -37,6 +37,11 @@ const createInMemoryRepository = (
     saveOrder: async () => undefined,
     // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
     findAllRaw: async () => rawStore.map((raw) => ({ ...raw })),
+    // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+    restoreAllRaw: async (raws) => {
+      rawStore.length = 0
+      rawStore.push(...raws.map((raw) => ({ ...raw })))
+    },
   }
 }
 
@@ -127,5 +132,550 @@ describe('createDeleteCustomProjectUseCase', () => {
     await expect(
       useCase({ projectId: createCustomProjectId('missing') }),
     ).rejects.toThrow(SavedTabsDomainError)
+  })
+
+  it('target の urlMetadata / projectKeywords / categoryOrder を uncategorized raw にマージして restoreAllRaw で書き戻す (issue #535 P2)', async () => {
+    // target に rich フィールドを設定し、uncategorized にも一部
+    // urlMetadata を入れておく。削除後、uncategorized 側に
+    // target の rich フィールドが残ることを検証する。
+    const baseTimestamp = 1_700_000_000_000
+    repo = createInMemoryRepository(
+      [
+        createCustomProject({
+          categories: ['research'],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1', 'url-2'],
+        }),
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: ['existing-url'],
+        }),
+      ],
+      [
+        {
+          categories: ['research'],
+          categoryOrder: ['research', 'news'],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          projectKeywords: {
+            domainKeywords: ['example.com'],
+            titleKeywords: ['design'],
+            urlKeywords: ['plan'],
+          },
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1', 'url-2'],
+          urlMetadata: {
+            'url-1': { category: 'research', notes: 'note-1' },
+            'url-2': { category: 'news', notes: 'note-2' },
+          },
+        },
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: ['existing-url'],
+          urlMetadata: {
+            'existing-url': { category: 'archive' },
+          },
+        },
+      ],
+    )
+
+    const useCase = createDeleteCustomProjectUseCase(createDeps(repo))
+    const result = await useCase({
+      projectId: createCustomProjectId('project-1'),
+    })
+
+    // entity 戻り値: target が消え、uncategorized に URL がマージされる
+    expect(result.all.map((p) => p.id)).toStrictEqual(['custom-uncategorized'])
+    const uncategorized = result.all[0]
+    expect(uncategorized?.urlIds).toStrictEqual([
+      'existing-url',
+      'url-1',
+      'url-2',
+    ])
+
+    // raw store 側: uncategorized に target の urlMetadata /
+    // projectKeywords / categoryOrder がマージされている
+    if (!repo.findAllRaw) {
+      throw new Error('findAllRaw is not implemented')
+    }
+    const rawAfter = await repo.findAllRaw()
+    const uncategorizedRaw = rawAfter.find(
+      (raw) => raw.id === 'custom-uncategorized',
+    )
+    expect(uncategorizedRaw).toBeDefined()
+    // urlMetadata は base + target の和集合 (target が後勝ち上書き)
+    expect(uncategorizedRaw?.urlMetadata).toStrictEqual({
+      'existing-url': { category: 'archive' },
+      'url-1': { category: 'research', notes: 'note-1' },
+      'url-2': { category: 'news', notes: 'note-2' },
+    })
+    // projectKeywords / categoryOrder は target 側が引き継がれる
+    expect(uncategorizedRaw?.projectKeywords).toStrictEqual({
+      domainKeywords: ['example.com'],
+      titleKeywords: ['design'],
+      urlKeywords: ['plan'],
+    })
+    expect(uncategorizedRaw?.categoryOrder).toStrictEqual(['research', 'news'])
+    // target は raw 側からも消えている
+    expect(rawAfter.find((raw) => raw.id === 'project-1')).toBeUndefined()
+  })
+
+  it('target の urlIds が空のときは uncategorized をそのまま返す (entity 経路の空マージパス)', async () => {
+    // raw 経路を通してもよいが、entity 経路 (`saveAll`) でマージロジックの
+    // 早期 return 分岐 (target urlIds 空) を踏むケースを別途検証する。
+    // ここでは `restoreAllRaw` を実装しない repository を使い、entity 経路に
+    // 強制的に落とす。
+    const baseTimestamp = 1_700_000_000_000
+    const noRestoreRepo: CustomProjectRepository = {
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findAll: async () => [
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-empty',
+          name: 'Empty',
+          updatedAt: baseTimestamp,
+          urlIds: [],
+        }),
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: ['existing-url'],
+        }),
+      ],
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findById: async () => null,
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      saveAll: async () => undefined,
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      removeByIds: async () => undefined,
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findOrder: async () => [],
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      saveOrder: async () => undefined,
+    }
+
+    const useCase = createDeleteCustomProjectUseCase(createDeps(noRestoreRepo))
+    const result = await useCase({
+      projectId: createCustomProjectId('project-empty'),
+    })
+    expect(result.all.map((p) => p.id)).toStrictEqual(['custom-uncategorized'])
+    // urlIds が空のため uncategorized の中身は変わらない
+    expect(result.all[0]?.urlIds).toStrictEqual(['existing-url'])
+  })
+
+  it('findAllRaw が未実装の repository では entity 経路 (saveAll) にフォールバックする (issue #535 P1)', async () => {
+    // `findAllRaw` / `restoreAllRaw` がない旧 repository で、P1 で導入した
+    // raw 経路が `findAll` (entity) にフォールバックすることを検証する。
+    const baseTimestamp = 1_700_000_000_000
+    const noRawRepo: CustomProjectRepository = {
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findAll: async () => [
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1', 'url-2'],
+        }),
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: ['existing-url'],
+        }),
+      ],
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findById: async () => null,
+      saveAll: vi.fn().mockResolvedValue(undefined),
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      removeByIds: async () => undefined,
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findOrder: async () => [],
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      saveOrder: async () => undefined,
+    }
+
+    const useCase = createDeleteCustomProjectUseCase(createDeps(noRawRepo))
+    const result = await useCase({
+      projectId: createCustomProjectId('project-1'),
+    })
+    // entity 経路 (saveAll) で書き戻される
+    expect(noRawRepo.saveAll).toHaveBeenCalled()
+    expect(result.all.map((p) => p.id)).toStrictEqual(['custom-uncategorized'])
+    expect(result.all[0]?.urlIds).toStrictEqual([
+      'existing-url',
+      'url-1',
+      'url-2',
+    ])
+  })
+
+  it('findAllRaw のみあり restoreAllRaw がない repository では saveAll フォールバック + removedSnapshot 構築パスを通る', async () => {
+    // `findAllRaw` は実装されているが `restoreAllRaw` が省略された
+    // レガシー repository 互換。raw 経路を使えないので entity 経路
+    // (saveAll) にフォールバックし、removedSnapshot 構築ブロック
+    // (Line 162-170) を踏む。
+    const baseTimestamp = 1_700_000_000_000
+    const repoNoRestore: CustomProjectRepository = {
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findAll: async () => [
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1'],
+        }),
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: ['existing-url'],
+        }),
+      ],
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findById: async () => null,
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      saveAll: vi.fn().mockResolvedValue(undefined),
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      removeByIds: async () => undefined,
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findOrder: async () => [],
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      saveOrder: async () => undefined,
+      // findAllRaw は実装するが restoreAllRaw は省略
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findAllRaw: async () => [
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1'],
+        },
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: ['existing-url'],
+        },
+      ],
+    }
+
+    const useCase = createDeleteCustomProjectUseCase(createDeps(repoNoRestore))
+    const result = await useCase({
+      projectId: createCustomProjectId('project-1'),
+    })
+    // restoreAllRaw 未実装 → saveAll 経路にフォールバック
+    expect(repoNoRestore.saveAll).toHaveBeenCalled()
+    expect(result.all.map((p) => p.id)).toStrictEqual(['custom-uncategorized'])
+    expect(result.all[0]?.urlIds).toStrictEqual(['existing-url', 'url-1'])
+  })
+
+  it('base.urls のみある場合は base.urls を引き継ぐ (mergeRawSnapshots のフォールバック)', async () => {
+    // issue #535 P2: target に urls が無く、base (uncategorized) に
+    // urls がある場合は base.urls を mergedRaw に引き継ぐ。
+    const baseTimestamp = 1_700_000_000_000
+    repo = createInMemoryRepository(
+      [
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1'],
+        }),
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: [],
+        }),
+      ],
+      [
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1'],
+        },
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: [],
+          urls: [
+            {
+              savedAt: baseTimestamp,
+              title: 'Pre-existing',
+              url: 'https://existing.example.com',
+            },
+          ],
+        },
+      ],
+    )
+
+    const useCase = createDeleteCustomProjectUseCase(createDeps(repo))
+    await useCase({ projectId: createCustomProjectId('project-1') })
+
+    if (!repo.findAllRaw) {
+      throw new Error('findAllRaw is not implemented')
+    }
+    const rawAfter = await repo.findAllRaw()
+    const uncategorizedRaw = rawAfter.find(
+      (raw) => raw.id === 'custom-uncategorized',
+    )
+    // base (uncategorized) 側の urls が mergedRaw に引き継がれる
+    expect(uncategorizedRaw?.urls).toStrictEqual([
+      {
+        savedAt: baseTimestamp,
+        title: 'Pre-existing',
+        url: 'https://existing.example.com',
+      },
+    ])
+  })
+
+  it('findAllRaw に uncategorized が無い場合、entityToRawSnapshot で mergedRawBase を widen する (Line 109 経路)', async () => {
+    // uncategorized の raw が findAllRaw() の結果に含まれない場合、
+    // `mergedRawBase = uncategorizedRaw ?? entityToRawSnapshot(merged)`
+    // の `??` 右辺 (entity → raw widen) を踏む。
+    // 同時に、`nextAll = all.map(...)` callback の default return (Line 109)
+    // を踏むため、target / uncategorized 以外の project (project-3) を
+    // `all` に含める。
+    const baseTimestamp = 1_700_000_000_000
+    const repo: CustomProjectRepository = {
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findAll: async () => [
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1'],
+        }),
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: ['existing-url'],
+        }),
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-3',
+          name: 'Project 3',
+          updatedAt: baseTimestamp,
+          urlIds: [],
+        }),
+      ],
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findById: async () => null,
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      saveAll: async () => undefined,
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      removeByIds: async () => undefined,
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findOrder: async () => [],
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      saveOrder: async () => undefined,
+      // findAllRaw に uncategorized を含めない (Line 109 ?? の右辺を踏ませる)
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      findAllRaw: async () => [
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1'],
+        },
+      ],
+      // eslint-disable-next-line @typescript-eslint/require-await, typescript/require-await -- Promise contract は CustomProjectRepository 側で必須
+      restoreAllRaw: vi.fn().mockResolvedValue(undefined),
+    }
+
+    const useCase = createDeleteCustomProjectUseCase(createDeps(repo))
+    const result = await useCase({
+      projectId: createCustomProjectId('project-1'),
+    })
+    // restoreAllRaw が呼ばれる
+    expect(repo.restoreAllRaw).toHaveBeenCalled()
+    // mergedRaw には uncategorized が新規作成され、url-1 がマージされる。
+    // project-3 はそのまま残る。
+    expect(result.all.map((p) => p.id)).toStrictEqual([
+      'custom-uncategorized',
+      'project-3',
+    ])
+    expect(result.all[0]?.urlIds).toStrictEqual(['existing-url', 'url-1'])
+  })
+
+  it('target に urls がある場合は target.urls を mergedRaw に採用する (mergeRawSnapshots の target.urls 分岐)', async () => {
+    // target.urls あり + base.urls あり → `if (target.urls)` 分岐で
+    // target.urls 側が mergedRaw に採用される。
+    const baseTimestamp = 1_700_000_000_000
+    repo = createInMemoryRepository(
+      [
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1'],
+        }),
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: [],
+        }),
+      ],
+      [
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1'],
+          urls: [
+            {
+              savedAt: baseTimestamp,
+              title: 'Target',
+              url: 'https://target.example.com',
+            },
+          ],
+        },
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: [],
+          urls: [
+            {
+              savedAt: baseTimestamp,
+              title: 'Base',
+              url: 'https://base.example.com',
+            },
+          ],
+        },
+      ],
+    )
+
+    const useCase = createDeleteCustomProjectUseCase(createDeps(repo))
+    await useCase({ projectId: createCustomProjectId('project-1') })
+
+    if (!repo.findAllRaw) {
+      throw new Error('findAllRaw is not implemented')
+    }
+    const rawAfter = await repo.findAllRaw()
+    const uncategorizedRaw = rawAfter.find(
+      (raw) => raw.id === 'custom-uncategorized',
+    )
+    // target.urls 側が mergedRaw に採用される
+    expect(uncategorizedRaw?.urls).toStrictEqual([
+      {
+        savedAt: baseTimestamp,
+        title: 'Target',
+        url: 'https://target.example.com',
+      },
+    ])
+  })
+
+  it('target と base のどちらにも urls が無い場合は urls キーを省く (mergeRawSnapshots の urls 省略)', async () => {
+    // mergeRawSnapshots 内の `urlsField` が `target.urls` / `base.urls` の
+    // どちらでも代入されないケース。mergedRaw には `urls` プロパティが
+    // 付かない (Line 261 の urls 省略分岐)。
+    const baseTimestamp = 1_700_000_000_000
+    repo = createInMemoryRepository(
+      [
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1'],
+        }),
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: [],
+        }),
+      ],
+      [
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1'],
+        },
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: [],
+        },
+      ],
+    )
+
+    const useCase = createDeleteCustomProjectUseCase(createDeps(repo))
+    await useCase({ projectId: createCustomProjectId('project-1') })
+
+    if (!repo.findAllRaw) {
+      throw new Error('findAllRaw is not implemented')
+    }
+    const rawAfter = await repo.findAllRaw()
+    const uncategorizedRaw = rawAfter.find(
+      (raw) => raw.id === 'custom-uncategorized',
+    )
+    // urls キー自体は省略される
+    expect(uncategorizedRaw).toBeDefined()
+    expect(uncategorizedRaw).not.toHaveProperty('urls')
   })
 })

--- a/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.test.ts
@@ -232,6 +232,77 @@ describe('createDeleteCustomProjectUseCase', () => {
     expect(rawAfter.find((raw) => raw.id === 'project-1')).toBeUndefined()
   })
 
+  it('urlId が両方のプロジェクトに既に存在する場合、base の urlMetadata を保持する (issue #535 P2 review)', async () => {
+    // issue #535 P2 Codex review: 旧実装は `{ ...baseUrlMetadata,
+    // ...targetUrlMetadata }` で衝突時も target の metadata を上書き
+    // していた。`addedUrlIds` のみ target metadata を反映するように
+    // 修正し、移動しなかった urlId では uncategorized 側の
+    // notes / category を保持する。
+    const baseTimestamp = 1_700_000_000_000
+    repo = createInMemoryRepository(
+      [
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['shared-url', 'new-url'],
+        }),
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: ['shared-url'],
+        }),
+      ],
+      [
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['shared-url', 'new-url'],
+          urlMetadata: {
+            'new-url': { category: 'project-cat', notes: 'project-note' },
+            'shared-url': { category: 'project-cat', notes: 'project-note' },
+          },
+        },
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: ['shared-url'],
+          urlMetadata: {
+            'shared-url': { category: 'uncat-cat', notes: 'uncat-note' },
+          },
+        },
+      ],
+    )
+
+    const useCase = createDeleteCustomProjectUseCase(createDeps(repo))
+    await useCase({ projectId: createCustomProjectId('project-1') })
+
+    if (!repo.findAllRaw) {
+      throw new Error('findAllRaw is not implemented')
+    }
+    const rawAfter = await repo.findAllRaw()
+    const uncategorizedRaw = rawAfter.find(
+      (raw) => raw.id === 'custom-uncategorized',
+    )
+    // shared-url は base (uncategorized) の metadata を保持
+    // new-url は target の metadata が新規追加される
+    expect(uncategorizedRaw?.urlMetadata).toStrictEqual({
+      'new-url': { category: 'project-cat', notes: 'project-note' },
+      'shared-url': { category: 'uncat-cat', notes: 'uncat-note' },
+    })
+  })
+
   it('target の urlIds が空のときは uncategorized をそのまま返す (entity 経路の空マージパス)', async () => {
     // raw 経路を通してもよいが、entity 経路 (`saveAll`) でマージロジックの
     // 早期 return 分岐 (target urlIds 空) を踏むケースを別途検証する。
@@ -543,9 +614,12 @@ describe('createDeleteCustomProjectUseCase', () => {
     expect(result.all[0]?.urlIds).toStrictEqual(['existing-url', 'url-1'])
   })
 
-  it('target に urls がある場合は target.urls を mergedRaw に採用する (mergeRawSnapshots の target.urls 分岐)', async () => {
-    // target.urls あり + base.urls あり → `if (target.urls)` 分岐で
-    // target.urls 側が mergedRaw に採用される。
+  it('target.urls と base.urls を union でマージし、url 文字列で dedupe する (issue #535 P2 review)', async () => {
+    // issue #535 P2 Codex review: 旧実装は `if (target.urls)` 分岐で
+    // target.urls を mergedRaw にそのまま採用しており、base.urls を
+    // 完全に捨てていた。両者を union でマージし、url 文字列で dedupe
+    // する (base 側が collision で勝つ)。URL 文字列が異なるエントリは
+    // すべて mergedRaw に残る。
     const baseTimestamp = 1_700_000_000_000
     repo = createInMemoryRepository(
       [
@@ -610,12 +684,94 @@ describe('createDeleteCustomProjectUseCase', () => {
     const uncategorizedRaw = rawAfter.find(
       (raw) => raw.id === 'custom-uncategorized',
     )
-    // target.urls 側が mergedRaw に採用される
+    // base と target の url 文字列が異なるので両方が mergedRaw に残る
     expect(uncategorizedRaw?.urls).toStrictEqual([
+      {
+        savedAt: baseTimestamp,
+        title: 'Base',
+        url: 'https://base.example.com',
+      },
       {
         savedAt: baseTimestamp,
         title: 'Target',
         url: 'https://target.example.com',
+      },
+    ])
+  })
+
+  it('target.urls と base.urls で同じ url 文字列が重複する場合は base を保持する (issue #535 P2 review)', async () => {
+    // 同じ url 文字列が両方に存在する場合、base (uncategorized) の
+    // エントリを保持し、target のエントリでは上書きしない。
+    const baseTimestamp = 1_700_000_000_000
+    repo = createInMemoryRepository(
+      [
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1'],
+        }),
+        createCustomProject({
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: ['existing-url'],
+        }),
+      ],
+      [
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'project-1',
+          name: 'Project 1',
+          updatedAt: baseTimestamp,
+          urlIds: ['url-1'],
+          urls: [
+            {
+              savedAt: baseTimestamp,
+              title: 'Target Title',
+              url: 'https://shared.example.com',
+            },
+          ],
+        },
+        {
+          categories: [],
+          createdAt: baseTimestamp,
+          id: 'custom-uncategorized',
+          name: '未分類',
+          updatedAt: baseTimestamp,
+          urlIds: ['existing-url'],
+          urls: [
+            {
+              savedAt: baseTimestamp - 1,
+              title: 'Base Title',
+              url: 'https://shared.example.com',
+            },
+          ],
+        },
+      ],
+    )
+
+    const useCase = createDeleteCustomProjectUseCase(createDeps(repo))
+    await useCase({ projectId: createCustomProjectId('project-1') })
+
+    if (!repo.findAllRaw) {
+      throw new Error('findAllRaw is not implemented')
+    }
+    const rawAfter = await repo.findAllRaw()
+    const uncategorizedRaw = rawAfter.find(
+      (raw) => raw.id === 'custom-uncategorized',
+    )
+    // 同じ url 文字列は base 側を保持
+    expect(uncategorizedRaw?.urls).toStrictEqual([
+      {
+        savedAt: baseTimestamp - 1,
+        title: 'Base Title',
+        url: 'https://shared.example.com',
       },
     ])
   })

--- a/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.ts
@@ -96,11 +96,9 @@ export const createDeleteCustomProjectUseCase = (
     // ので、ここでもその挙動を再現する。
     let merged: CustomProject
     let nextAll: CustomProject[]
+    let mergedRawBase: CustomProjectRawSnapshot | undefined
     if (uncategorized) {
-      merged = mergeIntoUncategorized(target, uncategorized, {
-        targetRaw: targetRaw ?? undefined,
-        uncategorizedRaw: uncategorizedRaw ?? undefined,
-      })
+      merged = mergeEntityUncategorized(target, uncategorized)
       nextAll = all.map((project, index) => {
         if (index === targetIndex) {
           return project
@@ -110,6 +108,13 @@ export const createDeleteCustomProjectUseCase = (
         }
         return project
       })
+      if (uncategorizedRaw) {
+        mergedRawBase = uncategorizedRaw
+      } else {
+        // issue #535 P2: uncategorized の raw が `findAllRaw` 結果に
+        // 含まれない場合は entity を widen して mergedRawBase を作る。
+        mergedRawBase = entityToRawSnapshot(merged)
+      }
     } else {
       const timestamp = now()
       const createdUncategorized: CustomProject = {
@@ -120,17 +125,7 @@ export const createDeleteCustomProjectUseCase = (
         updatedAt: timestamp as never,
         urlIds: [],
       }
-      const createdUncategorizedRaw: CustomProjectRawSnapshot = {
-        categories: [],
-        createdAt: timestamp,
-        id: deps.uncategorizedProjectId,
-        name: '未分類',
-        updatedAt: timestamp,
-      }
-      merged = mergeIntoUncategorized(target, createdUncategorized, {
-        targetRaw: targetRaw ?? undefined,
-        uncategorizedRaw: createdUncategorizedRaw,
-      })
+      merged = mergeEntityUncategorized(target, createdUncategorized)
       // PR #514 / Codex review: 旧 `findOrCreateUncategorizedProject` 経路を
       // 踏襲し、新規作成した uncategorized プロジェクトを `all` へ明示的に
       // push してから保存する (`all.map` だと createdUncategorized.id が
@@ -138,21 +133,46 @@ export const createDeleteCustomProjectUseCase = (
       nextAll = all
         .map((project, index) => (index === targetIndex ? project : project))
         .concat(merged)
+      mergedRawBase = entityToRawSnapshot(createdUncategorized)
     }
     const remaining = nextAll.filter(
       (project) => project.id !== command.projectId,
     )
-    await deps.customProjectRepository.saveAll(remaining)
-    if (targetRaw) {
-      const removedSnapshot: CustomProjectRawSnapshot = {
-        ...targetRaw,
-        urlIds: target.urlIds as unknown as readonly string[],
-        urls: targetRaw.urls,
-        urlMetadata: targetRaw.urlMetadata,
-        projectKeywords: targetRaw.projectKeywords,
-        categoryOrder: targetRaw.categoryOrder,
+    if (
+      targetRaw &&
+      mergedRawBase &&
+      deps.customProjectRepository.findAllRaw &&
+      deps.customProjectRepository.restoreAllRaw
+    ) {
+      // issue #535 P2: rich フィールド（`urlMetadata` / `projectKeywords` /
+      // `categoryOrder` / `urls`）は domain entity 境界で表現されないため、
+      // `saveAll` 経路だと target の metadata が uncategorized 側に
+      // 引き継がれずに消える。`restoreAllRaw` で merged raw を
+      // そのまま書き戻し、entity 経由の save とは別経路で永続化する。
+      const allRaws = await deps.customProjectRepository.findAllRaw()
+      const otherRaws = allRaws.filter((raw) => raw.id !== command.projectId)
+      const mergedRaw: CustomProjectRawSnapshot = mergeRawSnapshots(
+        mergedRawBase,
+        targetRaw,
+      )
+      const nextRaws: CustomProjectRawSnapshot[] = [
+        ...otherRaws.filter((raw) => raw.id !== mergedRaw.id),
+        mergedRaw,
+      ]
+      await deps.customProjectRepository.restoreAllRaw(nextRaws)
+    } else {
+      await deps.customProjectRepository.saveAll(remaining)
+      if (targetRaw) {
+        const removedSnapshot: CustomProjectRawSnapshot = {
+          ...targetRaw,
+          urlIds: target.urlIds as unknown as readonly string[],
+          urls: targetRaw.urls,
+          urlMetadata: targetRaw.urlMetadata,
+          projectKeywords: targetRaw.projectKeywords,
+          categoryOrder: targetRaw.categoryOrder,
+        }
+        void removedSnapshot
       }
-      void removedSnapshot
     }
     return {
       all: remaining,
@@ -171,16 +191,30 @@ const findRawForId = async (
   return raws.find((raw) => raw.id === id) ?? null
 }
 
-const mergeIntoUncategorized = (
+const entityToRawSnapshot = (
+  project: CustomProject,
+): CustomProjectRawSnapshot => ({
+  categories: [...project.categories],
+  createdAt: project.createdAt,
+  id: project.id,
+  name: project.name,
+  updatedAt: project.updatedAt,
+  ...(project.urlIds.length > 0 ? { urlIds: [...project.urlIds] } : {}),
+})
+
+/**
+ * entity 同士の `CustomProject` URL マージ。rich フィールド
+ * （`urlMetadata` / `projectKeywords` / `categoryOrder`）は entity
+ * 境界で表現されないため、ここでは `urlIds` の和集合のみを更新する。
+ * rich フィールドの引き継ぎは `mergeRawSnapshots` を併用して raw
+ * 経路で永続化する (issue #535 P2)。
+ */
+const mergeEntityUncategorized = (
   target: CustomProject,
   uncategorized: CustomProject,
-  raws: {
-    targetRaw: CustomProjectRawSnapshot | undefined
-    uncategorizedRaw: CustomProjectRawSnapshot | undefined
-  },
 ): CustomProject => {
   const targetUrlIds = target.urlIds as unknown as readonly string[]
-  if (targetUrlIds.length === 0 && !raws.targetRaw?.urlMetadata) {
+  if (targetUrlIds.length === 0) {
     return uncategorized
   }
   const existing = new Set(uncategorized.urlIds as unknown as readonly string[])
@@ -193,22 +227,48 @@ const mergeIntoUncategorized = (
       nextUrlIds.push(urlId)
     }
   }
-  // PR #514 review P2: 旧 `mergeUrlsIntoUncategorized` は
-  // `urlMetadata` まで持ち越していたが、本 use-case の entity には
-  // `urlMetadata` フィールドがない。raw snapshot から補完する。
-  const targetUrlMetadata = raws.targetRaw?.urlMetadata
-  const uncategorizedUrlMetadata = raws.uncategorizedRaw?.urlMetadata
-  const mergedUrlMetadata: CustomProjectRawSnapshot['urlMetadata'] = {
-    ...uncategorizedUrlMetadata,
-    ...targetUrlMetadata,
-  }
   return {
     ...uncategorized,
     urlIds: nextUrlIds as never,
     updatedAt: target.updatedAt,
-    ...(Object.keys(mergedUrlMetadata).length > 0
-      ? // eslint-disable-next-line typescript/no-unsafe-type-assertion
-        ({ urlMetadata: mergedUrlMetadata } as never)
-      : {}),
+  }
+}
+
+const mergeRawSnapshots = (
+  base: CustomProjectRawSnapshot,
+  target: CustomProjectRawSnapshot,
+): CustomProjectRawSnapshot => {
+  const baseUrlIds = base.urlIds ?? []
+  const existing = new Set<string>(baseUrlIds)
+  const nextUrlIds: string[] = [...baseUrlIds]
+  for (const urlId of target.urlIds ?? []) {
+    if (!existing.has(urlId)) {
+      existing.add(urlId)
+      nextUrlIds.push(urlId)
+    }
+  }
+  const baseUrlMetadata = base.urlMetadata ?? {}
+  const targetUrlMetadata = target.urlMetadata ?? {}
+  const mergedUrlMetadata: Record<
+    string,
+    { notes?: string; category?: string }
+  > = {
+    ...baseUrlMetadata,
+    ...targetUrlMetadata,
+  }
+  let urlsField: CustomProjectRawSnapshot['urls']
+  if (target.urls) {
+    urlsField = target.urls.map((entry) => ({ ...entry }))
+  } else if (base.urls) {
+    urlsField = base.urls.map((entry) => ({ ...entry }))
+  }
+  return {
+    ...base,
+    categoryOrder: base.categoryOrder ?? target.categoryOrder,
+    projectKeywords: base.projectKeywords ?? target.projectKeywords,
+    updatedAt: target.updatedAt,
+    urlIds: nextUrlIds,
+    urlMetadata: mergedUrlMetadata,
+    ...(urlsField ? { urls: urlsField } : {}),
   }
 }

--- a/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.ts
@@ -241,26 +241,62 @@ const mergeRawSnapshots = (
   const baseUrlIds = base.urlIds ?? []
   const existing = new Set<string>(baseUrlIds)
   const nextUrlIds: string[] = [...baseUrlIds]
+  // `addedUrlIds` は target から実際に追加された urlId 集合。
+  // urlMetadata の上書き判定と urlIds の和集合計算で同じ集合を使い、
+  // 「移動しなかった urlId には触らない」セマンティクスを保つ。
+  const addedUrlIds: string[] = []
   for (const urlId of target.urlIds ?? []) {
     if (!existing.has(urlId)) {
       existing.add(urlId)
       nextUrlIds.push(urlId)
+      addedUrlIds.push(urlId)
     }
   }
   const baseUrlMetadata = base.urlMetadata ?? {}
   const targetUrlMetadata = target.urlMetadata ?? {}
+  // issue #535 P2 review (Codex): `urlId` が両方のプロジェクトに既に
+  // 存在する場合 (= 移動しなかった URL) は base の metadata を保持する。
+  // target の metadata は `addedUrlIds` に含まれる urlId のみ反映し、
+  // 衝突で uncategorized 側の notes / category を上書きしないようにする。
+  const targetMetadataForAdded: Record<
+    string,
+    { notes?: string; category?: string }
+  > = {}
+  for (const urlId of addedUrlIds) {
+    const meta = targetUrlMetadata[urlId]
+    if (meta) {
+      targetMetadataForAdded[urlId] = { ...meta }
+    }
+  }
   const mergedUrlMetadata: Record<
     string,
     { notes?: string; category?: string }
   > = {
     ...baseUrlMetadata,
-    ...targetUrlMetadata,
+    ...targetMetadataForAdded,
   }
+  const baseUrls = base.urls ?? []
+  const targetUrls = target.urls ?? []
   let urlsField: CustomProjectRawSnapshot['urls']
-  if (target.urls) {
-    urlsField = target.urls.map((entry) => ({ ...entry }))
-  } else if (base.urls) {
-    urlsField = base.urls.map((entry) => ({ ...entry }))
+  if (baseUrls.length > 0 || targetUrls.length > 0) {
+    // issue #535 P2 review (Codex): base.urls と target.urls を union で
+    // マージし、`url` 文字列で dedupe する。base 側を先に登録してから
+    // target の未収載エントリを追加することで、衝突時は base (uncategorized)
+    // の display data を保持する。URL が消えることを防ぐのが目的で、
+    // 衝突時の title / savedAt 解決は UrlRecordRepository 側が canonical。
+    const urlMap = new Map<
+      string,
+      { url: string; title: string; id?: string; savedAt?: number }
+    >()
+    for (const entry of baseUrls) {
+      urlMap.set(entry.url, { ...entry })
+    }
+    for (const entry of targetUrls) {
+      if (!urlMap.has(entry.url)) {
+        urlMap.set(entry.url, { ...entry })
+      }
+    }
+    urlsField = Array.from(urlMap.values())
   }
   return {
     ...base,

--- a/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.test.ts
@@ -635,6 +635,87 @@ describe('ChromeSavedTabsStorageMapper', () => {
     })
   })
 
+  describe('toStorageCustomProject', () => {
+    it('raw snapshot を presentation 層 storage 形に投影し rich フィールドを保持する (issue #535 P1)', () => {
+      const raw = {
+        categories: ['research'],
+        categoryOrder: ['research', 'news'],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        projectKeywords: {
+          domainKeywords: ['example.com'],
+          titleKeywords: ['design'],
+          urlKeywords: ['plan'],
+        },
+        updatedAt: 2,
+        urlIds: ['url-1', 'url-2'],
+        urlMetadata: {
+          'url-1': { category: 'research', notes: 'note-1' },
+        },
+        urls: [{ title: 'A', url: 'https://example.com/a' }],
+      }
+      const result = ChromeSavedTabsStorageMapper.toStorageCustomProject(raw)
+      expect(result).toStrictEqual({
+        categories: ['research'],
+        categoryOrder: ['research', 'news'],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        projectKeywords: {
+          domainKeywords: ['example.com'],
+          titleKeywords: ['design'],
+          urlKeywords: ['plan'],
+        },
+        updatedAt: 2,
+        urlIds: ['url-1', 'url-2'],
+        urlMetadata: {
+          'url-1': { category: 'research', notes: 'note-1' },
+        },
+        urls: [{ title: 'A', url: 'https://example.com/a' }],
+      })
+    })
+
+    it('rich フィールドが undefined なら storage 形でも省略する', () => {
+      const result = ChromeSavedTabsStorageMapper.toStorageCustomProject({
+        categories: [],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        updatedAt: 2,
+        urlIds: ['url-1'],
+      })
+      expect(result).toStrictEqual({
+        categories: [],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        updatedAt: 2,
+        urlIds: ['url-1'],
+      })
+      expect(result).not.toHaveProperty('urlMetadata')
+      expect(result).not.toHaveProperty('projectKeywords')
+      expect(result).not.toHaveProperty('categoryOrder')
+      expect(result).not.toHaveProperty('urls')
+    })
+
+    it('空配列の rich フィールドは storage 形で省略する (toStrictEqual 安定化)', () => {
+      const result = ChromeSavedTabsStorageMapper.toStorageCustomProject({
+        categories: [],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Q4',
+        updatedAt: 2,
+        urlIds: [],
+        urlMetadata: {},
+        urls: [],
+      })
+      expect(result).not.toHaveProperty('urlIds')
+      expect(result).not.toHaveProperty('urlMetadata')
+      expect(result).not.toHaveProperty('urls')
+    })
+  })
+
   describe('id toString helpers', () => {
     it('各 ID は素の string に変換できる', () => {
       expect(

--- a/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts
+++ b/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts
@@ -1,3 +1,5 @@
+import type { CustomProject as StorageCustomProject } from '@/types/storage'
+
 import { createCustomProject } from '../../domain/entities/CustomProject'
 import type { CustomProject } from '../../domain/entities/CustomProject'
 import { createParentCategory } from '../../domain/entities/ParentCategory'
@@ -7,6 +9,7 @@ import type { TabGroup } from '../../domain/entities/TabGroup'
 import { createUrlRecord } from '../../domain/entities/UrlRecord'
 import type { UrlRecord } from '../../domain/entities/UrlRecord'
 import { SavedTabsDomainError } from '../../domain/errors/SavedTabsDomainError'
+import type { CustomProjectRawSnapshot } from '../../domain/repositories/CustomProjectRepository'
 import type { CustomProjectId } from '../../domain/value-objects/CustomProjectId'
 import type { DomainName } from '../../domain/value-objects/DomainName'
 import type { ParentCategoryId } from '../../domain/value-objects/ParentCategoryId'
@@ -334,6 +337,57 @@ const toCustomProjectRaw = (
 }
 
 /**
+ * `CustomProjectRawSnapshot` を presentation 層 (`src/types/storage`) の
+ * `CustomProject` 形へ投影する。
+ *
+ * domain `CustomProject` entity は `projectKeywords` / `categoryOrder` /
+ * `urlMetadata` / `urls` などの rich 補助フィールドを保持しないため、
+ * そのまま `findAll()` 戻り値を UI state に流すと初回ロード時にこれらの
+ * フィールドが落ちる (issue #535 P1)。raw snapshot を直接 projection
+ * することで、entity 境界を通さずに UI state を組み立てる。
+ *
+ * `urlIds` / `urls` / `urlMetadata` / `projectKeywords` / `categoryOrder`
+ * は rich snapshot 側に存在する場合のみ引き継ぎ、存在しない場合は
+ * storage 形の `?` optional として省略する (`toStrictEqual` 安定化のため)。
+ */
+const toStorageCustomProject = (
+  raw: CustomProjectRawSnapshot,
+): StorageCustomProject => {
+  const result: StorageCustomProject = {
+    categories: [...raw.categories],
+    createdAt: raw.createdAt,
+    id: raw.id,
+    name: raw.name,
+    updatedAt: raw.updatedAt,
+  }
+  if (raw.urlIds && raw.urlIds.length > 0) {
+    result.urlIds = [...raw.urlIds]
+  }
+  if (raw.urls && raw.urls.length > 0) {
+    result.urls = raw.urls.map((entry) => ({ ...entry }))
+  }
+  if (raw.urlMetadata && Object.keys(raw.urlMetadata).length > 0) {
+    result.urlMetadata = Object.fromEntries(
+      Object.entries(raw.urlMetadata).map(([urlId, metadata]) => [
+        urlId,
+        { ...metadata },
+      ]),
+    )
+  }
+  if (raw.projectKeywords) {
+    result.projectKeywords = {
+      domainKeywords: [...raw.projectKeywords.domainKeywords],
+      titleKeywords: [...raw.projectKeywords.titleKeywords],
+      urlKeywords: [...raw.projectKeywords.urlKeywords],
+    }
+  }
+  if (raw.categoryOrder && raw.categoryOrder.length > 0) {
+    result.categoryOrder = [...raw.categoryOrder]
+  }
+  return result
+}
+
+/**
  * `unknown` な生データをパースし、有効な `TabGroup` だけを返す。
  *
  * Zod parse 失敗 / entity 化失敗 / `null` / `undefined` の場合は `null` を返す。
@@ -498,6 +552,7 @@ export const ChromeSavedTabsStorageMapper = {
   toParentCategoryFromRaw,
   toParentCategoryRaw,
   toSavedTabRaw,
+  toStorageCustomProject,
   toTabGroupFromRaw,
   toUrlRecordFromRaw,
   toUrlRecordRaw,

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx
@@ -5,7 +5,10 @@ import { toast } from 'sonner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { UserSettingsDto } from '@/contexts/saved-tabs/domain/dto/UserSettingsDto'
-import type { CustomProjectRepository } from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
+import type {
+  CustomProjectRawSnapshot,
+  CustomProjectRepository,
+} from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
 import type { CustomProject } from '@/types/storage'
 
 import { useProjectManagement } from './useProjectManagement'
@@ -132,6 +135,32 @@ const waitForLoadedProjects = async (
   })
 }
 
+const toRawSnapshot = (project: CustomProject): CustomProjectRawSnapshot => {
+  const result: CustomProjectRawSnapshot = {
+    categories: project.categories,
+    createdAt: project.createdAt,
+    id: project.id,
+    name: project.name,
+    updatedAt: project.updatedAt,
+  }
+  if (project.urlIds) {
+    result.urlIds = project.urlIds
+  }
+  if (project.urls) {
+    result.urls = project.urls
+  }
+  if (project.urlMetadata) {
+    result.urlMetadata = project.urlMetadata
+  }
+  if (project.projectKeywords) {
+    result.projectKeywords = project.projectKeywords
+  }
+  if (project.categoryOrder) {
+    result.categoryOrder = project.categoryOrder
+  }
+  return result
+}
+
 describe('useProjectManagement', () => {
   let customProjectRepository: CustomProjectRepository
   /**
@@ -158,17 +187,29 @@ describe('useProjectManagement', () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
     vi.spyOn(console, 'log').mockImplementation(() => undefined)
     vi.setSystemTime(new Date('2026-01-02T03:04:05.000Z'))
-    // `customProjectRepository.findAll` は `getCustomProjects` の mock
-    // 値を通じて後方互換を維持する。テスト本体は
+    // issue #535 P1: 実装は `findAllRaw` を介して rich フィールド
+    // （`projectKeywords` / `categoryOrder` / `urlMetadata` / `urls`）を
+    // 保持した raw snapshot を取得する。テストでは
     // `projectManagementMocks.getCustomProjects.mockResolvedValue(...)` で
-    // 戻り値を制御できる。
+    // 設定した `CustomProject` (storage 形) を raw snapshot 形に widen
+    // して `findAllRaw` の戻り値にする。`findAllRaw` mock は
+    // `mockImplementation` で `getCustomProjects` ベースの widening を
+    // 担当し、テストケースで `mockResolvedValueOnce` /
+    // `mockImplementationOnce` で一時的に上書きできる。
     const findAllMock = vi
       .fn()
       .mockImplementation(() => projectManagementMocks.getCustomProjects())
+    const findAllRawMock = vi
+      .fn()
+      .mockImplementation(() =>
+        projectManagementMocks
+          .getCustomProjects()
+          .then((projects: CustomProject[]) => projects.map(toRawSnapshot)),
+      )
 
     customProjectRepository = {
       findAll: findAllMock,
-      findAllRaw: vi.fn(),
+      findAllRaw: findAllRawMock,
       findById: vi.fn(),
       removeByIds: vi.fn(),
       restoreAllRaw: vi.fn(),
@@ -176,11 +217,6 @@ describe('useProjectManagement', () => {
       findOrder: vi.fn(),
       saveOrder: vi.fn(),
     } as unknown as CustomProjectRepository
-    ;(
-      customProjectRepository.findAllRaw as unknown as {
-        mockResolvedValue: (value: unknown) => void
-      }
-    ).mockResolvedValue([])
     ;(
       customProjectRepository.findOrder as unknown as {
         mockResolvedValue: (value: unknown) => void
@@ -990,8 +1026,10 @@ describe('useProjectManagement', () => {
       await undoOptions?.action?.onClick?.()
     })
 
-    expect(customProjectRepository.saveAll).toHaveBeenLastCalledWith(
-      projectSnapshot,
+    expect(customProjectRepository.restoreAllRaw).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'project-1', name: 'Project A' }),
+      ]),
     )
     expect(customProjectRepository.saveOrder).toHaveBeenLastCalledWith([
       'project-1',
@@ -1022,16 +1060,14 @@ describe('useProjectManagement', () => {
         urls: [{ title: 'A', url: 'https://example.com/a' }],
       },
     ]
+    // 1 回目: 初回 load, 2 回目: undo snapshot, 3 回目: 削除後
+    // 初期 load / undo snapshot で rich な `projectSnapshotRaw` を返し、
+    // 削除後の再取得は `getCustomProjects` (= []) ベースでよい。
     ;(
       customProjectRepository.findAllRaw as unknown as {
-        mockResolvedValueOnce: (value: unknown) => void
+        mockResolvedValue: (value: unknown) => void
       }
-    ).mockResolvedValueOnce(projectSnapshotRaw)
-    // 1 回目: 初回 load, 2 回目: undo snapshot (projectSnapshot), 3 回目: 削除後
-    projectManagementMocks.getCustomProjects
-      .mockResolvedValueOnce(projectSnapshot)
-      .mockResolvedValueOnce(projectSnapshot)
-      .mockResolvedValueOnce([])
+    ).mockResolvedValue(projectSnapshotRaw)
 
     const { result } = renderHook(() =>
       useProjectManagement(
@@ -1046,7 +1082,15 @@ describe('useProjectManagement', () => {
       ),
     )
 
-    await waitForLoadedProjects(result)
+    // 初期ロード時に `findAllRaw` 経由で rich な snapshot が反映される
+    // (issue #535 P1: projectKeywords / urlMetadata / urls が保持される)
+    await waitFor(() => {
+      expect(result.current.customProjects[0]?.projectKeywords).toStrictEqual({
+        domainKeywords: ['example.com'],
+        titleKeywords: ['design'],
+        urlKeywords: ['plan'],
+      })
+    })
 
     await act(async () => {
       await result.current.handleDeleteUrlFromProject(
@@ -1173,16 +1217,30 @@ describe('useProjectManagement', () => {
 
   it('Undo の保存データがない場合は復元処理を行わず、復元失敗は通知する', async () => {
     // 1st delete: snapshot = []  → 復元スキップ
-    // 2nd delete: snapshot = projectSnapshot → 復元は saveAll (reject) → 失敗通知
+    // 2nd delete: snapshot = projectSnapshot → 復元は restoreAllRaw (reject) → 失敗通知
+    // queue 設計:
+    //  - 1st widening (useEffect): projectSnapshot
+    //  - 2nd widening (1st delete snapshot): mockImplementationOnce で
+    //    widening スキップ → queue 消費なし
+    //  - 3rd widening (1st delete 削除後): []
+    //  - 4th widening (2nd delete snapshot): projectSnapshot
+    //  - 5th widening (2nd delete 削除後): projectSnapshot
     projectManagementMocks.getCustomProjects
-      .mockResolvedValueOnce(projectSnapshot) // useEffect mount
-      .mockResolvedValueOnce([]) // 1st delete: snapshot
-      .mockResolvedValueOnce([]) // 1st delete: get updated (削除後)
-      .mockResolvedValueOnce(projectSnapshot) // 2nd delete: snapshot
-      .mockResolvedValueOnce(projectSnapshot) // 2nd delete: get updated
+      .mockResolvedValueOnce(projectSnapshot) // 1st: useEffect
+      .mockResolvedValueOnce([]) // 3rd: 1st delete 削除後
+      .mockResolvedValueOnce(projectSnapshot) // 4th: 2nd delete snapshot
+      .mockResolvedValueOnce(projectSnapshot) // 5th: 2nd delete 削除後
 
+    // issue #535 P1: `findAllRaw` を 1st delete の snapshot 取得タイミングで
+    // 空にしておくと、undo snapshot に `customProjectsRaw` が含まれず
+    // `restoreAllRaw` 経路をスキップする。`findAll` も空を返すため、
+    // UI 復元も `payload.customProjects` 経由で `saveAll` 経由になる。
+    // 2nd delete は通常経路 (snapshot = projectSnapshot) で `restoreAllRaw` を
+    // 通すが、mock で reject させて「restoreAllRaw 失敗 → error toast」を
+    // 検証する (issue #535 で raw 経路が主軸になったため `saveAll` 失敗
+    // ではなく `restoreAllRaw` 失敗で検証する)。
     ;(
-      customProjectRepository.saveAll as unknown as {
+      customProjectRepository.restoreAllRaw as unknown as {
         mockRejectedValueOnce: (value: unknown) => void
       }
     ).mockRejectedValueOnce(new Error('restore failed'))
@@ -1201,6 +1259,15 @@ describe('useProjectManagement', () => {
     )
 
     await waitForLoadedProjects(result)
+
+    // 1st delete の `getCustomProjectUndoSnapshot` 内の `findAllRaw` を
+    // 空配列にしておく。これで undo snapshot に `customProjectsRaw` が
+    // 含まれず `restoreAllRaw` 経路をスキップし、`saveAll` も呼ばれない。
+    ;(
+      customProjectRepository.findAllRaw as unknown as {
+        mockImplementationOnce: (impl: () => unknown) => void
+      }
+    ).mockImplementationOnce(() => Promise.resolve([]))
 
     await act(async () => {
       await result.current.handleDeleteUrlFromProject(
@@ -1221,7 +1288,7 @@ describe('useProjectManagement', () => {
       await missingUndoOptions?.action?.onClick?.()
     })
 
-    expect(customProjectRepository.saveAll).not.toHaveBeenCalled()
+    expect(customProjectRepository.restoreAllRaw).not.toHaveBeenCalled()
 
     await act(async () => {
       await result.current.handleDeleteUrlFromProject(
@@ -1242,7 +1309,7 @@ describe('useProjectManagement', () => {
       await failingUndoOptions?.action?.onClick?.()
     })
 
-    expect(customProjectRepository.saveAll).toHaveBeenCalledWith(
+    expect(customProjectRepository.restoreAllRaw).toHaveBeenCalledWith(
       projectSnapshot,
     )
     expect(toast.error).toHaveBeenCalledWith('保存データを復元できませんでした')

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.ts
@@ -13,6 +13,7 @@ import type { CreateCustomProjectUseCase } from '@/contexts/saved-tabs/applicati
 import type { DeleteCustomProjectUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase'
 import type { UpdateCustomProjectNameUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectNameUseCase'
 import type { UserSettingsDto } from '@/contexts/saved-tabs/domain/dto/UserSettingsDto'
+import { createCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import type { CustomProject as DomainCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import { UNCATEGORIZED_PROJECT_ID } from '@/contexts/saved-tabs/domain/entities/UncategorizedProject'
 import type {
@@ -20,6 +21,7 @@ import type {
   CustomProjectRepository,
 } from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
 import type { CustomProjectId as DomainCustomProjectId } from '@/contexts/saved-tabs/domain/value-objects/CustomProjectId'
+import { ChromeSavedTabsStorageMapper } from '@/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import type {
   CustomProject,
@@ -71,7 +73,7 @@ const getArraySnapshot = <T>(
 ): readonly T[] | undefined => (Array.isArray(value) ? value : undefined)
 
 /** domain entity (`CustomProject`) を presentation 層 state の storage 形へ投影する */
-const toStorageCustomProject = (
+const toEntityStorageCustomProject = (
   project: DomainCustomProject,
 ): CustomProject => {
   const result: CustomProject = {
@@ -87,18 +89,72 @@ const toStorageCustomProject = (
   return result
 }
 
+/** rich フィールド込みの `CustomProject` へ raw snapshot を投影する */
+const toRawStorageCustomProject = (
+  raw: CustomProjectRawSnapshot,
+): CustomProject => ChromeSavedTabsStorageMapper.toStorageCustomProject(raw)
+
+/**
+ * repository 実装から rich フィールドを保持した raw snapshot を取得する。
+ *
+ * `findAllRaw` がモックで未実装のケースに備え、`findAll` (entity) を
+ * フォールバックとして用意する。`findAll` 経由だと rich フィールドは
+ * 取得できないため、storage 形投影時に空になる (issue #535 P1 の本質)。
+ * テスト/本番実装では `findAllRaw` を必ず実装し、こちらを使う。
+ */
+const loadCustomProjectRaws = async (
+  repo: CustomProjectRepository,
+): Promise<readonly CustomProjectRawSnapshot[]> => {
+  if (repo.findAllRaw) {
+    return repo.findAllRaw()
+  }
+  // フォールバック: entity を取得し、各 entity の id/name/urlIds 等
+  // のみ取り出して raw snapshot 形へ widen する。rich フィールド
+  // (`projectKeywords` / `urlMetadata` / `categoryOrder` / `urls`) は
+  // 取得できないため storage 形 projection で省略される。
+  const projects = await repo.findAll()
+  return projects.map((project) => ({
+    categories: [...project.categories],
+    createdAt: project.createdAt,
+    id: project.id,
+    name: project.name,
+    updatedAt: project.updatedAt,
+    ...(project.urlIds.length > 0 ? { urlIds: [...project.urlIds] } : {}),
+  }))
+}
+
 const getCustomProjectUndoSnapshot = async (
   customProjectRepository: CustomProjectRepository,
 ): Promise<CustomProjectUndoSnapshot> => {
-  const [projects, order, raws] = await Promise.all([
-    customProjectRepository.findAll(),
-    customProjectRepository.findOrder(),
-    customProjectRepository.findAllRaw?.() ?? Promise.resolve([]),
-  ])
+  // issue #535 P1: undo snapshot 取得時に `findAll` (entity 経路) と
+  // `findAllRaw` (raw 経路) の両方を呼ぶと、テスト/本番で repository
+  // 実装を共有している場合に queue 消費が想定より多くなり、raw snapshot
+  // が「削除後」の値で上書きされる問題があった。raw 経路で 1 度だけ
+  // 取得し、entity 形が必要なら widen する。`findAllRaw` が未実装の
+  // レガシー repository 向けには `findAll` をフォールバックとする。
+  const order = await customProjectRepository.findOrder()
+  if (customProjectRepository.findAllRaw) {
+    const raws = await customProjectRepository.findAllRaw()
+    const projects: DomainCustomProject[] = raws.map((raw) =>
+      createCustomProject({
+        categories: raw.categories,
+        createdAt: raw.createdAt,
+        id: raw.id,
+        name: raw.name,
+        updatedAt: raw.updatedAt,
+        urlIds: raw.urlIds ?? [],
+      }),
+    )
+    return {
+      ...(order.length > 0 ? { customProjectOrder: order } : {}),
+      ...(projects.length > 0 ? { customProjects: projects } : {}),
+      ...(raws.length > 0 ? { customProjectsRaw: raws } : {}),
+    }
+  }
+  const projects = await customProjectRepository.findAll()
   return {
     ...(order.length > 0 ? { customProjectOrder: order } : {}),
     ...(projects.length > 0 ? { customProjects: projects } : {}),
-    ...(raws.length > 0 ? { customProjectsRaw: raws } : {}),
   }
 }
 
@@ -166,7 +222,9 @@ const showCustomProjectDeleteUndoToast = ({
               payload.customProjectOrder ?? [],
             )
             setCustomProjects(
-              payload.customProjects.map(toStorageCustomProject),
+              payload.customProjectsRaw
+                ? payload.customProjectsRaw.map(toRawStorageCustomProject)
+                : payload.customProjects.map(toEntityStorageCustomProject),
             )
             toast.success(t('savedTabs.undo.restored'))
           } catch (error) {
@@ -370,15 +428,19 @@ const useProjectManagement = (
     CustomProject[]
   > => {
     try {
-      const projects =
-        (await customProjectRepositoryRef.current.findAll()) as unknown as CustomProject[] // oxlint-disable-line typescript/no-unsafe-type-assertion
+      const raws = await loadCustomProjectRaws(
+        customProjectRepositoryRef.current,
+      )
+      const projects = raws.map(toRawStorageCustomProject)
       setCustomProjects(projects)
       return projects
     } catch (error) {
       console.error('データ同期エラー:', error)
       try {
-        const latestProjects =
-          (await customProjectRepositoryRef.current.findAll()) as unknown as CustomProject[] // oxlint-disable-line typescript/no-unsafe-type-assertion
+        const latestRaws = await loadCustomProjectRaws(
+          customProjectRepositoryRef.current,
+        )
+        const latestProjects = latestRaws.map(toRawStorageCustomProject)
         setCustomProjects(latestProjects)
         return latestProjects
       } catch (error) {
@@ -564,9 +626,10 @@ const useProjectManagement = (
           url,
           title,
         )
-        const updatedProjects =
-          (await customProjectRepositoryRef.current.findAll()) as unknown as CustomProject[] // oxlint-disable-line typescript/no-unsafe-type-assertion
-        setCustomProjects(updatedProjects)
+        const updatedRaws = await loadCustomProjectRaws(
+          customProjectRepositoryRef.current,
+        )
+        setCustomProjects(updatedRaws.map(toRawStorageCustomProject))
         toast.success(t('savedTabs.tab.added'))
       } catch (error) {
         console.error('URL追加エラー:', error)
@@ -583,16 +646,14 @@ const useProjectManagement = (
         const undoSnapshot = await getCustomProjectUndoSnapshot(
           customProjectRepository,
         )
-        const updatedProjects = await Promise.resolve(
-          customProjectsCommandServiceRef.current.removeUrlFromCustomProject(
-            projectId,
-            url,
-          ),
-        ).then(async () => {
-          const projects = await customProjectRepositoryRef.current.findAll()
-          return projects as unknown as CustomProject[] // oxlint-disable-line typescript/no-unsafe-type-assertion
-        })
-        setCustomProjects(updatedProjects)
+        await customProjectsCommandServiceRef.current.removeUrlFromCustomProject(
+          projectId,
+          url,
+        )
+        const updatedRaws = await loadCustomProjectRaws(
+          customProjectRepositoryRef.current,
+        )
+        setCustomProjects(updatedRaws.map(toRawStorageCustomProject))
         showCustomProjectDeleteUndoToast({
           count: 1,
           customProjectRepository,
@@ -616,16 +677,14 @@ const useProjectManagement = (
         const undoSnapshot = await getCustomProjectUndoSnapshot(
           customProjectRepository,
         )
-        const updatedProjects = await Promise.resolve(
-          customProjectsCommandServiceRef.current.removeUrlsFromCustomProject(
-            projectId,
-            urls,
-          ),
-        ).then(async () => {
-          const projects = await customProjectRepositoryRef.current.findAll()
-          return projects as unknown as CustomProject[] // oxlint-disable-line typescript/no-unsafe-type-assertion
-        })
-        setCustomProjects(updatedProjects)
+        await customProjectsCommandServiceRef.current.removeUrlsFromCustomProject(
+          projectId,
+          urls,
+        )
+        const updatedRaws = await loadCustomProjectRaws(
+          customProjectRepositoryRef.current,
+        )
+        setCustomProjects(updatedRaws.map(toRawStorageCustomProject))
         showCustomProjectDeleteUndoToast({
           count: urls.length,
           customProjectRepository,
@@ -696,9 +755,10 @@ const useProjectManagement = (
           projectId,
           categoryName,
         )
-        const updatedProjects =
-          (await customProjectRepositoryRef.current.findAll()) as unknown as CustomProject[] // oxlint-disable-line typescript/no-unsafe-type-assertion
-        setCustomProjects(updatedProjects)
+        const updatedRaws = await loadCustomProjectRaws(
+          customProjectRepositoryRef.current,
+        )
+        setCustomProjects(updatedRaws.map(toRawStorageCustomProject))
         toast.success(
           t('savedTabs.projectCategory.deleted', undefined, {
             name: categoryName,
@@ -725,9 +785,10 @@ const useProjectManagement = (
           url,
           category,
         )
-        const updatedProjects =
-          (await customProjectRepositoryRef.current.findAll()) as unknown as CustomProject[] // oxlint-disable-line typescript/no-unsafe-type-assertion
-        setCustomProjects(updatedProjects)
+        const updatedRaws = await loadCustomProjectRaws(
+          customProjectRepositoryRef.current,
+        )
+        setCustomProjects(updatedRaws.map(toRawStorageCustomProject))
       } catch (error) {
         console.error('URL分類エラー:', error)
         toast.error(t('savedTabs.tab.moveError'))
@@ -884,13 +945,16 @@ const useProjectManagement = (
         console.log(`ビューモード: ${mode}`)
 
         // カスタムプロジェクトを読み込む
-        const [projects, order] = await Promise.all([
-          customProjectRepositoryRef.current.findAll(),
+        // issue #535 P1: domain entity 化で rich フィールド
+        // (`projectKeywords` / `categoryOrder` / `urls` / `urlMetadata`)
+        // が落ちないように、raw snapshot を直接 storage 形へ投影する。
+        const [raws, order] = await Promise.all([
+          loadCustomProjectRaws(customProjectRepositoryRef.current),
           customProjectRepositoryRef.current.findOrder(),
         ])
-        const projectsAsCust = projects as unknown as CustomProject[] // oxlint-disable-line typescript/no-unsafe-type-assertion
+        const projectsAsCust = raws.map(toRawStorageCustomProject)
         // PR #514 review P1: 保存済みの `customProjectOrder` を反映し、
-        // 並び順が巻き戻らないようにする。order 未保存時は findAll 順を採用。
+        // 並び順が巻き戻らないようにする。order 未保存時は findAllRaw 順を採用。
         // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const orderKeys = order as unknown as readonly string[]
         const ordered =


### PR DESCRIPTION
## 概要

PR #534 (issue #531 / MessagingPort 移設) の Codex レビューで、本 PR の diff 範囲外にある 2 ファイルに対して指摘コメントが付いたため、別 issue (#535) として切り出して対応する。

## 変更内容

### P1: useProjectManagement の custom projects 初期ロード時に rich フィールドが落ちる問題

- `ChromeSavedTabsStorageMapper.toStorageCustomProject` を追加
  - raw snapshot を presentation 層 storage 形へ投影するヘルパー
  - `projectKeywords` / `categoryOrder` / `urlMetadata` / `urls` を保持
  - rich フィールドが undefined / 空配列の場合は storage 形でも省略 (`toStrictEqual` 安定化)
- `useProjectManagement` を `findAll` (entity) → `findAllRaw` (raw snapshot) 経路に統一
  - 初期ロード / undo 復元 / 各種更新経路 (URL 追加・削除・カテゴリ移動・復元) すべてで raw snapshot を storage 形へ投影
  - `findAllRaw` が未実装のレガシー repository 向けには `findAll` へフォールバック

### P2: DeleteCustomProjectUseCase の urlMetadata が uncategorized マージ時に落ちる問題

- target / uncategorized の raw snapshot を repository から取得
- `restoreAllRaw` 経路を追加し、merged raw を永続化
- `urlMetadata` / `projectKeywords` / `categoryOrder` / `urls` を uncategorized raw に引き継ぎ
- entity 経由の `saveAll` は rich フィールドが消えるため、`findAllRaw` / `restoreAllRaw` 不在の repository のみフォールバック

## テスト

- `ChromeSavedTabsStorageMapper.toStorageCustomProject` unit test
  - rich フィールド保持 (projectKeywords / categoryOrder / urlMetadata / urls)
  - rich フィールドが undefined なら storage 形でも省略
  - 空配列の rich フィールドは省略 (`toStrictEqual` 安定化)
- `useProjectManagement.test.tsx`
  - undo 経路で raw snapshot 経由の復元を検証
  - restoreAllRaw 失敗時に error toast が出ることを検証
- `DeleteCustomProjectUseCase.test.ts`
  - target の urlMetadata / projectKeywords / categoryOrder を uncategorized raw にマージ
  - target urlIds 空のときは entity 経路で early return
  - `findAllRaw` / `restoreAllRaw` 未実装 repository は `saveAll` へフォールバック

## 検証

- [x] `bun run test` 2743/2743 pass
- [x] `bun run compile` (tsgo --noEmit) clean
- [x] `bun run lint` (oxlint) 0 warnings, 0 errors
- [x] `bun run format:check` (oxfmt) all formatted
- [x] ローカル環境でエラーになっていない

## 関連

- 元 issue: #535
- 元 PR: #534 (issue #531 / MessagingPort 移設) Codex レビューで指摘
  - https://github.com/haruto-yamada1/TABBIN/pull/534#discussion_r3421626030 (P1)
  - https://github.com/haruto-yamada1/TABBIN/pull/534#discussion_r3421626032 (P2)
- 周辺 work: #531 (元 PR), #530 (customProjects legacy data 救済), #514 (review 関連)