### PR TITLE
fix: oxlint の React version 設定を 19.2.7 に修正

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -37,7 +37,7 @@
   },
   "settings": {
     "react": {
-      "version": "19.2.5"
+      "version": "19.2.7"
     }
   },
   "ignorePatterns": [


### PR DESCRIPTION
## 背景

`package.json` の React が `^19.2.7` だが、`.oxlintrc.json` の `settings.react.version` が `19.2.5` のままだったため一致させた。

## 変更内容

- `.oxlintrc.json` の `settings.react.version` を `19.2.5` → `19.2.7` に修正
- インストール済みの react / react-dom は共に `19.2.7` であることを確認済み

## 検証

- `bun run lint` → 0 errors 0 warnings

Closes #555