### PR TITLE
[DDD] Restrict cross-context imports to public APIs

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -25,19 +25,36 @@ const getContextNames = () => {
     .map((entry) => entry.name)
 }
 
+// ──────────────────────────────────────────────────────────────────────
+// Cross-context import policy (issue #585)
+//
+// A context may depend on another context ONLY through that context's
+// public API file: src/contexts/{context-name}/public-api.ts
+//
+// Internal files (domain, application, infrastructure, presentation,
+// testing, etc.) of another context must NOT be imported directly.
+//
+// src/contexts/shared/ is a shared kernel. Any context may import from
+// it freely — no public-api.ts restriction applies.
+// ──────────────────────────────────────────────────────────────────────
 const noCrossContextRules = getContextNames().map((contextName) => {
   const escapedContextName = escapeRegExp(contextName)
 
   return {
-    name: `no-${contextName}-to-other-context`,
-    comment: `${contextName} context must not directly depend on another context`,
+    name: `no-${contextName}-to-other-context-internal`,
+    comment: `${contextName} context must depend on another context only through its public-api.ts`,
     severity: 'error',
     from: {
       path: `^src/contexts/${escapedContextName}/`,
     },
     to: {
       path: `^src/contexts/(?!${escapedContextName}/)[^/]+/`,
-      pathNot: ['^src/contexts/shared/'],
+      pathNot: [
+        // shared kernel — freely importable by any context
+        '^src/contexts/shared/',
+        // public API entry point — the only allowed cross-context surface
+        String.raw`^src/contexts/[^/]+/public-api\.ts$`,
+      ],
     },
   }
 })

--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,7 @@ web-ext.config.ts
 
 
 # APM dependencies
-apm_modules/
+apm_modules/.worktrees/
+
+# Worktree directory
+.worktrees/

--- a/src/lib/architecture/dependencyCruiserConfig.test.ts
+++ b/src/lib/architecture/dependencyCruiserConfig.test.ts
@@ -334,8 +334,8 @@ describe('dependency-cruiser architecture rules', () => {
       },
     },
     {
-      name: 'direct dependencies between contexts',
-      rule: 'no-foo-to-other-context',
+      name: 'direct dependencies on another context internal file',
+      rule: 'no-foo-to-other-context-internal',
       files: {
         'src/contexts/bar/domain/entity.ts': 'export const entity = 1\n',
         'src/contexts/foo/domain/entity.ts':
@@ -343,8 +343,8 @@ describe('dependency-cruiser architecture rules', () => {
       },
     },
     {
-      name: 'type-only direct dependencies between contexts',
-      rule: 'no-foo-to-other-context',
+      name: 'type-only direct dependencies on another context internal file',
+      rule: 'no-foo-to-other-context-internal',
       files: {
         'src/contexts/bar/domain/entity.ts':
           'export interface OtherContextEntity {}\n',
@@ -363,6 +363,36 @@ describe('dependency-cruiser architecture rules', () => {
     const result = cruise({
       'src/contexts/foo/application/useCase.ts': "import '../domain/entity'\n",
       'src/contexts/foo/domain/entity.ts': 'export const entity = 1\n',
+    })
+
+    expect(result).toEqual({ status: 0, output: '' })
+  })
+
+  it('allows cross-context import through public-api.ts', () => {
+    const result = cruise({
+      'src/contexts/bar/public-api.ts': 'export const barApi = 1\n',
+      'src/contexts/foo/application/useCase.ts':
+        "import '../../bar/public-api'\n",
+    })
+
+    expect(result).toEqual({ status: 0, output: '' })
+  })
+
+  it('allows type-only cross-context import through public-api.ts', () => {
+    const result = cruise({
+      'src/contexts/bar/public-api.ts': 'export interface BarApi {}\n',
+      'src/contexts/foo/application/useCase.ts':
+        "import type { BarApi } from '../../bar/public-api'\nexport type FooApi = BarApi\n",
+    })
+
+    expect(result).toEqual({ status: 0, output: '' })
+  })
+
+  it('allows cross-context import to shared kernel', () => {
+    const result = cruise({
+      'src/contexts/shared/kernel.ts': 'export const sharedKernel = 1\n',
+      'src/contexts/foo/application/useCase.ts':
+        "import '../../shared/kernel'\n",
     })
 
     expect(result).toEqual({ status: 0, output: '' })


### PR DESCRIPTION
## 変更内容

issue #585: context 間の直接依存を禁止するルールを、`public-api.ts` 経由の依存のみ許可する方針に変更しました。

### 主な変更

- `.dependency-cruiser.cjs` の `noCrossContextRules` を更新:
  - ルール名を `no-{context}-to-other-context` → `no-{context}-to-other-context-internal` に変更
  - `pathNot` に `^src/contexts/[^/]+/public-api\.ts$` を追加し、他 context の `public-api.ts` 経由の import を許可
  - `src/contexts/shared/` は shared kernel として引き続き自由に import 可能
  - 設定ファイルに cross-context import policy のドキュメントコメントを追加

- `dependencyCruiserConfig.test.ts` にテストケースを追加・更新:
  - 既存の cross-context テストのルール名を更新
  - `public-api.ts` 経由の import が許可されることを検証するポジティブケースを追加
  - type-only import も `public-api.ts` 経由なら許可されることを検証
  - `shared/` kernel への import が許可されることを検証するケースを追加

### 方針

- 他 context の内部ファイル (domain, application, infrastructure, presentation, testing) への直接 import は禁止
- 他 context の `public-api.ts` のみ import 可能
- `src/contexts/shared/` は shared kernel として全 context から自由に import 可能

## チェックリスト

- [x] ローカル環境でエラーになっていない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated architecture enforcement rules to require cross-context imports to route through public API files, improving code organization and maintainability.
  * Refined git ignore patterns for better directory structure management.
  * Updated architecture validation tests to verify proper import routing and shared module access patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->