### PR TITLE
[DDD] SavedTabsApp から custom project repository / command service 注入を撤去する (issue #540)

### DIFF
--- a/src/contexts/saved-tabs/application/SavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/application/SavedTabsUseCases.ts
@@ -4,6 +4,7 @@ import type { GetCustomProjectsQuery } from './queries/GetCustomProjectsQuery'
 import type { GetCustomProjectUndoSnapshotQuery } from './queries/GetCustomProjectUndoSnapshotQuery'
 import type { GetSavedTabsPageDataQuery } from './queries/GetSavedTabsPageDataQuery'
 import type { GetSavedTabsQuery } from './queries/GetSavedTabsQuery'
+import type { AddCategoryToCustomProjectUseCase } from './use-cases/AddCategoryToCustomProjectUseCase'
 import type { AddDomainToParentCategoryUseCase } from './use-cases/AddDomainToParentCategoryUseCase'
 import type { AddUrlToCustomProjectUseCase } from './use-cases/AddUrlToCustomProjectUseCase'
 import type { AssignDomainToCategoryUseCase } from './use-cases/AssignDomainToCategoryUseCase'
@@ -21,10 +22,12 @@ import type { GetProjectUrlsUseCase } from './use-cases/GetProjectUrlsUseCase'
 import type { LoadTabGroupsWithUrlsUseCase } from './use-cases/LoadTabGroupsWithUrlsUseCase'
 import type { LoadTabGroupUrlsUseCase } from './use-cases/LoadTabGroupUrlsUseCase'
 import type { MoveDomainBetweenCategoriesUseCase } from './use-cases/MoveDomainBetweenCategoriesUseCase'
+import type { MoveUrlBetweenCustomProjectsUseCase } from './use-cases/MoveUrlBetweenCustomProjectsUseCase'
 import type { OpenAllSavedUrlsUseCase } from './use-cases/OpenAllSavedUrlsUseCase'
 import type { OpenSavedUrlUseCase } from './use-cases/OpenSavedUrlUseCase'
 import type { PrepareTabGroupDeletionUseCase } from './use-cases/PrepareTabGroupDeletionUseCase'
 import type { PrepareTabGroupsDeletionUseCase } from './use-cases/PrepareTabGroupsDeletionUseCase'
+import type { RemoveCategoryFromCustomProjectUseCase } from './use-cases/RemoveCategoryFromCustomProjectUseCase'
 import type { RemoveDomainFromParentCategoryUseCase } from './use-cases/RemoveDomainFromParentCategoryUseCase'
 import type { RemoveDomainsFromParentCategoriesUseCase } from './use-cases/RemoveDomainsFromParentCategoriesUseCase'
 import type { RemoveSubCategoryFromTabGroupsUseCase } from './use-cases/RemoveSubCategoryFromTabGroupsUseCase'
@@ -200,6 +203,30 @@ export interface SavedTabsUseCases {
    * `customProjectsCommandService.updateProjectKeywords` 直叩きを置換。
    */
   readonly updateCustomProjectKeywords: UpdateCustomProjectKeywordsUseCase
+  /**
+   * プロジェクトにカテゴリを追加する use-case (issue #540)。
+   * 旧 `useProjectManagement.handleAddCategory` 内の
+   * `customProjectsCommandService.addCategoryToProject` 直叩きを置換し、
+   * `useProjectManagement` 側の `CustomProjectsCommandService` 依存を
+   * 撤去する。
+   */
+  readonly addCategoryToCustomProject: AddCategoryToCustomProjectUseCase
+  /**
+   * プロジェクトからカテゴリを削除する use-case (issue #540)。
+   * 旧 `useProjectManagement.handleDeleteProjectCategory` 内の
+   * `customProjectsCommandService.removeCategoryFromProject` 直叩きを
+   * 置換し、`useProjectManagement` 側の `CustomProjectsCommandService`
+   * 依存を撤去する。
+   */
+  readonly removeCategoryFromCustomProject: RemoveCategoryFromCustomProjectUseCase
+  /**
+   * プロジェクト間で URL を移動する use-case (issue #540)。
+   * 旧 `SavedTabsApp.handleMoveUrlBetweenProjects` 内の
+   * `customProjectsCommandService.moveUrlBetweenCustomProjects` 直叩き
+   * を application 層へ移設し、`SavedTabsApp` が port を直接扱わない
+   * 構成に寄せる。
+   */
+  readonly moveUrlBetweenCustomProjects: MoveUrlBetweenCustomProjectsUseCase
   /**
    * `CustomProject` ドメイン entity 一覧の読み取り query (issue #538)。
    * 旧 `useProjectManagement` 内の `customProjectRepository.findAll`

--- a/src/contexts/saved-tabs/application/commands/AddCategoryToCustomProjectCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/AddCategoryToCustomProjectCommand.ts
@@ -1,0 +1,21 @@
+/**
+ * `AddCategoryToCustomProjectUseCase` の入力 (issue #540)。
+ *
+ * 旧 `useProjectManagement.handleAddCategory` が
+ * `CustomProjectsCommandService.addCategoryToProject` を直接呼んでいた
+ * 経路を application use-case へ移設する。`categoryName` は
+ * `lib/storage/projects.addCategoryToProject` と同じ positional 引数で
+ * そのまま port 実装へ伝搬する。
+ *
+ * @example
+ * ```ts
+ * const command: AddCategoryToCustomProjectCommand = {
+ *   projectId: 'project-1',
+ *   categoryName: 'Inbox',
+ * }
+ * ```
+ */
+export interface AddCategoryToCustomProjectCommand {
+  readonly projectId: string
+  readonly categoryName: string
+}

--- a/src/contexts/saved-tabs/application/commands/MoveUrlBetweenCustomProjectsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/MoveUrlBetweenCustomProjectsCommand.ts
@@ -1,0 +1,24 @@
+/**
+ * `MoveUrlBetweenCustomProjectsUseCase` の入力 (issue #540)。
+ *
+ * 旧 `SavedTabsApp.handleMoveUrlBetweenProjects` が
+ * `CustomProjectsCommandService.moveUrlBetweenCustomProjects` を
+ * 直接呼んでいた経路を application use-case へ移設する。
+ * `sourceProjectId` / `targetProjectId` / `url` は
+ * `lib/storage/projects.moveUrlBetweenCustomProjects` と同じ positional
+ * 引数でそのまま port 実装へ伝搬する。
+ *
+ * @example
+ * ```ts
+ * const command: MoveUrlBetweenCustomProjectsCommand = {
+ *   sourceProjectId: 'project-a',
+ *   targetProjectId: 'project-b',
+ *   url: 'https://example.com/a',
+ * }
+ * ```
+ */
+export interface MoveUrlBetweenCustomProjectsCommand {
+  readonly sourceProjectId: string
+  readonly targetProjectId: string
+  readonly url: string
+}

--- a/src/contexts/saved-tabs/application/commands/RemoveCategoryFromCustomProjectCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/RemoveCategoryFromCustomProjectCommand.ts
@@ -1,0 +1,21 @@
+/**
+ * `RemoveCategoryFromCustomProjectUseCase` の入力 (issue #540)。
+ *
+ * 旧 `useProjectManagement.handleDeleteProjectCategory` が
+ * `CustomProjectsCommandService.removeCategoryFromProject` を直接呼んでいた
+ * 経路を application use-case へ移設する。`categoryName` は
+ * `lib/storage/projects.removeCategoryFromProject` と同じ positional 引数で
+ * そのまま port 実装へ伝搬する。
+ *
+ * @example
+ * ```ts
+ * const command: RemoveCategoryFromCustomProjectCommand = {
+ *   projectId: 'project-1',
+ *   categoryName: 'Inbox',
+ * }
+ * ```
+ */
+export interface RemoveCategoryFromCustomProjectCommand {
+  readonly projectId: string
+  readonly categoryName: string
+}

--- a/src/contexts/saved-tabs/application/use-cases/AddCategoryToCustomProjectUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/AddCategoryToCustomProjectUseCase.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest' // eslint-disable-line
+
+import type { CustomProjectsCommandService } from '../ports/CustomProjectsCommandService'
+import { createAddCategoryToCustomProjectUseCase } from './AddCategoryToCustomProjectUseCase'
+
+const buildCommandService = (): {
+  commandService: CustomProjectsCommandService
+  addCategoryToProject: ReturnType<typeof vi.fn>
+} => {
+  const addCategoryToProject = vi.fn(
+    // eslint-disable-next-line typescript/require-await
+    async () => undefined,
+  )
+  const commandService = {
+    addCategoryToProject,
+    addUrlToCustomProject: vi.fn(),
+    moveUrlBetweenCustomProjects: vi.fn(),
+    removeCategoryFromProject: vi.fn(),
+    removeUrlFromCustomProject: vi.fn(),
+    removeUrlIdsFromAllCustomProjects: vi.fn(),
+    removeUrlsFromAllCustomProjects: vi.fn(),
+    removeUrlsFromCustomProject: vi.fn(),
+    renameCategoryInProject: vi.fn(),
+    reorderProjectUrls: vi.fn(),
+    setUrlCategory: vi.fn(),
+    updateCategoryOrder: vi.fn(),
+    updateProjectKeywords: vi.fn(),
+  }
+  return {
+    addCategoryToProject,
+    commandService: commandService as unknown as CustomProjectsCommandService,
+  }
+}
+
+describe('AddCategoryToCustomProjectUseCase', () => {
+  it('port の addCategoryToProject を projectId / categoryName で呼び出す', async () => {
+    const { commandService, addCategoryToProject } = buildCommandService()
+    const useCase = createAddCategoryToCustomProjectUseCase({
+      customProjectsCommandService: commandService,
+    })
+
+    await useCase({ projectId: 'project-1', categoryName: 'Inbox' })
+
+    expect(addCategoryToProject).toHaveBeenCalledWith('project-1', 'Inbox')
+  })
+
+  it('port が reject した例外をそのまま伝搬する', async () => {
+    const { commandService, addCategoryToProject } = buildCommandService()
+    addCategoryToProject.mockRejectedValueOnce(new Error('storage failure'))
+    const useCase = createAddCategoryToCustomProjectUseCase({
+      customProjectsCommandService: commandService,
+    })
+
+    await expect(
+      useCase({ projectId: 'project-1', categoryName: 'Inbox' }),
+    ).rejects.toThrow('storage failure')
+  })
+})

--- a/src/contexts/saved-tabs/application/use-cases/AddCategoryToCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/AddCategoryToCustomProjectUseCase.ts
@@ -1,0 +1,51 @@
+import type { AddCategoryToCustomProjectCommand } from '../commands/AddCategoryToCustomProjectCommand'
+import type { CustomProjectsCommandService } from '../ports/CustomProjectsCommandService'
+
+/**
+ * `AddCategoryToCustomProjectUseCase` が依存する port。
+ */
+export interface AddCategoryToCustomProjectUseCaseDeps {
+  readonly customProjectsCommandService: CustomProjectsCommandService
+}
+
+/**
+ * `AddCategoryToCustomProjectUseCase` の関数型。
+ */
+export type AddCategoryToCustomProjectUseCase = (
+  command: AddCategoryToCustomProjectCommand,
+) => Promise<void>
+
+/**
+ * `AddCategoryToCustomProjectUseCase` を生成する (issue #540)。
+ *
+ * 旧 `useProjectManagement.handleAddCategory` 内の
+ * `customProjectsCommandService.addCategoryToProject(...)` 直叩きを
+ * application use-case へ移設する薄いラッパ。
+ *
+ * issue #539 で 8 操作が use-case 化されたが、`addCategoryToProject` /
+ * `removeCategoryFromProject` は「カテゴリ並び順を持つ rich 補助
+ * フィールドを mutate する」性質上 port 仕様への薄いラッパにとどめ、
+ * presentation 層からの直接 port 呼び出しを置換するために本 use-case を
+ * 用意する。
+ *
+ * @example
+ * ```ts
+ * const addCategoryToCustomProject = createAddCategoryToCustomProjectUseCase({
+ *   customProjectsCommandService,
+ * })
+ * await addCategoryToCustomProject({
+ *   projectId: 'project-1',
+ *   categoryName: 'Inbox',
+ * })
+ * ```
+ */
+export const createAddCategoryToCustomProjectUseCase = (
+  deps: AddCategoryToCustomProjectUseCaseDeps,
+): AddCategoryToCustomProjectUseCase => {
+  return async (command) => {
+    await deps.customProjectsCommandService.addCategoryToProject(
+      command.projectId,
+      command.categoryName,
+    )
+  }
+}

--- a/src/contexts/saved-tabs/application/use-cases/MoveUrlBetweenCustomProjectsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/MoveUrlBetweenCustomProjectsUseCase.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest' // eslint-disable-line
+
+import type { CustomProjectsCommandService } from '../ports/CustomProjectsCommandService'
+import { createMoveUrlBetweenCustomProjectsUseCase } from './MoveUrlBetweenCustomProjectsUseCase'
+
+const buildCommandService = (): {
+  commandService: CustomProjectsCommandService
+  moveUrlBetweenCustomProjects: ReturnType<typeof vi.fn>
+} => {
+  const moveUrlBetweenCustomProjects = vi.fn(
+    // eslint-disable-next-line typescript/require-await
+    async () => undefined,
+  )
+  const commandService = {
+    addCategoryToProject: vi.fn(),
+    addUrlToCustomProject: vi.fn(),
+    moveUrlBetweenCustomProjects,
+    removeCategoryFromProject: vi.fn(),
+    removeUrlFromCustomProject: vi.fn(),
+    removeUrlIdsFromAllCustomProjects: vi.fn(),
+    removeUrlsFromAllCustomProjects: vi.fn(),
+    removeUrlsFromCustomProject: vi.fn(),
+    renameCategoryInProject: vi.fn(),
+    reorderProjectUrls: vi.fn(),
+    setUrlCategory: vi.fn(),
+    updateCategoryOrder: vi.fn(),
+    updateProjectKeywords: vi.fn(),
+  }
+  return {
+    commandService: commandService as unknown as CustomProjectsCommandService,
+    moveUrlBetweenCustomProjects,
+  }
+}
+
+describe('MoveUrlBetweenCustomProjectsUseCase', () => {
+  it('port の moveUrlBetweenCustomProjects を sourceProjectId / targetProjectId / url で呼び出す', async () => {
+    const { commandService, moveUrlBetweenCustomProjects } =
+      buildCommandService()
+    const useCase = createMoveUrlBetweenCustomProjectsUseCase({
+      customProjectsCommandService: commandService,
+    })
+
+    await useCase({
+      sourceProjectId: 'project-a',
+      targetProjectId: 'project-b',
+      url: 'https://example.com/a',
+    })
+
+    expect(moveUrlBetweenCustomProjects).toHaveBeenCalledWith(
+      'project-a',
+      'project-b',
+      'https://example.com/a',
+    )
+  })
+
+  it('port が reject した例外をそのまま伝搬する', async () => {
+    const { commandService, moveUrlBetweenCustomProjects } =
+      buildCommandService()
+    moveUrlBetweenCustomProjects.mockRejectedValueOnce(new Error('move failed'))
+    const useCase = createMoveUrlBetweenCustomProjectsUseCase({
+      customProjectsCommandService: commandService,
+    })
+
+    await expect(
+      useCase({
+        sourceProjectId: 'project-a',
+        targetProjectId: 'project-b',
+        url: 'https://example.com/a',
+      }),
+    ).rejects.toThrow('move failed')
+  })
+})

--- a/src/contexts/saved-tabs/application/use-cases/MoveUrlBetweenCustomProjectsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/MoveUrlBetweenCustomProjectsUseCase.ts
@@ -1,0 +1,57 @@
+import type { MoveUrlBetweenCustomProjectsCommand } from '../commands/MoveUrlBetweenCustomProjectsCommand'
+import type { CustomProjectsCommandService } from '../ports/CustomProjectsCommandService'
+
+/**
+ * `MoveUrlBetweenCustomProjectsUseCase` が依存する port。
+ */
+export interface MoveUrlBetweenCustomProjectsUseCaseDeps {
+  readonly customProjectsCommandService: CustomProjectsCommandService
+}
+
+/**
+ * `MoveUrlBetweenCustomProjectsUseCase` の関数型。
+ */
+export type MoveUrlBetweenCustomProjectsUseCase = (
+  command: MoveUrlBetweenCustomProjectsCommand,
+) => Promise<void>
+
+/**
+ * `MoveUrlBetweenCustomProjectsUseCase` を生成する (issue #540)。
+ *
+ * 旧 `SavedTabsApp.handleMoveUrlBetweenProjects` 内の
+ * `customProjectsCommandService.moveUrlBetweenCustomProjects(...)`
+ * 直叩きを application use-case へ移設する薄いラッパ。presentation 層
+ * (`SavedTabsApp` / `CustomModeContainer`) は本 use-case を介して
+ * 移動処理を呼び、port 仕様 (`CustomProjectsCommandService`) への
+ * 直接依存を撤去する (受け入れ条件「handleMoveUrlBetweenProjects が
+ * application use-case 経由になっている」)。
+ *
+ * 旧 `SavedTabsApp` 側の `customProjectRepository.findAll()` 直叩きも
+ * `getCustomProjects` query 経由へ置換済み (本 use-case 自体は
+ * 移動の mutation のみを担当し、presentation 側 state 同期は
+ * `getCustomProjects` query を `useEffect` / `setCustomProjects` で
+ * 行う)。
+ *
+ * @example
+ * ```ts
+ * const moveUrlBetweenCustomProjects = createMoveUrlBetweenCustomProjectsUseCase({
+ *   customProjectsCommandService,
+ * })
+ * await moveUrlBetweenCustomProjects({
+ *   sourceProjectId: 'project-a',
+ *   targetProjectId: 'project-b',
+ *   url: 'https://example.com/a',
+ * })
+ * ```
+ */
+export const createMoveUrlBetweenCustomProjectsUseCase = (
+  deps: MoveUrlBetweenCustomProjectsUseCaseDeps,
+): MoveUrlBetweenCustomProjectsUseCase => {
+  return async (command) => {
+    await deps.customProjectsCommandService.moveUrlBetweenCustomProjects(
+      command.sourceProjectId,
+      command.targetProjectId,
+      command.url,
+    )
+  }
+}

--- a/src/contexts/saved-tabs/application/use-cases/RemoveCategoryFromCustomProjectUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveCategoryFromCustomProjectUseCase.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest' // eslint-disable-line
+
+import type { CustomProjectsCommandService } from '../ports/CustomProjectsCommandService'
+import { createRemoveCategoryFromCustomProjectUseCase } from './RemoveCategoryFromCustomProjectUseCase'
+
+const buildCommandService = (): {
+  commandService: CustomProjectsCommandService
+  removeCategoryFromProject: ReturnType<typeof vi.fn>
+} => {
+  const removeCategoryFromProject = vi.fn(
+    // eslint-disable-next-line typescript/require-await
+    async () => undefined,
+  )
+  const commandService = {
+    addCategoryToProject: vi.fn(),
+    addUrlToCustomProject: vi.fn(),
+    moveUrlBetweenCustomProjects: vi.fn(),
+    removeCategoryFromProject,
+    removeUrlFromCustomProject: vi.fn(),
+    removeUrlIdsFromAllCustomProjects: vi.fn(),
+    removeUrlsFromAllCustomProjects: vi.fn(),
+    removeUrlsFromCustomProject: vi.fn(),
+    renameCategoryInProject: vi.fn(),
+    reorderProjectUrls: vi.fn(),
+    setUrlCategory: vi.fn(),
+    updateCategoryOrder: vi.fn(),
+    updateProjectKeywords: vi.fn(),
+  }
+  return {
+    commandService: commandService as unknown as CustomProjectsCommandService,
+    removeCategoryFromProject,
+  }
+}
+
+describe('RemoveCategoryFromCustomProjectUseCase', () => {
+  it('port の removeCategoryFromProject を projectId / categoryName で呼び出す', async () => {
+    const { commandService, removeCategoryFromProject } = buildCommandService()
+    const useCase = createRemoveCategoryFromCustomProjectUseCase({
+      customProjectsCommandService: commandService,
+    })
+
+    await useCase({ projectId: 'project-1', categoryName: 'Inbox' })
+
+    expect(removeCategoryFromProject).toHaveBeenCalledWith('project-1', 'Inbox')
+  })
+
+  it('port が reject した例外をそのまま伝搬する', async () => {
+    const { commandService, removeCategoryFromProject } = buildCommandService()
+    removeCategoryFromProject.mockRejectedValueOnce(
+      new Error('storage failure'),
+    )
+    const useCase = createRemoveCategoryFromCustomProjectUseCase({
+      customProjectsCommandService: commandService,
+    })
+
+    await expect(
+      useCase({ projectId: 'project-1', categoryName: 'Inbox' }),
+    ).rejects.toThrow('storage failure')
+  })
+})

--- a/src/contexts/saved-tabs/application/use-cases/RemoveCategoryFromCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveCategoryFromCustomProjectUseCase.ts
@@ -1,0 +1,45 @@
+import type { RemoveCategoryFromCustomProjectCommand } from '../commands/RemoveCategoryFromCustomProjectCommand'
+import type { CustomProjectsCommandService } from '../ports/CustomProjectsCommandService'
+
+/**
+ * `RemoveCategoryFromCustomProjectUseCase` が依存する port。
+ */
+export interface RemoveCategoryFromCustomProjectUseCaseDeps {
+  readonly customProjectsCommandService: CustomProjectsCommandService
+}
+
+/**
+ * `RemoveCategoryFromCustomProjectUseCase` の関数型。
+ */
+export type RemoveCategoryFromCustomProjectUseCase = (
+  command: RemoveCategoryFromCustomProjectCommand,
+) => Promise<void>
+
+/**
+ * `RemoveCategoryFromCustomProjectUseCase` を生成する (issue #540)。
+ *
+ * 旧 `useProjectManagement.handleDeleteProjectCategory` 内の
+ * `customProjectsCommandService.removeCategoryFromProject(...)` 直叩きを
+ * application use-case へ移設する薄いラッパ。
+ *
+ * @example
+ * ```ts
+ * const removeCategoryFromCustomProject = createRemoveCategoryFromCustomProjectUseCase({
+ *   customProjectsCommandService,
+ * })
+ * await removeCategoryFromCustomProject({
+ *   projectId: 'project-1',
+ *   categoryName: 'Inbox',
+ * })
+ * ```
+ */
+export const createRemoveCategoryFromCustomProjectUseCase = (
+  deps: RemoveCategoryFromCustomProjectUseCaseDeps,
+): RemoveCategoryFromCustomProjectUseCase => {
+  return async (command) => {
+    await deps.customProjectsCommandService.removeCategoryFromProject(
+      command.projectId,
+      command.categoryName,
+    )
+  }
+}

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -1044,4 +1044,71 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       ).toBe(false)
     })
   })
+
+  describe('issue #540: SavedTabsApp は customProjectRepository / customProjectsCommandService を deps 経由で利用しない', () => {
+    const savedTabsAppPath = resolve(
+      repoRoot,
+      'src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx',
+    )
+    const savedTabsAppSource = readFileSync(savedTabsAppPath, 'utf8')
+    const useProjectManagementPath = resolve(
+      repoRoot,
+      'src/contexts/saved-tabs/presentation/hooks/useProjectManagement.ts',
+    )
+    const useProjectManagementSource = readFileSync(
+      useProjectManagementPath,
+      'utf8',
+    )
+
+    it('SavedTabsApp は CustomProjectRepository を import していない', () => {
+      expect(savedTabsAppSource).not.toMatch(
+        /from\s+['"]@\/contexts\/saved-tabs\/domain\/repositories\/CustomProjectRepository['"]/,
+      )
+    })
+
+    it('SavedTabsApp は CustomProjectsCommandService を import していない', () => {
+      expect(savedTabsAppSource).not.toMatch(
+        /from\s+['"]@\/contexts\/saved-tabs\/application\/ports\/CustomProjectsCommandService['"]/,
+      )
+    })
+
+    it('SavedTabsApp の deps から customProjectRepository が消えている', () => {
+      // `deps.customProjectRepository.*` 形式のアクセスがないこと。
+      // 旧 `handleMoveUrlBetweenProjects` の `deps.customProjectRepository.findAll()`
+      // 直叩きを撤去した (issue #540 受け入れ条件) ことを担保する。
+      expect(savedTabsAppSource).not.toMatch(/deps\.customProjectRepository\b/)
+    })
+
+    it('SavedTabsApp の deps から customProjectsCommandService が消えている', () => {
+      // `deps.customProjectsCommandService.*` 形式のアクセスがないこと。
+      // 旧 `handleMoveUrlBetweenProjects` の `deps.customProjectsCommandService.moveUrlBetweenCustomProjects`
+      // 直叩きを撤去した (issue #540 受け入れ条件) ことを担保する。
+      expect(savedTabsAppSource).not.toMatch(
+        /deps\.customProjectsCommandService\b/,
+      )
+    })
+
+    it('useProjectManagement の deps は customProjectsCommandService を受け取らない', () => {
+      // issue #540 で `customProjectsCommandService` パラメータを
+      // 完全に撤去し、`addCategoryToProject` /
+      // `removeCategoryFromProject` も application use-case
+      // (`addCategoryToCustomProject` /
+      // `removeCategoryFromCustomProject`) へ移設した。
+      expect(useProjectManagementSource).not.toMatch(
+        /customProjectsCommandService/,
+      )
+    })
+
+    it('useProjectManagement は CustomProjectsCommandService を import していない', () => {
+      expect(useProjectManagementSource).not.toMatch(
+        /from\s+['"]@\/contexts\/saved-tabs\/application\/ports\/CustomProjectsCommandService['"]/,
+      )
+    })
+
+    it('useProjectManagement は CustomProjectRepository を import していない (issue #538 からの継続)', () => {
+      expect(useProjectManagementSource).not.toMatch(
+        /from\s+['"]@\/contexts\/saved-tabs\/domain\/repositories\/CustomProjectRepository['"]/,
+      )
+    })
+  })
 })

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts
@@ -5,6 +5,7 @@ import { createGetCustomProjectUndoSnapshotQuery } from '../../application/queri
 import { createGetSavedTabsPageDataQuery } from '../../application/queries/GetSavedTabsPageDataQuery'
 import { createGetSavedTabsQuery } from '../../application/queries/GetSavedTabsQuery'
 import type { SavedTabsUseCases } from '../../application/SavedTabsUseCases'
+import { createAddCategoryToCustomProjectUseCase } from '../../application/use-cases/AddCategoryToCustomProjectUseCase'
 import { createAddDomainToParentCategoryUseCase } from '../../application/use-cases/AddDomainToParentCategoryUseCase'
 import { createAddUrlToCustomProjectUseCase } from '../../application/use-cases/AddUrlToCustomProjectUseCase'
 import { createAssignDomainToCategoryUseCase } from '../../application/use-cases/AssignDomainToCategoryUseCase'
@@ -22,10 +23,12 @@ import { createGetProjectUrlsUseCase } from '../../application/use-cases/GetProj
 import { createLoadTabGroupsWithUrlsUseCase } from '../../application/use-cases/LoadTabGroupsWithUrlsUseCase'
 import { createLoadTabGroupUrlsUseCase } from '../../application/use-cases/LoadTabGroupUrlsUseCase'
 import { createMoveDomainBetweenCategoriesUseCase } from '../../application/use-cases/MoveDomainBetweenCategoriesUseCase'
+import { createMoveUrlBetweenCustomProjectsUseCase } from '../../application/use-cases/MoveUrlBetweenCustomProjectsUseCase'
 import { createOpenAllSavedUrlsUseCase } from '../../application/use-cases/OpenAllSavedUrlsUseCase'
 import { createOpenSavedUrlUseCase } from '../../application/use-cases/OpenSavedUrlUseCase'
 import { createPrepareTabGroupDeletionUseCase } from '../../application/use-cases/PrepareTabGroupDeletionUseCase'
 import { createPrepareTabGroupsDeletionUseCase } from '../../application/use-cases/PrepareTabGroupsDeletionUseCase'
+import { createRemoveCategoryFromCustomProjectUseCase } from '../../application/use-cases/RemoveCategoryFromCustomProjectUseCase'
 import { createRemoveDomainFromParentCategoryUseCase } from '../../application/use-cases/RemoveDomainFromParentCategoryUseCase'
 import { createRemoveDomainsFromParentCategoriesUseCase } from '../../application/use-cases/RemoveDomainsFromParentCategoriesUseCase'
 import { createRemoveSubCategoryFromTabGroupsUseCase } from '../../application/use-cases/RemoveSubCategoryFromTabGroupsUseCase'
@@ -252,6 +255,27 @@ export const createSavedTabsUseCases = (
     customProjectsCommandService: deps.customProjectsCommandService,
   }),
   updateCustomProjectKeywords: createUpdateCustomProjectKeywordsUseCase({
+    customProjectsCommandService: deps.customProjectsCommandService,
+  }),
+  // issue #540: 旧 `useProjectManagement` 配下に残っていた
+  // `CustomProjectsCommandService` 直叩き 2 操作
+  // (`addCategoryToProject` / `removeCategoryFromProject`) を
+  // application use-case へ移設し、presentation 層が port
+  // (`CustomProjectsCommandService`) を直接 import しない形へ
+  // 統一する。
+  addCategoryToCustomProject: createAddCategoryToCustomProjectUseCase({
+    customProjectsCommandService: deps.customProjectsCommandService,
+  }),
+  removeCategoryFromCustomProject: createRemoveCategoryFromCustomProjectUseCase(
+    {
+      customProjectsCommandService: deps.customProjectsCommandService,
+    },
+  ),
+  // issue #540: 旧 `SavedTabsApp.handleMoveUrlBetweenProjects` 内
+  // の `customProjectsCommandService.moveUrlBetweenCustomProjects`
+  // 直叩きを application use-case へ移設し、`SavedTabsApp` が port
+  // を直接扱わない構成に寄せる。
+  moveUrlBetweenCustomProjects: createMoveUrlBetweenCustomProjectsUseCase({
     customProjectsCommandService: deps.customProjectsCommandService,
   }),
   renameParentCategory: createRenameParentCategoryUseCase({

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
@@ -683,6 +683,11 @@ describe('SavedTabsApp custom search', () => {
         reorderCustomProjectUrls: vi.fn(),
         renameCustomProjectCategory: vi.fn(),
         updateCustomProjectKeywords: vi.fn(),
+        // issue #540: `useProjectManagement` deps と
+        // `handleMoveUrlBetweenProjects` 用に増えた use-case モック。
+        addCategoryToCustomProject: vi.fn(),
+        removeCategoryFromCustomProject: vi.fn(),
+        moveUrlBetweenCustomProjects: vi.fn(),
       },
       setCustomProjects: vi.fn(),
       snapshot: {
@@ -757,6 +762,11 @@ describe('SavedTabsApp custom search', () => {
         reorderCustomProjectUrls: vi.fn(),
         renameCustomProjectCategory: vi.fn(),
         updateCustomProjectKeywords: vi.fn(),
+        // issue #540: `useProjectManagement` deps と
+        // `handleMoveUrlBetweenProjects` 用に増えた use-case モック。
+        addCategoryToCustomProject: vi.fn(),
+        removeCategoryFromCustomProject: vi.fn(),
+        moveUrlBetweenCustomProjects: vi.fn(),
       },
       setCustomProjects: vi.fn(),
       t: (key) => key,

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -141,12 +141,10 @@ const useSavedTabsAppView = ({
     tabDataState.tabGroups,
     settings,
     initialViewMode,
-    // issue #539 範囲外: `addCategoryToProject` /
-    // `removeCategoryFromProject` のみ port 直叩きするため
-    // `customProjectsCommandService` を渡し、URL / カテゴリ
-    // 操作 8 メソッドは SavedTabsUseCases 経由の use-case
-    // 関数だけを deps に渡す。
-    deps.customProjectsCommandService,
+    // issue #540 範囲: `customProjectsCommandService` パラメータ
+    // を撤去し、`addCategoryToProject` /
+    // `removeCategoryFromProject` を含むすべての操作を
+    // SavedTabsUseCases 経由の use-case 関数として渡す形へ統一。
     savedTabsUseCases.createCustomProject,
     savedTabsUseCases.deleteCustomProject,
     savedTabsUseCases.updateCustomProjectName,
@@ -160,6 +158,8 @@ const useSavedTabsAppView = ({
     savedTabsUseCases.reorderCustomProjectUrls,
     savedTabsUseCases.renameCustomProjectCategory,
     savedTabsUseCases.updateCustomProjectKeywords,
+    savedTabsUseCases.addCategoryToCustomProject,
+    savedTabsUseCases.removeCategoryFromCustomProject,
   )
   const {
     categories,
@@ -515,8 +515,7 @@ const useSavedTabsAppView = ({
         // customProject 側の URL ID 同期削除は他 storage key を触る
         // ため、issue 範囲外として従来通り UI 側で実行していたが、
         // issue #512 で `removeUrlsFromCustomProjects` use-case へ
-        // 移設済み。`deps.customProjectsCommandService` 直叩きは
-        // 必要なくなった。
+        // 移設済み (issue #540 範囲)。
         await savedTabsUseCases.removeUrlsFromCustomProjects({
           tabGroups: groupsToDelete,
         })
@@ -979,6 +978,12 @@ const useSavedTabsAppView = ({
   }, [initialViewMode, onViewModeNavigate, viewMode])
 
   // カスタムプロジェクト間でURLを移動するハンドラ
+  // issue #540: `customProjectRepository` /
+  // `customProjectsCommandService` 直叩きを撤去し、
+  // `getCustomProjects` query (読み取り) と
+  // `moveUrlBetweenCustomProjects` use-case (更新) 経由で
+  // 移動と state 同期を行う。`SavedTabsApp` は port / repository
+  // モジュールを import しない構成に統一する。
   const handleMoveUrlBetweenProjects = useCallback(
     async (sourceProjectId: string, targetProjectId: string, url: string) => {
       try {
@@ -986,19 +991,27 @@ const useSavedTabsAppView = ({
           `URL移動: ${sourceProjectId} → ${targetProjectId}, URL: ${url}`,
         )
         await moveCustomProjectUrlAndSyncState({
+          // application query `getCustomProjects` は
+          // domain entity `CustomProject` を返すが、state 同期先で
+          // 必要なのは storage 形 (`@/types/storage` の `CustomProject`)
+          // のため、mapper 経由で projection する。
           getCustomProjects: async () => {
-            const projects = await deps.customProjectRepository.findAll()
+            const projects = await savedTabsUseCases.getCustomProjects()
             return projects.map((project) => ({
               categories: [...project.categories],
               createdAt: project.createdAt,
-              id: project.id,
+              // eslint-disable-next-line typescript/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-type-assertion -- domain CustomProjectId と storage 側の string 差 (issue #511 と同系統)
+              id: project.id as unknown as string,
               name: project.name,
               updatedAt: project.updatedAt,
-              urlIds: [...project.urlIds],
+              ...(project.urlIds.length > 0
+                ? // eslint-disable-next-line typescript/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-type-assertion -- domain UrlRecordId と storage 側の string 差 (issue #511 と同系統)
+                  { urlIds: [...project.urlIds] as unknown as string[] }
+                : {}),
             }))
           },
           moveUrlBetweenCustomProjects:
-            deps.customProjectsCommandService.moveUrlBetweenCustomProjects,
+            savedTabsUseCases.moveUrlBetweenCustomProjects,
           setCustomProjects,
           sourceProjectId,
           targetProjectId,
@@ -1012,12 +1025,7 @@ const useSavedTabsAppView = ({
         return null
       }
     },
-    [
-      deps.customProjectRepository,
-      deps.customProjectsCommandService,
-      setCustomProjects,
-      t,
-    ],
+    [savedTabsUseCases, setCustomProjects, t],
   )
 
   // カテゴリ間でURLを移動するハンドラ

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx
@@ -14,13 +14,14 @@ import type { CustomProject } from '@/types/storage'
 import { useProjectManagement } from './useProjectManagement'
 
 const projectManagementMocks = vi.hoisted(() => ({
-  // issue #539 範囲外: 旧 `customProjectsCommandService` 経由で
-  // 残る 2 操作 (`addCategoryToProject` / `removeCategoryFromProject`)
-  // の port mock。
-  addCategoryToProject: vi.fn(),
-  removeCategoryFromProject: vi.fn(),
-  // issue #539 で application use-case 化した 8 操作の use-case
-  // mock。`useProjectManagement` には use-case 関数として渡される。
+  // issue #539 / #540 で application use-case へ移設した 10 操作の
+  // use-case mock。`useProjectManagement` には use-case 関数として
+  // 渡される。issue #540 で `addCategoryToProject` /
+  // `removeCategoryFromProject` も use-case 化されたため、`addCategoryToCustomProject`
+  // / `removeCategoryFromCustomProject` mock として独立した
+  // deps に並ぶ。
+  addCategoryToCustomProject: vi.fn(),
+  removeCategoryFromCustomProject: vi.fn(),
   addUrlToCustomProject: vi.fn(),
   removeUrlFromCustomProject: vi.fn(),
   removeUrlsFromCustomProject: vi.fn(),
@@ -183,13 +184,13 @@ describe('useProjectManagement', () => {
    * 同名 mock 関数をそのまま参照する形に統一しつつ、presentation
    * 側で未使用の `removeUrlIdsFromAllCustomProjects` /
    * `removeUrlsFromAllCustomProjects` は no-op vi.fn で補完する。
+   *
+   * issue #540 で `useProjectManagement` から
+   * `customProjectsCommandService` パラメータも完全に撤去された
+   * (port 直接依存の 2 操作 `addCategoryToProject` /
+   * `removeCategoryFromProject` も use-case 化された) ため、
+   * `customProjectsCommandService` 変数は存在しない。
    */
-  // `customProjectsCommandService` は `useProjectManagement` の
-  // `CustomProjectsCommandService` として渡される。テストでは
-  // `projectManagementMocks` の同名関数をそのまま参照する形に統一しつつ、
-  // presentation 側で未使用のメソッドは no-op vi.fn で補完する。
-  // eslint-disable-next-line typescript/no-explicit-any
-  let customProjectsCommandService: any
 
   beforeEach(() => {
     for (const mock of Object.values(projectManagementMocks)) {
@@ -360,66 +361,6 @@ describe('useProjectManagement', () => {
       },
     )
 
-    customProjectsCommandService = {
-      // issue #539 で use-case 化されていない 2 操作 (
-      // `addCategoryToProject` / `removeCategoryFromProject`) のみ
-      // 旧 `CustomProjectsCommandService` port 経由で呼ばれる。
-      addCategoryToProject: projectManagementMocks.addCategoryToProject,
-      moveUrlBetweenCustomProjects: vi.fn(),
-      removeCategoryFromProject:
-        projectManagementMocks.removeCategoryFromProject,
-      // `removeUrlIdsFromAllCustomProjects` /
-      // `removeUrlsFromAllCustomProjects` は presentation 配下では
-      // use-case 経由 (`RemoveUrlsFromCustomProjectsUseCase`) の API
-      // として参照されるため、後方互換のため no-op vi.fn を
-      // 用意する。
-      removeUrlIdsFromAllCustomProjects: vi.fn(),
-      removeUrlsFromAllCustomProjects: vi.fn(),
-      // issue #539 で application use-case 化された 8 メソッドは
-      // `useProjectManagement` から port 経由で呼ばれないため、
-      // port mock には no-op を割り当てる (誤って port 経由で
-      // 呼ばれた場合はここで fail する)。
-      addUrlToCustomProject: vi.fn(() => {
-        throw new Error(
-          'addUrlToCustomProject port should not be called; use addUrlToCustomProjectUseCase',
-        )
-      }),
-      removeUrlFromCustomProject: vi.fn(() => {
-        throw new Error(
-          'removeUrlFromCustomProject port should not be called; use removeUrlFromCustomProjectUseCase',
-        )
-      }),
-      removeUrlsFromCustomProject: vi.fn(() => {
-        throw new Error(
-          'removeUrlsFromCustomProject port should not be called; use removeUrlsFromCustomProjectUseCase',
-        )
-      }),
-      renameCategoryInProject: vi.fn(() => {
-        throw new Error(
-          'renameCategoryInProject port should not be called; use renameCustomProjectCategoryUseCase',
-        )
-      }),
-      reorderProjectUrls: vi.fn(() => {
-        throw new Error(
-          'reorderProjectUrls port should not be called; use reorderCustomProjectUrlsUseCase',
-        )
-      }),
-      setUrlCategory: vi.fn(() => {
-        throw new Error(
-          'setUrlCategory port should not be called; use setCustomProjectUrlCategoryUseCase',
-        )
-      }),
-      updateCategoryOrder: vi.fn(() => {
-        throw new Error(
-          'updateCategoryOrder port should not be called; use updateCustomProjectCategoryOrderUseCase',
-        )
-      }),
-      updateProjectKeywords: vi.fn(() => {
-        throw new Error(
-          'updateProjectKeywords port should not be called; use updateCustomProjectKeywordsUseCase',
-        )
-      }),
-    } as never
     projectManagementMocks.createCustomProject.mockResolvedValue({
       category: projectSnapshot[0],
       project: projectSnapshot[0],
@@ -429,6 +370,15 @@ describe('useProjectManagement', () => {
       all: [projectSnapshot[0]],
       project: projectSnapshot[0],
     })
+    // issue #540: `addCategoryToCustomProject` /
+    // `removeCategoryFromCustomProject` は独立した use-case
+    // deps として `useProjectManagement` に渡される。
+    projectManagementMocks.addCategoryToCustomProject.mockResolvedValue(
+      undefined,
+    )
+    projectManagementMocks.removeCategoryFromCustomProject.mockResolvedValue(
+      undefined,
+    )
   })
 
   afterEach(() => {
@@ -452,7 +402,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'domain',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -467,6 +416,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -497,7 +449,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -512,6 +463,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -540,7 +494,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -555,6 +508,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
     unmount()
@@ -582,7 +538,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'domain',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -597,6 +552,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -626,7 +584,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'domain',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -641,6 +598,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -671,7 +631,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         undefined,
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -686,6 +645,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -721,7 +683,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -736,6 +697,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -781,7 +745,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -796,6 +759,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -839,7 +805,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -854,6 +819,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -919,7 +887,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -934,6 +901,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -959,8 +929,8 @@ describe('useProjectManagement', () => {
     })
 
     expect(
-      projectManagementMocks.removeCategoryFromProject,
-    ).toHaveBeenCalledWith('project-1', 'Inbox')
+      projectManagementMocks.removeCategoryFromCustomProject,
+    ).toHaveBeenCalledWith({ categoryName: 'Inbox', projectId: 'project-1' })
     expect(result.current.customProjects).toStrictEqual([])
 
     await act(async () => {
@@ -1025,7 +995,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -1040,6 +1009,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -1065,10 +1037,9 @@ describe('useProjectManagement', () => {
       await result.current.handleRenameCategory('project-4', 'Old', 'New')
     })
 
-    expect(projectManagementMocks.addCategoryToProject).toHaveBeenCalledWith(
-      'project-2',
-      'Review',
-    )
+    expect(
+      projectManagementMocks.addCategoryToCustomProject,
+    ).toHaveBeenCalledWith({ categoryName: 'Review', projectId: 'project-2' })
     expect(projectManagementMocks.updateCategoryOrder).toHaveBeenCalledWith({
       newOrder: ['Review', 'Inbox'],
       projectId: 'project-2',
@@ -1135,7 +1106,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -1150,6 +1120,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -1193,10 +1166,10 @@ describe('useProjectManagement', () => {
     projectManagementMocks.removeUrlsFromCustomProject.mockRejectedValue(
       new Error('delete urls failed'),
     )
-    projectManagementMocks.addCategoryToProject.mockRejectedValue(
+    projectManagementMocks.addCategoryToCustomProject.mockRejectedValue(
       new Error('add category failed'),
     )
-    projectManagementMocks.removeCategoryFromProject.mockRejectedValue(
+    projectManagementMocks.removeCategoryFromCustomProject.mockRejectedValue(
       new Error('delete category failed'),
     )
     projectManagementMocks.setUrlCategory.mockRejectedValue(
@@ -1227,7 +1200,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -1242,6 +1214,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -1322,7 +1297,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -1337,6 +1311,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -1437,7 +1414,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -1452,6 +1428,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -1510,7 +1489,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -1525,6 +1503,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 
@@ -1584,7 +1565,6 @@ describe('useProjectManagement', () => {
         [],
         defaultSettings,
         'custom',
-        customProjectsCommandService,
         projectManagementMocks.createCustomProject,
         projectManagementMocks.deleteCustomProject,
         projectManagementMocks.updateCustomProjectName,
@@ -1599,6 +1579,9 @@ describe('useProjectManagement', () => {
         projectManagementMocks.reorderProjectUrls,
         projectManagementMocks.renameCategoryInProject,
         projectManagementMocks.updateProjectKeywords,
+        // issue #540: 2 つの use-case を独立した deps として渡す。
+        projectManagementMocks.addCategoryToCustomProject,
+        projectManagementMocks.removeCategoryFromCustomProject,
       ),
     )
 

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.ts
@@ -4,9 +4,9 @@
  * プロジェクト内カテゴリ管理を担うカスタムフック。
  *
  * 旧 `customProjectRepository` 直接依存 (issue #538) と
- * 旧 `CustomProjectsCommandService` 直接依存 (issue #539) を撤去し、
- * 読み取り系は application query、更新・復元系は application use-case
- * 経由のみに寄せた。presentation 層は port モジュール
+ * 旧 `CustomProjectsCommandService` 直接依存 (issue #539 / #540) を
+ * 撤去し、読み取り系は application query、更新・復元系は application
+ * use-case 経由のみに寄せた。presentation 層は port モジュール
  * (`CustomProjectsCommandService`) も repository モジュール
  * (`CustomProjectRepository`) も import せず、deps は query 関数と
  * use-case 関数だけを受け取る。
@@ -16,7 +16,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { toast } from 'sonner'
 
-import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/application/ports/CustomProjectsCommandService'
 import type { GetCustomProjectOrderQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectOrderQuery'
 import type { GetCustomProjectRawsQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectRawsQuery'
 import type { GetCustomProjectsQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectsQuery'
@@ -24,9 +23,11 @@ import type {
   CustomProjectUndoSnapshot,
   GetCustomProjectUndoSnapshotQuery,
 } from '@/contexts/saved-tabs/application/queries/GetCustomProjectUndoSnapshotQuery'
+import type { AddCategoryToCustomProjectUseCase } from '@/contexts/saved-tabs/application/use-cases/AddCategoryToCustomProjectUseCase'
 import type { AddUrlToCustomProjectUseCase } from '@/contexts/saved-tabs/application/use-cases/AddUrlToCustomProjectUseCase'
 import type { CreateCustomProjectUseCase } from '@/contexts/saved-tabs/application/use-cases/CreateCustomProjectUseCase'
 import type { DeleteCustomProjectUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase'
+import type { RemoveCategoryFromCustomProjectUseCase } from '@/contexts/saved-tabs/application/use-cases/RemoveCategoryFromCustomProjectUseCase'
 import type { RemoveUrlFromCustomProjectUseCase } from '@/contexts/saved-tabs/application/use-cases/RemoveUrlFromCustomProjectUseCase'
 import type { RemoveUrlsFromCustomProjectUseCase } from '@/contexts/saved-tabs/application/use-cases/RemoveUrlsFromCustomProjectUseCase'
 import type { RenameCustomProjectCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RenameCustomProjectCategoryUseCase'
@@ -52,53 +53,22 @@ import type {
 } from '@/types/storage'
 
 /**
- * issue #539 で useProjectManagement から application use-case へ
- * 移設した 8 操作 (`addUrlToCustomProject` / `removeUrlFromCustomProject` /
- * `removeUrlsFromCustomProject` / `setUrlCategory` /
- * `updateCategoryOrder` / `reorderProjectUrls` /
- * `renameCategoryInProject` / `updateProjectKeywords`) の port
- * メソッド名一覧。
+ * issue #539 / #540 で `useProjectManagement` から application
+ * use-case へ移設した 10 操作。
  *
- * `addCategoryToProject` / `removeCategoryFromProject` は issue #539
- * 範囲外のため `customProjectsCommandServiceRef` 経由の port 直叩き
- * が残る (受け入れ条件「直接呼び出しが消えている、または最小化
- * されている」の「最小化」に該当)。
+ * - issue #539 範囲 (8 操作): `addUrlToCustomProject` /
+ *   `removeUrlFromCustomProject` / `removeUrlsFromCustomProject` /
+ *   `setUrlCategory` / `updateCategoryOrder` / `reorderProjectUrls` /
+ *   `renameCategoryInProject` / `updateProjectKeywords`
+ * - issue #540 範囲 (2 操作): `addCategoryToProject` /
+ *   `removeCategoryFromProject`
+ *
+ * 旧 `CustomProjectsCommandService` パラメータは issue #540 で完全
+ * に撤去され、port (`CustomProjectsCommandService`) 自体を
+ * presentation 層から import しない形に統一した (受け入れ条件
+ * 「useProjectManagement へ渡す CustomProject 依存が use-case /
+ * query 中心になっている」)。
  */
-const ISSUE_539_TARGET_PORT_METHODS = [
-  'addUrlToCustomProject',
-  'removeUrlFromCustomProject',
-  'removeUrlsFromCustomProject',
-  'setUrlCategory',
-  'updateCategoryOrder',
-  'reorderProjectUrls',
-  'renameCategoryInProject',
-  'updateProjectKeywords',
-] as const satisfies readonly (keyof CustomProjectsCommandService)[]
-const createMinimalCommandService = (): CustomProjectsCommandService => ({
-  // issue #539 で use-case 化した 8 メソッドは `useProjectManagement`
-  // から直接呼ばれない (dddLayerGuard で担保) ため no-op とし、
-  // port 仕様としての shape 維持だけを目的とする。
-  addCategoryToProject: () => Promise.resolve(undefined),
-  addUrlToCustomProject: () => Promise.resolve(undefined),
-  moveUrlBetweenCustomProjects: () => Promise.resolve(undefined),
-  removeCategoryFromProject: () => Promise.resolve(undefined),
-  removeUrlFromCustomProject: () => Promise.resolve(undefined),
-  removeUrlIdsFromAllCustomProjects: () => Promise.resolve(undefined),
-  removeUrlsFromAllCustomProjects: () => Promise.resolve(undefined),
-  removeUrlsFromCustomProject: () => Promise.resolve(undefined),
-  renameCategoryInProject: () => Promise.resolve(undefined),
-  reorderProjectUrls: () => Promise.resolve(undefined),
-  setUrlCategory: () => Promise.resolve(undefined),
-  updateCategoryOrder: () => Promise.resolve(undefined),
-  updateProjectKeywords: () => Promise.resolve(undefined),
-})
-// `ISSUE_539_TARGET_PORT_METHODS` の利用フック。lint 向けに空参照を
-// 維持しつつ、port の JSDoc コメントで列挙した 8 メソッドの整合性を
-// コンパイル時に検証する。
-const _ensureIssue539TargetsKnown: ReadonlySet<string> = new Set(
-  ISSUE_539_TARGET_PORT_METHODS,
-)
-void _ensureIssue539TargetsKnown
 
 const asyncNoopCreate: CreateCustomProjectUseCase = () => {
   throw new Error('createCustomProjectUseCase is not provided')
@@ -158,6 +128,14 @@ const asyncNoopRenameCustomProjectCategory: RenameCustomProjectCategoryUseCase =
 const asyncNoopUpdateCustomProjectKeywords: UpdateCustomProjectKeywordsUseCase =
   () => {
     throw new Error('updateCustomProjectKeywordsUseCase is not provided')
+  }
+const asyncNoopAddCategoryToCustomProject: AddCategoryToCustomProjectUseCase =
+  () => {
+    throw new Error('addCategoryToCustomProjectUseCase is not provided')
+  }
+const asyncNoopRemoveCategoryFromCustomProject: RemoveCategoryFromCustomProjectUseCase =
+  () => {
+    throw new Error('removeCategoryFromCustomProjectUseCase is not provided')
   }
 
 const getArraySnapshot = <T>(
@@ -402,16 +380,13 @@ interface UseProjectManagementReturn {
  * ビューモード切替・CRUD・URL管理・プロジェクト内カテゴリ管理を担う。
  *
  * 旧 `customProjectRepository` 直接依存 (issue #538) は application
- * query / use-case 経由へ移行済み。さらに issue #539 で issue 対象
- * 8 操作 (`addUrlToCustomProject` / `removeUrlFromCustomProject` /
- * `removeUrlsFromCustomProject` / `setUrlCategory` /
- * `updateCategoryOrder` / `reorderProjectUrls` /
- * `renameCategoryInProject` / `updateProjectKeywords`) を
+ * query / use-case 経由へ移行済み。issue #539 で 8 操作を
  * `CustomProjectsCommandService` 直叩きから application use-case 経由
- * へ移設した。`addCategoryToProject` / `removeCategoryFromProject`
- * は issue #539 範囲外のため `customProjectsCommandService` port
- * 経由の直接呼び出しが最小化されて残る (受け入れ条件「直接呼び出しが
- * 消えている、または最小化されている」を満たす)。
+ * へ移設し、issue #540 で残っていた `addCategoryToProject` /
+ * `removeCategoryFromProject` も application use-case へ移設する
+ * ことで、port (`CustomProjectsCommandService`) 自体を presentation
+ * 層から完全に撤去した (受け入れ条件「useProjectManagement へ渡す
+ * CustomProject 依存が use-case / query 中心になっている」)。
  *
  * @param getCustomProjectsQuery - `CustomProject` 一覧 query
  * @param getCustomProjectOrderQuery - 表示順 query
@@ -420,8 +395,6 @@ interface UseProjectManagementReturn {
  * @param _tabGroups - 現在のタブグループ一覧（ドメインモードのデータ）
  * @param _settings - ユーザー設定（将来の拡張用）
  * @param initialViewMode - 初期表示モード
- * @param customProjectsCommandService - `addCategoryToProject` /
- *   `removeCategoryFromProject` のみが呼ばれる port (issue #539 範囲外)
  * @param createCustomProjectUseCase - プロジェクト作成 use-case
  * @param deleteCustomProjectUseCase - プロジェクト削除 use-case
  * @param updateCustomProjectNameUseCase - プロジェクト名変更 use-case
@@ -435,6 +408,8 @@ interface UseProjectManagementReturn {
  * @param reorderCustomProjectUrlsUseCase - URL 順序更新 use-case
  * @param renameCustomProjectCategoryUseCase - カテゴリ名変更 use-case
  * @param updateCustomProjectKeywordsUseCase - キーワード更新 use-case
+ * @param addCategoryToCustomProjectUseCase - カテゴリ追加 use-case (issue #540)
+ * @param removeCategoryFromCustomProjectUseCase - カテゴリ削除 use-case (issue #540)
  * @returns UseProjectManagementReturn
  */
 // eslint-disable-next-line eslint/max-params, eslint/complexity -- presentation 入口でフック引数を束ねるため
@@ -447,7 +422,6 @@ const useProjectManagement = (
   _tabGroups: TabGroup[] = [],
   _settings?: UserSettingsDto,
   initialViewMode?: ViewMode,
-  customProjectsCommandService: CustomProjectsCommandService = createMinimalCommandService(),
   createCustomProjectUseCase: CreateCustomProjectUseCase = asyncNoopCreate,
   deleteCustomProjectUseCase: DeleteCustomProjectUseCase = asyncNoopDelete,
   updateCustomProjectNameUseCase: UpdateCustomProjectNameUseCase = asyncNoopRename,
@@ -461,6 +435,8 @@ const useProjectManagement = (
   reorderCustomProjectUrlsUseCase: ReorderCustomProjectUrlsUseCase = asyncNoopReorderCustomProjectUrls,
   renameCustomProjectCategoryUseCase: RenameCustomProjectCategoryUseCase = asyncNoopRenameCustomProjectCategory,
   updateCustomProjectKeywordsUseCase: UpdateCustomProjectKeywordsUseCase = asyncNoopUpdateCustomProjectKeywords,
+  addCategoryToCustomProjectUseCase: AddCategoryToCustomProjectUseCase = asyncNoopAddCategoryToCustomProject,
+  removeCategoryFromCustomProjectUseCase: RemoveCategoryFromCustomProjectUseCase = asyncNoopRemoveCategoryFromCustomProject,
 ): UseProjectManagementReturn => {
   const { t } = useI18n()
   const [customProjects, setCustomProjects] = useState<CustomProject[]>([])
@@ -480,7 +456,6 @@ const useProjectManagement = (
     getCustomProjectUndoSnapshotQuery,
   )
   const getCustomProjectRawsQueryRef = useRef(getCustomProjectRawsQuery)
-  const customProjectsCommandServiceRef = useRef(customProjectsCommandService)
   const createCustomProjectUseCaseRef = useRef(createCustomProjectUseCase)
   const deleteCustomProjectUseCaseRef = useRef(deleteCustomProjectUseCase)
   const updateCustomProjectNameUseCaseRef = useRef(
@@ -511,6 +486,12 @@ const useProjectManagement = (
   )
   const updateCustomProjectKeywordsUseCaseRef = useRef(
     updateCustomProjectKeywordsUseCase,
+  )
+  const addCategoryToCustomProjectUseCaseRef = useRef(
+    addCategoryToCustomProjectUseCase,
+  )
+  const removeCategoryFromCustomProjectUseCaseRef = useRef(
+    removeCategoryFromCustomProjectUseCase,
   )
 
   // Ref を最新の state に同期する
@@ -797,10 +778,10 @@ const useProjectManagement = (
   const handleAddCategory = useCallback(
     async (projectId: string, categoryName: string): Promise<void> => {
       try {
-        await customProjectsCommandServiceRef.current.addCategoryToProject(
-          projectId,
+        await addCategoryToCustomProjectUseCaseRef.current({
           categoryName,
-        )
+          projectId,
+        })
         setCustomProjects((prev) =>
           prev.map((p) => {
             if (p.id !== projectId) {
@@ -839,10 +820,10 @@ const useProjectManagement = (
   const handleDeleteProjectCategory = useCallback(
     async (projectId: string, categoryName: string): Promise<void> => {
       try {
-        await customProjectsCommandServiceRef.current.removeCategoryFromProject(
-          projectId,
+        await removeCategoryFromCustomProjectUseCaseRef.current({
           categoryName,
-        )
+          projectId,
+        })
         const updatedRaws = await getCustomProjectRawsQueryRef.current()
         setCustomProjects(updatedRaws.map(toRawStorageCustomProject))
         toast.success(

--- a/src/contexts/saved-tabs/presentation/lib/custom-project-move.test.ts
+++ b/src/contexts/saved-tabs/presentation/lib/custom-project-move.test.ts
@@ -37,11 +37,11 @@ describe('moveCustomProjectUrlAndSyncState', () => {
       setCustomProjects,
     })
 
-    expect(moveUrlBetweenCustomProjects).toHaveBeenCalledWith(
-      'project-a',
-      'project-b',
-      'https://example.com',
-    )
+    expect(moveUrlBetweenCustomProjects).toHaveBeenCalledWith({
+      sourceProjectId: 'project-a',
+      targetProjectId: 'project-b',
+      url: 'https://example.com',
+    })
     expect(getCustomProjects).toHaveBeenCalledTimes(1)
     expect(setCustomProjects).toHaveBeenCalledWith(updatedProjects)
   })

--- a/src/contexts/saved-tabs/presentation/lib/custom-project-move.ts
+++ b/src/contexts/saved-tabs/presentation/lib/custom-project-move.ts
@@ -1,19 +1,27 @@
 import type { Dispatch, SetStateAction } from 'react'
 
+import type { MoveUrlBetweenCustomProjectsCommand } from '@/contexts/saved-tabs/application/commands/MoveUrlBetweenCustomProjectsCommand'
+import type { MoveUrlBetweenCustomProjectsUseCase } from '@/contexts/saved-tabs/application/use-cases/MoveUrlBetweenCustomProjectsUseCase'
 import type { CustomProject } from '@/types/storage'
 
 interface MoveCustomProjectUrlAndSyncStateParams {
   sourceProjectId: string
   targetProjectId: string
   url: string
-  moveUrlBetweenCustomProjects: (
-    sourceProjectId: string,
-    targetProjectId: string,
-    url: string,
-  ) => Promise<void>
-  getCustomProjects: () => Promise<CustomProject[]>
+  moveUrlBetweenCustomProjects: MoveUrlBetweenCustomProjectsUseCase
+  getCustomProjects: () => Promise<readonly CustomProject[]>
   setCustomProjects: Dispatch<SetStateAction<CustomProject[]>>
 }
+
+const buildMoveCommand = (
+  sourceProjectId: string,
+  targetProjectId: string,
+  url: string,
+): MoveUrlBetweenCustomProjectsCommand => ({
+  sourceProjectId,
+  targetProjectId,
+  url,
+})
 
 export const moveCustomProjectUrlAndSyncState = async ({
   sourceProjectId,
@@ -27,7 +35,14 @@ export const moveCustomProjectUrlAndSyncState = async ({
     return
   }
 
-  await moveUrlBetweenCustomProjects(sourceProjectId, targetProjectId, url)
+  await moveUrlBetweenCustomProjects(
+    buildMoveCommand(sourceProjectId, targetProjectId, url),
+  )
+  // application query `getCustomProjects` は
+  // `readonly CustomProject[]` を返す。`setCustomProjects` 側の
+  // シグネチャは `CustomProject[]` だが、`Dispatch<SetStateAction<T>>` は
+  // 構造的部分型により `readonly` 要素を許容するためそのまま渡せる。
   const updatedProjects = await getCustomProjects()
-  setCustomProjects(updatedProjects)
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-type-assertion -- readonly 投影を setCustomProjects 経由で書き戻すための widening
+  setCustomProjects(updatedProjects as CustomProject[])
 }


### PR DESCRIPTION
## 変更内容

issue #540 の対応として、`SavedTabsApp` から `CustomProjectRepository` / `CustomProjectsCommandService` の直接注入を撤去し、presentation 層を application use-case / query 注入に統一した。

### 1. 新 use-case 追加
- `AddCategoryToCustomProjectUseCase` (`addCategoryToProject` port の薄いラップ)
- `RemoveCategoryFromCustomProjectUseCase` (`removeCategoryFromProject` port の薄いラップ)
- `MoveUrlBetweenCustomProjectsUseCase` (`moveUrlBetweenCustomProjects` port の薄いラップ)

### 2. `SavedTabsUseCases` interface 拡張
- 上記 3 use-case を `SavedTabsUseCases` バンドルに追加
- `createSavedTabsUseCases` (composition root) で wire

### 3. `useProjectManagement` 更新
- `customProjectsCommandService` パラメータを完全撤去 (issue #539 で残っていた最小化 2 操作も use-case 化)
- `addCategoryToCustomProject` / `removeCategoryFromCustomProject` use-case を独立した deps として受け取る
- port (`CustomProjectsCommandService`) モジュール自体を import しない形に統一

### 4. `SavedTabsApp` 更新
- `handleMoveUrlBetweenProjects` を `MoveUrlBetweenCustomProjectsUseCase` + `getCustomProjects` query 経由へ
- `deps.customProjectRepository` / `deps.customProjectsCommandService` 参照を撤去
- domain entity → storage 形 projection は component 側で明示的に mapper

### 5. `custom-project-move` helper 更新
- `moveUrlBetweenCustomProjects` パラメータを `MoveUrlBetweenCustomProjectsUseCase` 形に変更
- use-case command 形 (`{ sourceProjectId, targetProjectId, url }`) で呼び出す

### 6. dddLayerGuard 拡張
- `SavedTabsApp` が `CustomProjectRepository` / `CustomProjectsCommandService` を import しない
- `SavedTabsApp` の deps から `customProjectRepository` / `customProjectsCommandService` が消えている
- `useProjectManagement` の deps は `customProjectsCommandService` を受け取らない

## 受け入れ条件
- [x] `SavedTabsApp` が `CustomProjectRepository` を import していない
- [x] `SavedTabsApp` が `CustomProjectsCommandService` を import していない
- [x] `SavedTabsApp` の deps から `customProjectRepository` が消えている
- [x] `SavedTabsApp` の deps から `customProjectsCommandService` が消えている
- [x] `handleMoveUrlBetweenProjects` が application use-case 経由になっている
- [x] `useProjectManagement` へ渡す CustomProject 依存が use-case / query 中心になっている
- [x] 既存の CustomProject 機能の挙動が変わらない
- [x] `pnpm typecheck` / 関連テストが通る (`bun run compile`, `bun run test`, `bun run lint` すべて pass)

## 親 Issue
- #454 (saved-tabs DDD 移行)
- #538 (useProjectManagement の CustomProjectRepository 直接依存を query/use-case 経由へ移す)
- #539 (custom project の URL / カテゴリ操作を application use-case 化する)

## 検証
- [x] `bun run format` (oxfmt) pass
- [x] `bun run lint` (oxlint) pass
- [x] `bun run compile` (tsgo --noEmit) pass
- [x] `bun run test` 2792 tests pass
- [x] `bun run test:coverage` 新規 use-case / helper はすべて 100% coverage