### PR TITLE
[codex] dependency-cruiserの型依存検査を有効化する

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -144,8 +144,10 @@ module.exports = {
     ...noCrossContextRules,
   ],
   options: {
+    builtInModules: { add: ['chrome'] },
     doNotFollow: { path: 'node_modules' },
     parser: 'swc',
+    tsPreCompilationDeps: true,
     tsConfig: { fileName: 'tsconfig.json' },
     enhancedResolveOptions: {
       exportsFields: ['exports'],

--- a/src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.test.ts
+++ b/src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.test.ts
@@ -10,6 +10,7 @@ import {
   toDomainTabGroupsForReorder,
   toRestoreOpenedUrlsSnapshotCommand,
   toStorageCustomProject,
+  toStorageCustomProjectFromRaw,
   toStorageCustomProjects,
   toStorageParentCategory,
   toStorageParentCategories,
@@ -60,6 +61,48 @@ describe('SavedTabsSnapshotMapper.toStorageCustomProject', () => {
       result.urlIds.push('url-3')
     }
     expect(result.urlIds).toStrictEqual(['url-1', 'url-2', 'url-3'])
+  })
+})
+
+describe('SavedTabsSnapshotMapper.toStorageCustomProjectFromRaw', () => {
+  it('raw snapshot の rich フィールドを storage 形へ複製する', () => {
+    const result = toStorageCustomProjectFromRaw({
+      categories: ['research'],
+      categoryOrder: ['research', 'news'],
+      createdAt: 1,
+      id: 'project-1',
+      name: 'Q4',
+      projectKeywords: {
+        domainKeywords: ['example.com'],
+        titleKeywords: ['design'],
+        urlKeywords: ['plan'],
+      },
+      updatedAt: 2,
+      urlIds: ['url-1'],
+      urlMetadata: {
+        'url-1': { category: 'research', notes: 'note-1' },
+      },
+      urls: [{ title: 'A', url: 'https://example.com/a' }],
+    })
+
+    expect(result).toStrictEqual({
+      categories: ['research'],
+      categoryOrder: ['research', 'news'],
+      createdAt: 1,
+      id: 'project-1',
+      name: 'Q4',
+      projectKeywords: {
+        domainKeywords: ['example.com'],
+        titleKeywords: ['design'],
+        urlKeywords: ['plan'],
+      },
+      updatedAt: 2,
+      urlIds: ['url-1'],
+      urlMetadata: {
+        'url-1': { category: 'research', notes: 'note-1' },
+      },
+      urls: [{ title: 'A', url: 'https://example.com/a' }],
+    })
   })
 })
 

--- a/src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.ts
+++ b/src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.ts
@@ -3,6 +3,7 @@ import type { CustomProject, ParentCategory, TabGroup } from '@/types/storage'
 import type { CustomProject as DomainCustomProject } from '../../domain/entities/CustomProject'
 import type { ParentCategory as DomainParentCategory } from '../../domain/entities/ParentCategory'
 import type { TabGroup as DomainTabGroup } from '../../domain/entities/TabGroup'
+import type { CustomProjectRawSnapshot } from '../../domain/repositories/CustomProjectRepository'
 import type { BuildSavedTabsSnapshotCommand } from '../commands/BuildSavedTabsSnapshotCommand'
 import type {
   OpenedUrlsRestoreSnapshot,
@@ -43,6 +44,44 @@ export const toStorageCustomProject = (
   updatedAt: project.updatedAt,
   urlIds: [...project.urlIds],
 })
+
+/** raw snapshot の rich 補助フィールドを保持したまま storage 形へ投影する。 */
+export const toStorageCustomProjectFromRaw = (
+  raw: CustomProjectRawSnapshot,
+): CustomProject => {
+  const result: CustomProject = {
+    categories: [...raw.categories],
+    createdAt: raw.createdAt,
+    id: raw.id,
+    name: raw.name,
+    updatedAt: raw.updatedAt,
+  }
+  if (raw.urlIds && raw.urlIds.length > 0) {
+    result.urlIds = [...raw.urlIds]
+  }
+  if (raw.urls && raw.urls.length > 0) {
+    result.urls = raw.urls.map((entry) => ({ ...entry }))
+  }
+  if (raw.urlMetadata && Object.keys(raw.urlMetadata).length > 0) {
+    result.urlMetadata = Object.fromEntries(
+      Object.entries(raw.urlMetadata).map(([urlId, metadata]) => [
+        urlId,
+        { ...metadata },
+      ]),
+    )
+  }
+  if (raw.projectKeywords) {
+    result.projectKeywords = {
+      domainKeywords: [...raw.projectKeywords.domainKeywords],
+      titleKeywords: [...raw.projectKeywords.titleKeywords],
+      urlKeywords: [...raw.projectKeywords.urlKeywords],
+    }
+  }
+  if (raw.categoryOrder && raw.categoryOrder.length > 0) {
+    result.categoryOrder = [...raw.categoryOrder]
+  }
+  return result
+}
 
 /**
  * domain entity の `ParentCategory` を storage 形 `ParentCategory` へ

--- a/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts
+++ b/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts
@@ -1,5 +1,4 @@
-import type { CustomProject as StorageCustomProject } from '@/types/storage'
-
+import { toStorageCustomProjectFromRaw } from '../../application/mappers/SavedTabsSnapshotMapper'
 import { createCustomProject } from '../../domain/entities/CustomProject'
 import type { CustomProject } from '../../domain/entities/CustomProject'
 import { createParentCategory } from '../../domain/entities/ParentCategory'
@@ -9,7 +8,6 @@ import type { TabGroup } from '../../domain/entities/TabGroup'
 import { createUrlRecord } from '../../domain/entities/UrlRecord'
 import type { UrlRecord } from '../../domain/entities/UrlRecord'
 import { SavedTabsDomainError } from '../../domain/errors/SavedTabsDomainError'
-import type { CustomProjectRawSnapshot } from '../../domain/repositories/CustomProjectRepository'
 import type { CustomProjectId } from '../../domain/value-objects/CustomProjectId'
 import type { DomainName } from '../../domain/value-objects/DomainName'
 import type { ParentCategoryId } from '../../domain/value-objects/ParentCategoryId'
@@ -368,57 +366,6 @@ const toCustomProjectRaw = (
 }
 
 /**
- * `CustomProjectRawSnapshot` を presentation 層 (`src/types/storage`) の
- * `CustomProject` 形へ投影する。
- *
- * domain `CustomProject` entity は `projectKeywords` / `categoryOrder` /
- * `urlMetadata` / `urls` などの rich 補助フィールドを保持しないため、
- * そのまま `findAll()` 戻り値を UI state に流すと初回ロード時にこれらの
- * フィールドが落ちる (issue #535 P1)。raw snapshot を直接 projection
- * することで、entity 境界を通さずに UI state を組み立てる。
- *
- * `urlIds` / `urls` / `urlMetadata` / `projectKeywords` / `categoryOrder`
- * は rich snapshot 側に存在する場合のみ引き継ぎ、存在しない場合は
- * storage 形の `?` optional として省略する (`toStrictEqual` 安定化のため)。
- */
-const toStorageCustomProject = (
-  raw: CustomProjectRawSnapshot,
-): StorageCustomProject => {
-  const result: StorageCustomProject = {
-    categories: [...raw.categories],
-    createdAt: raw.createdAt,
-    id: raw.id,
-    name: raw.name,
-    updatedAt: raw.updatedAt,
-  }
-  if (raw.urlIds && raw.urlIds.length > 0) {
-    result.urlIds = [...raw.urlIds]
-  }
-  if (raw.urls && raw.urls.length > 0) {
-    result.urls = raw.urls.map((entry) => ({ ...entry }))
-  }
-  if (raw.urlMetadata && Object.keys(raw.urlMetadata).length > 0) {
-    result.urlMetadata = Object.fromEntries(
-      Object.entries(raw.urlMetadata).map(([urlId, metadata]) => [
-        urlId,
-        { ...metadata },
-      ]),
-    )
-  }
-  if (raw.projectKeywords) {
-    result.projectKeywords = {
-      domainKeywords: [...raw.projectKeywords.domainKeywords],
-      titleKeywords: [...raw.projectKeywords.titleKeywords],
-      urlKeywords: [...raw.projectKeywords.urlKeywords],
-    }
-  }
-  if (raw.categoryOrder && raw.categoryOrder.length > 0) {
-    result.categoryOrder = [...raw.categoryOrder]
-  }
-  return result
-}
-
-/**
  * `unknown` な生データをパースし、有効な `TabGroup` だけを返す。
  *
  * Zod parse 失敗 / entity 化失敗 / `null` / `undefined` の場合は `null` を返す。
@@ -583,7 +530,7 @@ export const ChromeSavedTabsStorageMapper = {
   toParentCategoryFromRaw,
   toParentCategoryRaw,
   toSavedTabRaw,
-  toStorageCustomProject,
+  toStorageCustomProject: toStorageCustomProjectFromRaw,
   toTabGroupFromRaw,
   toUrlRecordFromRaw,
   toUrlRecordRaw,

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -28,8 +28,8 @@ import { useFilteredCustomProjects } from '@/contexts/saved-tabs/presentation/ho
 import { useProjectManagement } from '@/contexts/saved-tabs/presentation/hooks/useProjectManagement'
 import { useTabData } from '@/contexts/saved-tabs/presentation/hooks/useTabData'
 import { createCategorizedDisplayState } from '@/contexts/saved-tabs/presentation/lib/categorized-display'
-import type { ResolveActiveRef } from '@/contexts/saved-tabs/presentation/pages/SavedTabsPage'
 import { syncStorageChanges } from '@/contexts/saved-tabs/presentation/services/modeSyncService'
+import type { ResolveActiveRef } from '@/contexts/saved-tabs/presentation/types/ResolveActiveRef'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import type { TabGroup, ViewMode } from '@/types/storage'
 

--- a/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.tsx
@@ -19,12 +19,6 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Tooltip, TooltipTrigger } from '@/components/ui/tooltip'
-import type { CategoryAssignmentPort } from '@/contexts/saved-tabs/application/ports/CategoryAssignmentPort'
-import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
-import type { AddDomainToParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/AddDomainToParentCategoryUseCase'
-import type { DeleteParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteParentCategoryUseCase'
-import type { RemoveDomainFromParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RemoveDomainFromParentCategoryUseCase'
-import type { RenameParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RenameParentCategoryUseCase'
 import { DeleteEntityConfirmPanel } from '@/contexts/saved-tabs/presentation/components/shared/DeleteEntityConfirmPanel'
 import {
   SavedTabsResponsiveLabel,
@@ -33,8 +27,17 @@ import {
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import type { ParentCategory, TabGroup } from '@/types/storage'
 
+import type {
+  CategoryManagementModalDeps,
+  CategoryManagementModalUseCases,
+} from './CategoryManagementModal.types'
 import { useCategoryActions } from './useCategoryActions'
 import { useCategoryFormState } from './useCategoryFormState'
+
+export type {
+  CategoryManagementModalDeps,
+  CategoryManagementModalUseCases,
+} from './CategoryManagementModal.types'
 
 // 型定義
 interface AvailableDomain {
@@ -50,23 +53,6 @@ interface AvailableDomain {
  * 撤去され、削除・更新は `CategoryManagementModalUseCases` 経由で
  * 実行する。
  */
-export interface CategoryManagementModalDeps {
-  readonly categoryAssignmentPort: CategoryAssignmentPort
-  readonly getSavedTabsPageDataQuery: GetSavedTabsPageDataQuery
-}
-
-/**
- * `CategoryManagementModal` が直接実行する use-case 群。
- * 旧 `onCategoryUpdate` コールバックを置換し、storage 直叩きを撤去する
- * （issue #502, #518）。
- */
-export interface CategoryManagementModalUseCases {
-  readonly renameParentCategory: RenameParentCategoryUseCase
-  readonly addDomainToParentCategory: AddDomainToParentCategoryUseCase
-  readonly removeDomainFromParentCategory: RemoveDomainFromParentCategoryUseCase
-  readonly deleteParentCategory: DeleteParentCategoryUseCase
-}
-
 // 親カテゴリ管理モーダルの型定義
 interface CategoryManagementModalProps {
   isOpen: boolean

--- a/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.types.ts
+++ b/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.types.ts
@@ -1,0 +1,18 @@
+import type { CategoryAssignmentPort } from '@/contexts/saved-tabs/application/ports/CategoryAssignmentPort'
+import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
+import type { AddDomainToParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/AddDomainToParentCategoryUseCase'
+import type { DeleteParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteParentCategoryUseCase'
+import type { RemoveDomainFromParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RemoveDomainFromParentCategoryUseCase'
+import type { RenameParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RenameParentCategoryUseCase'
+
+export interface CategoryManagementModalDeps {
+  readonly categoryAssignmentPort: CategoryAssignmentPort
+  readonly getSavedTabsPageDataQuery: GetSavedTabsPageDataQuery
+}
+
+export interface CategoryManagementModalUseCases {
+  readonly renameParentCategory: RenameParentCategoryUseCase
+  readonly addDomainToParentCategory: AddDomainToParentCategoryUseCase
+  readonly removeDomainFromParentCategory: RemoveDomainFromParentCategoryUseCase
+  readonly deleteParentCategory: DeleteParentCategoryUseCase
+}

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.tsx
@@ -11,7 +11,7 @@ import {
 import type { UseSavedTabsControllerReturn } from '@/contexts/saved-tabs/presentation/controllers/useSavedTabsController'
 import type { ViewMode } from '@/types/storage'
 
-import type { ResolveActiveRef } from '../pages/SavedTabsPage'
+import type { ResolveActiveRef } from '../types/ResolveActiveRef'
 import { SavedTabsChatWidgetBridge } from './SavedTabsChatWidgetBridge'
 import { SavedTabsResponsiveLayoutProvider } from './SavedTabsResponsiveLayoutContext'
 import { SavedTabsScrollControls } from './SavedTabsScrollControls'

--- a/src/contexts/saved-tabs/presentation/components/shared/CardGroupTitle.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/CardGroupTitle.tsx
@@ -1,12 +1,14 @@
-import type { DraggableAttributes } from '@dnd-kit/core'
-import type { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities'
+import type {
+  DraggableAttributes,
+  DraggableSyntheticListeners,
+} from '@dnd-kit/core'
 import { GripVertical } from 'lucide-react'
 
 interface CardGroupTitleProps {
   title: string
   badges?: React.ReactNode
   sortableAttributes?: DraggableAttributes
-  sortableListeners?: SyntheticListenerMap
+  sortableListeners?: DraggableSyntheticListeners
   className?: string
 }
 

--- a/src/contexts/saved-tabs/presentation/components/useCategoryActions.ts
+++ b/src/contexts/saved-tabs/presentation/components/useCategoryActions.ts
@@ -4,8 +4,9 @@ import { toast } from 'sonner'
 import type { DomainName } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 import { createParentCategoryId } from '@/contexts/saved-tabs/domain/value-objects/ParentCategoryId'
 import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabGroupId'
-import type { CategoryManagementModalUseCases } from '@/contexts/saved-tabs/presentation/components/CategoryManagementModal'
 import type { ParentCategory, TabGroup } from '@/types/storage'
+
+import type { CategoryManagementModalUseCases } from './CategoryManagementModal.types'
 
 interface AvailableDomain {
   id: string

--- a/src/contexts/saved-tabs/presentation/hooks/projectManagementDefaults.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/projectManagementDefaults.ts
@@ -6,6 +6,7 @@
 import type { Dispatch, RefObject, SetStateAction } from 'react'
 import { toast } from 'sonner'
 
+import { toStorageCustomProjectFromRaw } from '@/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper'
 import type { GetCustomProjectOrderQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectOrderQuery'
 import type { GetCustomProjectRawsQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectRawsQuery'
 import type { GetCustomProjectsQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectsQuery'
@@ -31,7 +32,6 @@ import type { SetCustomProjectUrlCategoryUseCase } from '@/contexts/saved-tabs/a
 import type { UpdateCustomProjectCategoryOrderUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectCategoryOrderUseCase'
 import type { UpdateCustomProjectKeywordsUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectKeywordsUseCase'
 import type { UpdateCustomProjectNameUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectNameUseCase'
-import { ChromeSavedTabsStorageMapper } from '@/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper'
 import type {
   CustomProject,
   ProjectKeywordSettings,
@@ -125,7 +125,7 @@ type RawCustomProjectEntry = Awaited<
 
 /** rich フィールド込みの `CustomProject` へ raw snapshot を投影する */
 const toRawStorageCustomProject = (raw: RawCustomProjectEntry): CustomProject =>
-  ChromeSavedTabsStorageMapper.toStorageCustomProject(raw)
+  toStorageCustomProjectFromRaw(raw)
 
 const createCustomProjectUndoPayload = (
   snapshot: CustomProjectUndoSnapshot,

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
@@ -16,7 +16,10 @@ import { SavedTabsUseCasesProvider } from '../controllers/SavedTabsUseCasesConte
 import { createSavedTabsUseCasesContextValueFromDeps } from '../controllers/SavedTabsUseCasesContext.utils'
 import { useSavedTabsController } from '../controllers/useSavedTabsController'
 import type { UseSavedTabsControllerReturn } from '../controllers/useSavedTabsController'
+import type { ResolveActiveRef } from '../types/ResolveActiveRef'
 import type { SavedTabsViewModel } from '../view-models/SavedTabsViewModel'
+
+export type { ResolveActiveRef } from '../types/ResolveActiveRef'
 
 /**
  * `SavedTabsPage` の props。
@@ -61,10 +64,6 @@ export interface SavedTabsPageProps {
  * ref を介すことで use-case 自体は mount 時に 1 度だけ組み立てればよく、
  * 設定変更のたびに use-case / port を作り直す必要がない。
  */
-export interface ResolveActiveRef {
-  current: () => boolean
-}
-
 /**
  * `SavedTabsPage` 内部の controller 状態。
  *

--- a/src/contexts/saved-tabs/presentation/types/ResolveActiveRef.ts
+++ b/src/contexts/saved-tabs/presentation/types/ResolveActiveRef.ts
@@ -1,0 +1,4 @@
+/** BrowserTabPort の active 判定を最新設定へ接続する関数 ref。 */
+export interface ResolveActiveRef {
+  current: () => boolean
+}

--- a/src/lib/architecture/dependencyCruiserConfig.test.ts
+++ b/src/lib/architecture/dependencyCruiserConfig.test.ts
@@ -200,12 +200,32 @@ describe('dependency-cruiser architecture rules', () => {
       },
     },
     {
+      name: 'type-only presentation dependencies on infrastructure',
+      rule: 'no-presentation-to-infrastructure',
+      files: {
+        'src/contexts/foo/infrastructure/repository.ts':
+          'export interface Repository {}\n',
+        'src/contexts/foo/presentation/view.ts':
+          "import type { Repository } from '../infrastructure/repository'\nexport type ViewRepository = Repository\n",
+      },
+    },
+    {
       name: 'direct dependencies between contexts',
       rule: 'no-foo-to-other-context',
       files: {
         'src/contexts/bar/domain/entity.ts': 'export const entity = 1\n',
         'src/contexts/foo/domain/entity.ts':
           "import '../../bar/domain/entity'\n",
+      },
+    },
+    {
+      name: 'type-only direct dependencies between contexts',
+      rule: 'no-foo-to-other-context',
+      files: {
+        'src/contexts/bar/domain/entity.ts':
+          'export interface OtherContextEntity {}\n',
+        'src/contexts/foo/domain/entity.ts':
+          "import type { OtherContextEntity } from '../../bar/domain/entity'\nexport type FooEntity = OtherContextEntity\n",
       },
     },
   ])('rejects $name with $rule', ({ files, rule }) => {


### PR DESCRIPTION
## 変更内容

- dependency-cruiser の `tsPreCompilationDeps` を有効化し、`import type` を含む依存グラフを検査
- type-only のレイヤー違反とコンテキスト間違反を検証する回帰 fixture を追加
- Chrome ambient API を browser built-in として resolver に伝え、dnd-kit の内部型 import を公開 API へ置換
- raw custom project の投影を application mapper に移し、presentation から infrastructure への逆向き依存を解消
- presentation 内で共有する型を中立な型モジュールへ移し、3件の循環依存を解消

## 背景

TypeScript のコンパイル前依存が dependency-cruiser の検査対象外だったため、`import type` によるレイヤー境界・コンテキスト境界違反が見逃されていました。有効化によって顕在化した unresolved 2件、presentation → infrastructure 1件、circular 3件を、例外や warning 化を追加せず修正しています。

## 確認内容

- [x] `bun run arch:check`
- [x] `bun run compile`
- [x] `bun run test`（273 files / 2903 tests）
- [x] `bun run quality`
- [x] React Doctor 100/100
- [x] `bun run test:coverage`（exit 0、Statements 95.26% / Branches 90.96% / Functions 93.35% / Lines 95.31%）
- [x] ローカル環境でエラーになっていない

Closes #568


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CardGroupTitle component now supports an optional `className` property for additional styling flexibility.

* **Refactor**
  * Reorganized type definitions and imports across the saved tabs module for better code structure.
  * Consolidated data mapping logic to reduce duplication in custom project handling.

* **Tests**
  * Added test cases for custom project data transformation and type-only import validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->