### PR TITLE
docs: oxlint と dependency-cruiser の責務分担を DDD ドキュメントへ反映

### DIFF
--- a/docs/architecture/ddd.md
+++ b/docs/architecture/ddd.md
@@ -111,15 +111,29 @@ src/contexts/saved-tabs/
 | infrastructure | presentation への依存 / domain interface を通さない直接アクセス                                                                                    |
 | presentation   | `chrome.storage.local` / `chrome.*` API の直接利用 / ドメインルールの埋め込み                                                                      |
 
-## oxlint による機械的ガード
+## oxlint と dependency-cruiser による機械的ガード
 
-上記の禁止ルールは `.oxlintrc.json` の `overrides` で機械的にチェックされます。`bun run lint` を実行すると、`src/contexts/saved-tabs/{domain,application,infrastructure,presentation}/**` 配下で禁止された import / global 参照 / プロパティアクセスを即座に検出します。
+DDD の機械的ガードは 1 つの lint ルールへ寄せず、`dependency-cruiser` と `oxlint`
+で責務を分担します。
 
-- `eslint/no-restricted-imports` — layer を越えた依存（`@/components/*` / `@/features/**/components/**` / `@/contexts/**/application/**` など）をブロック
-- `eslint/no-restricted-globals` — domain 層での `chrome` / `localStorage` / `sessionStorage` / `document` / `window` 利用をブロック
-- `eslint/no-restricted-properties` — `chrome.tabs` / `chrome.storage` / `chrome.contextMenus` / `chrome.alarms` / `chrome.notifications` / `chrome.runtime` の直叩きを layer 別にブロック
+- `dependency-cruiser` (`bun run arch:check`)
+  - import graph を検査し、context 境界・layer 境界・依存方向をチェックします。
+  - domain から application / infrastructure / presentation への逆流、
+    context 間の禁止依存、circular dependency、unresolvable import を検出します。
+  - layer / context の import 制御はここが source of truth です。`oxlint` 側へ
+    `eslint/no-restricted-imports` や `import/no-cycle` を追加して代用しません。
+- `oxlint` (`bun run lint`)
+  - TypeScript / React / Promise / a11y / perf などのコード品質ルールを担当します。
+  - `eslint/no-restricted-globals` で domain 層の `chrome` / `localStorage` /
+    `sessionStorage` / `document` / `window` 利用をブロックします。
+  - `eslint/no-restricted-properties` で `chrome.tabs` / `chrome.storage` /
+    `chrome.contextMenus` / `chrome.alarms` / `chrome.notifications` /
+    `chrome.runtime` の直叩きを layer 別にブロックします。
 
-false positive が出たら `// oxlint-disable-next-line` ではなく、ルール側（許可リストや `allowImportNames`）で解決することを優先してください。Issue #462 がガード設定の source of truth です。
+false positive が出たら `// oxlint-disable-next-line` のような局所回避より、
+責務に応じて `dependency-cruiser` または `oxlint` の設定・wrapper・adapter
+設計を見直すことを優先してください。Issue #462 がガード設定の source of truth
+です。
 
 ## composition ルール
 


### PR DESCRIPTION
## 変更内容
- DDD ドキュメントの機械的ガード説明を `dependency-cruiser` と `oxlint` の責務分担に合わせて更新
- layer / context の import 制御は `dependency-cruiser` が source of truth であることを明記
- `oxlint` はコード品質ルールと `chrome.*` 直叩き禁止を担当することを明記

## 検証
- `/Users/tarou/Desktop/TABBIN/node_modules/.bin/oxfmt --check /Users/tarou/Desktop/TABBIN-issue-572-docs-oxlint-depcruise-roles/docs/architecture/ddd.md`

Closes #572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural guidelines to clarify the roles and responsibilities of code validation tools, improving clarity on how development safeguards are implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->