### PR TITLE
[DDD] useProjectManagement の CustomProjectRepository 直接依存を query/use-case 経由へ移す (issue #538)

### DIFF
--- a/src/contexts/saved-tabs/application/SavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/application/SavedTabsUseCases.ts
@@ -1,3 +1,7 @@
+import type { GetCustomProjectOrderQuery } from './queries/GetCustomProjectOrderQuery'
+import type { GetCustomProjectRawsQuery } from './queries/GetCustomProjectRawsQuery'
+import type { GetCustomProjectsQuery } from './queries/GetCustomProjectsQuery'
+import type { GetCustomProjectUndoSnapshotQuery } from './queries/GetCustomProjectUndoSnapshotQuery'
 import type { GetSavedTabsPageDataQuery } from './queries/GetSavedTabsPageDataQuery'
 import type { GetSavedTabsQuery } from './queries/GetSavedTabsQuery'
 import type { AddDomainToParentCategoryUseCase } from './use-cases/AddDomainToParentCategoryUseCase'
@@ -31,8 +35,11 @@ import type { ReorderParentCategoriesUseCase } from './use-cases/ReorderParentCa
 import type { ReorderTabGroupsUseCase } from './use-cases/ReorderTabGroupsUseCase'
 import type { ReorderTabGroupUrlsUseCase } from './use-cases/ReorderTabGroupUrlsUseCase'
 import type { RepairTabGroupParentCategoryIdsUseCase } from './use-cases/RepairTabGroupParentCategoryIdsUseCase'
+import type { RestoreCustomProjectsSnapshotUseCase } from './use-cases/RestoreCustomProjectsSnapshotUseCase'
 import type { RestoreOpenedUrlsSnapshotUseCase } from './use-cases/RestoreOpenedUrlsSnapshotUseCase'
 import type { RestoreOpenedUrlsSnapshotViewUseCase } from './use-cases/RestoreOpenedUrlsSnapshotViewUseCase'
+import type { SaveCustomProjectOrderUseCase } from './use-cases/SaveCustomProjectOrderUseCase'
+import type { SaveCustomProjectsUseCase } from './use-cases/SaveCustomProjectsUseCase'
 import type { SetCategoryKeywordsUseCase } from './use-cases/SetCategoryKeywordsUseCase'
 import type { SyncCategoryAssignmentsUseCase } from './use-cases/SyncCategoryAssignmentsUseCase'
 import type { UpdateCustomProjectNameUseCase } from './use-cases/UpdateCustomProjectNameUseCase'
@@ -135,6 +142,50 @@ export interface SavedTabsUseCases {
   readonly createCustomProject: CreateCustomProjectUseCase
   readonly deleteCustomProject: DeleteCustomProjectUseCase
   readonly updateCustomProjectName: UpdateCustomProjectNameUseCase
+  /**
+   * `CustomProject` ドメイン entity 一覧の読み取り query (issue #538)。
+   * 旧 `useProjectManagement` 内の `customProjectRepository.findAll`
+   * 直叩きを置換する application query 経由の読み取り口。
+   */
+  readonly getCustomProjects: GetCustomProjectsQuery
+  /**
+   * `CustomProject` の表示順 (`customProjectOrder`) 読み取り query
+   * (issue #538)。旧 `customProjectRepository.findOrder` 直叩きを置換。
+   */
+  readonly getCustomProjectOrder: GetCustomProjectOrderQuery
+  /**
+   * undo 用途の `CustomProject` snapshot 読み取り query (issue #538)。
+   * `customProjectOrder` + `customProjects` (entity) + `customProjectsRaw`
+   * を 1 関数で束ねる。旧 `useProjectManagement` 内の
+   * `getCustomProjectUndoSnapshot` private helper 責務を application
+   * 層へ移設。
+   */
+  readonly getCustomProjectUndoSnapshot: GetCustomProjectUndoSnapshotQuery
+  /**
+   * rich フィールド付き `CustomProject` raw snapshot 読み取り query
+   * (issue #538)。undo 復元 / sync で raw 経路を保ったまま storage
+   * 形へ投影したい場面で利用。
+   */
+  readonly getCustomProjectRaws: GetCustomProjectRawsQuery
+  /**
+   * `CustomProject` 表示順保存 use-case (issue #538)。
+   * 旧 `useProjectManagement.handleReorderProjects` 内の
+   * `customProjectRepository.saveOrder` 直叩きを置換。
+   */
+  readonly saveCustomProjectOrder: SaveCustomProjectOrderUseCase
+  /**
+   * `CustomProject` entity 保存 use-case (issue #538)。
+   * undo 復元で `restoreAllRaw` が無い / 無い時の entity 経由
+   * フォールバックのラッパ。
+   */
+  readonly saveCustomProjects: SaveCustomProjectsUseCase
+  /**
+   * undo 復元 use-case (issue #538)。
+   * 旧 `useProjectManagement.showCustomProjectDeleteUndoToast` 内の
+   * `restoreAllRaw` / `saveAll` / `saveOrder` 3 段呼び出しを
+   * 1 つの use-case に統合。
+   */
+  readonly restoreCustomProjectsSnapshot: RestoreCustomProjectsSnapshotUseCase
   readonly getProjectUrls: GetProjectUrlsUseCase
   readonly getSavedTabsPageData: GetSavedTabsPageDataQuery
   /**

--- a/src/contexts/saved-tabs/application/queries/GetCustomProjectOrderQuery.ts
+++ b/src/contexts/saved-tabs/application/queries/GetCustomProjectOrderQuery.ts
@@ -1,0 +1,47 @@
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+import type { CustomProjectId } from '../../domain/value-objects/CustomProjectId'
+
+/**
+ * presentation 層が「`CustomProject` の表示順 (ID 配列)」を必要とするときの
+ * application query (issue #538)。
+ *
+ * 旧 `useProjectManagement` 内の `customProjectRepository.findOrder()`
+ * 直叩きを、application query 経由へ寄せるラッパ。`getSavedTabsQuery` と
+ * 同じ「`Repository.findX` への 1 メソッドブリッジ」パターンで、
+ * presentation 層が `CustomProjectRepository` を import する経路を
+ * 閉じる。
+ *
+ * 戻り値の `readonly CustomProjectId[]` は domain value-object の
+ * branded 型を維持し、presentation 層で `string` 配列として扱いたい
+ * 場合は呼び出し側で widen する。
+ */
+export type GetCustomProjectOrderQuery = () => Promise<
+  readonly CustomProjectId[]
+>
+
+/**
+ * `GetCustomProjectOrderQuery` が依存する repository 群。
+ */
+export interface GetCustomProjectOrderQueryDeps {
+  readonly customProjectRepository: CustomProjectRepository
+}
+
+/**
+ * `GetCustomProjectOrderQuery` を生成する。
+ *
+ * 責務は `customProjectRepository.findOrder()` を呼び出して
+ * `readonly CustomProjectId[]` を返すだけ。
+ *
+ * @example
+ * ```ts
+ * const getCustomProjectOrder = createGetCustomProjectOrderQuery({
+ *   customProjectRepository,
+ * })
+ * const order = await getCustomProjectOrder()
+ * ```
+ */
+export const createGetCustomProjectOrderQuery = (
+  deps: GetCustomProjectOrderQueryDeps,
+): GetCustomProjectOrderQuery => {
+  return async () => deps.customProjectRepository.findOrder()
+}

--- a/src/contexts/saved-tabs/application/queries/GetCustomProjectRawsQuery.ts
+++ b/src/contexts/saved-tabs/application/queries/GetCustomProjectRawsQuery.ts
@@ -1,0 +1,73 @@
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import type {
+  CustomProjectRawSnapshot,
+  CustomProjectRepository,
+} from '../../domain/repositories/CustomProjectRepository'
+
+/**
+ * presentation 層が「rich フィールド付き `CustomProject` の生
+ * snapshot」を必要とするときの application query (issue #538)。
+ *
+ * 旧 `useProjectManagement.loadCustomProjectRaws` (private helper) の
+ * 責務を application query として切り出す。`findAllRaw` 実装が
+ * ある repository では raw snapshot をそのまま返し、未実装の legacy
+ * repository では `findAll()` (entity) を widen して最低限の
+ * フィールドだけを埋めた raw snapshot を返す。
+ *
+ * `getCustomProjectsQuery` との対比: 本 query は undo / sync 用途に
+ * rich フィールド (`projectKeywords` / `categoryOrder` / `urls` /
+ * `urlMetadata`) を保持したまま storage 形へ投影したい場面で
+ * 利用する。エンティティだけが必要な軽量経路は
+ * `getCustomProjectsQuery` を併用する。
+ */
+export type GetCustomProjectRawsQuery = () => Promise<
+  readonly CustomProjectRawSnapshot[]
+>
+
+/**
+ * `GetCustomProjectRawsQuery` が依存する repository 群。
+ */
+export interface GetCustomProjectRawsQueryDeps {
+  readonly customProjectRepository: CustomProjectRepository
+}
+
+const entityToRawSnapshot = (
+  project: CustomProject,
+): CustomProjectRawSnapshot => ({
+  categories: [...project.categories],
+  createdAt: project.createdAt,
+  id: project.id,
+  name: project.name,
+  updatedAt: project.updatedAt,
+  ...(project.urlIds.length > 0 ? { urlIds: [...project.urlIds] } : {}),
+})
+
+/**
+ * `GetCustomProjectRawsQuery` を生成する。
+ *
+ * 責務:
+ * 1. `customProjectRepository.findAllRaw` があればそれを呼び、
+ *    rich フィールド保持 snapshot をそのまま返す
+ * 2. 未実装なら `findAll()` で entity を取得し、必要最低限の
+ *    フィールドだけを埋めた raw snapshot へ widen する
+ *    (rich フィールドは storage 形 projection で省略される)
+ *
+ * @example
+ * ```ts
+ * const getCustomProjectRaws = createGetCustomProjectRawsQuery({
+ *   customProjectRepository,
+ * })
+ * const raws = await getCustomProjectRaws()
+ * ```
+ */
+export const createGetCustomProjectRawsQuery = (
+  deps: GetCustomProjectRawsQueryDeps,
+): GetCustomProjectRawsQuery => {
+  return async (): Promise<readonly CustomProjectRawSnapshot[]> => {
+    if (deps.customProjectRepository.findAllRaw) {
+      return deps.customProjectRepository.findAllRaw()
+    }
+    const projects = await deps.customProjectRepository.findAll()
+    return projects.map(entityToRawSnapshot)
+  }
+}

--- a/src/contexts/saved-tabs/application/queries/GetCustomProjectUndoSnapshotQuery.ts
+++ b/src/contexts/saved-tabs/application/queries/GetCustomProjectUndoSnapshotQuery.ts
@@ -1,0 +1,102 @@
+import { createCustomProject } from '../../domain/entities/CustomProject'
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import type {
+  CustomProjectRawSnapshot,
+  CustomProjectRepository,
+} from '../../domain/repositories/CustomProjectRepository'
+import type { CustomProjectId } from '../../domain/value-objects/CustomProjectId'
+
+/**
+ * undo 用途の `CustomProject` 読み取りスナップショット (issue #538)。
+ *
+ * - `customProjectOrder`: 削除直前の `customProjectOrder`。
+ * - `customProjects`: `findAll()` (entity 経路) で取得した entity 一覧。
+ * - `customProjectsRaw`: `findAllRaw()` (raw 経路) で取得した snapshot
+ *   一覧。rich フィールド (`urls` / `urlMetadata` / `projectKeywords` /
+ *   `categoryOrder`) を保持する。
+ *
+ * それぞれ「該当データが存在しない」場合に省略される optional フィールド。
+ * `RestoreCustomProjectsSnapshotUseCase` 側で payload 化してから
+ * `customProjectRepository.restoreAllRaw` / `saveAll` に渡す。
+ */
+export interface CustomProjectUndoSnapshot {
+  customProjectOrder?: readonly CustomProjectId[]
+  customProjects?: readonly CustomProject[]
+  customProjectsRaw?: readonly CustomProjectRawSnapshot[]
+}
+
+/**
+ * presentation 層が undo 用途に「`CustomProject` 表示順 + entity +
+ * raw snapshot」を一括取得するときの application query (issue #538)。
+ *
+ * 旧 `useProjectManagement.getCustomProjectUndoSnapshot` (private
+ * helper) の責務を application query として切り出す。`findOrder` と
+ * `findAllRaw` (`findAll` フォールバック) を 1 関数に束ね、
+ * presentation 層が「order / entity / raw を別々に取得して組み立てる」
+ * ロジックを持つ必要をなくす。
+ *
+ * 旧実装と異なり、`customProjectOrder` は array length > 0 のときだけ
+ * 設定する (空配列を payload 化すると `saveOrder([])` が誤って
+ * 走ってしまうため)。
+ */
+export type GetCustomProjectUndoSnapshotQuery =
+  () => Promise<CustomProjectUndoSnapshot>
+
+/**
+ * `GetCustomProjectUndoSnapshotQuery` が依存する repository 群。
+ */
+export interface GetCustomProjectUndoSnapshotQueryDeps {
+  readonly customProjectRepository: CustomProjectRepository
+}
+
+const entityFromRaw = (raw: CustomProjectRawSnapshot): CustomProject =>
+  createCustomProject({
+    categories: raw.categories,
+    createdAt: raw.createdAt,
+    id: raw.id,
+    name: raw.name,
+    updatedAt: raw.updatedAt,
+    urlIds: raw.urlIds ?? [],
+  })
+
+/**
+ * `GetCustomProjectUndoSnapshotQuery` を生成する。
+ *
+ * 責務:
+ * 1. `customProjectRepository.findOrder()` で order を取得
+ * 2. `findAllRaw` 実装があればそれを使い、raw snapshot と entity 形を
+ *    両方返す (issue #535 P1: rich フィールド保持)
+ * 3. `findAllRaw` 未実装の legacy repository では `findAll()` (entity)
+ *    だけでフォールバックする
+ *
+ * @example
+ * ```ts
+ * const getCustomProjectUndoSnapshot = createGetCustomProjectUndoSnapshotQuery({
+ *   customProjectRepository,
+ * })
+ * const snapshot = await getCustomProjectUndoSnapshot()
+ * ```
+ */
+export const createGetCustomProjectUndoSnapshotQuery = (
+  deps: GetCustomProjectUndoSnapshotQueryDeps,
+): GetCustomProjectUndoSnapshotQuery => {
+  return async (): Promise<CustomProjectUndoSnapshot> => {
+    const order = await deps.customProjectRepository.findOrder()
+    const base: CustomProjectUndoSnapshot =
+      order.length > 0 ? { customProjectOrder: order } : {}
+    if (deps.customProjectRepository.findAllRaw) {
+      const raws = await deps.customProjectRepository.findAllRaw()
+      const projects: CustomProject[] = raws.map(entityFromRaw)
+      return {
+        ...base,
+        ...(projects.length > 0 ? { customProjects: projects } : {}),
+        ...(raws.length > 0 ? { customProjectsRaw: raws } : {}),
+      }
+    }
+    const projects = await deps.customProjectRepository.findAll()
+    return {
+      ...base,
+      ...(projects.length > 0 ? { customProjects: projects } : {}),
+    }
+  }
+}

--- a/src/contexts/saved-tabs/application/queries/GetCustomProjectsQuery.ts
+++ b/src/contexts/saved-tabs/application/queries/GetCustomProjectsQuery.ts
@@ -1,0 +1,45 @@
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+
+/**
+ * presentation 層が「`CustomProject` ドメイン entity の生一覧」を
+ * 必要とするときの application query (issue #538)。
+ *
+ * 旧 `useProjectManagement` 内の `customProjectRepository.findAll()`
+ * 直叩きを、application query 経由へ寄せるラッパ。`getCustomProjectRawsQuery`
+ * とは戻り値 shape が異なり、entity 形 (`CustomProject`) と raw
+ * snapshot 形 (`CustomProjectRawSnapshot`) のどちらが必要かで
+ * 呼び分けられる。
+ *
+ * 純粋な read-only query。state は持たず、副作用は
+ * `customProjectRepository.findAll()` 呼び出しのみ。
+ */
+export type GetCustomProjectsQuery = () => Promise<readonly CustomProject[]>
+
+/**
+ * `GetCustomProjectsQuery` が依存する repository 群。
+ */
+export interface GetCustomProjectsQueryDeps {
+  readonly customProjectRepository: CustomProjectRepository
+}
+
+/**
+ * `GetCustomProjectsQuery` を生成する。
+ *
+ * 責務は `customProjectRepository.findAll()` を呼び出して
+ * `readonly CustomProject[]` を返すだけ。shape 変換や
+ * 並び替えは行わない。
+ *
+ * @example
+ * ```ts
+ * const getCustomProjects = createGetCustomProjectsQuery({
+ *   customProjectRepository,
+ * })
+ * const projects = await getCustomProjects()
+ * ```
+ */
+export const createGetCustomProjectsQuery = (
+  deps: GetCustomProjectsQueryDeps,
+): GetCustomProjectsQuery => {
+  return async () => deps.customProjectRepository.findAll()
+}

--- a/src/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
+
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import type {
+  CustomProjectRawSnapshot,
+  CustomProjectRepository,
+} from '../../domain/repositories/CustomProjectRepository'
+import type { CustomProjectId } from '../../domain/value-objects/CustomProjectId'
+import { createRestoreCustomProjectsSnapshotUseCase } from './RestoreCustomProjectsSnapshotUseCase'
+
+const makeRepository = (options: {
+  readonly restoreAllRaw?: (
+    raws: readonly CustomProjectRawSnapshot[],
+  ) => Promise<void>
+  readonly saveAll?: (projects: readonly CustomProject[]) => Promise<void>
+  readonly saveOrder?: (order: readonly CustomProjectId[]) => Promise<void>
+}): CustomProjectRepository =>
+  ({
+    findAll: vi.fn().mockResolvedValue([]),
+    findById: vi.fn().mockResolvedValue(null),
+    removeByIds: vi.fn().mockResolvedValue(undefined),
+    saveAll: options.saveAll ?? vi.fn().mockResolvedValue(undefined),
+    findOrder: vi.fn().mockResolvedValue([]),
+    saveOrder: options.saveOrder ?? vi.fn().mockResolvedValue(undefined),
+    ...(options.restoreAllRaw ? { restoreAllRaw: options.restoreAllRaw } : {}),
+  }) as unknown as CustomProjectRepository
+
+describe('RestoreCustomProjectsSnapshotUseCase', () => {
+  const projects: CustomProject[] = [
+    {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      id: 'project-1' as never,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      name: 'Project A' as never,
+      categories: [],
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      createdAt: 1 as never,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      updatedAt: 2 as never,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      urlIds: ['url-a' as never],
+    },
+  ]
+  const raws: CustomProjectRawSnapshot[] = [
+    {
+      categories: [],
+      createdAt: 1,
+      id: 'project-1',
+      name: 'Q4',
+      updatedAt: 2,
+      urlIds: ['url-1'],
+      urls: [{ url: 'https://example.com/a', title: 'A' }],
+    },
+  ]
+  const order: CustomProjectId[] = ['project-1' as never]
+
+  it('payload に raw snapshot があり restoreAllRaw が実装されていれば restoreAllRaw 経由で書き戻す', async () => {
+    const restoreAllRaw = vi.fn().mockResolvedValue(undefined)
+    const saveAll = vi.fn().mockResolvedValue(undefined)
+    const saveOrder = vi.fn().mockResolvedValue(undefined)
+    const customProjectRepository = makeRepository({
+      restoreAllRaw,
+      saveAll,
+      saveOrder,
+    })
+    const useCase = createRestoreCustomProjectsSnapshotUseCase({
+      customProjectRepository,
+    })
+
+    await useCase({
+      payload: {
+        customProjects: projects,
+        customProjectsRaw: raws,
+        customProjectOrder: order,
+      },
+    })
+
+    expect(restoreAllRaw).toHaveBeenCalledWith(raws)
+    // restoreAllRaw 経路では saveAll は呼ばれない。
+    expect(saveAll).not.toHaveBeenCalled()
+    expect(saveOrder).toHaveBeenCalledWith(order)
+  })
+
+  it('payload に customProjectsRaw が無い場合、saveAll へフォールバックする (issue #535 P1 / PR #506 review P2)', async () => {
+    const saveAll = vi.fn().mockResolvedValue(undefined)
+    const saveOrder = vi.fn().mockResolvedValue(undefined)
+    const restoreAllRaw = vi.fn().mockResolvedValue(undefined)
+    const customProjectRepository = makeRepository({
+      restoreAllRaw,
+      saveAll,
+      saveOrder,
+    })
+    const useCase = createRestoreCustomProjectsSnapshotUseCase({
+      customProjectRepository,
+    })
+
+    await useCase({
+      payload: {
+        customProjects: projects,
+        customProjectOrder: order,
+      },
+    })
+
+    expect(saveAll).toHaveBeenCalledWith(projects)
+    expect(restoreAllRaw).not.toHaveBeenCalled()
+    expect(saveOrder).toHaveBeenCalledWith(order)
+  })
+
+  it('restoreAllRaw が repository に未実装の場合、saveAll へフォールバックする (旧 mock / legacy 経路)', async () => {
+    const saveAll = vi.fn().mockResolvedValue(undefined)
+    const saveOrder = vi.fn().mockResolvedValue(undefined)
+    const customProjectRepository = makeRepository({
+      saveAll,
+      saveOrder,
+    })
+    const useCase = createRestoreCustomProjectsSnapshotUseCase({
+      customProjectRepository,
+    })
+
+    await useCase({
+      payload: {
+        customProjects: projects,
+        customProjectsRaw: raws,
+        customProjectOrder: order,
+      },
+    })
+
+    expect(saveAll).toHaveBeenCalledWith(projects)
+    expect(saveOrder).toHaveBeenCalledWith(order)
+  })
+
+  it('customProjectOrder が省略された payload は saveOrder([]) 相当の「全消去」セマンティクスで書き戻す', async () => {
+    const saveOrder = vi.fn().mockResolvedValue(undefined)
+    const customProjectRepository = makeRepository({ saveOrder })
+    const useCase = createRestoreCustomProjectsSnapshotUseCase({
+      customProjectRepository,
+    })
+
+    await useCase({
+      payload: {
+        customProjects: projects,
+      },
+    })
+
+    expect(saveOrder).toHaveBeenCalledWith([])
+  })
+})

--- a/src/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase.ts
@@ -1,0 +1,94 @@
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import type {
+  CustomProjectRawSnapshot,
+  CustomProjectRepository,
+} from '../../domain/repositories/CustomProjectRepository'
+import type { CustomProjectId } from '../../domain/value-objects/CustomProjectId'
+
+/**
+ * undo 復元で `RestoreCustomProjectsSnapshotUseCase` に渡す payload。
+ *
+ * `getCustomProjectUndoSnapshotQuery` の戻り値 (`CustomProjectUndoSnapshot`)
+ * は「該当データが無いときフィールドが省略される optional」だが、
+ * 復元用 payload では `customProjects` を必須とし、order / raw は
+ * optional に固定する。order 省略時は `saveOrder([])` 相当の
+ * 「全消去」セマンティクスを明示するため、呼び出し側で
+ * `customProjectOrder ?? []` ではなく省略有無を意識する。
+ */
+export interface RestoreCustomProjectsSnapshotPayload {
+  readonly customProjectOrder?: readonly CustomProjectId[]
+  readonly customProjects: readonly CustomProject[]
+  readonly customProjectsRaw?: readonly CustomProjectRawSnapshot[]
+}
+
+/**
+ * `RestoreCustomProjectsSnapshotUseCase` の入力。
+ */
+export interface RestoreCustomProjectsSnapshotCommand {
+  readonly payload: RestoreCustomProjectsSnapshotPayload
+}
+
+/**
+ * `RestoreCustomProjectsSnapshotUseCase` の戻り値。
+ *
+ * 副作用完了だけを表す `void`。
+ */
+export type RestoreCustomProjectsSnapshotUseCase = (
+  command: RestoreCustomProjectsSnapshotCommand,
+) => Promise<void>
+
+/**
+ * `RestoreCustomProjectsSnapshotUseCase` が依存する repository 群。
+ */
+export interface RestoreCustomProjectsSnapshotUseCaseDeps {
+  readonly customProjectRepository: CustomProjectRepository
+}
+
+/**
+ * `RestoreCustomProjectsSnapshotUseCase` を生成する (issue #538)。
+ *
+ * 責務:
+ * 1. payload に `customProjectsRaw` があり repository 側に
+ *    `restoreAllRaw` 実装があれば、それで生 snapshot をそのまま
+ *    書き戻す (issue #535 P1: `urls` / `urlMetadata` /
+ *    `projectKeywords` / `categoryOrder` などの rich フィールドを
+ *    merge 介在なしで保持)
+ * 2. それ以外は `customProjectRepository.saveAll(payload.customProjects)`
+ *    にフォールバックする (`DeleteCustomProjectUseCase` と同じ挙動)
+ * 3. 続けて `customProjectRepository.saveOrder(payload.customProjectOrder ?? [])`
+ *    で表示順を書き戻す
+ *
+ * 旧 `useProjectManagement.showCustomProjectDeleteUndoToast` 内の
+ * `restoreAllRaw` / `saveAll` / `saveOrder` 3 段呼び出しを 1 つの
+ * use-case に統合する。
+ *
+ * @example
+ * ```ts
+ * const restoreCustomProjectsSnapshot = createRestoreCustomProjectsSnapshotUseCase({
+ *   customProjectRepository,
+ * })
+ * await restoreCustomProjectsSnapshot({ payload: snapshot })
+ * ```
+ */
+export const createRestoreCustomProjectsSnapshotUseCase = (
+  deps: RestoreCustomProjectsSnapshotUseCaseDeps,
+): RestoreCustomProjectsSnapshotUseCase => {
+  return async (command) => {
+    const { payload } = command
+    if (
+      payload.customProjectsRaw &&
+      deps.customProjectRepository.restoreAllRaw
+    ) {
+      await deps.customProjectRepository.restoreAllRaw(
+        payload.customProjectsRaw,
+      )
+    } else {
+      await deps.customProjectRepository.saveAll(payload.customProjects)
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const order = (payload.customProjectOrder ?? []) as unknown as Parameters<
+      CustomProjectRepository['saveOrder']
+    >[0]
+    await deps.customProjectRepository.saveOrder(order)
+  }
+}

--- a/src/contexts/saved-tabs/application/use-cases/SaveCustomProjectOrderUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/SaveCustomProjectOrderUseCase.ts
@@ -1,0 +1,64 @@
+import type { CustomProjectRepository } from '../../domain/repositories/CustomProjectRepository'
+
+/**
+ * `SaveCustomProjectOrderUseCase` の入力。
+ *
+ * `newOrder` は表示順の `CustomProjectId` 配列。UI 側で並び替え後に
+ * presentation hook から渡される。
+ */
+export interface SaveCustomProjectOrderCommand {
+  readonly newOrder: readonly string[]
+}
+
+/**
+ * `SaveCustomProjectOrderUseCase` の戻り値。
+ *
+ * 現状は副作用完了だけを表す `void` だが、`CustomProjectRepository` 側で
+ * 将来的に「保存後の order を含んだ entity 配列」を返すようになっても
+ * 影響を閉じ込められるよう、interface を切って export しておく。
+ */
+export type SaveCustomProjectOrderUseCase = (
+  command: SaveCustomProjectOrderCommand,
+) => Promise<void>
+
+/**
+ * `SaveCustomProjectOrderUseCase` が依存する repository 群。
+ */
+export interface SaveCustomProjectOrderUseCaseDeps {
+  readonly customProjectRepository: CustomProjectRepository
+}
+
+/**
+ * `SaveCustomProjectOrderUseCase` を生成する (issue #538)。
+ *
+ * 責務は `customProjectRepository.saveOrder(newOrder)` を呼び出す
+ * だけ。並び替えそのものは presentation hook 側で行い、確定した
+ * 配列を use-case へ渡す。
+ *
+ * 旧 `useProjectManagement.handleReorderProjects` 内の
+ * `customProjectRepository.saveOrder(...)` 直叩きを置換する。
+ *
+ * `newOrder` は UI 入力の都合で `readonly string[]` として受け取る。
+ * `CustomProjectRepository.saveOrder` は branded `CustomProjectId` を
+ * 要求するため、use-case 境界で `unknown` キャストを 1 度だけ行う
+ * (storage 実装側は branded 検証に依存しない素のマッピング)。
+ *
+ * @example
+ * ```ts
+ * const saveCustomProjectOrder = createSaveCustomProjectOrderUseCase({
+ *   customProjectRepository,
+ * })
+ * await saveCustomProjectOrder({ newOrder: ['project-1', 'project-2'] })
+ * ```
+ */
+export const createSaveCustomProjectOrderUseCase = (
+  deps: SaveCustomProjectOrderUseCaseDeps,
+): SaveCustomProjectOrderUseCase => {
+  return async (command) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const order = command.newOrder as unknown as Parameters<
+      CustomProjectRepository['saveOrder']
+    >[0]
+    await deps.customProjectRepository.saveOrder(order)
+  }
+}

--- a/src/contexts/saved-tabs/application/use-cases/SaveCustomProjectsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/SaveCustomProjectsUseCase.ts
@@ -1,0 +1,80 @@
+import type { CustomProject } from '../../domain/entities/CustomProject'
+import type {
+  CustomProjectRawSnapshot,
+  CustomProjectRepository,
+} from '../../domain/repositories/CustomProjectRepository'
+
+/**
+ * `SaveCustomProjectsUseCase` の入力。
+ *
+ * `projects` は domain entity 形の `CustomProject` 配列。
+ * `findAll()` 経由で取得した entity をそのまま `saveAll` に渡す
+ * 用途を想定。
+ */
+export interface SaveCustomProjectsCommand {
+  readonly projects: readonly CustomProject[]
+}
+
+export type SaveCustomProjectsUseCase = (
+  command: SaveCustomProjectsCommand,
+) => Promise<void>
+
+/**
+ * `SaveCustomProjectsUseCase` が依存する repository 群。
+ */
+export interface SaveCustomProjectsUseCaseDeps {
+  readonly customProjectRepository: CustomProjectRepository
+}
+
+/**
+ * `SaveCustomProjectsUseCase` を生成する (issue #538)。
+ *
+ * 責務は `customProjectRepository.saveAll(projects)` を呼び出す
+ * だけ。rich フィールド (`urls` / `urlMetadata` / `projectKeywords` /
+ * `categoryOrder`) は mapper 側で original raw から持ち越される
+ * ため、entity 形を渡しても rich フィールドが脱落しない。
+ *
+ * 旧 `useProjectManagement` の undo フォールバック
+ * (`customProjectRepository.saveAll(payload.customProjects)`) を
+ * 使うため use-case 経由で呼ぶ。
+ *
+ * 互換 raw 入出力 (`restoreAllRaw`) が必要なら
+ * `RestoreCustomProjectsSnapshotUseCase` 側を優先する。
+ *
+ * @example
+ * ```ts
+ * const saveCustomProjects = createSaveCustomProjectsUseCase({
+ *   customProjectRepository,
+ * })
+ * await saveCustomProjects({ projects })
+ * ```
+ */
+export const createSaveCustomProjectsUseCase = (
+  deps: SaveCustomProjectsUseCaseDeps,
+): SaveCustomProjectsUseCase => {
+  return async (command) => {
+    await deps.customProjectRepository.saveAll(command.projects)
+  }
+}
+
+/**
+ * `SaveCustomProjectsUseCase` で `saveAll` に渡せるよう、entity
+ * (`CustomProject`) のうち undo 用に最低限必要なフィールドだけを
+ * `CustomProjectRawSnapshot` 形へ widen するヘルパー。
+ *
+ * `urls` / `urlMetadata` / `projectKeywords` / `categoryOrder` は
+ * entity 境界で表現されないため、ここでは widening できない。
+ * rich フィールドを保持したまま永続化したい場合は
+ * `RestoreCustomProjectsSnapshotUseCase` 経由で `restoreAllRaw` を
+ * 使うこと。
+ */
+export const toCustomProjectRawFromEntity = (
+  project: CustomProject,
+): CustomProjectRawSnapshot => ({
+  categories: [...project.categories],
+  createdAt: project.createdAt,
+  id: project.id,
+  name: project.name,
+  updatedAt: project.updatedAt,
+  ...(project.urlIds.length > 0 ? { urlIds: [...project.urlIds] } : {}),
+})

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -929,4 +929,64 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       })
     }
   })
+
+  describe('issue #538: useProjectManagement は CustomProjectRepository を import しない', () => {
+    const useProjectManagementPath = resolve(
+      repoRoot,
+      'src/contexts/saved-tabs/presentation/hooks/useProjectManagement.ts',
+    )
+    const useProjectManagementSource = readFileSync(
+      useProjectManagementPath,
+      'utf8',
+    )
+
+    it('useProjectManagement は CustomProjectRepository を import していない', () => {
+      expect(useProjectManagementSource).not.toMatch(
+        /from\s+['"]@\/contexts\/saved-tabs\/domain\/repositories\/CustomProjectRepository['"]/,
+      )
+    })
+
+    it('useProjectManagement の deps は customProjectRepository を受け取らない', () => {
+      // 第 1 引数が `customProjectRepository` でなく、application
+      // query / use-case 関数のみ受け取る形に更新されていること。
+      // まず deps 引数 (関数シグネチャ) の型注釈レベルを検証し、
+      // import 自体が repository モジュールを直接引いていないかを
+      // 別途検証する。
+      expect(useProjectManagementSource).not.toMatch(
+        /customProjectRepository\s*:\s*CustomProjectRepository/,
+      )
+      // import 文での repository モジュール直接依存を検証する。
+      // JSDoc 中の言及は許容するため、`from '...repository'` 形式
+      // の import のみ検出する。
+      expect(useProjectManagementSource).not.toMatch(
+        /from\s+['"]@\/contexts\/saved-tabs\/domain\/repositories\/CustomProjectRepository['"]/,
+      )
+    })
+
+    it('useProjectManagement は CustomProjectRepository.findOrder / saveOrder / findAll / findAllRaw / restoreAllRaw / saveAll を直接呼ばない', () => {
+      // JSDoc 内の言及は除外し、関数呼び出し形式のみ検出。
+      // `repo.findAll` のようなメソッド呼び出しを許容するため、
+      // 識別子単体 (`.findOrder` / `.saveOrder` ...) を
+      // `customProjectRepositoryRef` 系が保有している経路に限定して
+      // 検出する。
+      expect(useProjectManagementSource).not.toMatch(
+        /customProjectRepositoryRef\.current\.findOrder\(/,
+      )
+      expect(useProjectManagementSource).not.toMatch(
+        /customProjectRepositoryRef\.current\.saveOrder\(/,
+      )
+      expect(useProjectManagementSource).not.toMatch(
+        /customProjectRepositoryRef\.current\.findAll\(/,
+      )
+      expect(useProjectManagementSource).not.toMatch(
+        /customProjectRepositoryRef\.current\.findAllRaw\(/,
+      )
+      expect(useProjectManagementSource).not.toMatch(
+        /customProjectRepositoryRef\.current\.restoreAllRaw\(/,
+      )
+      expect(useProjectManagementSource).not.toMatch(
+        /customProjectRepositoryRef\.current\.saveAll\(/,
+      )
+    })
+  })
 })

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts
@@ -1,3 +1,7 @@
+import { createGetCustomProjectOrderQuery } from '../../application/queries/GetCustomProjectOrderQuery'
+import { createGetCustomProjectRawsQuery } from '../../application/queries/GetCustomProjectRawsQuery'
+import { createGetCustomProjectsQuery } from '../../application/queries/GetCustomProjectsQuery'
+import { createGetCustomProjectUndoSnapshotQuery } from '../../application/queries/GetCustomProjectUndoSnapshotQuery'
 import { createGetSavedTabsPageDataQuery } from '../../application/queries/GetSavedTabsPageDataQuery'
 import { createGetSavedTabsQuery } from '../../application/queries/GetSavedTabsQuery'
 import type { SavedTabsUseCases } from '../../application/SavedTabsUseCases'
@@ -32,8 +36,11 @@ import { createReorderParentCategoriesUseCase } from '../../application/use-case
 import { createReorderTabGroupsUseCase } from '../../application/use-cases/ReorderTabGroupsUseCase'
 import { createReorderTabGroupUrlsUseCase } from '../../application/use-cases/ReorderTabGroupUrlsUseCase'
 import { createRepairTabGroupParentCategoryIdsUseCase } from '../../application/use-cases/RepairTabGroupParentCategoryIdsUseCase'
+import { createRestoreCustomProjectsSnapshotUseCase } from '../../application/use-cases/RestoreCustomProjectsSnapshotUseCase'
 import { createRestoreOpenedUrlsSnapshotUseCase } from '../../application/use-cases/RestoreOpenedUrlsSnapshotUseCase'
 import { createRestoreOpenedUrlsSnapshotViewUseCase } from '../../application/use-cases/RestoreOpenedUrlsSnapshotViewUseCase'
+import { createSaveCustomProjectOrderUseCase } from '../../application/use-cases/SaveCustomProjectOrderUseCase'
+import { createSaveCustomProjectsUseCase } from '../../application/use-cases/SaveCustomProjectsUseCase'
 import { createSetCategoryKeywordsUseCase } from '../../application/use-cases/SetCategoryKeywordsUseCase'
 import { createSyncCategoryAssignmentsUseCase } from '../../application/use-cases/SyncCategoryAssignmentsUseCase'
 import { createUpdateCustomProjectNameUseCase } from '../../application/use-cases/UpdateCustomProjectNameUseCase'
@@ -125,6 +132,27 @@ export const createSavedTabsUseCases = (
   getProjectUrls: createGetProjectUrlsUseCase({
     customProjectRepository: deps.customProjectRepository,
     urlRecordRepository: deps.urlRecordRepository,
+  }),
+  getCustomProjects: createGetCustomProjectsQuery({
+    customProjectRepository: deps.customProjectRepository,
+  }),
+  getCustomProjectOrder: createGetCustomProjectOrderQuery({
+    customProjectRepository: deps.customProjectRepository,
+  }),
+  getCustomProjectUndoSnapshot: createGetCustomProjectUndoSnapshotQuery({
+    customProjectRepository: deps.customProjectRepository,
+  }),
+  getCustomProjectRaws: createGetCustomProjectRawsQuery({
+    customProjectRepository: deps.customProjectRepository,
+  }),
+  saveCustomProjectOrder: createSaveCustomProjectOrderUseCase({
+    customProjectRepository: deps.customProjectRepository,
+  }),
+  saveCustomProjects: createSaveCustomProjectsUseCase({
+    customProjectRepository: deps.customProjectRepository,
+  }),
+  restoreCustomProjectsSnapshot: createRestoreCustomProjectsSnapshotUseCase({
+    customProjectRepository: deps.customProjectRepository,
   }),
   getSavedTabsPageData: createGetSavedTabsPageDataQuery({
     parentCategoryRepository: deps.parentCategoryRepository,

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
@@ -660,6 +660,15 @@ describe('SavedTabsApp custom search', () => {
         removeSubCategoryFromTabGroups: vi.fn(),
         restoreOpenedUrlsSnapshot: vi.fn(),
         restoreOpenedUrlsSnapshotView,
+        // issue #538: `useProjectManagement` の deps に追加された
+        // application query / use-case モック。
+        getCustomProjects: vi.fn(),
+        getCustomProjectOrder: vi.fn(),
+        getCustomProjectUndoSnapshot: vi.fn(),
+        getCustomProjectRaws: vi.fn(),
+        saveCustomProjectOrder: vi.fn(),
+        saveCustomProjects: vi.fn(),
+        restoreCustomProjectsSnapshot: vi.fn(),
         setCategoryKeywords: vi.fn(),
         syncCategoryAssignments: vi.fn(),
         updateCustomProjectName: vi.fn(),
@@ -716,6 +725,15 @@ describe('SavedTabsApp custom search', () => {
         removeSubCategoryFromTabGroups: vi.fn(),
         restoreOpenedUrlsSnapshot: vi.fn(),
         restoreOpenedUrlsSnapshotView,
+        // issue #538: `useProjectManagement` の deps に追加された
+        // application query / use-case モック。
+        getCustomProjects: vi.fn(),
+        getCustomProjectOrder: vi.fn(),
+        getCustomProjectUndoSnapshot: vi.fn(),
+        getCustomProjectRaws: vi.fn(),
+        saveCustomProjectOrder: vi.fn(),
+        saveCustomProjects: vi.fn(),
+        restoreCustomProjectsSnapshot: vi.fn(),
         setCategoryKeywords: vi.fn(),
         syncCategoryAssignments: vi.fn(),
         updateCustomProjectName: vi.fn(),

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -134,7 +134,10 @@ const useSavedTabsAppView = ({
     onSettingsLoaded: setSettings,
   })
   const projectState = useProjectManagement(
-    deps.customProjectRepository,
+    savedTabsUseCases.getCustomProjects,
+    savedTabsUseCases.getCustomProjectOrder,
+    savedTabsUseCases.getCustomProjectUndoSnapshot,
+    savedTabsUseCases.getCustomProjectRaws,
     tabDataState.tabGroups,
     settings,
     initialViewMode,
@@ -142,6 +145,8 @@ const useSavedTabsAppView = ({
     savedTabsUseCases.createCustomProject,
     savedTabsUseCases.deleteCustomProject,
     savedTabsUseCases.updateCustomProjectName,
+    savedTabsUseCases.saveCustomProjectOrder,
+    savedTabsUseCases.restoreCustomProjectsSnapshot,
   )
   const {
     categories,

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx
@@ -16,12 +16,12 @@ import { useProjectManagement } from './useProjectManagement'
 const projectManagementMocks = vi.hoisted(() => ({
   addCategoryToProject: vi.fn(),
   addUrlToCustomProject: vi.fn(),
+  // 旧テスト互換: 実装は `getCustomProjectsQuery` (= `findAll`) を使う。
+  // `getCustomProjects` というキー名で mock しても、
+  // `findAll` の戻り値を `getCustomProjects` の戻り値に同期する実装で
+  // そのまま動く。
   createCustomProject: vi.fn().mockResolvedValue({}),
   deleteCustomProject: vi.fn().mockResolvedValue({}),
-  // 後方互換: 旧テストが `getCustomProjects` を mock していた名残。
-  // 実装は `customProjectRepository.findAll` を使うが、テストでは
-  // customProjectRepository の `findAll` 実装を `getCustomProjects` の
-  // 戻り値で書き換えるだけで動かせる。
   getCustomProjects: vi.fn(),
   removeCategoryFromProject: vi.fn(),
   removeUrlFromCustomProject: vi.fn(),
@@ -32,8 +32,17 @@ const projectManagementMocks = vi.hoisted(() => ({
   updateCategoryOrder: vi.fn(),
   updateCustomProjectName: vi.fn().mockResolvedValue({}),
   updateProjectKeywords: vi.fn(),
-  // 旧テスト互換: 実装は `customProjectRepository.saveOrder` を使う。
-  updateProjectOrder: vi.fn(),
+  // 旧テスト互換: 実装は `saveCustomProjectOrderUseCase` (= `saveOrder`) を使う。
+  // `getCustomProjectOrder` の戻り値も `findOrder` mock と同期して
+  // 初期 load / undo snapshot で同じ order を返す。
+  saveCustomProjectOrder: vi.fn(),
+  getCustomProjectOrder: vi.fn(),
+  getCustomProjectUndoSnapshot: vi.fn(),
+  // 旧テスト互換: 旧 `customProjectRepository.restoreAllRaw` /
+  // `saveOrder` を直接 mock していた検証を新 use-case 経由でも
+  // 検証できるよう、use-case mock を expose する。
+  restoreCustomProjectsSnapshot: vi.fn(),
+  getCustomProjectRaws: vi.fn(),
 }))
 
 vi.mock('sonner', () => ({
@@ -162,20 +171,18 @@ const toRawSnapshot = (project: CustomProject): CustomProjectRawSnapshot => {
 }
 
 describe('useProjectManagement', () => {
-  let customProjectRepository: CustomProjectRepository
   /**
-   * issue #509 で `useProjectManagement` の引数として
-   * `customProjectsCommandService` と 3 つの use-case
-   * (`createCustomProject` / `deleteCustomProject` /
-   * `updateCustomProjectName`) を port として注入する形に
-   * なった。これらは `projectManagementMocks` 内の同名 mock 関数
-   * をそのまま参照する。
+   * issue #538 で `useProjectManagement` の deps から
+   * `customProjectRepository` を撤去し、application query / use-case
+   * 経由の依存に統一した。これらは `projectManagementMocks` 内の
+   * 同名 mock 関数をそのまま参照する形に統一しつつ、presentation
+   * 側で未使用の `removeUrlIdsFromAllCustomProjects` /
+   * `removeUrlsFromAllCustomProjects` は no-op vi.fn で補完する。
    */
-  // `customProjectsCommandService` は `useProjectManagement` の第 5 引数
+  // `customProjectsCommandService` は `useProjectManagement` の
   // `CustomProjectsCommandService` として渡される。テストでは
   // `projectManagementMocks` の同名関数をそのまま参照する形に統一しつつ、
-  // presentation 側で未使用の `removeUrlIdsFromAllCustomProjects` /
-  // `removeUrlsFromAllCustomProjects` は no-op vi.fn で補完する。
+  // presentation 側で未使用のメソッドは no-op vi.fn で補完する。
   // eslint-disable-next-line typescript/no-explicit-any
   let customProjectsCommandService: any
 
@@ -192,10 +199,10 @@ describe('useProjectManagement', () => {
     // 保持した raw snapshot を取得する。テストでは
     // `projectManagementMocks.getCustomProjects.mockResolvedValue(...)` で
     // 設定した `CustomProject` (storage 形) を raw snapshot 形に widen
-    // して `findAllRaw` の戻り値にする。`findAllRaw` mock は
-    // `mockImplementation` で `getCustomProjects` ベースの widening を
-    // 担当し、テストケースで `mockResolvedValueOnce` /
-    // `mockImplementationOnce` で一時的に上書きできる。
+    // して `getCustomProjectRaws` の戻り値にする。
+    // issue #538 で `getCustomProjectRaws` (= `findAllRaw` 相当) は
+    // application query 経由になったため、mock 関数 `getCustomProjectRaws`
+    // を widening 担当として `getCustomProjects` ベースの結果を返す。
     const findAllMock = vi
       .fn()
       .mockImplementation(() => projectManagementMocks.getCustomProjects())
@@ -207,7 +214,7 @@ describe('useProjectManagement', () => {
           .then((projects: CustomProject[]) => projects.map(toRawSnapshot)),
       )
 
-    customProjectRepository = {
+    const customProjectRepository = {
       findAll: findAllMock,
       findAllRaw: findAllRawMock,
       findById: vi.fn(),
@@ -244,11 +251,113 @@ describe('useProjectManagement', () => {
     ).mockResolvedValue(undefined)
     projectManagementMocks.getCustomProjects.mockResolvedValue(projectSnapshot)
 
+    // `getCustomProjectOrder` (= `findOrder` 相当) は
+    // `projectManagementMocks.getCustomProjectOrder` を widening として
+    // 委譲する。テストで `getCustomProjectOrder.mockResolvedValueOnce` /
+    // `mockImplementationOnce` で一時的に上書きできる。
+    projectManagementMocks.getCustomProjectOrder.mockImplementation(
+      () =>
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        customProjectRepository.findOrder() as unknown as ReturnType<
+          typeof projectManagementMocks.getCustomProjectOrder
+        >,
+    )
+    // `saveCustomProjectOrder` (= `saveOrder` 相当) は
+    // `customProjectRepository.saveOrder` を widening として委譲する。
+    projectManagementMocks.saveCustomProjectOrder.mockImplementation(
+      (command: { newOrder: readonly string[] }) =>
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        customProjectRepository.saveOrder(
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+          command.newOrder as unknown as Parameters<
+            CustomProjectRepository['saveOrder']
+          >[0],
+        ),
+    )
+    // `getCustomProjectRaws` は `customProjectRepository.findAllRaw` を
+    // widening として委譲する。
+    projectManagementMocks.getCustomProjectRaws.mockImplementation(() =>
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      (
+        customProjectRepository.findAllRaw as () => Promise<
+          readonly CustomProjectRawSnapshot[]
+        >
+      )(),
+    )
+    // `getCustomProjectUndoSnapshot` は `getCustomProjectRaws` /
+    // `getCustomProjectOrder` 経由で取得する。これにより、テストで
+    // `getCustomProjectRaws.mockImplementationOnce(...)` 等で
+    // snapshot 取得タイミングの値を一時的に上書きできる。
+    projectManagementMocks.getCustomProjectUndoSnapshot.mockImplementation(
+      async () => {
+        const order = await projectManagementMocks.getCustomProjectOrder()
+        const base: { customProjectOrder?: readonly unknown[] } = {}
+        if (order.length > 0) {
+          base.customProjectOrder = order
+        }
+        const raws = await projectManagementMocks.getCustomProjectRaws()
+        const projects: {
+          categories: readonly string[]
+          createdAt: number
+          id: string
+          name: string
+          updatedAt: number
+          urlIds: readonly string[]
+        }[] = raws.map((raw: CustomProjectRawSnapshot) => ({
+          categories: [...raw.categories],
+          createdAt: raw.createdAt,
+          id: raw.id,
+          name: raw.name,
+          updatedAt: raw.updatedAt,
+          urlIds: [...(raw.urlIds ?? [])],
+        }))
+        return {
+          ...base,
+          ...(projects.length > 0 ? { customProjects: projects } : {}),
+          ...(raws.length > 0 ? { customProjectsRaw: raws } : {}),
+        }
+      },
+    )
+    // `restoreCustomProjectsSnapshot` は payload を見て
+    // `restoreAllRaw` / `saveAll` / `saveOrder` を委譲する。
+    // 旧 `customProjectRepository.restoreAllRaw` / `saveAll` /
+    // `saveOrder` を直接 mock していた検証を新 use-case mock 経由でも
+    // 検証できるよう、repository mock と同期する。
+    // `saveOrder` 部分は `saveCustomProjectOrder` use-case mock 経由で
+    // 委譲し、presentation hook の `handleReorderProjects` 経路と
+    // 同じ use-case を通る形に統一する。
+    projectManagementMocks.restoreCustomProjectsSnapshot.mockImplementation(
+      async (command: {
+        payload: {
+          customProjects?: readonly unknown[]
+          customProjectsRaw?: readonly CustomProjectRawSnapshot[]
+          customProjectOrder?: readonly unknown[]
+        }
+      }) => {
+        const { payload } = command
+        if (
+          payload.customProjectsRaw &&
+          customProjectRepository.restoreAllRaw
+        ) {
+          await customProjectRepository.restoreAllRaw(payload.customProjectsRaw)
+        } else if (payload.customProjects) {
+          await customProjectRepository.saveAll(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+            payload.customProjects as unknown as Parameters<
+              CustomProjectRepository['saveAll']
+            >[0],
+          )
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        const order = (payload.customProjectOrder ??
+          []) as unknown as readonly string[]
+        await projectManagementMocks.saveCustomProjectOrder({ newOrder: order })
+      },
+    )
+
     customProjectsCommandService = {
       addCategoryToProject: projectManagementMocks.addCategoryToProject,
       addUrlToCustomProject: projectManagementMocks.addUrlToCustomProject,
-      // 旧 `updateProjectOrder` テスト互換: 実装は
-      // `customProjectRepository.saveOrder` を使うため、空の no-op。
       moveUrlBetweenCustomProjects: vi.fn(),
       removeCategoryFromProject:
         projectManagementMocks.removeCategoryFromProject,
@@ -292,7 +401,10 @@ describe('useProjectManagement', () => {
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'domain',
@@ -300,6 +412,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -323,7 +437,10 @@ describe('useProjectManagement', () => {
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -331,6 +448,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -352,7 +471,10 @@ describe('useProjectManagement', () => {
 
     const { result: pendingResult, unmount } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -360,6 +482,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
     unmount()
@@ -380,7 +504,10 @@ describe('useProjectManagement', () => {
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'domain',
@@ -388,6 +515,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -410,7 +539,10 @@ describe('useProjectManagement', () => {
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'domain',
@@ -418,6 +550,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -441,7 +575,10 @@ describe('useProjectManagement', () => {
   it('initialViewMode 未指定なら domain モードで初期化する', async () => {
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         undefined,
@@ -449,6 +586,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -477,7 +616,10 @@ describe('useProjectManagement', () => {
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -485,6 +627,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -523,7 +667,10 @@ describe('useProjectManagement', () => {
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -531,6 +678,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -567,7 +716,10 @@ describe('useProjectManagement', () => {
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -575,6 +727,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -633,7 +787,10 @@ describe('useProjectManagement', () => {
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -641,6 +798,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -725,7 +884,10 @@ describe('useProjectManagement', () => {
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -733,6 +895,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -770,10 +934,9 @@ describe('useProjectManagement', () => {
       'project-2',
       reorderedUrls,
     )
-    expect(customProjectRepository.saveOrder).toHaveBeenCalledWith([
-      'project-1',
-      'project-2',
-    ])
+    expect(projectManagementMocks.saveCustomProjectOrder).toHaveBeenCalledWith({
+      newOrder: ['project-1', 'project-2'],
+    })
     expect(projectManagementMocks.renameCategoryInProject).toHaveBeenCalledWith(
       'project-2',
       'Inbox',
@@ -820,7 +983,10 @@ describe('useProjectManagement', () => {
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -828,6 +994,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -887,19 +1055,21 @@ describe('useProjectManagement', () => {
       new Error('url order failed'),
     )
     // 旧 `updateProjectOrder` テスト互換: 実装は
-    // `customProjectRepository.saveOrder` を使うため、ここで reject。
-    ;(
-      customProjectRepository.saveOrder as unknown as {
-        mockRejectedValue: (e: unknown) => void
-      }
-    ).mockRejectedValue(new Error('project order failed'))
+    // `saveCustomProjectOrderUseCase` (= `customProjectRepository.saveOrder`)
+    // を使うため、ここで reject。
+    projectManagementMocks.saveCustomProjectOrder.mockRejectedValue(
+      new Error('project order failed'),
+    )
     projectManagementMocks.renameCategoryInProject.mockRejectedValue(
       new Error('category rename failed'),
     )
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -907,6 +1077,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -974,15 +1146,16 @@ describe('useProjectManagement', () => {
       .mockResolvedValueOnce(updatedProjects)
     // PR #514 review P1: 初期 load 時に customProjectOrder を取り込み、
     // undo snapshot にも order を含める。
-    ;(
-      customProjectRepository.findOrder as unknown as {
-        mockResolvedValue: (value: unknown) => void
-      }
-    ).mockResolvedValue(['project-1'])
+    projectManagementMocks.getCustomProjectOrder.mockResolvedValue([
+      'project-1',
+    ])
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -990,6 +1163,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -1026,21 +1201,32 @@ describe('useProjectManagement', () => {
       await undoOptions?.action?.onClick?.()
     })
 
-    expect(customProjectRepository.restoreAllRaw).toHaveBeenLastCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ id: 'project-1', name: 'Project A' }),
-      ]),
+    expect(
+      projectManagementMocks.restoreCustomProjectsSnapshot,
+    ).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          customProjects: expect.arrayContaining([
+            expect.objectContaining({ id: 'project-1', name: 'Project A' }),
+          ]),
+          customProjectOrder: ['project-1'],
+        }),
+      }),
     )
-    expect(customProjectRepository.saveOrder).toHaveBeenLastCalledWith([
-      'project-1',
-    ])
+    // `restoreCustomProjectsSnapshot` mock は `saveCustomProjectOrder` 経由
+    // で `customProjectRepository.saveOrder` を委譲する実装なので、
+    // payload 内の order が use-case 経由で `saveCustomProjectOrder` へ
+    // 伝搬したことを検証する。
+    expect(
+      projectManagementMocks.saveCustomProjectOrder,
+    ).toHaveBeenLastCalledWith({ newOrder: ['project-1'] })
     expect(result.current.customProjects).toStrictEqual(projectSnapshot)
   })
 
-  it('Undo は生 snapshot があれば restoreAllRaw 経由で urls / urlMetadata を含めて復元する（PR #506 review P2 対応）', async () => {
+  it('Undo は生 snapshot があれば restoreCustomProjectsSnapshot 経由で urls / urlMetadata を含めて復元する（PR #506 review P2 対応）', async () => {
     // 生 snapshot にだけ存在する urls / urlMetadata / projectKeywords は
     // entity snapshot には載らないため、saveAll 経由だと merge で脱落する。
-    // restoreAllRaw 経由で書けば全フィールドを保存できる。
+    // restoreCustomProjectsSnapshot 経由で書けば全フィールドを保存できる。
     const projectSnapshotRaw = [
       {
         categories: ['research'],
@@ -1063,15 +1249,16 @@ describe('useProjectManagement', () => {
     // 1 回目: 初回 load, 2 回目: undo snapshot, 3 回目: 削除後
     // 初期 load / undo snapshot で rich な `projectSnapshotRaw` を返し、
     // 削除後の再取得は `getCustomProjects` (= []) ベースでよい。
-    ;(
-      customProjectRepository.findAllRaw as unknown as {
-        mockResolvedValue: (value: unknown) => void
-      }
-    ).mockResolvedValue(projectSnapshotRaw)
+    projectManagementMocks.getCustomProjectRaws.mockResolvedValue(
+      projectSnapshotRaw,
+    )
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -1079,10 +1266,13 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
-    // 初期ロード時に `findAllRaw` 経由で rich な snapshot が反映される
+    // 初期ロード時に `getCustomProjectRaws` (= `findAllRaw`) 経由で rich な
+    // snapshot が反映される
     // (issue #535 P1: projectKeywords / urlMetadata / urls が保持される)
     await waitFor(() => {
       expect(result.current.customProjects[0]?.projectKeywords).toStrictEqual({
@@ -1111,64 +1301,14 @@ describe('useProjectManagement', () => {
       await undoOptions?.action?.onClick?.()
     })
 
-    expect(customProjectRepository.restoreAllRaw).toHaveBeenCalledWith(
-      projectSnapshotRaw,
-    )
-    expect(customProjectRepository.saveAll).not.toHaveBeenCalled()
-  })
-
-  it('restoreAllRaw が未実装の repository では saveAll にフォールバックする', async () => {
-    // テストモック等で restoreAllRaw / findAllRaw が省略されているケースを
-    // 想定し、entity 経由の saveAll へ安全側に倒れることを確認する。
-    const repoWithoutRaw = {
-      findAll: customProjectRepository.findAll,
-      findById: customProjectRepository.findById,
-      removeByIds: customProjectRepository.removeByIds,
-      saveAll: customProjectRepository.saveAll,
-      findOrder: customProjectRepository.findOrder,
-      saveOrder: customProjectRepository.saveOrder,
-    } as unknown as CustomProjectRepository
-    projectManagementMocks.getCustomProjects
-      .mockResolvedValueOnce(projectSnapshot)
-      .mockResolvedValueOnce(projectSnapshot)
-      .mockResolvedValueOnce([])
-
-    const { result } = renderHook(() =>
-      useProjectManagement(
-        repoWithoutRaw,
-        [],
-        defaultSettings,
-        'custom',
-        customProjectsCommandService,
-        projectManagementMocks.createCustomProject,
-        projectManagementMocks.deleteCustomProject,
-        projectManagementMocks.updateCustomProjectName,
-      ),
-    )
-
-    await waitForLoadedProjects(result)
-
-    await act(async () => {
-      await result.current.handleDeleteUrlFromProject(
-        'project-1',
-        'https://example.com/a',
-      )
-    })
-
-    const undoOptions = vi.mocked(toast.info).mock.calls.at(-1)?.[1] as
-      | {
-          action?: {
-            onClick?: () => Promise<void>
-          }
-        }
-      | undefined
-
-    await act(async () => {
-      await undoOptions?.action?.onClick?.()
-    })
-
-    expect(customProjectRepository.saveAll).toHaveBeenLastCalledWith(
-      projectSnapshot,
+    expect(
+      projectManagementMocks.restoreCustomProjectsSnapshot,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          customProjectsRaw: projectSnapshotRaw,
+        }),
+      }),
     )
   })
 
@@ -1179,7 +1319,10 @@ describe('useProjectManagement', () => {
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -1187,6 +1330,8 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
@@ -1217,7 +1362,7 @@ describe('useProjectManagement', () => {
 
   it('Undo の保存データがない場合は復元処理を行わず、復元失敗は通知する', async () => {
     // 1st delete: snapshot = []  → 復元スキップ
-    // 2nd delete: snapshot = projectSnapshot → 復元は restoreAllRaw (reject) → 失敗通知
+    // 2nd delete: snapshot = projectSnapshot → 復元は失敗 → error toast
     // queue 設計:
     //  - 1st widening (useEffect): projectSnapshot
     //  - 2nd widening (1st delete snapshot): mockImplementationOnce で
@@ -1231,23 +1376,18 @@ describe('useProjectManagement', () => {
       .mockResolvedValueOnce(projectSnapshot) // 4th: 2nd delete snapshot
       .mockResolvedValueOnce(projectSnapshot) // 5th: 2nd delete 削除後
 
-    // issue #535 P1: `findAllRaw` を 1st delete の snapshot 取得タイミングで
-    // 空にしておくと、undo snapshot に `customProjectsRaw` が含まれず
-    // `restoreAllRaw` 経路をスキップする。`findAll` も空を返すため、
-    // UI 復元も `payload.customProjects` 経由で `saveAll` 経由になる。
-    // 2nd delete は通常経路 (snapshot = projectSnapshot) で `restoreAllRaw` を
-    // 通すが、mock で reject させて「restoreAllRaw 失敗 → error toast」を
-    // 検証する (issue #535 で raw 経路が主軸になったため `saveAll` 失敗
-    // ではなく `restoreAllRaw` 失敗で検証する)。
-    ;(
-      customProjectRepository.restoreAllRaw as unknown as {
-        mockRejectedValueOnce: (value: unknown) => void
-      }
-    ).mockRejectedValueOnce(new Error('restore failed'))
+    // issue #538: `restoreCustomProjectsSnapshot` use-case を 1 度だけ
+    // reject させ、undo 復元の失敗 error toast を検証する。
+    projectManagementMocks.restoreCustomProjectsSnapshot.mockImplementationOnce(
+      () => Promise.reject(new Error('restore failed')),
+    )
 
     const { result } = renderHook(() =>
       useProjectManagement(
-        customProjectRepository,
+        projectManagementMocks.getCustomProjects,
+        projectManagementMocks.getCustomProjectOrder,
+        projectManagementMocks.getCustomProjectUndoSnapshot,
+        projectManagementMocks.getCustomProjectRaws,
         [],
         defaultSettings,
         'custom',
@@ -1255,19 +1395,23 @@ describe('useProjectManagement', () => {
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
+        projectManagementMocks.saveCustomProjectOrder,
+        projectManagementMocks.restoreCustomProjectsSnapshot,
       ),
     )
 
     await waitForLoadedProjects(result)
 
-    // 1st delete の `getCustomProjectUndoSnapshot` 内の `findAllRaw` を
-    // 空配列にしておく。これで undo snapshot に `customProjectsRaw` が
-    // 含まれず `restoreAllRaw` 経路をスキップし、`saveAll` も呼ばれない。
-    ;(
-      customProjectRepository.findAllRaw as unknown as {
-        mockImplementationOnce: (impl: () => unknown) => void
-      }
-    ).mockImplementationOnce(() => Promise.resolve([]))
+    // 1st delete の `getCustomProjectUndoSnapshot` 内の
+    // `getCustomProjects` を空にしておくと、undo snapshot に
+    // `customProjectsRaw` / `customProjects` が含まれず、payload 化
+    // で `null` が返り `restoreCustomProjectsSnapshot` 経路をスキップする。
+    projectManagementMocks.getCustomProjectRaws.mockImplementationOnce(() =>
+      Promise.resolve([] as CustomProjectRawSnapshot[]),
+    )
+    projectManagementMocks.getCustomProjects.mockImplementationOnce(() =>
+      Promise.resolve([] as CustomProject[]),
+    )
 
     await act(async () => {
       await result.current.handleDeleteUrlFromProject(
@@ -1288,7 +1432,9 @@ describe('useProjectManagement', () => {
       await missingUndoOptions?.action?.onClick?.()
     })
 
-    expect(customProjectRepository.restoreAllRaw).not.toHaveBeenCalled()
+    expect(
+      projectManagementMocks.restoreCustomProjectsSnapshot,
+    ).not.toHaveBeenCalled()
 
     await act(async () => {
       await result.current.handleDeleteUrlFromProject(
@@ -1309,9 +1455,9 @@ describe('useProjectManagement', () => {
       await failingUndoOptions?.action?.onClick?.()
     })
 
-    expect(customProjectRepository.restoreAllRaw).toHaveBeenCalledWith(
-      projectSnapshot,
-    )
+    expect(
+      projectManagementMocks.restoreCustomProjectsSnapshot,
+    ).toHaveBeenCalled()
     expect(toast.error).toHaveBeenCalledWith('保存データを復元できませんでした')
   })
 })

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.ts
@@ -2,6 +2,13 @@
  * @file useProjectManagement.ts
  * @description カスタムプロジェクトの CRUD・ビューモード切替・URL管理・
  * プロジェクト内カテゴリ管理を担うカスタムフック。
+ *
+ * 旧 `customProjectRepository` 直接依存 (issue #538) を撤去し、
+ * 読み取り系は application query (`getCustomProjectsQuery` /
+ * `getCustomProjectOrderQuery` / `getCustomProjectUndoSnapshotQuery` /
+ * `getCustomProjectRawsQuery`)、更新・復元系は application use-case
+ * (`saveCustomProjectOrderUseCase` /
+ * `restoreCustomProjectsSnapshotUseCase`) 経由に寄せた。
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -9,18 +16,23 @@ import type { Dispatch, SetStateAction } from 'react'
 import { toast } from 'sonner'
 
 import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/application/ports/CustomProjectsCommandService'
+import type { GetCustomProjectOrderQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectOrderQuery'
+import type { GetCustomProjectRawsQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectRawsQuery'
+import type { GetCustomProjectsQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectsQuery'
+import type {
+  CustomProjectUndoSnapshot,
+  GetCustomProjectUndoSnapshotQuery,
+} from '@/contexts/saved-tabs/application/queries/GetCustomProjectUndoSnapshotQuery'
 import type { CreateCustomProjectUseCase } from '@/contexts/saved-tabs/application/use-cases/CreateCustomProjectUseCase'
 import type { DeleteCustomProjectUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase'
+import type {
+  RestoreCustomProjectsSnapshotPayload,
+  RestoreCustomProjectsSnapshotUseCase,
+} from '@/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase'
+import type { SaveCustomProjectOrderUseCase } from '@/contexts/saved-tabs/application/use-cases/SaveCustomProjectOrderUseCase'
 import type { UpdateCustomProjectNameUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectNameUseCase'
 import type { UserSettingsDto } from '@/contexts/saved-tabs/domain/dto/UserSettingsDto'
-import { createCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
-import type { CustomProject as DomainCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import { UNCATEGORIZED_PROJECT_ID } from '@/contexts/saved-tabs/domain/entities/UncategorizedProject'
-import type {
-  CustomProjectRawSnapshot,
-  CustomProjectRepository,
-} from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
-import type { CustomProjectId as DomainCustomProjectId } from '@/contexts/saved-tabs/domain/value-objects/CustomProjectId'
 import { ChromeSavedTabsStorageMapper } from '@/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import type {
@@ -29,12 +41,6 @@ import type {
   TabGroup,
   ViewMode,
 } from '@/types/storage'
-
-interface CustomProjectUndoSnapshot {
-  customProjectOrder?: readonly DomainCustomProjectId[]
-  customProjects?: readonly DomainCustomProject[]
-  customProjectsRaw?: readonly CustomProjectRawSnapshot[]
-}
 
 const createNoopCommandService = (): CustomProjectsCommandService => ({
   addCategoryToProject: () => Promise.resolve(undefined),
@@ -61,106 +67,50 @@ const asyncNoopDelete: DeleteCustomProjectUseCase = () => {
 const asyncNoopRename: UpdateCustomProjectNameUseCase = () => {
   throw new Error('updateCustomProjectNameUseCase is not provided')
 }
-
-interface CustomProjectUndoPayload {
-  customProjectOrder?: readonly DomainCustomProjectId[]
-  customProjects: readonly DomainCustomProject[]
-  customProjectsRaw?: readonly CustomProjectRawSnapshot[]
+const asyncNoopSaveOrder: SaveCustomProjectOrderUseCase = () => {
+  throw new Error('saveCustomProjectOrderUseCase is not provided')
+}
+const asyncNoopRestore: RestoreCustomProjectsSnapshotUseCase = () => {
+  throw new Error('restoreCustomProjectsSnapshotUseCase is not provided')
+}
+const asyncNoopGetCustomProjects: GetCustomProjectsQuery = () => {
+  throw new Error('getCustomProjectsQuery is not provided')
+}
+const asyncNoopGetCustomProjectOrder: GetCustomProjectOrderQuery = () => {
+  throw new Error('getCustomProjectOrderQuery is not provided')
+}
+const asyncNoopGetCustomProjectUndoSnapshot: GetCustomProjectUndoSnapshotQuery =
+  () => {
+    throw new Error('getCustomProjectUndoSnapshotQuery is not provided')
+  }
+const asyncNoopGetCustomProjectRaws: GetCustomProjectRawsQuery = () => {
+  throw new Error('getCustomProjectRawsQuery is not provided')
 }
 
 const getArraySnapshot = <T>(
   value: readonly T[] | undefined,
 ): readonly T[] | undefined => (Array.isArray(value) ? value : undefined)
 
-/** domain entity (`CustomProject`) を presentation 層 state の storage 形へ投影する */
-const toEntityStorageCustomProject = (
-  project: DomainCustomProject,
-): CustomProject => {
-  const result: CustomProject = {
-    categories: [...project.categories],
-    createdAt: project.createdAt,
-    id: project.id,
-    name: project.name,
-    updatedAt: project.updatedAt,
-  }
-  if (project.urlIds.length > 0) {
-    result.urlIds = [...project.urlIds]
-  }
-  return result
-}
+/**
+ * `getCustomProjectRawsQuery` 戻り値の要素 shape (issue #538)。
+ *
+ * `CustomProjectRepository.findAllRaw()` 由来の `CustomProjectRawSnapshot`
+ * を domain repository モジュールから直接 import するのを避け、
+ * `GetCustomProjectRawsQuery` 戻り値から派生させたローカル alias を
+ * 使う。presentation 層が `CustomProjectRepository` 型を import しない
+ * ことを保証する目的 (issue 受け入れ条件)。
+ */
+type RawCustomProjectEntry = Awaited<
+  ReturnType<GetCustomProjectRawsQuery>
+>[number]
 
 /** rich フィールド込みの `CustomProject` へ raw snapshot を投影する */
-const toRawStorageCustomProject = (
-  raw: CustomProjectRawSnapshot,
-): CustomProject => ChromeSavedTabsStorageMapper.toStorageCustomProject(raw)
-
-/**
- * repository 実装から rich フィールドを保持した raw snapshot を取得する。
- *
- * `findAllRaw` がモックで未実装のケースに備え、`findAll` (entity) を
- * フォールバックとして用意する。`findAll` 経由だと rich フィールドは
- * 取得できないため、storage 形投影時に空になる (issue #535 P1 の本質)。
- * テスト/本番実装では `findAllRaw` を必ず実装し、こちらを使う。
- */
-const loadCustomProjectRaws = async (
-  repo: CustomProjectRepository,
-): Promise<readonly CustomProjectRawSnapshot[]> => {
-  if (repo.findAllRaw) {
-    return repo.findAllRaw()
-  }
-  // フォールバック: entity を取得し、各 entity の id/name/urlIds 等
-  // のみ取り出して raw snapshot 形へ widen する。rich フィールド
-  // (`projectKeywords` / `urlMetadata` / `categoryOrder` / `urls`) は
-  // 取得できないため storage 形 projection で省略される。
-  const projects = await repo.findAll()
-  return projects.map((project) => ({
-    categories: [...project.categories],
-    createdAt: project.createdAt,
-    id: project.id,
-    name: project.name,
-    updatedAt: project.updatedAt,
-    ...(project.urlIds.length > 0 ? { urlIds: [...project.urlIds] } : {}),
-  }))
-}
-
-const getCustomProjectUndoSnapshot = async (
-  customProjectRepository: CustomProjectRepository,
-): Promise<CustomProjectUndoSnapshot> => {
-  // issue #535 P1: undo snapshot 取得時に `findAll` (entity 経路) と
-  // `findAllRaw` (raw 経路) の両方を呼ぶと、テスト/本番で repository
-  // 実装を共有している場合に queue 消費が想定より多くなり、raw snapshot
-  // が「削除後」の値で上書きされる問題があった。raw 経路で 1 度だけ
-  // 取得し、entity 形が必要なら widen する。`findAllRaw` が未実装の
-  // レガシー repository 向けには `findAll` をフォールバックとする。
-  const order = await customProjectRepository.findOrder()
-  if (customProjectRepository.findAllRaw) {
-    const raws = await customProjectRepository.findAllRaw()
-    const projects: DomainCustomProject[] = raws.map((raw) =>
-      createCustomProject({
-        categories: raw.categories,
-        createdAt: raw.createdAt,
-        id: raw.id,
-        name: raw.name,
-        updatedAt: raw.updatedAt,
-        urlIds: raw.urlIds ?? [],
-      }),
-    )
-    return {
-      ...(order.length > 0 ? { customProjectOrder: order } : {}),
-      ...(projects.length > 0 ? { customProjects: projects } : {}),
-      ...(raws.length > 0 ? { customProjectsRaw: raws } : {}),
-    }
-  }
-  const projects = await customProjectRepository.findAll()
-  return {
-    ...(order.length > 0 ? { customProjectOrder: order } : {}),
-    ...(projects.length > 0 ? { customProjects: projects } : {}),
-  }
-}
+const toRawStorageCustomProject = (raw: RawCustomProjectEntry): CustomProject =>
+  ChromeSavedTabsStorageMapper.toStorageCustomProject(raw)
 
 const createCustomProjectUndoPayload = (
   snapshot: CustomProjectUndoSnapshot,
-): CustomProjectUndoPayload | null => {
+): RestoreCustomProjectsSnapshotPayload | null => {
   const customProjects = getArraySnapshot(snapshot.customProjects)
   if (!customProjects) {
     return null
@@ -177,13 +127,13 @@ const createCustomProjectUndoPayload = (
 
 const showCustomProjectDeleteUndoToast = ({
   count,
-  customProjectRepository,
+  restoreCustomProjectsSnapshotUseCase,
   setCustomProjects,
   snapshot,
   t,
 }: {
   count: number
-  customProjectRepository: CustomProjectRepository
+  restoreCustomProjectsSnapshotUseCase: RestoreCustomProjectsSnapshotUseCase
   setCustomProjects: Dispatch<SetStateAction<CustomProject[]>>
   snapshot: CustomProjectUndoSnapshot
   t: (key: string, fallback?: string, values?: Record<string, string>) => string
@@ -204,27 +154,28 @@ const showCustomProjectDeleteUndoToast = ({
             }
 
             // 削除した URL の `urls` / `urlMetadata` / `projectKeywords` のような
-            // domain entity 化されない rich フィールドを保持するため、生 snapshot
-            // があれば merge を介さず `restoreAllRaw` で書き戻す（PR #506 review
-            // P2 対応）。モック等で `restoreAllRaw` が未実装の場合は
-            // フォールバックとして `saveAll` を使う。
-            if (
-              payload.customProjectsRaw &&
-              customProjectRepository.restoreAllRaw
-            ) {
-              await customProjectRepository.restoreAllRaw(
-                payload.customProjectsRaw,
-              )
-            } else {
-              await customProjectRepository.saveAll(payload.customProjects)
-            }
-            await customProjectRepository.saveOrder(
-              payload.customProjectOrder ?? [],
-            )
+            // domain entity 化されない rich フィールドを保持するため、payload に
+            // raw snapshot があれば `restoreCustomProjectsSnapshotUseCase` 内で
+            // `restoreAllRaw` 経路 (rich 保持) が走り、無ければ entity 経由
+            // `saveAll` へフォールバックする (issue #535 P1 / PR #506 review
+            // P2 対応の責務を application 層へ移設)。
+            await restoreCustomProjectsSnapshotUseCase({ payload })
             setCustomProjects(
               payload.customProjectsRaw
                 ? payload.customProjectsRaw.map(toRawStorageCustomProject)
-                : payload.customProjects.map(toEntityStorageCustomProject),
+                : payload.customProjects.map((project) => {
+                    const result: CustomProject = {
+                      categories: [...project.categories],
+                      createdAt: project.createdAt,
+                      id: project.id,
+                      name: project.name,
+                      updatedAt: project.updatedAt,
+                    }
+                    if (project.urlIds.length > 0) {
+                      result.urlIds = [...project.urlIds]
+                    }
+                    return result
+                  }),
             )
             toast.success(t('savedTabs.undo.restored'))
           } catch (error) {
@@ -377,22 +328,42 @@ interface UseProjectManagementReturn {
  * カスタムプロジェクト管理フック。
  * ビューモード切替・CRUD・URL管理・プロジェクト内カテゴリ管理を担う。
  *
- * @param customProjectRepository - カスタムプロジェクトの永続化 port
+ * 旧 `customProjectRepository` 直接依存 (issue #538) は application
+ * query / use-case 経由へ移行済み。presentation 層は
+ * `CustomProjectRepository` を import せず、deps は query 関数と
+ * use-case 関数だけを受け取る。
+ *
+ * @param getCustomProjectsQuery - `CustomProject` 一覧 query
+ * @param getCustomProjectOrderQuery - 表示順 query
+ * @param getCustomProjectUndoSnapshotQuery - undo 用途 snapshot query
+ * @param getCustomProjectRawsQuery - rich フィールド付き raw snapshot query
  * @param _tabGroups - 現在のタブグループ一覧（ドメインモードのデータ）
  * @param _settings - ユーザー設定（将来の拡張用）
+ * @param initialViewMode - 初期表示モード
+ * @param customProjectsCommandService - URL/カテゴリ/keyword 更新 port
+ * @param createCustomProjectUseCase - プロジェクト作成 use-case
+ * @param deleteCustomProjectUseCase - プロジェクト削除 use-case
+ * @param updateCustomProjectNameUseCase - プロジェクト名変更 use-case
+ * @param saveCustomProjectOrderUseCase - 表示順保存 use-case
+ * @param restoreCustomProjectsSnapshotUseCase - undo 復元 use-case
  * @returns UseProjectManagementReturn
  */
 // eslint-disable-next-line eslint/max-params -- presentation 入口でフック引数を束ねるため
 const useProjectManagement = (
   // eslint-disable-line eslint/max-lines-per-function
-  customProjectRepository: CustomProjectRepository,
-  _tabGroups: TabGroup[],
-  _settings: UserSettingsDto,
+  getCustomProjectsQuery: GetCustomProjectsQuery = asyncNoopGetCustomProjects,
+  getCustomProjectOrderQuery: GetCustomProjectOrderQuery = asyncNoopGetCustomProjectOrder,
+  getCustomProjectUndoSnapshotQuery: GetCustomProjectUndoSnapshotQuery = asyncNoopGetCustomProjectUndoSnapshot,
+  getCustomProjectRawsQuery: GetCustomProjectRawsQuery = asyncNoopGetCustomProjectRaws,
+  _tabGroups: TabGroup[] = [],
+  _settings?: UserSettingsDto,
   initialViewMode?: ViewMode,
   customProjectsCommandService: CustomProjectsCommandService = createNoopCommandService(),
   createCustomProjectUseCase: CreateCustomProjectUseCase = asyncNoopCreate,
   deleteCustomProjectUseCase: DeleteCustomProjectUseCase = asyncNoopDelete,
   updateCustomProjectNameUseCase: UpdateCustomProjectNameUseCase = asyncNoopRename,
+  saveCustomProjectOrderUseCase: SaveCustomProjectOrderUseCase = asyncNoopSaveOrder,
+  restoreCustomProjectsSnapshotUseCase: RestoreCustomProjectsSnapshotUseCase = asyncNoopRestore,
 ): UseProjectManagementReturn => {
   const { t } = useI18n()
   const [customProjects, setCustomProjects] = useState<CustomProject[]>([])
@@ -407,12 +378,20 @@ const useProjectManagement = (
   // 全 useCallback ハンドラから参照する。`exhaustive-deps` を
   // 個別 disable せず、ref 経由で最新値を読むことで hooks の
   // 再生成サイクルを最小化する。
-  const customProjectRepositoryRef = useRef(customProjectRepository)
+  const getCustomProjectOrderQueryRef = useRef(getCustomProjectOrderQuery)
+  const getCustomProjectUndoSnapshotQueryRef = useRef(
+    getCustomProjectUndoSnapshotQuery,
+  )
+  const getCustomProjectRawsQueryRef = useRef(getCustomProjectRawsQuery)
   const customProjectsCommandServiceRef = useRef(customProjectsCommandService)
   const createCustomProjectUseCaseRef = useRef(createCustomProjectUseCase)
   const deleteCustomProjectUseCaseRef = useRef(deleteCustomProjectUseCase)
   const updateCustomProjectNameUseCaseRef = useRef(
     updateCustomProjectNameUseCase,
+  )
+  const saveCustomProjectOrderUseCaseRef = useRef(saveCustomProjectOrderUseCase)
+  const restoreCustomProjectsSnapshotUseCaseRef = useRef(
+    restoreCustomProjectsSnapshotUseCase,
   )
 
   // Ref を最新の state に同期する
@@ -428,18 +407,14 @@ const useProjectManagement = (
     CustomProject[]
   > => {
     try {
-      const raws = await loadCustomProjectRaws(
-        customProjectRepositoryRef.current,
-      )
+      const raws = await getCustomProjectRawsQueryRef.current()
       const projects = raws.map(toRawStorageCustomProject)
       setCustomProjects(projects)
       return projects
     } catch (error) {
       console.error('データ同期エラー:', error)
       try {
-        const latestRaws = await loadCustomProjectRaws(
-          customProjectRepositoryRef.current,
-        )
+        const latestRaws = await getCustomProjectRawsQueryRef.current()
         const latestProjects = latestRaws.map(toRawStorageCustomProject)
         setCustomProjects(latestProjects)
         return latestProjects
@@ -626,9 +601,7 @@ const useProjectManagement = (
           url,
           title,
         )
-        const updatedRaws = await loadCustomProjectRaws(
-          customProjectRepositoryRef.current,
-        )
+        const updatedRaws = await getCustomProjectRawsQueryRef.current()
         setCustomProjects(updatedRaws.map(toRawStorageCustomProject))
         toast.success(t('savedTabs.tab.added'))
       } catch (error) {
@@ -643,20 +616,18 @@ const useProjectManagement = (
   const handleDeleteUrlFromProject = useCallback(
     async (projectId: string, url: string): Promise<void> => {
       try {
-        const undoSnapshot = await getCustomProjectUndoSnapshot(
-          customProjectRepository,
-        )
+        const undoSnapshot =
+          await getCustomProjectUndoSnapshotQueryRef.current()
         await customProjectsCommandServiceRef.current.removeUrlFromCustomProject(
           projectId,
           url,
         )
-        const updatedRaws = await loadCustomProjectRaws(
-          customProjectRepositoryRef.current,
-        )
+        const updatedRaws = await getCustomProjectRawsQueryRef.current()
         setCustomProjects(updatedRaws.map(toRawStorageCustomProject))
         showCustomProjectDeleteUndoToast({
           count: 1,
-          customProjectRepository,
+          restoreCustomProjectsSnapshotUseCase:
+            restoreCustomProjectsSnapshotUseCaseRef.current,
           setCustomProjects,
           snapshot: undoSnapshot,
           t,
@@ -667,27 +638,25 @@ const useProjectManagement = (
         toast.error(t('savedTabs.tab.deleteError'))
       }
     },
-    [customProjectRepository, t],
+    [t],
   )
 
   /** プロジェクトから 複数のURL を削除する */
   const handleDeleteUrlsFromProject = useCallback(
     async (projectId: string, urls: string[]): Promise<void> => {
       try {
-        const undoSnapshot = await getCustomProjectUndoSnapshot(
-          customProjectRepository,
-        )
+        const undoSnapshot =
+          await getCustomProjectUndoSnapshotQueryRef.current()
         await customProjectsCommandServiceRef.current.removeUrlsFromCustomProject(
           projectId,
           urls,
         )
-        const updatedRaws = await loadCustomProjectRaws(
-          customProjectRepositoryRef.current,
-        )
+        const updatedRaws = await getCustomProjectRawsQueryRef.current()
         setCustomProjects(updatedRaws.map(toRawStorageCustomProject))
         showCustomProjectDeleteUndoToast({
           count: urls.length,
-          customProjectRepository,
+          restoreCustomProjectsSnapshotUseCase:
+            restoreCustomProjectsSnapshotUseCaseRef.current,
           setCustomProjects,
           snapshot: undoSnapshot,
           t,
@@ -702,7 +671,7 @@ const useProjectManagement = (
         toast.error(t('savedTabs.tab.deleteError'))
       }
     },
-    [customProjectRepository, t],
+    [t],
   )
 
   /** プロジェクトにカテゴリを追加する */
@@ -755,9 +724,7 @@ const useProjectManagement = (
           projectId,
           categoryName,
         )
-        const updatedRaws = await loadCustomProjectRaws(
-          customProjectRepositoryRef.current,
-        )
+        const updatedRaws = await getCustomProjectRawsQueryRef.current()
         setCustomProjects(updatedRaws.map(toRawStorageCustomProject))
         toast.success(
           t('savedTabs.projectCategory.deleted', undefined, {
@@ -785,9 +752,7 @@ const useProjectManagement = (
           url,
           category,
         )
-        const updatedRaws = await loadCustomProjectRaws(
-          customProjectRepositoryRef.current,
-        )
+        const updatedRaws = await getCustomProjectRawsQueryRef.current()
         setCustomProjects(updatedRaws.map(toRawStorageCustomProject))
       } catch (error) {
         console.error('URL分類エラー:', error)
@@ -857,9 +822,7 @@ const useProjectManagement = (
     async (newOrder: string[]): Promise<void> => {
       try {
         console.log('プロジェクト順序を更新:', newOrder)
-        await customProjectRepositoryRef.current.saveOrder(
-          newOrder as unknown as DomainCustomProjectId[], // oxlint-disable-line typescript/no-unsafe-type-assertion
-        )
+        await saveCustomProjectOrderUseCaseRef.current({ newOrder })
         setCustomProjects((prev) =>
           prev.toSorted((a, b) => {
             const indexA = newOrder.indexOf(a.id)
@@ -949,8 +912,8 @@ const useProjectManagement = (
         // (`projectKeywords` / `categoryOrder` / `urls` / `urlMetadata`)
         // が落ちないように、raw snapshot を直接 storage 形へ投影する。
         const [raws, order] = await Promise.all([
-          loadCustomProjectRaws(customProjectRepositoryRef.current),
-          customProjectRepositoryRef.current.findOrder(),
+          getCustomProjectRawsQueryRef.current(),
+          getCustomProjectOrderQueryRef.current(),
         ])
         const projectsAsCust = raws.map(toRawStorageCustomProject)
         // PR #514 review P1: 保存済みの `customProjectOrder` を反映し、


### PR DESCRIPTION
## 変更内容

`saved-tabs` DDD移行の仕上げとして、presentation hook である `useProjectManagement` から `CustomProjectRepository` への直接依存を撤去し、application query / use-case 経由に寄せた。

### 追加した application 層

- query
  - `GetCustomProjectsQuery` (`findAll` 相当)
  - `GetCustomProjectOrderQuery` (`findOrder` 相当)
  - `GetCustomProjectRawsQuery` (`findAllRaw` 相当、entity widen フォールバック付き)
  - `GetCustomProjectUndoSnapshotQuery` (`findOrder` + `findAllRaw` を 1 関数で束ねる undo snapshot 取得)
- use-case
  - `SaveCustomProjectOrderUseCase` (`saveOrder` ラッパ)
  - `SaveCustomProjectsUseCase` (`saveAll` ラッパ、undo フォールバック用)
  - `RestoreCustomProjectsSnapshotUseCase` (payload から `restoreAllRaw` / `saveAll` + `saveOrder` をディスパッチする undo 復元 use-case)

`SavedTabsUseCases` interface に上記 7 個を追加し、composition root (`createSavedTabsUseCases`) で wired する形に更新。

### presentation 層の移行

- `useProjectManagement` の deps から `customProjectRepository` を撤去し、上記 query / use-case 関数のみ受け取る形に変更。
- 旧 private helper (`loadCustomProjectRaws` / `getCustomProjectUndoSnapshot` / `showCustomProjectDeleteUndoToast` 内 `restoreAllRaw` / `saveAll` / `saveOrder` 3 段呼び出し) の責務を application 層へ移設。
- `RawCustomProjectEntry` 形は `GetCustomProjectRawsQuery` の `Awaited<ReturnType<...>[number]>` から派生させ、`CustomProjectRepository` モジュールを import しない方針を維持。

### テスト

- `useProjectManagement.test.tsx` を新シグネチャ (query 4 / use-case 2 を明示) に合わせて全面更新。
- `RestoreCustomProjectsSnapshotUseCase.test.ts` を新設し、4 ケース (raw 経路 / entity フォールバック / restoreAllRaw 未実装 / order 省略) を検証。
- `SavedTabsApp.test.tsx` の `savedTabsUseCases` モックに 7 プロパティを追加。
- `dddLayerGuard.test.ts` に issue #538 受け入れ条件 (`useProjectManagement` が `CustomProjectRepository` を import しない / `findOrder` / `saveOrder` / `findAll` / `findAllRaw` / `restoreAllRaw` / `saveAll` を直接呼ばない) を検証する describe を追加。

## 受け入れ条件

- [x] `useProjectManagement` が `CustomProjectRepository` を import していない
- [x] `useProjectManagement` の deps から `customProjectRepository` が消えている
- [x] `useProjectManagement` 内で `findOrder` / `saveOrder` / `findAll` / `findAllRaw` / `restoreAllRaw` / `saveAll` を直接呼んでいない
- [x] 必要な読み取りは application query 経由になっている
- [x] 必要な更新・復元は application use-case 経由になっている
- [x] 既存のCustomProject機能の挙動が変わらない (`useProjectManagement` 16 テスト + 既存 `SavedTabsApp` テストすべてグリーン)
- [x] `bun run format` / `bun run lint` / `bun run compile` / `bun run test` すべてクリーン

## 関連 issue

- Closes #538
- 親 issue: #454