### PR TITLE
domain/repositories を contract のみに固定する guard test を追加

### DIFF
--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -1303,7 +1303,7 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
         expect(
           source,
           `${relativePath} should not instantiate classes`,
-        ).not.toMatch(/\bnew\s+[A-Z]/)
+        ).not.toMatch(/\bnew\s+[a-zA-Z]/)
         expect(source, `${relativePath} should not use chrome API`).not.toMatch(
           /\bchrome\./,
         )
@@ -1319,7 +1319,7 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
           /\bindexedDB\b/,
         )
         expect(source, `${relativePath} should not call fetch()`).not.toMatch(
-          /\bfetch\(/,
+          /\bfetch\s*\(/,
         )
       })
     }

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -1263,4 +1263,65 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       expect(source).toContain('import type { ClockPort }')
     })
   })
+
+  describe('issue #584: domain/repositories/ は contract のみで実装を含まない', () => {
+    // `src/contexts/*/domain/repositories/` 配下は interface / type /
+    // DTO contract の置き場であり、実装 class や Chrome Storage /
+    // IndexedDB / localStorage / fetch などの外部 API 呼び出しを
+    // 混入させない。実装は infrastructure 層に置く。
+    //
+    // JSDoc 内の禁止 API 言及は対象外とするため、コメントを除去してから
+    // 検査する (issue #582 の stripComments と同じ方針)。
+    const contextsDir = resolve(repoRoot, 'src/contexts')
+    const repositoryFiles: string[] = []
+    for (const entry of readdirSync(contextsDir)) {
+      const repositoriesDir = resolve(
+        contextsDir,
+        entry,
+        'domain',
+        'repositories',
+      )
+      repositoryFiles.push(...collectSourceFiles(repositoriesDir))
+    }
+
+    it('検査対象の repository contract ファイルが存在する', () => {
+      expect(repositoryFiles.length).toBeGreaterThan(0)
+    })
+
+    const stripComments = (source: string): string =>
+      source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+
+    for (const absolutePath of repositoryFiles) {
+      const relativePath = relative(repoRoot, absolutePath).split(sep).join('/')
+
+      it(`${relativePath} は実装 class / 外部 API 呼び出しを含まない`, () => {
+        const source = stripComments(readFileSync(absolutePath, 'utf8'))
+        expect(
+          source,
+          `${relativePath} should not contain class declarations`,
+        ).not.toMatch(/\bclass\b/)
+        expect(
+          source,
+          `${relativePath} should not instantiate classes`,
+        ).not.toMatch(/\bnew\s+[A-Z]/)
+        expect(source, `${relativePath} should not use chrome API`).not.toMatch(
+          /\bchrome\./,
+        )
+        expect(
+          source,
+          `${relativePath} should not use localStorage`,
+        ).not.toMatch(/\blocalStorage\./)
+        expect(
+          source,
+          `${relativePath} should not use sessionStorage`,
+        ).not.toMatch(/\bsessionStorage\./)
+        expect(source, `${relativePath} should not use indexedDB`).not.toMatch(
+          /\bindexedDB\b/,
+        )
+        expect(source, `${relativePath} should not call fetch()`).not.toMatch(
+          /\bfetch\(/,
+        )
+      })
+    }
+  })
 })


### PR DESCRIPTION
Closes #584

## 変更内容

issue #584 の対応として、`dddLayerGuard.test.ts` に `src/contexts/*/domain/repositories/` 配下の純度を検査する guard test を追加した。

DDD では `domain/repositories/` は repository contract / interface の置き場であり、Chrome Storage / IndexedDB / localStorage / fetch などの実装詳細は infrastructure 層に置く。本 guard test は `dependency-cruiser` では検出しにくい「domain への実装 class や外部 API 呼び出しの混入」をテストで防ぐ。

### 検査内容

`src/contexts/*/domain/repositories/` 配下の全 `.ts` ファイル（テストファイル除外）について、JSDoc コメントを除去した上で以下を検査する:

- `class` 宣言を含まない
- `new SomeClass` 形式のインスタンス化を含まない
- `chrome.` プロパティアクセスを含まない
- `localStorage.` を含まない
- `sessionStorage.` を含まない
- `indexedDB` を含まない
- `fetch(` を含まない

JSDoc 内の「`chrome.storage.local` の直接アクセスは禁止」のような禁止 API 言及は false positive になるため、コメント除去後に検査する (issue #582 の `stripComments` と同じ方針)。

### 設計判断

- 既存の `dddLayerGuard.test.ts` の書き方に合わせ、新規ファイルではなく既存テストへの追加とした
- `src/contexts/*/domain/repositories/` に一般化し、将来の context 追加にも自動で効くようにした
- 既存の issue #457 guard test (4 ファイル限定、raw source に厳密な regex) と相補して、全ファイル × より広いパターンをカバーする

## チェックリスト

- [x] ローカル環境でエラーになっていない
- [x] `bun run test` が通る (3079 tests passed)
- [x] `bun run compile` が通る
- [x] `bun run lint` / `bun run format` が通る
- [x] `bun run knip` / `bun run arch:check` / `bun run secretlint` が通る


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added new test coverage to enforce architectural consistency across repository contract implementations, ensuring they avoid prohibited constructs and direct browser/external API usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->