### PR TITLE
AIチャットツール定義のタイトル・説明をi18n対応する

### DIFF
--- a/src/constants/aiChatTools.ts
+++ b/src/constants/aiChatTools.ts
@@ -1,60 +1,110 @@
+import { getMessage } from '@/features/i18n/lib/language'
+import type { AppLanguage } from '@/features/i18n/messages'
+
+interface AiChatToolDefinition {
+  descriptionKey: string
+  name: string
+  titleKey: string
+}
+
 const AI_CHAT_TOOL_DEFINITIONS = [
   {
-    description:
-      '現在時刻を取得する。今日、今月、何日前、相対日付を扱う前に使う',
+    descriptionKey: 'aiChat.tool.getCurrentDateTime.description',
     name: 'getCurrentDateTime',
-    title: '現在時刻確認',
+    titleKey: 'aiChat.tool.getCurrentDateTime.title',
   },
   {
-    description:
-      '現在保存されているタブを保存日時順に一覧化する。page/pageSize/sortDirection を指定できる',
+    descriptionKey: 'aiChat.tool.listSavedUrls.description',
     name: 'listSavedUrls',
-    title: '保存済みタブ一覧',
+    titleKey: 'aiChat.tool.listSavedUrls.title',
   },
   {
-    description:
-      '指定した年月に保存されたタブを一覧化する。page/pageSize/sortDirection を指定できる',
+    descriptionKey: 'aiChat.tool.findUrlsByMonth.description',
     name: 'findUrlsByMonth',
-    title: '月別タブ検索',
+    titleKey: 'aiChat.tool.findUrlsByMonth.title',
   },
   {
-    description:
-      'キーワードで保存済みタブを検索する。page/pageSize/sortDirection を指定できる',
+    descriptionKey: 'aiChat.tool.searchSavedUrls.description',
     name: 'searchSavedUrls',
-    title: 'キーワードタブ検索',
+    titleKey: 'aiChat.tool.searchSavedUrls.title',
   },
   {
-    description:
-      '保存済みタブをドメイン、カテゴリ、プロジェクト、時系列で集計し、chartSpecs を返す。チャートや分析を求められたら優先して使う',
+    descriptionKey: 'aiChat.tool.generateSavedTabsAnalytics.description',
     name: 'generateSavedTabsAnalytics',
-    title: '保存分析',
+    titleKey: 'aiChat.tool.generateSavedTabsAnalytics.title',
   },
   {
-    description: '保存傾向から興味のありそうなテーマを推定する',
+    descriptionKey: 'aiChat.tool.inferUserInterests.description',
     name: 'inferUserInterests',
-    title: '興味推定',
+    titleKey: 'aiChat.tool.inferUserInterests.title',
   },
-] as const
+] as const satisfies readonly AiChatToolDefinition[]
 
-type AiChatToolDefinition = (typeof AI_CHAT_TOOL_DEFINITIONS)[number]
+type AiChatToolDefinitionEntry = (typeof AI_CHAT_TOOL_DEFINITIONS)[number]
+type AiChatToolName = AiChatToolDefinitionEntry['name']
 
-const AI_CHAT_TOOL_TITLES: Record<string, string> = Object.fromEntries(
-  AI_CHAT_TOOL_DEFINITIONS.map((toolDefinition) => [
-    toolDefinition.name,
-    toolDefinition.title,
-  ]),
-)
+const AI_CHAT_TOOL_NAMES: readonly AiChatToolName[] =
+  AI_CHAT_TOOL_DEFINITIONS.map((toolDefinition) => toolDefinition.name)
 
-const AI_CHAT_TOOL_DESCRIPTIONS: Record<string, string> = Object.fromEntries(
-  AI_CHAT_TOOL_DEFINITIONS.map((toolDefinition) => [
-    toolDefinition.name,
-    toolDefinition.description,
-  ]),
-)
+const getAiChatToolDefinition = (
+  toolName: string,
+): AiChatToolDefinition | undefined =>
+  AI_CHAT_TOOL_DEFINITIONS.find(
+    (toolDefinition) => toolDefinition.name === toolName,
+  )
 
-export type { AiChatToolDefinition }
+const getAiChatToolTitle = (
+  language: AppLanguage,
+  toolName: string,
+): string => {
+  const toolDefinition = getAiChatToolDefinition(toolName)
+  if (!toolDefinition) {
+    return toolName
+  }
+  return getMessage(language, toolDefinition.titleKey, toolName)
+}
+
+const getAiChatToolDescription = (
+  language: AppLanguage,
+  toolName: string,
+): string => {
+  const toolDefinition = getAiChatToolDefinition(toolName)
+  if (!toolDefinition) {
+    return toolName
+  }
+  return getMessage(language, toolDefinition.descriptionKey, toolName)
+}
+
+interface ResolvedAiChatToolDefinition {
+  description: string
+  name: string
+  title: string
+}
+
+const getAiChatToolDefinitions = (
+  language: AppLanguage,
+): readonly ResolvedAiChatToolDefinition[] =>
+  AI_CHAT_TOOL_DEFINITIONS.map((toolDefinition) => ({
+    description: getMessage(
+      language,
+      toolDefinition.descriptionKey,
+      toolDefinition.name,
+    ),
+    name: toolDefinition.name,
+    title: getMessage(language, toolDefinition.titleKey, toolDefinition.name),
+  }))
+
+export type {
+  AiChatToolDefinition,
+  AiChatToolDefinitionEntry,
+  AiChatToolName,
+  ResolvedAiChatToolDefinition,
+}
 export {
   AI_CHAT_TOOL_DEFINITIONS,
-  AI_CHAT_TOOL_DESCRIPTIONS,
-  AI_CHAT_TOOL_TITLES,
+  AI_CHAT_TOOL_NAMES,
+  getAiChatToolDefinition,
+  getAiChatToolDefinitions,
+  getAiChatToolDescription,
+  getAiChatToolTitle,
 }

--- a/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
@@ -16,7 +16,7 @@ import {
 } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import { AI_CHAT_TOOL_DEFINITIONS } from '@/constants/aiChatTools'
+import { getAiChatToolDefinitions } from '@/constants/aiChatTools'
 import type { UserSettings } from '@/types/storage'
 
 const mocked = vi.hoisted(() => ({
@@ -996,7 +996,7 @@ describe('SavedTabsChatWidget', () => {
 
     expect(within(dialog).getByText('Available tools')).toBeTruthy()
 
-    for (const toolDefinition of AI_CHAT_TOOL_DEFINITIONS) {
+    for (const toolDefinition of getAiChatToolDefinitions('en')) {
       expect(
         within(dialog).getByText(toolDefinition.name, {
           exact: false,

--- a/src/features/ai-chat/components/SystemPromptManagerDialog.tsx
+++ b/src/features/ai-chat/components/SystemPromptManagerDialog.tsx
@@ -13,12 +13,13 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
-import { AI_CHAT_TOOL_DEFINITIONS } from '@/constants/aiChatTools'
+import { getAiChatToolDefinitions } from '@/constants/aiChatTools'
 import {
   MAX_AI_SYSTEM_PROMPT_NAME_LENGTH,
   MAX_AI_SYSTEM_PROMPT_PRESETS,
 } from '@/features/ai-chat/lib/systemPromptPresets'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
+import type { AppLanguage } from '@/features/i18n/messages'
 import { cn } from '@/lib/utils'
 import type { AiSystemPromptPreset } from '@/types/storage'
 
@@ -89,6 +90,7 @@ const PromptEditorPanel = ({
   errorMessage,
   isDeleteDisabled,
   isLimitReached,
+  language,
   onChangePromptName,
   onChangePromptTemplate,
   onDeletePrompt,
@@ -99,6 +101,7 @@ const PromptEditorPanel = ({
   errorMessage: string
   isDeleteDisabled: boolean
   isLimitReached: boolean
+  language: AppLanguage
   onChangePromptName: (value: string) => void
   onChangePromptTemplate: (value: string) => void
   onDeletePrompt: () => void
@@ -184,7 +187,7 @@ const PromptEditorPanel = ({
           </p>
         </div>
         <div className='grid gap-2 xl:grid-cols-2'>
-          {AI_CHAT_TOOL_DEFINITIONS.map((toolDefinition) => (
+          {getAiChatToolDefinitions(language).map((toolDefinition) => (
             <div
               className='rounded-md border border-border/70 bg-muted/20 p-3'
               key={toolDefinition.name}
@@ -282,7 +285,7 @@ export const SystemPromptManagerDialog = ({
   onSave,
   onSelectPrompt,
 }: SystemPromptManagerDialogProps) => {
-  const { t } = useI18n()
+  const { language, t } = useI18n()
   const selectedPrompt = getSelectedPrompt(presets, selectedPromptId)
   const isLimitReached = presets.length >= MAX_AI_SYSTEM_PROMPT_PRESETS
   const isDeleteDisabled = presets.length <= 1
@@ -316,6 +319,7 @@ export const SystemPromptManagerDialog = ({
                   errorMessage={errorMessage}
                   isDeleteDisabled={isDeleteDisabled}
                   isLimitReached={isLimitReached}
+                  language={language}
                   onChangePromptName={onChangePromptName}
                   onChangePromptTemplate={onChangePromptTemplate}
                   onDeletePrompt={onDeletePrompt}

--- a/src/features/i18n/messages.ts
+++ b/src/features/i18n/messages.ts
@@ -119,6 +119,24 @@ const messages = {
     'aiChat.streaming.receivedQuestion': '- Received question: {{prompt}}',
     'aiChat.streaming.toolsFollow':
       '- Tools and reasoning update after each completed step.',
+    'aiChat.tool.findUrlsByMonth.description':
+      'List tabs saved in the specified year and month. page/pageSize/sortDirection are configurable.',
+    'aiChat.tool.findUrlsByMonth.title': 'Search tabs by month',
+    'aiChat.tool.generateSavedTabsAnalytics.description':
+      'Aggregate saved tabs by domain, category, project, and time series, then return chartSpecs. Prefer this when charts or analysis are requested.',
+    'aiChat.tool.generateSavedTabsAnalytics.title': 'Saved tabs analytics',
+    'aiChat.tool.getCurrentDateTime.description':
+      'Get the current time. Use this before handling today, this month, days ago, or relative dates.',
+    'aiChat.tool.getCurrentDateTime.title': 'Check current time',
+    'aiChat.tool.inferUserInterests.description':
+      'Estimate themes that may match your interests from saved trends.',
+    'aiChat.tool.inferUserInterests.title': 'Infer interests',
+    'aiChat.tool.listSavedUrls.description':
+      'List currently saved tabs in order of saved time. page/pageSize/sortDirection are configurable.',
+    'aiChat.tool.listSavedUrls.title': 'List saved tabs',
+    'aiChat.tool.searchSavedUrls.description':
+      'Search saved tabs by keyword. page/pageSize/sortDirection are configurable.',
+    'aiChat.tool.searchSavedUrls.title': 'Search tabs by keyword',
     'aiChat.suggestion.favoriteContent':
       'What kinds of content do I save most often?',
     'aiChat.suggestion.recentTabs': 'Show me the tabs I added this month',
@@ -947,6 +965,24 @@ const messages = {
     'aiChat.streaming.receivedQuestion': '- 質問を受け取りました: {{prompt}}',
     'aiChat.streaming.toolsFollow':
       '- ステップ完了ごとにツール実行結果と推論を更新します。',
+    'aiChat.tool.findUrlsByMonth.description':
+      '指定した年月に保存されたタブを一覧化する。page/pageSize/sortDirection を指定できる',
+    'aiChat.tool.findUrlsByMonth.title': '月別タブ検索',
+    'aiChat.tool.generateSavedTabsAnalytics.description':
+      '保存済みタブをドメイン、カテゴリ、プロジェクト、時系列で集計し、chartSpecs を返す。チャートや分析を求められたら優先して使う',
+    'aiChat.tool.generateSavedTabsAnalytics.title': '保存分析',
+    'aiChat.tool.getCurrentDateTime.description':
+      '現在時刻を取得する。今日、今月、何日前、相対日付を扱う前に使う',
+    'aiChat.tool.getCurrentDateTime.title': '現在時刻確認',
+    'aiChat.tool.inferUserInterests.description':
+      '保存傾向から興味のありそうなテーマを推定する',
+    'aiChat.tool.inferUserInterests.title': '興味推定',
+    'aiChat.tool.listSavedUrls.description':
+      '現在保存されているタブを保存日時順に一覧化する。page/pageSize/sortDirection を指定できる',
+    'aiChat.tool.listSavedUrls.title': '保存済みタブ一覧',
+    'aiChat.tool.searchSavedUrls.description':
+      'キーワードで保存済みタブを検索する。page/pageSize/sortDirection を指定できる',
+    'aiChat.tool.searchSavedUrls.title': 'キーワードタブ検索',
     'aiChat.suggestion.favoriteContent': '最近よく保存しているジャンルは？',
     'aiChat.suggestion.recentTabs': '今月追加したタブを教えて',
     'aiChat.suggestion.recommendation': 'どんなコンテンツが好きそうか教えて',

--- a/src/lib/background/ai-chat-tools.test.ts
+++ b/src/lib/background/ai-chat-tools.test.ts
@@ -85,3 +85,25 @@ describe('createAiChatTools', () => {
     )
   })
 })
+
+describe('createAiChatTools (language-aware descriptions)', () => {
+  it('language=ja のとき日本語 description を AI SDK tool へ渡す', () => {
+    const tools = createAiChatTools(records, 'ja')
+    expect(tools.getCurrentDateTime.description).toBe(
+      '現在時刻を取得する。今日、今月、何日前、相対日付を扱う前に使う',
+    )
+    expect(tools.listSavedUrls.description).toBe(
+      '現在保存されているタブを保存日時順に一覧化する。page/pageSize/sortDirection を指定できる',
+    )
+  })
+
+  it('language=en のとき英語 description を AI SDK tool へ渡す', () => {
+    const tools = createAiChatTools(records, 'en')
+    expect(tools.getCurrentDateTime.description).toBe(
+      'Get the current time. Use this before handling today, this month, days ago, or relative dates.',
+    )
+    expect(tools.listSavedUrls.description).toBe(
+      'List currently saved tabs in order of saved time. page/pageSize/sortDirection are configurable.',
+    )
+  })
+})

--- a/src/lib/background/ai-chat-tools.ts
+++ b/src/lib/background/ai-chat-tools.ts
@@ -2,7 +2,7 @@
 import { tool } from 'ai'
 import { z } from 'zod'
 
-import { AI_CHAT_TOOL_DESCRIPTIONS } from '@/constants/aiChatTools'
+import { getAiChatToolDescription } from '@/constants/aiChatTools'
 import { inferUserInterests } from '@/features/ai-chat/lib/inferInterests'
 import {
   DEFAULT_SAVED_URL_PAGE,
@@ -155,7 +155,7 @@ const createAiChatTools = (
   language: AppLanguage = 'ja',
 ) => ({
   findUrlsByMonth: tool({
-    description: AI_CHAT_TOOL_DESCRIPTIONS.findUrlsByMonth,
+    description: getAiChatToolDescription(language, 'findUrlsByMonth'),
     inputSchema: paginationSchema.extend({
       year: z.number().int(),
       month: z.number().int().min(MIN_MONTH).max(MAX_MONTH),
@@ -165,7 +165,10 @@ const createAiChatTools = (
       mapPageForToolOutput(findSavedUrlsAddedInMonthPage(records, input)),
   }),
   generateSavedTabsAnalytics: tool({
-    description: AI_CHAT_TOOL_DESCRIPTIONS.generateSavedTabsAnalytics,
+    description: getAiChatToolDescription(
+      language,
+      'generateSavedTabsAnalytics',
+    ),
     inputSchema: z.object({
       chartType: z.enum(['area', 'bar', 'line', 'pie', 'radar']).default('bar'),
       compareBy: z.enum(['mode', 'none']).default('none'),
@@ -226,20 +229,20 @@ const createAiChatTools = (
       }),
   }),
   getCurrentDateTime: tool({
-    description: AI_CHAT_TOOL_DESCRIPTIONS.getCurrentDateTime,
+    description: getAiChatToolDescription(language, 'getCurrentDateTime'),
     inputSchema: z.object({}),
 
     execute: async () => createCurrentDateTimeOutput(),
   }),
 
   inferUserInterests: tool({
-    description: AI_CHAT_TOOL_DESCRIPTIONS.inferUserInterests,
+    description: getAiChatToolDescription(language, 'inferUserInterests'),
     inputSchema: z.object({}),
 
     execute: async () => inferUserInterests(records, language),
   }),
   listSavedUrls: tool({
-    description: AI_CHAT_TOOL_DESCRIPTIONS.listSavedUrls,
+    description: getAiChatToolDescription(language, 'listSavedUrls'),
     inputSchema: paginationSchema,
 
     execute: async (input) =>
@@ -247,7 +250,7 @@ const createAiChatTools = (
   }),
 
   searchSavedUrls: tool({
-    description: AI_CHAT_TOOL_DESCRIPTIONS.searchSavedUrls,
+    description: getAiChatToolDescription(language, 'searchSavedUrls'),
     inputSchema: paginationSchema.extend({
       query: z.string().min(1),
     }),

--- a/src/lib/background/ai-chat.test.ts
+++ b/src/lib/background/ai-chat.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import { AI_CHAT_TOOL_DEFINITIONS } from '@/constants/aiChatTools'
+import { getAiChatToolDefinitions } from '@/constants/aiChatTools'
 
 const mocked = vi.hoisted(() => ({
   createOllama: vi.fn(),
@@ -463,7 +463,7 @@ describe('runAiChatRequest', () => {
       tools: Record<string, { description: string }>
     }
 
-    for (const toolDefinition of AI_CHAT_TOOL_DEFINITIONS) {
+    for (const toolDefinition of getAiChatToolDefinitions('ja')) {
       expect(generateArgs.tools[toolDefinition.name]?.description).toBe(
         toolDefinition.description,
       )
@@ -492,6 +492,59 @@ describe('runAiChatRequest', () => {
         type: 'dynamic-tool',
       }),
     ])
+  })
+  it('言語設定が en のとき AI SDK へ英語 description を渡し reasoning も英語タイトルになる', async () => {
+    ;(
+      globalThis as typeof globalThis & {
+        chrome?: typeof chrome
+      }
+    ).chrome = {
+      i18n: {
+        getUILanguage: () => 'en-US',
+      },
+      runtime: {
+        id: 'test-extension-id',
+      },
+      storage: {
+        local: {
+          get: vi.fn(async (key: string) =>
+            key === 'savedTabs'
+              ? {
+                  savedTabs: [
+                    {
+                      domain: 'react.dev',
+                      id: 'group-1',
+                      urlIds: ['url-1'],
+                    },
+                  ],
+                }
+              : {},
+          ),
+        },
+      },
+    } as unknown as typeof chrome
+
+    mocked.getUserSettings.mockResolvedValue({
+      language: 'en',
+      ollamaModel: 'llama3.2',
+    })
+
+    const result = await runAiChatRequest({
+      history: [],
+      prompt: 'What tabs did I add this month?',
+    })
+
+    const generateArgs = mocked.generateText.mock.calls[0]?.[0] as {
+      tools: Record<string, { description: string }>
+    }
+
+    for (const toolDefinition of getAiChatToolDefinitions('en')) {
+      expect(generateArgs.tools[toolDefinition.name]?.description).toBe(
+        toolDefinition.description,
+      )
+    }
+    expect(result.reasoning).toContain('List saved tabs')
+    expect(result.toolTraces[0]?.title).toBe('List saved tabs')
   })
 
   it('active system prompt template を使い、placeholder に context を差し込む', async () => {

--- a/src/lib/background/ai-chat.ts
+++ b/src/lib/background/ai-chat.ts
@@ -1,7 +1,7 @@
 import { generateText, stepCountIs } from 'ai'
 import { createOllama } from 'ai-sdk-ollama'
 
-import { AI_CHAT_TOOL_TITLES } from '@/constants/aiChatTools'
+import { getAiChatToolTitle } from '@/constants/aiChatTools'
 import { buildTextAttachmentContext } from '@/features/ai-chat/lib/attachments'
 import { buildAiSavedUrlRecords } from '@/features/ai-chat/lib/buildAiContext'
 import { inferUserInterests } from '@/features/ai-chat/lib/inferInterests'
@@ -275,8 +275,8 @@ const getStringValue = (
   return typeof value === 'string' ? value : undefined
 }
 
-const getToolTitle = (toolName: string): string =>
-  AI_CHAT_TOOL_TITLES[toolName] || toolName
+const getToolTitle = (language: AppLanguage, toolName: string): string =>
+  getAiChatToolTitle(language, toolName)
 
 const getToolResultCount = (output: unknown): number | null => {
   if (Array.isArray(output)) {
@@ -365,9 +365,11 @@ const getAllToolResults = (
 }
 
 const createToolTracesFromParts = ({
+  language,
   toolCalls,
   toolResults,
 }: {
+  language: AppLanguage
   toolCalls?: GenerateTextToolCallLike[]
   toolResults?: GenerateTextToolResultLike[]
 }): AiChatToolTrace[] => {
@@ -385,7 +387,7 @@ const createToolTracesFromParts = ({
       input: toolCall.input,
       output: toolResult?.output,
       state: toolResult ? 'output-available' : 'input-available',
-      title: getToolTitle(toolCall.toolName),
+      title: getToolTitle(language, toolCall.toolName),
       toolCallId: toolCall.toolCallId,
       toolName: toolCall.toolName,
       type: 'dynamic-tool',
@@ -393,8 +395,12 @@ const createToolTracesFromParts = ({
   })
 }
 
-const createToolTraces = (result: GenerateTextResultLike): AiChatToolTrace[] =>
+const createToolTraces = (
+  result: GenerateTextResultLike,
+  language: AppLanguage,
+): AiChatToolTrace[] =>
   createToolTracesFromParts({
+    language,
     toolCalls: getAllToolCalls(result),
     toolResults: getAllToolResults(result),
   })
@@ -686,6 +692,7 @@ const runAiChatRequest = async (
         model: ollama(ollamaModel),
         onStepFinish: (stepResult) => {
           const stepToolTraces = createToolTracesFromParts({
+            language,
             toolCalls: stepResult.toolCalls,
             toolResults: stepResult.toolResults,
           })
@@ -725,7 +732,7 @@ const runAiChatRequest = async (
 
   const toolTraces = mergeToolTraces(
     streamedToolTraces,
-    createToolTraces(result),
+    createToolTraces(result, language),
   )
   const toolCharts = getChartsFromToolTraces(toolTraces)
   const fallbackCharts =


### PR DESCRIPTION
## 変更内容

`src/constants/aiChatTools.ts` の `AI_CHAT_TOOL_DEFINITIONS` に日本語固定で定義されていた `title` / `description` を、`messages.ts` の i18n key へ置き換え、表示言語と AI SDK へ渡す description が選択言語に応じて切り替わるようにしました。

- `aiChatTools.ts`: 固定文言を廃止し `titleKey` / `descriptionKey` を持つ形へ変更。`getAiChatToolTitle` / `getAiChatToolDescription` / `getAiChatToolDefinitions` を追加。未知の toolName は `toolName` へ fallback。`AI_CHAT_TOOL_TITLES` / `AI_CHAT_TOOL_DESCRIPTIONS` を削除。
- `messages.ts`: `aiChat.tool.<name>.title` / `.description` を en / ja 両方に追加（ja は現行文言相当、en は新規訳）。
- `ai-chat-tools.ts`: `createAiChatTools(records, language)` が言語別 description を AI SDK tool へ渡すよう変更。
- `ai-chat.ts`: `getToolTitle` / `createToolTracesFromParts` / `createToolTraces` が `language` を受け取り、reasoning と tool traces のタイトルが言語別に出るように変更。
- `SystemPromptManagerDialog.tsx`: 「Available tools」の説明を `useI18n()` の `language` で解決するよう変更。

## テスト

- `ai-chat-tools.test.ts`: `language=ja` / `language=en` で AI SDK tool の description が切替わるテストを追加。
- `ai-chat.test.ts`: `language=en` で英語 description が渡り、reasoning と tool trace の title が英語になるテストを追加。
- `SavedTabsChatWidget.test.tsx`: Available tools 表示検証を `getAiChatToolDefinitions('en')` へ更新。

Closes #576

## チェックリスト

- [x] ローカル環境でエラーになっていない（`bun run compile` / `bun run test:node` / `bun run test:dom` / `bun run knip` / format 通過）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI chat tools now fully support internationalization. Tool titles, descriptions, and related content dynamically display in your selected UI language, providing a consistent multilingual experience across system prompts and AI-assisted features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->