### PR TITLE
domain層の現在時刻直接依存をClockPort経由に変更

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -592,6 +592,11 @@
             "object": "chrome",
             "property": "runtime",
             "message": "domain 層は chrome.runtime を直接利用できません"
+          },
+          {
+            "object": "Date",
+            "property": "now",
+            "message": "domain 層は Date.now() を直接利用できません。ClockPort 経由で時刻を注入してください"
           }
         ]
       }

--- a/src/contexts/saved-tabs/application/SavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/application/SavedTabsUseCasesDeps.ts
@@ -10,6 +10,7 @@ import type { BrowserTabPort } from './ports/BrowserTabPort'
 import type { BrowserWindowPort } from './ports/BrowserWindowPort'
 import type { CategoriesCommandService } from './ports/CategoriesCommandService'
 import type { CategoryAssignmentPort } from './ports/CategoryAssignmentPort'
+import type { ClockPort } from './ports/ClockPort'
 import type { CustomProjectsCommandService } from './ports/CustomProjectsCommandService'
 import type { MessagingPort } from './ports/MessagingPort'
 import type { MigrationPort } from './ports/MigrationPort'
@@ -25,6 +26,7 @@ export interface SavedTabsUseCasesDeps {
   readonly browserWindowPort: BrowserWindowPort
   readonly categoriesCommandService: CategoriesCommandService
   readonly categoryAssignmentPort: CategoryAssignmentPort
+  readonly clock: ClockPort
   readonly customProjectRepository: CustomProjectRepository
   readonly customProjectsCommandService: CustomProjectsCommandService
   readonly domainCategoryMappingRepository: DomainCategoryMappingRepository

--- a/src/contexts/saved-tabs/application/createSavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/application/createSavedTabsUseCases.ts
@@ -101,6 +101,7 @@ export const createSavedTabsUseCases = (
     urlRecordRepository: deps.urlRecordRepository,
   }),
   createCustomProject: createCreateCustomProjectUseCase({
+    clock: deps.clock,
     customProjectRepository: deps.customProjectRepository,
   }),
   createParentCategory: createCreateParentCategoryUseCase({
@@ -108,6 +109,7 @@ export const createSavedTabsUseCases = (
     parentCategoryRepository: deps.parentCategoryRepository,
   }),
   deleteCustomProject: createDeleteCustomProjectUseCase({
+    clock: deps.clock,
     customProjectRepository: deps.customProjectRepository,
     uncategorizedProjectId:
       // `lib/storage/projects` 側の sentinel に揃える。`chrome.storage.local`
@@ -331,6 +333,7 @@ export const createSavedTabsUseCases = (
     tabGroupRepository: deps.tabGroupRepository,
   }),
   updateCustomProjectName: createUpdateCustomProjectNameUseCase({
+    clock: deps.clock,
     customProjectRepository: deps.customProjectRepository,
   }),
 })

--- a/src/contexts/saved-tabs/application/ports/ClockPort.ts
+++ b/src/contexts/saved-tabs/application/ports/ClockPort.ts
@@ -1,0 +1,21 @@
+/**
+ * 現在時刻の取得を application / infrastructure から注入するための port。
+ *
+ * domain 層は現在時刻へ直接依存してはならず (`.oxlintrc.json` の
+ * `no-restricted-properties` と `dddLayerGuard.test.ts` で検出)。
+ * 現在時刻が必要な use-case は本 port 経由で `now()` を呼び、
+ * 取得した値を domain value object (例: `createSavedAt`) へ渡す。
+ *
+ * 戻り値は `SavedAt` value object が前提とする UNIX epoch ミリ秒
+ * (`number`) とする。`Date` オブジェクトへの変換は呼び出し側の
+ * 責務に任せ、port 自体は epoch ms のみを返す。
+ *
+ * @example
+ * ```ts
+ * const now = clock.now()
+ * const savedAt = createSavedAt(now)
+ * ```
+ */
+export interface ClockPort {
+  readonly now: () => number
+}

--- a/src/contexts/saved-tabs/application/use-cases/CreateCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/CreateCustomProjectUseCase.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 import type { SavedTabsCustomProjectDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { toSavedTabsCustomProjectDto } from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
+import type { ClockPort } from '@/contexts/saved-tabs/application/ports/ClockPort'
 import type { CustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import { createCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import type { CustomProjectRepository } from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
@@ -25,12 +26,11 @@ export type CreateCustomProjectUseCase = (
 
 export interface CreateCustomProjectUseCaseDeps {
   readonly customProjectRepository: CustomProjectRepository
+  readonly clock: ClockPort
   readonly generateId?: () => string
-  readonly now?: () => number
 }
 
 const defaultGenerateId = (): string => uuidv4()
-const defaultNow = (): number => Date.now()
 
 /**
  * `CreateCustomProjectUseCase` を生成する。
@@ -62,7 +62,7 @@ export const createCreateCustomProjectUseCase = (
     }
     // eslint-disable-next-line typescript/no-unsafe-type-assertion
     const id = (deps.generateId ?? defaultGenerateId)() as CustomProjectId
-    const now = (deps.now ?? defaultNow)()
+    const now = deps.clock.now()
     const newProject = createCustomProject({
       categories: [],
       createdAt: now,

--- a/src/contexts/saved-tabs/application/use-cases/CustomProjectManagementUseCases.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/CustomProjectManagementUseCases.test.ts
@@ -42,7 +42,7 @@ describe('custom project management use-cases', () => {
     const createProject = createCreateCustomProjectUseCase({
       customProjectRepository,
       generateId: () => 'project-2',
-      now: () => 10,
+      clock: { now: () => 10 },
     })
 
     const result = await createProject({ name: '  Reading  ' })
@@ -62,6 +62,7 @@ describe('custom project management use-cases', () => {
   it('既定ID・時刻生成でもprojectを生成できる', async () => {
     const customProjectRepository = createRepository()
     const createProject = createCreateCustomProjectUseCase({
+      clock: { now: () => 1_700_000_000_000 },
       customProjectRepository,
     })
 
@@ -79,6 +80,7 @@ describe('custom project management use-cases', () => {
   ])('空名と重複名を拒否する: %s', async (name, message) => {
     const customProjectRepository = createRepository([existingProject()])
     const createProject = createCreateCustomProjectUseCase({
+      clock: { now: () => 0 },
       customProjectRepository,
     })
 
@@ -98,7 +100,7 @@ describe('custom project management use-cases', () => {
     const customProjectRepository = createRepository([existingProject(), other])
     const updateName = createUpdateCustomProjectNameUseCase({
       customProjectRepository,
-      now: () => 20,
+      clock: { now: () => 20 },
     })
 
     const result = await updateName({
@@ -129,6 +131,7 @@ describe('custom project management use-cases', () => {
     })
     const customProjectRepository = createRepository([existingProject(), other])
     const updateName = createUpdateCustomProjectNameUseCase({
+      clock: { now: () => 0 },
       customProjectRepository,
     })
 

--- a/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.test.ts
@@ -50,6 +50,7 @@ const baseTimestamp = 1_700_000_000_000
 const createDeps = (
   repo: CustomProjectRepository,
 ): DeleteCustomProjectUseCaseDeps => ({
+  clock: { now: () => baseTimestamp },
   customProjectRepository: repo,
   uncategorizedProjectId: 'custom-uncategorized',
 })
@@ -107,7 +108,7 @@ describe('createDeleteCustomProjectUseCase', () => {
 
     const useCase = createDeleteCustomProjectUseCase({
       ...createDeps(repo),
-      now: () => baseTimestamp,
+      clock: { now: () => baseTimestamp },
     })
     const result = await useCase({
       projectId: createCustomProjectId('project-1'),

--- a/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-type-assertion */
 import type { SavedTabsCustomProjectDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { toSavedTabsCustomProjectDto } from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
+import type { ClockPort } from '@/contexts/saved-tabs/application/ports/ClockPort'
 import type { CustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import { SavedTabsDomainError } from '@/contexts/saved-tabs/domain/errors/SavedTabsDomainError'
 import type {
@@ -31,11 +32,11 @@ export interface DeleteCustomProjectUseCaseDeps {
   readonly customProjectRepository: CustomProjectRepository
   readonly uncategorizedProjectId: string
   /**
-   * 現在のエポックミリ秒。未分類プロジェクトを新規作成するときの
-   * `createdAt` / `updatedAt` に使う（テスト時は固定値を注入して
-   * 時刻依存を排除する）。
+   * 現在時刻の取得 port。未分類プロジェクトを新規作成するときの
+   * `createdAt` / `updatedAt` に使う（テスト時は固定時刻を返す stub
+   * を注入して時刻依存を排除する）。
    */
-  readonly now?: () => number
+  readonly clock: ClockPort
 }
 
 /**
@@ -58,7 +59,6 @@ export interface DeleteCustomProjectUseCaseDeps {
 export const createDeleteCustomProjectUseCase = (
   deps: DeleteCustomProjectUseCaseDeps,
 ): DeleteCustomProjectUseCase => {
-  const now = deps.now ?? ((): number => Date.now())
   return async (command) => {
     if (command.projectId === deps.uncategorizedProjectId) {
       throw new SavedTabsDomainError(
@@ -118,7 +118,7 @@ export const createDeleteCustomProjectUseCase = (
         mergedRawBase = entityToRawSnapshot(merged)
       }
     } else {
-      const timestamp = now()
+      const timestamp = deps.clock.now()
       const createdUncategorized: CustomProject = {
         categories: [],
         createdAt: timestamp as never,

--- a/src/contexts/saved-tabs/application/use-cases/UpdateCustomProjectNameUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/UpdateCustomProjectNameUseCase.ts
@@ -1,5 +1,6 @@
 import type { SavedTabsCustomProjectDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { toSavedTabsCustomProjectDto } from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
+import type { ClockPort } from '@/contexts/saved-tabs/application/ports/ClockPort'
 import type { CustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import type { CustomProjectRepository } from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
 import { createCategoryName } from '@/contexts/saved-tabs/domain/value-objects/CategoryName'
@@ -22,10 +23,8 @@ export type UpdateCustomProjectNameUseCase = (
 
 export interface UpdateCustomProjectNameUseCaseDeps {
   readonly customProjectRepository: CustomProjectRepository
-  readonly now?: () => number
+  readonly clock: ClockPort
 }
-
-const defaultNow = (): number => Date.now()
 
 /**
  * `UpdateCustomProjectNameUseCase` を生成する。
@@ -52,7 +51,7 @@ export const createUpdateCustomProjectNameUseCase = (
       throw new Error(`DUPLICATE_PROJECT_NAME:${newName}`)
     }
     const targetId = createCustomProjectId(command.projectId)
-    const now = createSavedAt((deps.now ?? defaultNow)())
+    const now = createSavedAt(deps.clock.now())
     const updatedAll: CustomProject[] = []
     let updated: CustomProject | null = null
     for (const project of all) {

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -192,6 +192,36 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       expect(names).toContain('chrome.notifications')
       expect(names).toContain('chrome.runtime')
     })
+
+    it('issue #582: Date.now() を no-restricted-properties で禁止している', () => {
+      const names = getRestrictedProperties(override)
+      expect(names).toContain('Date.now')
+    })
+
+    it('issue #582: domain 層のソースファイルが Date.now( / new Date( を直接使わない', () => {
+      // JSDoc やコメント内の言及は対象外とする。
+      // 検出したいのは「現在時刻の取得」という
+      // 副作用での実際のコード呼び出しのみ。
+      const stripComments = (source: string): string =>
+        source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+      const domainRoot = resolve(repoRoot, 'src/contexts/saved-tabs/domain')
+      const domainSourceFiles = collectSourceFiles(domainRoot)
+      expect(domainSourceFiles.length).toBeGreaterThan(0)
+      for (const absolutePath of domainSourceFiles) {
+        const relativePath = relative(repoRoot, absolutePath)
+          .split(sep)
+          .join('/')
+        const source = stripComments(readFileSync(absolutePath, 'utf8'))
+        expect(
+          source,
+          `${relativePath} should not call Date.now() directly (use ClockPort)`,
+        ).not.toMatch(/\bDate\.now\s*\(/)
+        expect(
+          source,
+          `${relativePath} should not call new Date() directly (use ClockPort)`,
+        ).not.toMatch(/\bnew\s+Date\s*\(/)
+      }
+    })
   })
 
   describe('application 層', () => {
@@ -1104,6 +1134,71 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       expect(savedTabsAppSource).not.toMatch(
         /Chrome\.storage\.local\.set\(\{\s*savedTabs:\s*newGroups/,
       )
+    })
+  })
+
+  describe('issue #582: domain 層の直接時刻依存を禁止する ClockPort 導入', () => {
+    it('ClockPort が定義されている', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/ports/ClockPort.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('interface ClockPort')
+      expect(source).toContain('now:')
+    })
+
+    it('ClockPort は chrome API を import / 利用しない', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/ports/ClockPort.ts',
+        ),
+        'utf8',
+      )
+      expect(source).not.toMatch(/from\s+['"]chrome['"]/)
+      // ClockPort はプリントの interface のみで、Date.now() も使わない
+      expect(source).not.toMatch(/\bDate\.now\s*\(/)
+    })
+
+    it('SystemClockAdapter が定義されている', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/infrastructure/browser/SystemClockAdapter.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('ClockPort')
+      expect(source).toContain('createSystemClock')
+      // SystemClock は infrastructure 層なので Date.now() 使用は OK
+      expect(source).toContain('Date.now()')
+    })
+
+    it('createSavedTabsUseCasesDeps は clock を組み立てる', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('clock:')
+      expect(source).toContain('createSystemClock')
+    })
+
+    it('SavedTabsUseCasesDeps は clock を含む', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/SavedTabsUseCasesDeps.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('clock: ClockPort')
+      expect(source).toContain('import type { ClockPort }')
     })
   })
 })

--- a/src/contexts/saved-tabs/domain/README.md
+++ b/src/contexts/saved-tabs/domain/README.md
@@ -20,4 +20,3 @@
 - `toast` / router / DOM API 依存
 - 副作用（`Date.now()` などの現在時刻依存は `application/ports/ClockPort` 経由で注入）
 - `repositories/` から `infrastructure/` 配下を import する（interface のみで完結させる）
-- 現在の時刻取得は `Date.now()` を直接利用する。現在時刻依存を port 経由で注入したくなったら別途 `application/ports/` へ追加する。

--- a/src/contexts/saved-tabs/domain/value-objects/SavedAt.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/SavedAt.ts
@@ -5,10 +5,10 @@ declare const savedAtBrand: unique symbol
 /**
  * 保存タブの保存時刻（UNIX epoch ミリ秒）を表す不変値オブジェクト。
  *
- * `Date.now()` で得られる数値を想定する。0 以上の整数で、
- * `Number.isFinite` を満たす値のみ許容する。domain 層では値の妥当性のみ
- * 検証し、現在時刻取得の抽象化が必要な use-case では `Date.now()` を直接
- * 利用する（専用の port を導入する判断は use-case 側で個別に行う）。
+ * 主に `ClockPort.now()` で得られる UNIX epoch ミリ秒を想定する。
+ * 0 以上の整数で、`Number.isFinite` を満たす値のみ許容する。
+ * domain 層では値の妥当性のみ検証し、現在時刻の取得は
+ * `application/ports/ClockPort` 経由で use-case から注入する。
  *
  * @example
  * ```ts

--- a/src/contexts/saved-tabs/infrastructure/browser/SystemClockAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/SystemClockAdapter.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createSystemClock } from './SystemClockAdapter'
+
+describe('SystemClockAdapter', () => {
+  it('Date.now() を呼び出して epoch ms を返す', () => {
+    const clock = createSystemClock()
+    const spy = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+    expect(clock.now()).toBe(1_700_000_000_000)
+    expect(spy).toHaveBeenCalledOnce()
+    spy.mockRestore()
+  })
+
+  it('ClockPort interface に適合する', () => {
+    const clock = createSystemClock()
+    expect(clock.now).toBeTypeOf('function')
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/browser/SystemClockAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/SystemClockAdapter.test.ts
@@ -1,14 +1,17 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createSystemClock } from './SystemClockAdapter'
 
 describe('SystemClockAdapter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('Date.now() を呼び出して epoch ms を返す', () => {
     const clock = createSystemClock()
     const spy = vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
     expect(clock.now()).toBe(1_700_000_000_000)
     expect(spy).toHaveBeenCalledOnce()
-    spy.mockRestore()
   })
 
   it('ClockPort interface に適合する', () => {

--- a/src/contexts/saved-tabs/infrastructure/browser/SystemClockAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/SystemClockAdapter.ts
@@ -1,0 +1,12 @@
+import type { ClockPort } from '@/contexts/saved-tabs/application/ports/ClockPort'
+
+/**
+ * `Date.now()` を `ClockPort` に適合させる adapter。
+ *
+ * 現在時刻の取得を `Date.now()` に直接依存するのは infrastructure 層の
+ * 責務であり、application / domain 層は本 adapter 経由で注入された
+ * `ClockPort` を利用する。テストでは固定時刻を返す stub に差し替える。
+ */
+export const createSystemClock = (): ClockPort => ({
+  now: () => Date.now(),
+})

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
@@ -6,6 +6,7 @@ import { createChromeMessagingAdapter } from '@/contexts/saved-tabs/infrastructu
 import type { ChromeApiLike as ChromeMessagingApiLike } from '@/contexts/saved-tabs/infrastructure/browser/ChromeMessagingAdapter'
 import { createChromeStorageChangeAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter'
 import { createSonnerNotificationAdapter } from '@/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter'
+import { createSystemClock } from '@/contexts/saved-tabs/infrastructure/browser/SystemClockAdapter'
 import { createChromeCustomProjectRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository'
 import { createChromeDomainCategoryMappingRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeDomainCategoryMappingRepository'
 import { createChromeDomainCategorySettingsRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeDomainCategorySettingsRepository'
@@ -123,6 +124,7 @@ export const createSavedTabsUseCasesDeps = (
       getApi: () => getChromeApi(),
     }),
     categoriesCommandService: createLibCategoriesCommandService(),
+    clock: createSystemClock(),
     categoryAssignmentPort: createLibCategoryAssignmentPort({
       parentCategoryRepository: createChromeParentCategoryRepository(port),
       tabGroupRepository: createChromeTabGroupRepository(port),

--- a/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
@@ -120,6 +120,7 @@ const createBundle = (initial: StorageState = {}): Bundle => {
   const notification = createCaptureNotificationPort()
   const deps: SavedTabsUseCasesDeps = {
     browserTabPort: browserTabPort.port,
+    clock: { now: () => 0 },
     browserWindowPort: browserWindowPort.port,
     categoriesCommandService: {
       updateDomainCategorySettings: vi.fn().mockResolvedValue(undefined),
@@ -462,6 +463,7 @@ describe('savedTabs DDD 移行 後 回帰テスト', () => {
       const notification = createCaptureNotificationPort()
       const deps: SavedTabsUseCasesDeps = {
         browserTabPort,
+        clock: { now: () => 0 },
         browserWindowPort,
         categoriesCommandService: {
           updateDomainCategorySettings: vi.fn().mockResolvedValue(undefined),

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
@@ -89,6 +89,7 @@ const buildLayoutComposition = () => {
     browserTabPort: {
       open: async (input: { url: string }) => ({ url: input.url }),
     },
+    clock: { now: () => 0 },
     browserWindowPort: {
       openWithUrls: async (input: { urls: readonly string[] }) => ({
         urls: [...input.urls],


### PR DESCRIPTION
## 変更内容

issue #582 に対応し、DDD の domain 層が現在時刻へ直接依存しないよう修正しました。

### 新規追加

- **ClockPort** (`application/ports/ClockPort.ts`) — 現在時刻の取得を application / infrastructure から注入する port interface。`now(): number` で UNIX epoch ミリ秒を返す（`SavedAt` value object と整合）。
- **SystemClockAdapter** (`infrastructure/browser/SystemClockAdapter.ts`) — `Date.now()` を `ClockPort` に適合させる infrastructure 層 adapter。他の `BrowserTabPort` / `NotificationPort` と同じ port-adapter パターン。

### 修正

- **SavedTabsUseCasesDeps** に `clock: ClockPort` を追加し、composition で `createSystemClock()` を組み立てる。
- **3 つの use-case**（`CreateCustomProjectUseCase` / `UpdateCustomProjectNameUseCase` / `DeleteCustomProjectUseCase`）を `now?: () => number` + 重複 `defaultNow` から `clock: ClockPort` へ統一。
- `.oxlintrc.json` の domain override に `no-restricted-properties` で `Date.now` を禁止。
- `dddLayerGuard.test.ts` に domain 層ソースファイルの `Date.now(` / `new Date(` 検出テストを追加（コメント除去後にコードのみ検査）。
- domain README と `SavedAt.ts` の JSDoc から「`Date.now()` を直接利用する」という矛盾記述を削除し、ClockPort を参照するよう更新。

## チェックリスト

- [x] ローカル環境でエラーになっていない

Closes #582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a `ClockPort` time abstraction for the saved tabs context and updated relevant use cases and dependency wiring to use it for all timestamp generation.
  * Added a system clock adapter to provide real-time values via the port.
* **Tests**
  * Updated use-case and integration tests to inject deterministic clock values.
  * Added guard tests ensuring the domain layer no longer directly uses system time.
* **Documentation**
  * Clarified “no direct system time” rules and updated domain documentation around time sourcing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->