### PR TITLE
[DDD] SavedTabsApp の旧 handleDragEnd コメントアウトコードを削除する (issue #544)

### DIFF
--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -1111,4 +1111,27 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       )
     })
   })
+
+  describe('issue #544: SavedTabsApp に旧コメントアウトの chrome.storage 直叩きコードを残さない', () => {
+    const savedTabsAppPath = resolve(
+      repoRoot,
+      'src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx',
+    )
+    const savedTabsAppSource = readFileSync(savedTabsAppPath, 'utf8')
+
+    it('SavedTabsApp は旧コメントアウト handleDragEnd ブロックを残さない', () => {
+      // DDD 移行前に残っていた `Chrome.storage.local.set({ savedTabs: ... })`
+      // を含むコメントアウト済み handleDragEnd (大文字始まりの keyword
+      // 表記 = 旧実装のメモ書き) の再発を防ぐ。
+      expect(savedTabsAppSource).not.toMatch(/Chrome\.storage\.local\.set\(/)
+      expect(savedTabsAppSource).not.toMatch(/savedTabs:\s*newGroups/)
+      // `Const` / `Set` / `If` / `Return` のような旧コードの keyword 表記。
+      // `const` / `set` / `if` / `return` の通常コードは影響しないよう、
+      // 旧 handleDragEnd ブロック固有の context を含めて厳密検出する。
+      expect(savedTabsAppSource).not.toMatch(/^.*Const handleDragEnd/m)
+      expect(savedTabsAppSource).not.toMatch(
+        /Chrome\.storage\.local\.set\(\{\s*savedTabs:\s*newGroups/,
+      )
+    })
+  })
 })

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -694,24 +694,6 @@ const useSavedTabsAppView = ({
     }),
   )
 
-  // Const handleDragEnd = (event: DragEndEvent) => {
-  //   Const { active, over } = event
-
-  //   If (over && active.id !== over.id) {
-  //     SetTabGroups((groups: TabGroup[]) => {
-  //       Const oldIndex = groups.findIndex(group => group.id === active.id)
-  //       Const newIndex = groups.findIndex(group => group.id === over.id)
-
-  //       Const newGroups = arrayMove(groups, oldIndex, newIndex)
-
-  //       // ストレージに保存
-  //       Chrome.storage.local.set({ savedTabs: newGroups })
-
-  //       Return newGroups
-  //     })
-  //   }
-  // }
-
   // 未分類ドメインの並び替えをキャンセルする
   const handleCancelUncategorizedReorder = useCallback(() => {
     if (!isUncategorizedReorderMode) {


### PR DESCRIPTION
## 変更内容

DDD 移行の最終掃除として、`SavedTabsApp.tsx` に残っていた旧実装のコメントアウト済みコードを削除する。

- `SavedTabsApp.tsx` から旧 `handleDragEnd` のコメントブロック (697-713 行) を削除
  - 旧コードは `Chrome.storage.local.set({ savedTabs: newGroups })` のような DDD 移行前の
    storage 直叩きを含んでおり、実行経路ではないが誤検出・誤読の原因になっていた
- `dddLayerGuard.test.ts` に旧 dead code パターン (`Chrome.storage.local.set(` /
  `savedTabs: newGroups` / `Const handleDragEnd`) の再発防止テストを追加
  - 今後の検索・AI 実装・依存調査で旧実装の混入を早期検出できる

## 受け入れ条件の充足

- [x] `SavedTabsApp.tsx` から旧コメントアウト済み実装が削除されている
- [x] `Chrome.storage.local.set` などの旧実装コメントが dead code としては残っていない
  - JSDoc 内の歴史的文脈 (例: `chrome.storage.local.set の直叩きを撤去する (issue #494)`) は
    意図的な説明として保持
- [x] saved-tabs presentation 層の依存境界がレイヤーガードで保護されている
- [x] saved-tabs の主要操作が application use-case / query / port 経由で表現されている
- [x] #454 を close しても問題ない状態であることが確認されている

## 検証

ローカル実行で以下を確認:

- `bun run format:check` ✅
- `bun run lint` ✅ (0 warnings / 0 errors)
- `bun run compile` ✅ (`tsgo --noEmit`)
- `bun run test:node` ✅ (1984 tests)
- `bun run test:dom` ✅ (809 tests, 既存 SavedTabsApp テスト含む)
- presentation 層に `chrome.storage.*` 直参照なし (既存ガードで担保)
- domain 層に `@/types/storage` 依存なし (既存ガードで担保)
- `SavedTabsApp` が `CustomProjectRepository` /
  `CustomProjectsCommandService` を import / 経由利用していない (issue #540 ガード)

## 関連

- Closes #544
- 親: #454 (saved-tabs DDD 移行の最終確認)
- 関連: #494, #538, #539, #540, #531, #530, #503