### PR TITLE
インポート後のドメイン形式不整合でsaved-tabsが読み込めない不具合を修正する

### DIFF
--- a/src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.ts
+++ b/src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.ts
@@ -15,6 +15,7 @@ import type { ParentCategory as DomainParentCategory } from '@/contexts/saved-ta
 import { createTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
 import type { TabGroup as DomainTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
 import type { CustomProjectRawSnapshot } from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
+import { normalizeDomainString } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 import type { CustomProject, ParentCategory, TabGroup } from '@/types/storage'
 
 import { toSavedTabsTabGroupDto } from './SavedTabsPresentationMapper'
@@ -180,7 +181,7 @@ export const toPresentationTabGroups = (
 export const toDomainTabGroupFromStorage = (group: TabGroup): DomainTabGroup =>
   createTabGroup({
     categoryKeywords: group.categoryKeywords,
-    domain: group.domain,
+    domain: normalizeDomainString(group.domain),
     id: group.id,
     parentCategoryId: group.parentCategoryId,
     savedAt: group.savedAt,

--- a/src/contexts/saved-tabs/application/use-cases/RepairTabGroupParentCategoryIdsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RepairTabGroupParentCategoryIdsUseCase.test.ts
@@ -221,4 +221,37 @@ describe('RepairTabGroupParentCategoryIdsUseCase', () => {
     expect(result.updated).toBe(true)
     expect(result.tabGroups[0].parentCategoryId).toBe('cat-1')
   })
+
+  it('スキーム付き domain を含む DTO でも例外を投げずに正規化する', async () => {
+    const category = createParentCategory({
+      domainNames: ['example.com'],
+      domains: [],
+      id: 'cat-1',
+      name: 'Docs',
+    })
+    const tabGroup = createTabGroup({
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: [],
+    })
+    const repos = createInMemoryRepositories({
+      parentCategories: [category],
+      tabGroups: [tabGroup],
+    })
+    const useCase = createRepairTabGroupParentCategoryIdsUseCase(repos)
+
+    // DTO の domain にスキームが含まれていても、use-case 内で
+    // normalizeDomainString が hostname へ正規化するため例外にならない
+    const result = await useCase({
+      parentCategories: [category],
+      tabGroups: [
+        {
+          ...toSavedTabsDisplayTabGroupDto(tabGroup),
+          domain: 'https://example.com',
+        },
+      ],
+    })
+
+    expect(result.tabGroups[0].parentCategoryId).toBe('cat-1')
+  })
 })

--- a/src/contexts/saved-tabs/application/use-cases/RepairTabGroupParentCategoryIdsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RepairTabGroupParentCategoryIdsUseCase.ts
@@ -9,6 +9,7 @@ import { createTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
 import type { TabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
 import type { ParentCategoryRepository } from '@/contexts/saved-tabs/domain/repositories/ParentCategoryRepository'
 import type { TabGroupRepository } from '@/contexts/saved-tabs/domain/repositories/TabGroupRepository'
+import { normalizeDomainString } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 
 /**
  * `RepairTabGroupParentCategoryIdsUseCase` の入力。
@@ -102,6 +103,7 @@ export const createRepairTabGroupParentCategoryIdsUseCase = (
             command.tabGroups.map((group) =>
               createTabGroup({
                 ...group,
+                domain: normalizeDomainString(group.domain),
                 urlIds: group.urlIds ?? [],
               }),
             ),

--- a/src/contexts/saved-tabs/domain/value-objects/DomainName.test.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/DomainName.test.ts
@@ -6,6 +6,7 @@ import {
   createDomainName,
   domainNameToString,
   equalsDomainName,
+  normalizeDomainString,
 } from './DomainName'
 
 describe('DomainName 値オブジェクト', () => {
@@ -33,5 +34,29 @@ describe('DomainName 値オブジェクト', () => {
     expect(
       equalsDomainName(createDomainName('a.com'), createDomainName('A.com')),
     ).toBe(true)
+  })
+})
+
+describe('normalizeDomainString', () => {
+  it('スキームが無い場合は入力をそのまま返す', () => {
+    expect(normalizeDomainString('example.com')).toBe('example.com')
+  })
+
+  it('https スキーム付き文字列から hostname を取り出す', () => {
+    expect(normalizeDomainString('https://example.com')).toBe('example.com')
+  })
+
+  it('http スキーム付き文字列から hostname を取り出す', () => {
+    expect(normalizeDomainString('http://example.com/path')).toBe('example.com')
+  })
+
+  it('パース失敗時は入力をそのまま返す', () => {
+    expect(normalizeDomainString('://invalid')).toBe('://invalid')
+  })
+
+  it('normalizeDomainString 経由なら createDomainName は例外を投げない', () => {
+    expect(() =>
+      createDomainName(normalizeDomainString('https://example.com')),
+    ).not.toThrow()
   })
 })

--- a/src/contexts/saved-tabs/domain/value-objects/DomainName.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/DomainName.ts
@@ -20,6 +20,26 @@ export type DomainName = string & { readonly [domainNameBrand]: 'DomainName' }
 const SCHEME_SEPARATOR = '://'
 
 /**
+ * スキーム付き URL 文字列から hostname を取り出し、
+ * `createDomainName` に渡せる形へ正規化する。
+ *
+ * 旧 chrome.storage やインポートデータの `domain` フィールドに
+ * `https://example.com` のような URL 形式が入っていたケースの互換用。
+ * スキームが無い場合は入力をそのまま返し、パース失敗時も入力をそのまま返す
+ *（後段の `createDomainName` で再度弾く）。
+ */
+export const normalizeDomainString = (value: string): string => {
+  if (!value.includes(SCHEME_SEPARATOR)) {
+    return value
+  }
+  try {
+    return new URL(value).hostname
+  } catch {
+    return value
+  }
+}
+
+/**
  * `DomainName` 値オブジェクトを生成する。
  *
  * 入力は trim と小文字化のみを行い、`hostname` 抽出のような

--- a/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts
+++ b/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts
@@ -9,6 +9,7 @@ import { createUrlRecord } from '@/contexts/saved-tabs/domain/entities/UrlRecord
 import type { UrlRecord } from '@/contexts/saved-tabs/domain/entities/UrlRecord'
 import { SavedTabsDomainError } from '@/contexts/saved-tabs/domain/errors/SavedTabsDomainError'
 import type { CustomProjectId } from '@/contexts/saved-tabs/domain/value-objects/CustomProjectId'
+import { normalizeDomainString } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 import type { DomainName } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 import type { ParentCategoryId } from '@/contexts/saved-tabs/domain/value-objects/ParentCategoryId'
 import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabGroupId'
@@ -47,28 +48,10 @@ const isSavedTabsDomainError = (
   error: unknown,
 ): error is SavedTabsDomainError => error instanceof SavedTabsDomainError
 
-/**
- * 既存 chrome.storage では `domain` フィールドに `https://example.com` の
- * ような URL 形式が入っていた。新しい domain `DomainName` は hostname
- * のみを受け付けるので、URL 形式なら hostname を取り出して渡す。
- *
- * パース失敗時は入力をそのまま返す（後段の `createDomainName` で再度弾く）。
- */
-const normalizeDomainField = (value: string): string => {
-  if (!value.includes('://')) {
-    return value
-  }
-  try {
-    return new URL(value).hostname
-  } catch {
-    return value
-  }
-}
-
 const toTabGroupFromRaw = (raw: SavedTabRaw): TabGroup | null => {
   try {
     return createTabGroup({
-      domain: normalizeDomainField(raw.domain),
+      domain: normalizeDomainString(raw.domain),
       id: raw.id,
       parentCategoryId: raw.parentCategoryId,
       savedAt: raw.savedAt,
@@ -109,7 +92,7 @@ const toParentCategoryFromRaw = (
 ): ParentCategory | null => {
   try {
     return createParentCategory({
-      domainNames: raw.domainNames.map((name) => normalizeDomainField(name)),
+      domainNames: raw.domainNames.map((name) => normalizeDomainString(name)),
       domains: raw.domains,
       id: raw.id,
       name: raw.name,
@@ -290,10 +273,10 @@ const toParentCategoryRaw = (
   if (original) {
     const originalByHostname = new Map<string, string>()
     for (const name of original.domainNames) {
-      originalByHostname.set(normalizeDomainField(name), name)
+      originalByHostname.set(normalizeDomainString(name), name)
     }
     domainNames = entity.domainNames.map((name) => {
-      const hostname = normalizeDomainField(name)
+      const hostname = normalizeDomainString(name)
       return originalByHostname.get(hostname) ?? name
     })
   } else {

--- a/src/features/options/lib/import-export.test.ts
+++ b/src/features/options/lib/import-export.test.ts
@@ -479,11 +479,11 @@ describe('import-export ユーティリティ', () => {
       language: 'en',
       tabGroups: [
         {
-          domain: 'https://empty.example.com',
+          domain: 'empty.example.com',
           id: 'group-empty',
         },
         {
-          domain: 'https://aligned.example.com',
+          domain: 'aligned.example.com',
           id: 'group-1',
           urlIds: ['url-a', 'url-b'],
         },
@@ -519,7 +519,7 @@ describe('import-export ユーティリティ', () => {
       language: 'en',
       tabGroups: [
         {
-          domain: 'https://legacy-uncategorized.example.com',
+          domain: 'legacy-uncategorized.example.com',
           id: 'legacy-group',
           urlIds: ['legacy-url'],
         },
@@ -734,7 +734,7 @@ describe('import-export ユーティリティ', () => {
     const parentCategories = [
       { id: 'cat-1', name: 'Work', domains: [], domainNames: [] },
     ]
-    const savedTabs = [{ id: 'tab-1', domain: 'https://example.com', urls: [] }]
+    const savedTabs = [{ id: 'tab-1', domain: 'example.com', urls: [] }]
 
     createChromeMock({
       customProjectOrder: [],
@@ -791,7 +791,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'project-urlids-group',
-          domain: 'https://project-urlids.example.com',
+          domain: 'project-urlids.example.com',
           urlIds: ['imported-project-url', 'current-project-url'],
         },
       ],
@@ -842,7 +842,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'saved-group',
-          domain: 'https://example.com',
+          domain: 'example.com',
           urls: [
             {
               url: 'https://example.com/docs',
@@ -964,7 +964,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'dedupe-group',
-          domain: 'https://dedupe.example.com',
+          domain: 'dedupe.example.com',
           urlIds: ['url-known', 'url-known', 'missing-tab-id'],
         },
       ],
@@ -1048,7 +1048,7 @@ describe('import-export ユーティリティ', () => {
       parentCategories: [],
       savedTabs: [
         {
-          domain: 'https://fallback-language.example.com',
+          domain: 'fallback-language.example.com',
           id: 'fallback-language-group',
           urlIds: ['fallback-url'],
         },
@@ -1205,7 +1205,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'project-urlids-group',
-          domain: 'https://project-urlids.example.com',
+          domain: 'project-urlids.example.com',
           urlIds: ['imported-project-url', 'current-project-url'],
         },
       ],
@@ -1664,7 +1664,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'group-1',
-          domain: 'https://portable.example.com',
+          domain: 'portable.example.com',
           urlIds: ['url-1', 'url-2'],
           urlSubCategories: { 'url-2': 'Docs' },
         },
@@ -1691,7 +1691,7 @@ describe('import-export ユーティリティ', () => {
     expect(result.savedTabs[0]).toEqual(
       expect.objectContaining({
         id: 'group-1',
-        domain: 'https://portable.example.com',
+        domain: 'portable.example.com',
         urls: [
           {
             url: 'https://portable.example.com/home',
@@ -1718,7 +1718,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'missing-group',
-          domain: 'https://missing-export.example.com',
+          domain: 'missing-export.example.com',
           urlIds: ['missing-id-1', 'missing-id-2'],
           urlSubCategories: { 'missing-id-2': 'RecoveredSub' },
           savedAt: 100,
@@ -1733,7 +1733,7 @@ describe('import-export ユーティリティ', () => {
     expect(result.savedTabs[0]).toEqual(
       expect.objectContaining({
         id: 'missing-group',
-        domain: 'https://missing-export.example.com',
+        domain: 'missing-export.example.com',
         urls: [
           {
             url: 'https://missing-export.example.com/#tabbin-export-missing-missing-id-1',
@@ -1771,7 +1771,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'missing-en-group',
-          domain: 'https://missing-en.example.com',
+          domain: 'missing-en.example.com',
           urlIds: ['missing-en-id'],
         },
       ],
@@ -1795,7 +1795,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'legacy-group',
-          domain: 'https://legacy.example.com',
+          domain: 'legacy.example.com',
           urls: [
             { url: 'https://legacy.example.com/ok', title: 'ok' },
             { title: 'missing-url' },
@@ -1822,12 +1822,12 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'placeholder-no-savedat',
-          domain: 'https://placeholder-branch.example.com/',
+          domain: 'placeholder-branch.example.com',
           urlIds: ['missing-no-savedat'],
         },
         {
           id: 'titleless-record-group',
-          domain: 'https://titleless-record.example.com',
+          domain: 'titleless-record.example.com',
           urlIds: ['titleless-record-id'],
         },
       ],
@@ -1890,7 +1890,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'forced-skip-group',
-          domain: 'https://forced-skip.example.com',
+          domain: 'forced-skip.example.com',
           urlIds: ['forced-skip-placeholder-id'],
         },
       ],
@@ -2079,7 +2079,7 @@ describe('import-export ユーティリティ', () => {
         savedTabs: [
           {
             id: 'translated-missing-group',
-            domain: 'https://translated-missing.example.com',
+            domain: 'translated-missing.example.com',
             urlIds: ['translated-missing-id'],
           },
         ],
@@ -2149,7 +2149,7 @@ describe('import-export ユーティリティ', () => {
         savedTabs: [
           {
             id: 'preview-group',
-            domain: 'https://preview.example.com',
+            domain: 'preview.example.com',
             urls: [],
           },
         ],
@@ -2334,7 +2334,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'restored-group',
-          domain: 'https://restored.example.com',
+          domain: 'restored.example.com',
           urlIds: ['backup-url-1'],
           urlSubCategories: { 'backup-url-1': 'FromBackup' },
         },
@@ -2369,7 +2369,7 @@ describe('import-export ユーティリティ', () => {
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
         id: 'restored-group',
-        domain: 'https://restored.example.com',
+        domain: 'restored.example.com',
         urlIds: ['restored-url-id'],
         urlSubCategories: { 'restored-url-id': 'FromBackup' },
       }),
@@ -2405,7 +2405,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'restored-titleless-group',
-          domain: 'https://restored-titleless.example.com',
+          domain: 'restored-titleless.example.com',
           urlIds: ['backup-titleless-url-1'],
         },
       ],
@@ -2464,7 +2464,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'missing-group',
-          domain: 'https://missing.example.com',
+          domain: 'missing.example.com',
           urlIds: ['missing-url-id'],
         },
       ],
@@ -2493,7 +2493,7 @@ describe('import-export ユーティリティ', () => {
         savedTabs: [
           {
             id: 'missing-group',
-            domain: 'https://missing.example.com',
+            domain: 'missing.example.com',
             urlIds: ['missing-url-id'],
             urlSubCategories: undefined,
             parentCategoryId: undefined,
@@ -2537,7 +2537,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'missing-overwrite-group',
-          domain: 'https://missing-overwrite.example.com',
+          domain: 'missing-overwrite.example.com',
           urlIds: ['missing-overwrite-url-id'],
         },
       ],
@@ -2564,7 +2564,7 @@ describe('import-export ユーティリティ', () => {
         savedTabs: [
           {
             id: 'missing-overwrite-group',
-            domain: 'https://missing-overwrite.example.com',
+            domain: 'missing-overwrite.example.com',
             urlIds: ['missing-overwrite-url-id'],
             urlSubCategories: undefined,
             parentCategoryId: undefined,
@@ -2662,7 +2662,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'raw-fallback-group',
-          domain: 'https://fallback.example.com/',
+          domain: 'fallback.example.com',
           urlIds: ['raw-fallback-id', 'raw-fallback-id'],
           urlSubCategories: {
             'raw-fallback-id': 'KeepMe',
@@ -2686,7 +2686,7 @@ describe('import-export ユーティリティ', () => {
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
         id: 'raw-fallback-group',
-        domain: 'https://fallback.example.com/',
+        domain: 'fallback.example.com',
         urlIds: ['raw-fallback-id'],
         urlSubCategories: { 'raw-fallback-id': 'KeepMe' },
       }),
@@ -2736,7 +2736,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'empty-group',
-          domain: 'https://empty.example.com',
+          domain: 'empty.example.com',
         },
       ],
     }
@@ -2754,7 +2754,7 @@ describe('import-export ユーティリティ', () => {
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
         id: 'empty-group',
-        domain: 'https://empty.example.com',
+        domain: 'empty.example.com',
         urlIds: [],
         urlSubCategories: undefined,
         subCategories: [],
@@ -2786,7 +2786,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'invalid-current-urls-group',
-          domain: 'https://invalid-current-urls.example.com',
+          domain: 'invalid-current-urls.example.com',
           urlIds: ['invalid-current-urls-id'],
         },
       ],
@@ -2841,7 +2841,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'safe-group',
-          domain: 'https://safe.example.com',
+          domain: 'safe.example.com',
           urls: [{ url: 'https://safe.example.com/path' }],
         },
       ],
@@ -2875,7 +2875,7 @@ describe('import-export ユーティリティ', () => {
         savedTabs: [
           {
             id: 'safe-group',
-            domain: 'https://safe.example.com',
+            domain: 'safe.example.com',
             urlIds: ['new-url-id'],
             urlSubCategories: undefined,
             parentCategoryId: undefined,
@@ -2894,7 +2894,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'existing-group',
-          domain: 'https://existing-fallback.example.com',
+          domain: 'existing-fallback.example.com',
           parentCategoryId: 'parent-old',
           savedAt: 777,
         },
@@ -2923,7 +2923,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'imported-existing',
-          domain: 'https://existing-fallback.example.com',
+          domain: 'existing-fallback.example.com',
           urls: [{ url: 'https://existing-fallback.example.com/path' }],
         },
       ],
@@ -2941,7 +2941,7 @@ describe('import-export ユーティリティ', () => {
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
         id: 'existing-group',
-        domain: 'https://existing-fallback.example.com',
+        domain: 'existing-fallback.example.com',
         parentCategoryId: 'parent-old',
         savedAt: 777,
         urlIds: ['new-id'],
@@ -2958,7 +2958,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'dup-group',
-          domain: 'https://dup.example.com',
+          domain: 'dup.example.com',
           urlIds: ['dup-id'],
           urlSubCategories: {},
           categoryKeywords: [{ categoryName: 'news', keywords: ['old'] }],
@@ -2989,7 +2989,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'dup-group-imported',
-          domain: 'https://dup.example.com',
+          domain: 'dup.example.com',
           urls: [{ url: 'https://dup.example.com/path' }],
           categoryKeywords: [
             { categoryName: 'news', keywords: 'not-array' },
@@ -3056,7 +3056,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'new-domain-edge-group',
-          domain: 'https://new-edge.example.com',
+          domain: 'new-edge.example.com',
           urls: [{ url: 'https://new-edge.example.com' }],
           categoryKeywords: [{ categoryName: 'edge', keywords: 'not-array' }],
           subCategories: [{ name: 'Obj' }, { name: 'Obj' }, 'Str', 'Str', 0],
@@ -3086,7 +3086,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'ordered-group',
-          domain: 'https://ordered.example.com',
+          domain: 'ordered.example.com',
           urlIds: ['ordered-url-id'],
           subCategories: ['ExistingA', 'ExistingB'],
           subCategoryOrder: ['ExistingA', 'ExistingB'],
@@ -3121,7 +3121,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'ordered-group-imported',
-          domain: 'https://ordered.example.com',
+          domain: 'ordered.example.com',
           urls: [{ url: 'https://ordered.example.com/path' }],
           subCategories: ['ImportedB', 'ExistingB', 'ImportedA'],
           subCategoryOrder: ['ImportedB', 'ExistingB', 'ImportedA'],
@@ -3178,7 +3178,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'force-group',
-          domain: 'https://force.example.com',
+          domain: 'force.example.com',
           categoryKeywords: [
             {
               categoryName: 'force-undefined-existing-item',
@@ -3211,7 +3211,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'force-group-imported',
-          domain: 'https://force.example.com',
+          domain: 'force.example.com',
           urls: [{ url: 'https://force.example.com' }],
           categoryKeywords: [
             {
@@ -3247,7 +3247,7 @@ describe('import-export ユーティリティ', () => {
     const currentTabs = [
       {
         id: 'group-1',
-        domain: 'https://existing.example.com',
+        domain: 'existing.example.com',
         urlIds: ['url-existing'],
         urlSubCategories: { 'url-existing': 'OldSub' },
         parentCategoryId: 'cat-1',
@@ -3311,7 +3311,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'imported-existing-group',
-          domain: 'https://existing.example.com',
+          domain: 'existing.example.com',
           urls: [
             {
               url: 'https://existing.example.com/new',
@@ -3333,7 +3333,7 @@ describe('import-export ユーティリティ', () => {
         },
         {
           id: 'imported-new-group',
-          domain: 'https://new.example.com',
+          domain: 'new.example.com',
           urls: [
             {
               url: 'https://new.example.com/path',
@@ -3393,13 +3393,13 @@ describe('import-export ユーティリティ', () => {
     expect(savedTabsArg).toHaveLength(2)
 
     const mergedExisting = savedTabsArg.find(
-      (tab) => tab.domain === 'https://existing.example.com',
+      (tab) => tab.domain === 'existing.example.com',
     )
 
     expect(mergedExisting).toEqual(
       expect.objectContaining({
         id: 'group-1',
-        domain: 'https://existing.example.com',
+        domain: 'existing.example.com',
         parentCategoryId: 'cat-2',
         savedAt: 50,
       }),
@@ -3428,13 +3428,13 @@ describe('import-export ユーティリティ', () => {
     ])
 
     const mergedNewDomain = savedTabsArg.find(
-      (tab) => tab.domain === 'https://new.example.com',
+      (tab) => tab.domain === 'new.example.com',
     )
 
     expect(mergedNewDomain).toEqual(
       expect.objectContaining({
         id: 'imported-new-group',
-        domain: 'https://new.example.com',
+        domain: 'new.example.com',
         urlIds: ['url-imported-new-domain'],
         subCategories: ['ProjectObj', 'ProjectStr'],
         categoryKeywords: [{ categoryName: 'topic', keywords: ['keyword'] }],
@@ -3452,7 +3452,7 @@ describe('import-export ユーティリティ', () => {
     const currentTabs = [
       {
         id: 'group-1',
-        domain: 'https://existing.example.com',
+        domain: 'existing.example.com',
         urlIds: ['url-existing'],
         // 孤児 urlId (url-existing-orphan) を含む
         urlSubCategories: {
@@ -3484,7 +3484,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'imported-existing-group',
-          domain: 'https://existing.example.com',
+          domain: 'existing.example.com',
           urls: [
             {
               url: 'https://existing.example.com/new',
@@ -3505,7 +3505,7 @@ describe('import-export ユーティリティ', () => {
       unknown
     >[]
     const mergedExisting = savedTabsArg.find(
-      (tab) => tab.domain === 'https://existing.example.com',
+      (tab) => tab.domain === 'existing.example.com',
     )
 
     expect(mergedExisting?.urlIds).toEqual([
@@ -3537,7 +3537,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'current-group',
-          domain: 'https://current.example.com',
+          domain: 'current.example.com',
           urlIds: ['url-current'],
         },
       ],
@@ -3621,7 +3621,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'imported-group',
-          domain: 'https://imported.example.com',
+          domain: 'imported.example.com',
           urls: [
             {
               url: 'https://duplicate.example.com/1',
@@ -3690,7 +3690,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'saved-group',
-          domain: 'https://example.com',
+          domain: 'example.com',
           urls: [
             { url: 'https://example.com/a', title: 'A' },
             { url: 'https://example.com/b', title: 'B' },
@@ -3770,7 +3770,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'saved-group',
-          domain: 'https://example.com',
+          domain: 'example.com',
           urls: [
             { url: 'https://example.com/a', title: 'A' },
             { url: 'https://example.com/b', title: 'B' },
@@ -3855,7 +3855,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'replace-group',
-          domain: 'https://replace.example.com',
+          domain: 'replace.example.com',
           urls: [
             { url: 'https://replace.example.com/fail', title: 'fail' },
             {
@@ -3913,7 +3913,7 @@ describe('import-export ユーティリティ', () => {
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
         id: 'replace-group',
-        domain: 'https://replace.example.com',
+        domain: 'replace.example.com',
         urlIds: ['url-overwrite-2'],
         urlSubCategories: { 'url-overwrite-2': 'SubA' },
         subCategories: ['ObjectSub', 'StringSub'],
@@ -4013,7 +4013,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'saved-group',
-          domain: 'https://restored.example.com',
+          domain: 'restored.example.com',
           urls: [
             {
               url: 'https://restored.example.com/1',
@@ -4290,7 +4290,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'group-main',
-          domain: 'https://example.com',
+          domain: 'example.com',
           urls: [
             { url: 'https://example.com/a', title: 'A' },
             { url: 'https://example.com/b', title: 'B' },
@@ -4353,7 +4353,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'current-group',
-          domain: 'https://current.example.com',
+          domain: 'current.example.com',
           urlIds: ['url-current'],
         },
       ],
@@ -4448,7 +4448,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'imported-group',
-          domain: 'https://imported.example.com',
+          domain: 'imported.example.com',
           urls: [
             {
               url: 'https://imported.example.com/a',
@@ -4549,7 +4549,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'sync-failure-group',
-          domain: 'https://sync-failure.example.com',
+          domain: 'sync-failure.example.com',
           urls: [
             {
               url: 'https://sync-failure.example.com',
@@ -4630,7 +4630,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'bulk-group',
-          domain: 'https://bulk.example.com',
+          domain: 'bulk.example.com',
           urls: importedUrls,
         },
       ],
@@ -4680,7 +4680,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'normalize-group',
-          domain: 'https://normalize.example.com',
+          domain: 'normalize.example.com',
           urls: [{ url: 'https://normalize.example.com', title: 'Normalize' }],
           subCategories: [{ name: 'ObjSub' }, 123, 'StrSub', { name: 999 }],
           categoryKeywords: [
@@ -4734,7 +4734,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'ordered-overwrite-group',
-          domain: 'https://ordered-overwrite.example.com',
+          domain: 'ordered-overwrite.example.com',
           urls: [
             {
               url: 'https://ordered-overwrite.example.com',
@@ -4795,7 +4795,7 @@ describe('import-export ユーティリティ', () => {
       savedTabs: [
         {
           id: 'minimal-group',
-          domain: 'https://minimal.example.com',
+          domain: 'minimal.example.com',
           urls: [{ url: 'https://minimal.example.com' }],
         },
       ],
@@ -4812,7 +4812,7 @@ describe('import-export ユーティリティ', () => {
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
         id: 'minimal-group',
-        domain: 'https://minimal.example.com',
+        domain: 'minimal.example.com',
         urlIds: ['url-minimal'],
         subCategories: [],
         categoryKeywords: [],

--- a/src/features/options/lib/import-export/settings-merge.ts
+++ b/src/features/options/lib/import-export/settings-merge.ts
@@ -1,3 +1,4 @@
+import { normalizeDomainString } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 import type { AiChatConversation } from '@/features/ai-chat/types'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
 import type { SavedAnalyticsView } from '@/lib/storage/analytics'
@@ -245,7 +246,7 @@ const buildMergedExistingDomainTab = async (
     })
   return {
     id: existingTab.id,
-    domain: existingTab.domain,
+    domain: normalizeDomainString(existingTab.domain),
     urlIds: mergedUrlData.urlIds,
     urlSubCategories: mergedUrlData.urlSubCategories,
     parentCategoryId:
@@ -291,7 +292,7 @@ const buildMergedNewDomainTab = async (
     )
   return {
     id: importedTab.id,
-    domain: importedTab.domain,
+    domain: normalizeDomainString(importedTab.domain),
     urlIds: resolvedUrlData.urlIds,
     urlSubCategories: resolvedUrlData.urlSubCategories,
     parentCategoryId: importedTab.parentCategoryId,
@@ -317,7 +318,7 @@ const mergeTabsByDomain = async (
 ): Promise<TabGroup[]> => {
   const tabMapByDomain = new Map<string, TabGroup>()
   for (const tab of currentTabs) {
-    tabMapByDomain.set(tab.domain, tab)
+    tabMapByDomain.set(normalizeDomainString(tab.domain), tab)
   }
   const mergedImportedTabs = await Promise.all(
     normalizedImportedTabs.map(async (importedTab) => {

--- a/src/features/options/lib/import-export/url-conversion.ts
+++ b/src/features/options/lib/import-export/url-conversion.ts
@@ -1,3 +1,4 @@
+import { normalizeDomainString } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 import {
   getBrowserUiLocale,
   getMessage,
@@ -47,6 +48,19 @@ const getUncategorizedProjectName = (
 ) => getMessage(resolveCurrentLanguage({ language }), 'savedTabs.uncategorized')
 
 const normalizeUrlKey = (url: string): string => url.trim()
+
+/**
+ * ドメイン文字列からプレースホルダー URL のベースを構築する。
+ * hostname 単位のドメイン（`example.com`）には `https://` を付与し、
+ * URL 形式のドメイン（`https://example.com`）はそのまま使う。
+ */
+const toPlaceholderBaseUrl = (domain: string): string => {
+  const stripped = domain.replace(/\/+$/, '')
+  if (stripped.includes('://')) {
+    return stripped
+  }
+  return `https://${stripped}`
+}
 
 const buildConvertedUrlData = (
   urls: ImportedUrlData[],
@@ -176,9 +190,11 @@ const normalizeImportedTabsForImport = (
   const normalizedImportedTabs: (ImportedTabData & {
     urls: ImportedUrlData[]
   })[] = importedTabs.map((tab) => {
+    const normalizedDomain = normalizeDomainString(tab.domain)
     if (Array.isArray(tab.urls)) {
       return {
         ...tab,
+        domain: normalizedDomain,
         urls: tab.urls,
       }
     }
@@ -193,13 +209,14 @@ const normalizeImportedTabsForImport = (
       restoredUrls.length === 0
     ) {
       unresolvedTabs.push({
-        domain: tab.domain,
+        domain: normalizedDomain,
         savedAt: tab.savedAt,
         urlIds: Array.from(new Set(tab.urlIds)),
       })
     }
     return {
       ...tab,
+      domain: normalizedDomain,
       urls: restoredUrls,
     }
   })
@@ -276,7 +293,7 @@ const ensurePlaceholderUrlRecords = async (
   const newRecords: UrlRecord[] = []
   let offset = 0
   for (const tab of unresolvedTabs) {
-    const baseDomain = tab.domain.replace(/\/+$/, '')
+    const baseDomain = toPlaceholderBaseUrl(tab.domain)
     for (const urlId of tab.urlIds) {
       if (existingIdSet.has(urlId)) {
         continue
@@ -320,7 +337,7 @@ const convertTabGroupToExportUrls = (
     return []
   }
   const exportedUrls: NonNullable<TabGroup['urls']> = []
-  const baseDomain = tab.domain.replace(/\/+$/, '')
+  const baseDomain = toPlaceholderBaseUrl(tab.domain)
   let offset = 0
   for (const urlId of tab.urlIds) {
     const urlRecord =


### PR DESCRIPTION
## 変更内容

PR #577 マージ後、「設定とタブデータをインポート」して `/saved-tabs?mode=domain` に遷移すると URL が取り込まれず、以下のエラーが発生していました。

```
useTabData.ts:329 保存されたタブの読み込みエラー: SavedTabsDomainError: ドメイン名にスキームを含めることはできません
    at createDomainName (DomainName.ts:43)
    at createTabGroup (TabGroup.ts:92)
    at RepairTabGroupParentCategoryIdsUseCase.ts:103
    at loadSavedTabs (useTabData.ts:320)
```

### 原因

PR #577 で `RepairTabGroupParentCategoryIdsUseCase` が DTO を直接 `createTabGroup` に渡すようになりました。`createTabGroup` → `createDomainName` のチェーンで `https://example.com` のようなスキーム付きドメインを弾くよう設計されていたため、インポートデータの `domain` に URL 形式が含まれていると例外が飛んでいました。PR 前は単なる型キャスト (`as unknown as DomainTabGroup`) だったため、この検証は走っていませんでした。

### 修正

`DomainName.ts` に `normalizeDomainString` ヘルパーを新設し、スキーム付き文字列から hostname を抽出するようにしました。これを以下の経路で共通利用しています。

- **RepairTabGroupParentCategoryIdsUseCase** — `createTabGroup` 呼び出し前にドメインを正規化（クラッシュ回避）
- **SavedTabsSnapshotMapper** — `toDomainTabGroupFromStorage` で同様に正規化
- **ChromeSavedTabsStorageMapper** — ローカルにあった `normalizeDomainField` を共通ヘルパーへ統合（重複解消）
- **url-conversion.ts** — インポート時にドメインを正規化し、新たにストレージへ悪いデータが入るのを防止。プレースホルダー URL 生成時には `https://` を補完する `toPlaceholderBaseUrl` も追加
- **settings-merge.ts** — マージ時の既存タブ・新規タブ両方のドメインを正規化し、スキーム有無でマージ不一致が起きないよう修正

## チェックリスト

- [x] ローカル環境でエラーになっていない
- [x] `bun run test` 全テスト通過 (3042 passed)
- [x] `bun run compile` 型チェック通過
- [x] `bun run quality` (format / lint / test / Knip / 重複チェック) 通過
- [x] dependency-cruiser 違反なし

## 関連

- #577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced domain normalization for tab group import/export and merge operations. The system now properly handles domains containing URL schemes (e.g., `https://example.com`), normalizing them to hostname form (e.g., `example.com`). This ensures consistent storage and correct tab group identification across all operations, improving data compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->