### PR TITLE
infrastructure 実装の wiring を composition 層に制限するルールを追加

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -110,13 +110,12 @@ module.exports = {
       },
     },
     {
-      name: 'no-application-to-infrastructure-or-presentation',
-      comment:
-        'Application code must not depend on infrastructure or presentation',
+      name: 'no-application-to-presentation',
+      comment: 'Application code must not depend on presentation',
       severity: 'error',
       from: { path: '^src/contexts/[^/]+/application/' },
       to: {
-        path: '^src/contexts/[^/]+/(infrastructure|presentation)/',
+        path: '^src/contexts/[^/]+/presentation/',
       },
     },
     {
@@ -160,20 +159,24 @@ module.exports = {
       },
     },
     {
-      name: 'no-presentation-to-infrastructure',
-      comment:
-        'Presentation code must use infrastructure through application ports',
-      severity: 'error',
-      from: { path: '^src/contexts/[^/]+/presentation/' },
-      to: { path: '^src/contexts/[^/]+/infrastructure/' },
-    },
-    {
       name: 'no-presentation-to-domain',
       comment:
         'Presentation code must use application DTOs/view-models instead of domain entities',
       severity: 'error',
       from: { path: '^src/contexts/[^/]+/presentation/' },
       to: { path: '^src/contexts/[^/]+/domain/' },
+    },
+    {
+      name: 'no-infrastructure-construction-outside-composition',
+      comment:
+        'Infrastructure implementations must be wired only from composition, entrypoints, or infrastructure itself',
+      severity: 'error',
+      from: {
+        path: '^src/(?!app/composition/|entrypoints/|contexts/[^/]+/infrastructure/)',
+      },
+      to: {
+        path: '^src/contexts/[^/]+/infrastructure/',
+      },
     },
     {
       name: 'no-presentation-tests-to-domain',

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -275,7 +275,7 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
     it('@/components / @/features/*/components / @/contexts/*/presentation への依存を禁止している', () => {
       expect(dependencyCruiserSource).toContain("name: 'no-application-to-ui'")
       expect(dependencyCruiserSource).toContain(
-        "name: 'no-application-to-infrastructure-or-presentation'",
+        "name: 'no-application-to-presentation'",
       )
     })
 

--- a/src/lib/architecture/dependencyCruiserConfig.test.ts
+++ b/src/lib/architecture/dependencyCruiserConfig.test.ts
@@ -183,12 +183,21 @@ describe('dependency-cruiser architecture rules', () => {
     },
     {
       name: 'application dependencies on infrastructure',
-      rule: 'no-application-to-infrastructure-or-presentation',
+      rule: 'no-infrastructure-construction-outside-composition',
       files: {
         'src/contexts/foo/application/useCase.ts':
           "import '../infrastructure/repository'\n",
         'src/contexts/foo/infrastructure/repository.ts':
           'export const repository = 1\n',
+      },
+    },
+    {
+      name: 'application dependencies on presentation',
+      rule: 'no-application-to-presentation',
+      files: {
+        'src/contexts/foo/presentation/view.ts': 'export const view = 1\n',
+        'src/contexts/foo/application/useCase.ts':
+          "import '../presentation/view'\n",
       },
     },
     {
@@ -278,7 +287,7 @@ describe('dependency-cruiser architecture rules', () => {
     },
     {
       name: 'presentation dependencies on infrastructure',
-      rule: 'no-presentation-to-infrastructure',
+      rule: 'no-infrastructure-construction-outside-composition',
       files: {
         'src/contexts/foo/infrastructure/repository.ts':
           'export const repository = 1\n',
@@ -288,12 +297,32 @@ describe('dependency-cruiser architecture rules', () => {
     },
     {
       name: 'type-only presentation dependencies on infrastructure',
-      rule: 'no-presentation-to-infrastructure',
+      rule: 'no-infrastructure-construction-outside-composition',
       files: {
         'src/contexts/foo/infrastructure/repository.ts':
           'export interface Repository {}\n',
         'src/contexts/foo/presentation/view.ts':
           "import type { Repository } from '../infrastructure/repository'\nexport type ViewRepository = Repository\n",
+      },
+    },
+    {
+      name: 'domain dependencies on infrastructure',
+      rule: 'no-infrastructure-construction-outside-composition',
+      files: {
+        'src/contexts/foo/infrastructure/repository.ts':
+          'export const repository = 1\n',
+        'src/contexts/foo/domain/entity.ts':
+          "import '../infrastructure/repository'\n",
+      },
+    },
+    {
+      name: 'shared utility dependencies on infrastructure',
+      rule: 'no-infrastructure-construction-outside-composition',
+      files: {
+        'src/contexts/foo/infrastructure/repository.ts':
+          'export const repository = 1\n',
+        'src/lib/helper.ts':
+          "import '../contexts/foo/infrastructure/repository'\n",
       },
     },
     {
@@ -378,6 +407,17 @@ describe('dependency-cruiser architecture rules', () => {
     expect(result).toEqual({ status: 0, output: '' })
   })
 
+  it('allows composition layer to wire infrastructure implementations', () => {
+    const result = cruise({
+      'src/contexts/foo/infrastructure/repository.ts':
+        'export const repository = 1\n',
+      'src/app/composition/wireRepositories.ts':
+        "import '../../contexts/foo/infrastructure/repository'\n",
+    })
+
+    expect(result).toEqual({ status: 0, output: '' })
+  })
+
   it('allows type-only cross-context import through public-api.ts', () => {
     const result = cruise({
       'src/contexts/bar/public-api.ts': 'export interface BarApi {}\n',
@@ -388,11 +428,32 @@ describe('dependency-cruiser architecture rules', () => {
     expect(result).toEqual({ status: 0, output: '' })
   })
 
+  it('allows entrypoints to wire infrastructure implementations', () => {
+    const result = cruise({
+      'src/contexts/foo/infrastructure/repository.ts':
+        'export const repository = 1\n',
+      'src/entrypoints/background.ts':
+        "import '../contexts/foo/infrastructure/repository'\n",
+    })
+
+    expect(result).toEqual({ status: 0, output: '' })
+  })
+
   it('allows cross-context import to shared kernel', () => {
     const result = cruise({
       'src/contexts/shared/kernel.ts': 'export const sharedKernel = 1\n',
       'src/contexts/foo/application/useCase.ts':
         "import '../../shared/kernel'\n",
+    })
+
+    expect(result).toEqual({ status: 0, output: '' })
+  })
+
+  it('allows infrastructure to import from other infrastructure', () => {
+    const result = cruise({
+      'src/contexts/foo/infrastructure/repository.ts':
+        'export const repository = 1\n',
+      'src/contexts/foo/infrastructure/adapter.ts': "import './repository'\n",
     })
 
     expect(result).toEqual({ status: 0, output: '' })


### PR DESCRIPTION
## 変更内容

issue #586 に対応し、`.dependency-cruiser.cjs` に `no-infrastructure-construction-outside-composition` ルールを `severity: "error"` で追加しました。

### 追加したルール

```js
{
  name: "no-infrastructure-construction-outside-composition",
  comment:
    "Infrastructure implementations must be wired only from composition, entrypoints, or infrastructure itself",
  severity: "error",
  from: {
    path: "^src/(?!app/composition/|entrypoints/|contexts/[^/]+/infrastructure/)",
  },
  to: {
    path: "^src/contexts/[^/]+/infrastructure/",
  },
}
```

`src/app/composition/`、`src/entrypoints/`、`src/contexts/*/infrastructure/` 以外からの infrastructure 実装 import を禁止します。

### 既存ルールの整理（重複排除）

- `no-application-to-infrastructure-or-presentation` → `no-application-to-presentation` に縮約（infrastructure 部は新ルールがカバー）
- `no-presentation-to-infrastructure` は削除（新ルールに完全包含）

### テスト

- `dependencyCruiserConfig.test.ts`: 新ルール名に追従、domain→infra / shared utility→infra の否定テスト、composition / entrypoints / infrastructure からの import を許可する肯定テストを追加
- `dddLayerGuard.test.ts`: ルール名参照を更新

## チェックリスト

- [x] ローカル環境でエラーになっていない
- [x] `bun run arch:check` が通る
- [x] `bun run quality` が通る

Closes #586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refined architectural dependency rules to better separate application, presentation, and infrastructure layers.
  * Updated architecture validation tests to align with the new rule names and expanded allowed/blocked wiring scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->