### PR TITLE
[DDD] saved-tabs README/architecture の現状化と application/mappers ガード追加 (issue #526 followup)

### DIFF
--- a/docs/architecture/ddd.md
+++ b/docs/architecture/ddd.md
@@ -44,7 +44,8 @@ src/contexts/saved-tabs/
     queries/          # 読み取り専用リクエスト型
     use-cases/        # 1 操作 1 ファイル
     dto/              # presentation へ返す読み取り専用モデル
-    ports/            # BrowserTabPort / NotificationPort / ClockPort / IdGeneratorPort
+    mappers/          # application 層内の DTO / snapshot 相互変換（chrome 非依存）
+    ports/            # BrowserTabPort / NotificationPort / ClockPort / IdGeneratorPort / StorageChangePort / MessagingPort
   infrastructure/
     persistence/
       chrome-storage/ # Chrome*Repository 実装 / storage key / schema
@@ -78,9 +79,10 @@ src/contexts/saved-tabs/
 - React に依存しません。`presentation` 層を参照しません。`chrome.*` API を直接呼ばず、Repository interface / port interface 経由で外部依存に触れます。
 - Repository は `domain/repositories/` の interface だけを import し、`infrastructure/` 配下は import しません（依存性注入は composition 層で配線）。
 - 1 つの use-case は 1 つのユーザー操作または background 操作を表し、複数の操作をまとめないでください。
-- `application/ports/` には `BrowserTabPort` / `NotificationPort` / `ClockPort` / `IdGeneratorPort` などの interface を置き、`chrome.tabs` や `chrome.notifications` への直接依存を排除します。
+- `application/ports/` には `BrowserTabPort` / `NotificationPort` / `ClockPort` / `IdGeneratorPort` / `StorageChangePort` / `MessagingPort` などの interface を置き、`chrome.tabs` や `chrome.notifications` / `chrome.storage.onChanged` / `chrome.runtime.sendMessage` への直接依存を排除します。
 - `application/dto/` は presentation 層へ返す読み取り専用モデルです。domain entity を直接 UI へ渡さないでください。
 - `application/commands/` と `application/queries/` はそれぞれ状態変更リクエスト・読み取りリクエストの型定義置き場です。
+- `application/mappers/` は application 層内の DTO / snapshot 相互変換（`@/types/storage` 形 ↔ domain DTO ↔ snapshot）を集約する pure な変換層です。`chrome.*` API には触れません。storage ↔ domain entity の変換は `infrastructure/mappers/` の責務です。
 
 ### infrastructure
 

--- a/docs/architecture/ddd.md
+++ b/docs/architecture/ddd.md
@@ -82,7 +82,7 @@ src/contexts/saved-tabs/
 - `application/ports/` には `BrowserTabPort` / `NotificationPort` / `ClockPort` / `IdGeneratorPort` / `StorageChangePort` / `MessagingPort` などの interface を置き、`chrome.tabs` や `chrome.notifications` / `chrome.storage.onChanged` / `chrome.runtime.sendMessage` への直接依存を排除します。
 - `application/dto/` は presentation 層へ返す読み取り専用モデルです。domain entity を直接 UI へ渡さないでください。
 - `application/commands/` と `application/queries/` はそれぞれ状態変更リクエスト・読み取りリクエストの型定義置き場です。
-- `application/mappers/` は application 層内の DTO / snapshot 相互変換（`@/types/storage` 形 ↔ domain DTO ↔ snapshot）を集約する pure な変換層です。`chrome.*` API には触れません。storage ↔ domain entity の変換は `infrastructure/mappers/` の責務です。
+- `application/mappers/` は application 層内の DTO / snapshot 相互変換（`@/types/storage` 形 ↔ domain DTO / domain entity）を集約する pure な変換層です。`chrome.*` API には触れません。`SavedTabsDtosMapper` は DTO ↔ storage 形、`SavedTabsSnapshotMapper` は undo / snapshot 用に domain entity ↔ storage 形を双方向で持ち替えます（chrome.storage への I/O 自体は行わない）。一方、`infrastructure/mappers/` の `ChromeSavedTabsStorageMapper` は `chrome.storage.local` の生データ (`unknown` → Zod parse) ↔ domain entity の I/O 変換を担います。
 
 ### infrastructure
 

--- a/src/contexts/saved-tabs/README.md
+++ b/src/contexts/saved-tabs/README.md
@@ -9,7 +9,7 @@
 ```
 contexts/saved-tabs/
   domain/             # ビジネスルール・値オブジェクト・repository interface・domain service・domain DTO
-  application/        # use-case / command / query / dto / port / mapper
+  application/        # use-case / command / query / dto / mapper / port
   infrastructure/     # chrome-storage / browser adapter / mapper / composition root
   presentation/       # route / page / app / controller / hook / container / view-model / service
   testing/            # テスト用 mock factory
@@ -17,7 +17,7 @@ contexts/saved-tabs/
   README.md
 ```
 
-旧 `src/features/saved-tabs/` 配下の UI / hooks / lib は DDD 移行完了に伴い撤去済みです（Issue #488）。`SavedTabsPage` / `SavedTabsRoute` などの組み立ては `presentation/` 配下にあり、`src/entrypoints/saved-tabs/main.tsx` から呼び出されます。
+旧 `src/features/saved-tabs/` 配下の UI / hooks / lib は DDD 移行完了に伴い撤去済みです（Issue #488）。`SavedTabsPage` / `SavedTabsRoute` などの組み立ては `presentation/` 配下にあり、`src/features/navigation/app/AppRouter.tsx`（`src/entrypoints/app/main.tsx` から lazy import される）から `SavedTabsRoute` 経由で読み込まれます。`src/entrypoints/saved-tabs/main.tsx` はレガシー URL のリダイレクト専用エントリです。
 
 ## 開発時の参照順序
 

--- a/src/contexts/saved-tabs/application/README.md
+++ b/src/contexts/saved-tabs/application/README.md
@@ -4,13 +4,16 @@
 
 ## サブディレクトリ
 
-| ディレクトリ | 役割                                                                                         |
-| ------------ | -------------------------------------------------------------------------------------------- |
-| `commands/`  | 状態を変更するリクエスト型（`OpenSavedUrlCommand` / `DeleteTabGroupCommand` など）           |
-| `queries/`   | 読み取り専用リクエスト型（`GetSavedTabsQuery` / `SearchSavedTabsQuery` など）                |
-| `use-cases/` | 1 操作 1 ファイルを基本とするオーケストレーション。副作用は repository interface / port 経由 |
-| `dto/`       | presentation 層へ返す読み取り専用モデル（domain entity を UI に渡さない）                    |
-| `ports/`     | `BrowserTabPort` / `NotificationPort` などの interface（chrome / toast 副作用の抽象）        |
+| ディレクトリ | 役割                                                                                                       |
+| ------------ | ---------------------------------------------------------------------------------------------------------- |
+| `commands/`  | 状態を変更するリクエスト型（`OpenSavedUrlCommand` / `DeleteTabGroupCommand` など）                         |
+| `queries/`   | 読み取り専用リクエスト型（`GetSavedTabsQuery` / `SearchSavedTabsQuery` / `GetSavedTabsPageDataQuery` など） |
+| `use-cases/` | 1 操作 1 ファイルを基本とするオーケストレーション。副作用は repository interface / port 経由               |
+| `dto/`       | presentation 層へ返す読み取り専用モデル（domain entity を UI に渡さない）                                  |
+| `mappers/`   | application 層内の DTO / snapshot 相互変換（`SavedTabsDtosMapper` / `SavedTabsSnapshotMapper`）            |
+| `ports/`     | `BrowserTabPort` / `NotificationPort` / `StorageChangePort` / `MessagingPort` などの interface（chrome / toast 副作用の抽象） |
+
+`mappers/` は `@/types/storage` 形 ↔ domain DTO / snapshot の pure 変換専用で、`chrome.*` API には触れません。storage ↔ domain entity 変換は `infrastructure/mappers/` の責務です。
 
 ## 禁止
 

--- a/src/contexts/saved-tabs/application/README.md
+++ b/src/contexts/saved-tabs/application/README.md
@@ -13,7 +13,7 @@
 | `mappers/`   | application 層内の DTO / snapshot 相互変換（`SavedTabsDtosMapper` / `SavedTabsSnapshotMapper`）                               |
 | `ports/`     | `BrowserTabPort` / `NotificationPort` / `StorageChangePort` / `MessagingPort` などの interface（chrome / toast 副作用の抽象） |
 
-`mappers/` は `@/types/storage` 形 ↔ domain DTO / snapshot の pure 変換専用で、`chrome.*` API には触れません。storage ↔ domain entity 変換は `infrastructure/mappers/` の責務です。
+`mappers/` は `@/types/storage` 形 ↔ domain DTO / domain entity の pure な構造変換専用で、`chrome.*` API には触れません。`SavedTabsDtosMapper` は DTO ↔ storage 形、`SavedTabsSnapshotMapper` は undo / snapshot 用に domain entity ↔ storage 形を双方向で持ち替えます（chrome.storage への I/O 自体は行わず、純関数として use-case / command の入出力整形に専念）。一方、`infrastructure/mappers/ChromeSavedTabsStorageMapper` は `chrome.storage.local` の生データ (`unknown` → Zod parse) ↔ domain entity の I/O 変換を担い、Zod 検証と entity 化失敗時の `null` フォールバックを持ちます。
 
 ## 禁止
 

--- a/src/contexts/saved-tabs/application/README.md
+++ b/src/contexts/saved-tabs/application/README.md
@@ -4,13 +4,13 @@
 
 ## サブディレクトリ
 
-| ディレクトリ | 役割                                                                                                       |
-| ------------ | ---------------------------------------------------------------------------------------------------------- |
-| `commands/`  | 状態を変更するリクエスト型（`OpenSavedUrlCommand` / `DeleteTabGroupCommand` など）                         |
-| `queries/`   | 読み取り専用リクエスト型（`GetSavedTabsQuery` / `SearchSavedTabsQuery` / `GetSavedTabsPageDataQuery` など） |
-| `use-cases/` | 1 操作 1 ファイルを基本とするオーケストレーション。副作用は repository interface / port 経由               |
-| `dto/`       | presentation 層へ返す読み取り専用モデル（domain entity を UI に渡さない）                                  |
-| `mappers/`   | application 層内の DTO / snapshot 相互変換（`SavedTabsDtosMapper` / `SavedTabsSnapshotMapper`）            |
+| ディレクトリ | 役割                                                                                                                          |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `commands/`  | 状態を変更するリクエスト型（`OpenSavedUrlCommand` / `DeleteTabGroupCommand` など）                                            |
+| `queries/`   | 読み取り専用リクエスト型（`GetSavedTabsQuery` / `SearchSavedTabsQuery` / `GetSavedTabsPageDataQuery` など）                   |
+| `use-cases/` | 1 操作 1 ファイルを基本とするオーケストレーション。副作用は repository interface / port 経由                                  |
+| `dto/`       | presentation 層へ返す読み取り専用モデル（domain entity を UI に渡さない）                                                     |
+| `mappers/`   | application 層内の DTO / snapshot 相互変換（`SavedTabsDtosMapper` / `SavedTabsSnapshotMapper`）                               |
 | `ports/`     | `BrowserTabPort` / `NotificationPort` / `StorageChangePort` / `MessagingPort` などの interface（chrome / toast 副作用の抽象） |
 
 `mappers/` は `@/types/storage` 形 ↔ domain DTO / snapshot の pure 変換専用で、`chrome.*` API には触れません。storage ↔ domain entity 変換は `infrastructure/mappers/` の責務です。

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -873,28 +873,23 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
   })
 
   describe('issue #526 followup: application/mappers/ は DTO / snapshot 変換の責務だけに閉じる', () => {
-    const expectedMapperFiles = [
-      'src/contexts/saved-tabs/application/mappers/SavedTabsDtosMapper.ts',
-      'src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.ts',
-    ]
-
-    for (const file of expectedMapperFiles) {
-      it(`${file} が存在する`, () => {
-        const source = readFileSync(resolve(repoRoot, file), 'utf8')
-        expect(source.length).toBeGreaterThan(0)
-      })
-    }
-
-    const mapperSourceFiles = expectedMapperFiles.map((file) =>
-      resolve(repoRoot, file),
+    const mappersRoot = resolve(
+      repoRoot,
+      'src/contexts/saved-tabs/application/mappers',
     )
+    // 追加された mapper も同じガードで再帰検出するため、ディレクトリ列挙で
+    // 取得する (test ファイルは collectSourceFiles 側で除外される)。
+    const mapperSourceFiles = collectSourceFiles(mappersRoot)
 
-    it('application/mappers/ 配下の .ts は React / chrome モジュールを import しない', () => {
-      for (const absolutePath of mapperSourceFiles) {
+    it('application/mappers/ 配下に production ソースファイルが存在する', () => {
+      expect(mapperSourceFiles.length).toBeGreaterThan(0)
+    })
+
+    for (const absolutePath of mapperSourceFiles) {
+      const relativePath = relative(repoRoot, absolutePath).split(sep).join('/')
+
+      it(`${relativePath} は React / chrome モジュールを import しない`, () => {
         const source = readFileSync(absolutePath, 'utf8')
-        const relativePath = relative(repoRoot, absolutePath)
-          .split(sep)
-          .join('/')
         expect(source, `${relativePath} should not import react`).not.toMatch(
           /from\s+['"]react['"]/,
         )
@@ -915,33 +910,23 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
           source,
           `${relativePath} should not call chrome.runtime`,
         ).not.toMatch(/chrome\.runtime\.\w+\(/)
-      }
-    })
+      })
 
-    it('application/mappers/ 配下の .ts は presentation 層に依存しない', () => {
-      for (const absolutePath of mapperSourceFiles) {
+      it(`${relativePath} は presentation 層に依存しない`, () => {
         const source = readFileSync(absolutePath, 'utf8')
-        const relativePath = relative(repoRoot, absolutePath)
-          .split(sep)
-          .join('/')
         expect(
           source,
           `${relativePath} should not import presentation layer`,
         ).not.toMatch(/from\s+['"]@\/contexts\/[^/]+\/presentation/)
-      }
-    })
+      })
 
-    it('application/mappers/ 配下の .ts は infrastructure 層に依存しない', () => {
-      for (const absolutePath of mapperSourceFiles) {
+      it(`${relativePath} は infrastructure 層に依存しない`, () => {
         const source = readFileSync(absolutePath, 'utf8')
-        const relativePath = relative(repoRoot, absolutePath)
-          .split(sep)
-          .join('/')
         expect(
           source,
           `${relativePath} should not import infrastructure layer`,
         ).not.toMatch(/from\s+['"]@\/contexts\/[^/]+\/infrastructure/)
-      }
-    })
+      })
+    }
   })
 })

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -871,4 +871,79 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       expect(source).toContain('SavedTabsPresentationLayout')
     })
   })
+
+  describe('issue #526 followup: application/mappers/ は DTO / snapshot 変換の責務だけに閉じる', () => {
+    const expectedMapperFiles = [
+      'src/contexts/saved-tabs/application/mappers/SavedTabsDtosMapper.ts',
+      'src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.ts',
+    ]
+
+    for (const file of expectedMapperFiles) {
+      it(`${file} が存在する`, () => {
+        const source = readFileSync(resolve(repoRoot, file), 'utf8')
+        expect(source.length).toBeGreaterThan(0)
+      })
+    }
+
+    const mapperSourceFiles = expectedMapperFiles.map((file) =>
+      resolve(repoRoot, file),
+    )
+
+    it('application/mappers/ 配下の .ts は React / chrome モジュールを import しない', () => {
+      for (const absolutePath of mapperSourceFiles) {
+        const source = readFileSync(absolutePath, 'utf8')
+        const relativePath = relative(repoRoot, absolutePath)
+          .split(sep)
+          .join('/')
+        expect(
+          source,
+          `${relativePath} should not import react`,
+        ).not.toMatch(/from\s+['"]react['"]/)
+        expect(
+          source,
+          `${relativePath} should not import chrome`,
+        ).not.toMatch(/from\s+['"]chrome['"]/)
+        // `chrome.storage` への直接関数呼び出しがないことを確認する
+        // (JSDoc 内テキストの言及は除外するため、`(local|onChanged|sync)(` で関数呼び出しのみ検出)
+        expect(
+          source,
+          `${relativePath} should not call chrome.storage directly`,
+        ).not.toMatch(/chrome\.storage\.(local|onChanged|sync)\(/)
+        expect(
+          source,
+          `${relativePath} should not call chrome.tabs`,
+        ).not.toMatch(/chrome\.tabs\.\w+\(/)
+        expect(
+          source,
+          `${relativePath} should not call chrome.runtime`,
+        ).not.toMatch(/chrome\.runtime\.\w+\(/)
+      }
+    })
+
+    it('application/mappers/ 配下の .ts は presentation 層に依存しない', () => {
+      for (const absolutePath of mapperSourceFiles) {
+        const source = readFileSync(absolutePath, 'utf8')
+        const relativePath = relative(repoRoot, absolutePath)
+          .split(sep)
+          .join('/')
+        expect(
+          source,
+          `${relativePath} should not import presentation layer`,
+        ).not.toMatch(/from\s+['"]@\/contexts\/[^/]+\/presentation/)
+      }
+    })
+
+    it('application/mappers/ 配下の .ts は infrastructure 層に依存しない', () => {
+      for (const absolutePath of mapperSourceFiles) {
+        const source = readFileSync(absolutePath, 'utf8')
+        const relativePath = relative(repoRoot, absolutePath)
+          .split(sep)
+          .join('/')
+        expect(
+          source,
+          `${relativePath} should not import infrastructure layer`,
+        ).not.toMatch(/from\s+['"]@\/contexts\/[^/]+\/infrastructure/)
+      }
+    })
+  })
 })

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -895,14 +895,12 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
         const relativePath = relative(repoRoot, absolutePath)
           .split(sep)
           .join('/')
-        expect(
-          source,
-          `${relativePath} should not import react`,
-        ).not.toMatch(/from\s+['"]react['"]/)
-        expect(
-          source,
-          `${relativePath} should not import chrome`,
-        ).not.toMatch(/from\s+['"]chrome['"]/)
+        expect(source, `${relativePath} should not import react`).not.toMatch(
+          /from\s+['"]react['"]/,
+        )
+        expect(source, `${relativePath} should not import chrome`).not.toMatch(
+          /from\s+['"]chrome['"]/,
+        )
         // `chrome.storage` への直接関数呼び出しがないことを確認する
         // (JSDoc 内テキストの言及は除外するため、`(local|onChanged|sync)(` で関数呼び出しのみ検出)
         expect(

--- a/src/contexts/saved-tabs/infrastructure/README.md
+++ b/src/contexts/saved-tabs/infrastructure/README.md
@@ -4,12 +4,12 @@
 
 ## サブディレクトリ
 
-| サブディレクトリ              | 役割                                                                                                          |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `persistence/chrome-storage/` | `Chrome*Repository` 実装 / `savedTabsStorageKeys.ts` / `savedTabsStorageSchema.ts` / `ChromeStorageLocalPort` |
+| サブディレクトリ              | 役割                                                                                                                   |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `persistence/chrome-storage/` | `Chrome*Repository` 実装 / `savedTabsStorageKeys.ts` / `savedTabsStorageSchema.ts` / `ChromeStorageLocalPort`          |
 | `browser/`                    | `chrome.tabs` / `chrome.contextMenus` / `chrome.alarms` / `chrome.storage.onChanged` / `chrome.runtime` などの adapter |
-| `mappers/`                    | storage の生データ ↔ domain entity / DTO の相互変換（`ChromeSavedTabsStorageMapper` など）                    |
-| `composition/`                | use-case / port を組み立てる composition root（`createSavedTabsUseCases` / `createSavedTabsUseCasesDeps`）   |
+| `mappers/`                    | storage の生データ ↔ domain entity / DTO の相互変換（`ChromeSavedTabsStorageMapper` など）                             |
+| `composition/`                | use-case / port を組み立てる composition root（`createSavedTabsUseCases` / `createSavedTabsUseCasesDeps`）             |
 
 `persistence/migrations/` は `savedTabsStorageSchema.ts` のコメントで将来の配置先として言及されていますが、現時点で実装ファイルはありません。新規の legacy 移行が必要になったタイミングで追加します。
 

--- a/src/contexts/saved-tabs/infrastructure/README.md
+++ b/src/contexts/saved-tabs/infrastructure/README.md
@@ -7,9 +7,11 @@
 | サブディレクトリ              | 役割                                                                                                          |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `persistence/chrome-storage/` | `Chrome*Repository` 実装 / `savedTabsStorageKeys.ts` / `savedTabsStorageSchema.ts` / `ChromeStorageLocalPort` |
-| `persistence/migrations/`     | 既存保存データを壊さない migration（`migrateLegacySavedTabs.ts` など）                                        |
-| `browser/`                    | `chrome.tabs` / `chrome.contextMenus` / `chrome.alarms` などの adapter                                        |
-| `mappers/`                    | storage の生データ ↔ domain entity / DTO の相互変換                                                           |
+| `browser/`                    | `chrome.tabs` / `chrome.contextMenus` / `chrome.alarms` / `chrome.storage.onChanged` / `chrome.runtime` などの adapter |
+| `mappers/`                    | storage の生データ ↔ domain entity / DTO の相互変換（`ChromeSavedTabsStorageMapper` など）                    |
+| `composition/`                | use-case / port を組み立てる composition root（`createSavedTabsUseCases` / `createSavedTabsUseCasesDeps`）   |
+
+`persistence/migrations/` は `savedTabsStorageSchema.ts` のコメントで将来の配置先として言及されていますが、現時点で実装ファイルはありません。新規の legacy 移行が必要になったタイミングで追加します。
 
 ## 禁止
 
@@ -25,5 +27,4 @@
   use-case へ注入する。
 - `ChromeStorageLocalPort` 経由で `chrome.storage.local` を抽象化し、テスト時は
   in-memory モックを注入する。
-- 旧 `src/lib/storage/*` の `chrome.storage.local` 直叩きは並行稼働させる。
-  段階的にこの repository へ移行する（use-case 化と併せて別 issue で進める）。
+- 旧 `src/lib/storage/*` の `chrome.storage.local` 直叩きは saved-tabs 関連で撤去済み（Issue #488 / #509）。他 feature での段階移行は別 issue で進める。


### PR DESCRIPTION
## 変更内容

issue #526 の追加クリーンアップとして、saved-tabs DDD 移行の README / architecture ドキュメントとガードテストを現状実装に合わせて更新しました。

### 変更ファイル

- **`docs/architecture/ddd.md`**
  - application 層のディレクトリ構成に `mappers/` を追加
  - application/ports の一覧に `StorageChangePort` / `MessagingPort` を追加（#495, #531 で導入済み）
  - application 層の説明に `mappers/` の責務を追加
- **`src/contexts/saved-tabs/README.md`**
  - 構成図の `application/` 説明順を `use-case / command / query / dto / mapper / port` に整列
  - `SavedTabsRoute` の呼び出し元を実態に合わせて修正（`src/features/navigation/app/AppRouter.tsx` → `src/entrypoints/app/main.tsx` 経由）。`src/entrypoints/saved-tabs/main.tsx` はレガシー URL のリダイレクト専用である旨を明記。
- **`src/contexts/saved-tabs/application/README.md`**
  - サブディレクトリ表に `mappers/` 行を追加（`SavedTabsDtosMapper` / `SavedTabsSnapshotMapper`）
  - `mappers/` は `@/types/storage` 形 ↔ domain DTO / snapshot の pure 変換専用で chrome.* には触れない旨と、storage ↔ domain entity 変換は `infrastructure/mappers/` の責務である旨を明記
  - `queries/` の例に `GetSavedTabsPageDataQuery` を追加
  - `ports/` の例に `StorageChangePort` / `MessagingPort` を追加
- **`src/contexts/saved-tabs/infrastructure/README.md`**
  - 実装ファイルが存在しない `persistence/migrations/` 行を削除し、`savedTabsStorageSchema.ts` のコメントで言及されている将来の配置先である旨を脚注に分離
  - `browser/` の説明に `chrome.storage.onChanged` / `chrome.runtime` を追加
  - `mappers/` の例に `ChromeSavedTabsStorageMapper` を追加
  - `composition/` 行を追加（`createSavedTabsUseCases` / `createSavedTabsUseCasesDeps`）
  - 「旧 `src/lib/storage/*` の `chrome.storage.local` 直叩きは並行稼働させる」記述を「saved-tabs 関連で撤去済み（#488 / #509）」に現状化
- **`src/contexts/saved-tabs/dddLayerGuard.test.ts`**
  - `application/mappers/` 専用の新しい describe ブロックを追加
    - `SavedTabsDtosMapper.ts` / `SavedTabsSnapshotMapper.ts` の存在確認
    - React / chrome モジュールを import しないこと
    - chrome.storage / chrome.tabs / chrome.runtime を直接呼び出さないこと
    - presentation 層 / infrastructure 層に依存しないこと

### 残課題

- `TODO(#502-followup)` の branded 差異・react-perf 系の disable コメントは元の PR #532 の判断どおり別 issue 対応として残置。
- `SavedTabsApp.test.tsx` の `@/lib/storage/tabs` 等 `vi.mock` 用 import は test ファイルであり production code ではないためガード対象外。必要なら `SavedTabsApp.test.tsx` のリファクタを別 issue で検討。

## 検証

- `bun run lint` → 0 errors / 0 warnings
- `bun run compile` → エラーなし
- `bun run test:node` → 1940 tests pass (138 files)
- `bunx vitest run --config vitest.ci.config.ts src/contexts/saved-tabs` → 1700 tests pass (141 files)
- 新規追加した `application/mappers/` ガード 4 ケースすべて pass

## 関連

- #454 (親 issue)
- #526 (元 issue)
- #532 (元の cleanup PR)
- #495, #531, #488, #509 (各 README 反映の元になった issue)