### PR TITLE
[DDD] Disallow presentation tests from importing domain layer directly

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -158,6 +158,16 @@ module.exports = {
       from: { path: '^src/contexts/[^/]+/presentation/' },
       to: { path: '^src/contexts/[^/]+/domain/' },
     },
+    {
+      name: 'no-presentation-tests-to-domain',
+      comment:
+        'Presentation tests must use application DTO fixtures instead of domain entities',
+      severity: 'error',
+      from: {
+        path: '^src/contexts/[^/]+/presentation/.*\\.(test|spec)\\.(ts|tsx)$',
+      },
+      to: { path: '^src/contexts/[^/]+/domain/' },
+    },
     ...noCrossContextRules,
   ],
   options: {

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -114,6 +114,41 @@ const collectSourceFiles = (dir: string): string[] => {
   return result
 }
 
+const collectTestFiles = (dir: string): string[] => {
+  const result: string[] = []
+  let entries: string[]
+  try {
+    entries = readdirSync(dir)
+  } catch {
+    return result
+  }
+  for (const entry of entries) {
+    const fullPath = resolve(dir, entry)
+    let stats
+    try {
+      stats = statSync(fullPath)
+    } catch {
+      continue
+    }
+    if (stats.isDirectory()) {
+      result.push(...collectTestFiles(fullPath))
+      continue
+    }
+    if (!stats.isFile()) {
+      continue
+    }
+    if (
+      entry.endsWith('.test.ts') ||
+      entry.endsWith('.test.tsx') ||
+      entry.endsWith('.spec.ts') ||
+      entry.endsWith('.spec.tsx')
+    ) {
+      result.push(fullPath)
+    }
+  }
+  return result
+}
+
 describe('src/contexts/saved-tabs DDD layer guard', () => {
   const config = loadOxlintConfig()
   const dependencyCruiserSource = readFileSync(
@@ -280,6 +315,33 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
           source,
           `${relativePath} should not import @/types/storage`,
         ).not.toMatch(/from\s+['"]@\/types\/storage['"]/)
+      }
+    })
+  })
+
+  describe('issue #583: presentation test は domain 層を直接 import しない', () => {
+    it('dependency-cruiser に presentation test → domain 依存禁止 rule が定義されている', () => {
+      expect(dependencyCruiserSource).toContain(
+        "name: 'no-presentation-tests-to-domain'",
+      )
+    })
+
+    it('presentation 配下の test / spec ファイルが domain を直接 import していない', () => {
+      const presentationRoot = resolve(
+        repoRoot,
+        'src/contexts/saved-tabs/presentation',
+      )
+      const presentationTestFiles = collectTestFiles(presentationRoot)
+      expect(presentationTestFiles.length).toBeGreaterThan(0)
+      for (const absolutePath of presentationTestFiles) {
+        const relativePath = relative(repoRoot, absolutePath)
+          .split(sep)
+          .join('/')
+        const source = readFileSync(absolutePath, 'utf8')
+        expect(
+          source,
+          `${relativePath} should not import from domain/`,
+        ).not.toMatch(/from\s+['"][^'"]*domain\//)
       }
     })
   })

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -341,7 +341,7 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
         expect(
           source,
           `${relativePath} should not import from domain/`,
-        ).not.toMatch(/from\s+['"][^'"]*domain\//)
+        ).not.toMatch(/import\s+['"][^'"]*domain\/|from\s+['"][^'"]*domain\//)
       }
     })
   })

--- a/src/lib/architecture/dependencyCruiserConfig.test.ts
+++ b/src/lib/architecture/dependencyCruiserConfig.test.ts
@@ -315,6 +315,25 @@ describe('dependency-cruiser architecture rules', () => {
       },
     },
     {
+      name: 'presentation test dependencies on domain',
+      rule: 'no-presentation-tests-to-domain',
+      files: {
+        'src/contexts/foo/domain/entity.ts': 'export const entity = 1\n',
+        'src/contexts/foo/presentation/view.test.ts':
+          "import '../domain/entity'\n",
+      },
+    },
+    {
+      name: 'type-only presentation test dependencies on domain',
+      rule: 'no-presentation-tests-to-domain',
+      files: {
+        'src/contexts/foo/domain/entity.ts':
+          'export interface DomainEntity {}\n',
+        'src/contexts/foo/presentation/view.test.tsx':
+          "import type { DomainEntity } from '../domain/entity'\nexport type ViewEntity = DomainEntity\n",
+      },
+    },
+    {
       name: 'direct dependencies between contexts',
       rule: 'no-foo-to-other-context',
       files: {


### PR DESCRIPTION
Closes #583

## 変更内容

- `.dependency-cruiser.cjs` に `no-presentation-tests-to-domain` ルールを追加し、presentation 配下の test / spec ファイルから domain 層への直接 import を禁止する
- `dependencyCruiserConfig.test.ts` に新ルールのテストケース（値 import / type-only import）を追加
- `dddLayerGuard.test.ts` に `collectTestFiles` ヘルパーと、presentation test が domain を import していないことを検証するガードテストを追加

## 背景

PR #577 (issue #573) で `no-presentation-to-domain` ルールを追加し、presentation 層全体の domain 直接依存を禁止済みです。本 PR は presentation test 専用のルールを追加し、テストファイルが domain entity / repository / value object を fixture として直接使わないことを明示的に担保します。

## チェックリスト

- [x] ローカル環境でエラーになっていない
- [x] `bun run arch:check` が通る
- [x] `bun run test` が通る
- [x] `bun run quality` が通る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure presentation-layer test/spec files don’t import from their corresponding domain modules, including both standard and type-only imports.
  * Added a helper to recursively enumerate presentation test/spec files and validate they don’t reference domain code.
  * Extended architecture validation tests to exercise the new boundary rule.
* **Chores**
  * Introduced an automated dependency validation rule to prevent cross-layer coupling between presentation tests/specs and domain modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->