### PR TITLE
legacy features から context 内部への直接 import を禁止する (#588)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -179,6 +179,18 @@ module.exports = {
       },
     },
     {
+      name: 'no-legacy-features-to-context-internals',
+      comment:
+        'Legacy feature code must not depend on context internals (domain, application, infrastructure). Use the context public API (public-api.ts), a facade, or a presentation entry point instead. See issue #588.',
+      severity: 'error',
+      from: {
+        path: '^src/features/',
+      },
+      to: {
+        path: '^src/contexts/[^/]+/(domain|application|infrastructure)/',
+      },
+    },
+    {
       name: 'no-presentation-tests-to-domain',
       comment:
         'Presentation tests must use application DTO fixtures instead of domain entities',

--- a/src/app/composition/createSavedTabsUseCases.test.ts
+++ b/src/app/composition/createSavedTabsUseCases.test.ts
@@ -39,6 +39,25 @@ const buildChromeStorageLocal = (state: Record<string, unknown>) =>
     // eslint-disable-next-line typescript/no-explicit-any
   }) as any
 
+const buildSavedTabsState = () => ({
+  customProjects: [],
+  savedTabs: [
+    {
+      domain: 'example.com',
+      id: 'group-1',
+      urlIds: ['url-1'],
+    },
+  ],
+  urls: [
+    {
+      id: 'url-1',
+      savedAt: 1,
+      title: 'A',
+      url: 'https://example.com/a',
+    },
+  ],
+})
+
 describe('createSavedTabsUseCases (app/composition)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -104,24 +123,7 @@ describe('createSavedTabsUseCases (app/composition)', () => {
   })
 
   it('options.resolveActive を渡すと openSavedUrl が active 設定を反映する', async () => {
-    const state: Record<string, unknown> = {
-      customProjects: [],
-      savedTabs: [
-        {
-          domain: 'example.com',
-          id: 'group-1',
-          urlIds: ['url-1'],
-        },
-      ],
-      urls: [
-        {
-          id: 'url-1',
-          savedAt: 1,
-          title: 'A',
-          url: 'https://example.com/a',
-        },
-      ],
-    }
+    const state: Record<string, unknown> = buildSavedTabsState()
     vi.mocked(getChromeStorageLocal).mockReturnValue(
       buildChromeStorageLocal(state),
     )
@@ -186,24 +188,7 @@ describe('createSavedTabsPresentationComposition (app/composition)', () => {
   })
 
   it('resolveActive を渡すと use-case に反映される', async () => {
-    const state: Record<string, unknown> = {
-      customProjects: [],
-      savedTabs: [
-        {
-          domain: 'example.com',
-          id: 'group-1',
-          urlIds: ['url-1'],
-        },
-      ],
-      urls: [
-        {
-          id: 'url-1',
-          savedAt: 1,
-          title: 'A',
-          url: 'https://example.com/a',
-        },
-      ],
-    }
+    const state: Record<string, unknown> = buildSavedTabsState()
     vi.mocked(getChromeStorageLocal).mockReturnValue(
       buildChromeStorageLocal(state),
     )

--- a/src/app/composition/createSavedTabsUseCases.test.ts
+++ b/src/app/composition/createSavedTabsUseCases.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import * as chromeStorageModule from '@/lib/browser/chrome-storage'
 
-import { createSavedTabsUseCases } from './createSavedTabsUseCases'
+import {
+  createSavedTabsPresentationComposition,
+  createSavedTabsUseCases,
+} from './createSavedTabsUseCases'
 
 vi.mock('@/lib/browser/chrome-storage', async () => {
   const actual = await vi.importActual<typeof chromeStorageModule>(
@@ -136,6 +139,88 @@ describe('createSavedTabsUseCases (app/composition)', () => {
       typeof useCases.openSavedUrl
     >[0]['urlRecordId']
     await useCases.openSavedUrl({
+      origin: 'click',
+      settings: {
+        removeTabAfterExternalDrop: false,
+        removeTabAfterOpen: false,
+      },
+      urlRecordId,
+    })
+
+    expect(create).toHaveBeenCalledWith({
+      active: false,
+      url: 'https://example.com/a',
+    })
+  })
+})
+
+describe('createSavedTabsPresentationComposition (app/composition)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    restoreChromeApi()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    restoreChromeApi()
+  })
+
+  it('presentation ports と use-case 群のバンドルを返す', () => {
+    vi.mocked(getChromeStorageLocal).mockReturnValue(
+      buildChromeStorageLocal({}),
+    )
+    setChromeApi({
+      // eslint-disable-next-line typescript/require-await -- mock 用に同期的な async を意図
+      tabs: { create: vi.fn(async () => ({ url: 'https://example.com' })) },
+    })
+
+    const composition = createSavedTabsPresentationComposition()
+
+    expect(composition.deps.browserTabPort).toBeTypeOf('object')
+    expect(composition.deps.categoryAssignmentPort).toBeTypeOf('object')
+    expect(composition.deps.messagingPort).toBeTypeOf('object')
+    expect(composition.deps.migrationPort).toBeTypeOf('object')
+    expect(composition.deps.storageChangePort).toBeTypeOf('object')
+    expect(composition.useCases.openSavedUrl).toBeTypeOf('function')
+    expect(composition.useCases.deleteTabGroup).toBeTypeOf('function')
+  })
+
+  it('resolveActive を渡すと use-case に反映される', async () => {
+    const state: Record<string, unknown> = {
+      customProjects: [],
+      savedTabs: [
+        {
+          domain: 'example.com',
+          id: 'group-1',
+          urlIds: ['url-1'],
+        },
+      ],
+      urls: [
+        {
+          id: 'url-1',
+          savedAt: 1,
+          title: 'A',
+          url: 'https://example.com/a',
+        },
+      ],
+    }
+    vi.mocked(getChromeStorageLocal).mockReturnValue(
+      buildChromeStorageLocal(state),
+    )
+    const create = vi.fn(
+      // eslint-disable-next-line typescript/require-await -- mock 用に同期的な async を意図
+      async ({ url }: { active?: boolean; url: string }) => ({ url }),
+    )
+    setChromeApi({ tabs: { create } })
+
+    const composition = createSavedTabsPresentationComposition({
+      resolveActive: () => false,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const urlRecordId = 'url-1' as unknown as Parameters<
+      typeof composition.useCases.openSavedUrl
+    >[0]['urlRecordId']
+    await composition.useCases.openSavedUrl({
       origin: 'click',
       settings: {
         removeTabAfterExternalDrop: false,

--- a/src/app/composition/createSavedTabsUseCases.ts
+++ b/src/app/composition/createSavedTabsUseCases.ts
@@ -1,4 +1,5 @@
 import { createSavedTabsUseCases as createApplicationSavedTabsUseCases } from '@/contexts/saved-tabs/application/createSavedTabsUseCases'
+import type { SavedTabsPresentationPorts } from '@/contexts/saved-tabs/application/ports/SavedTabsPresentationPorts'
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/SavedTabsUseCases'
 import type { SavedTabsUseCasesDeps } from '@/contexts/saved-tabs/application/SavedTabsUseCasesDeps'
 import { createSavedTabsUseCasesDeps as createInfrastructureSavedTabsUseCasesDeps } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps'
@@ -47,4 +48,50 @@ export const createSavedTabsUseCases = (
 ): SavedTabsUseCases => {
   const deps: SavedTabsUseCasesDeps = createSavedTabsUseCasesDeps(options)
   return createApplicationSavedTabsUseCases(deps)
+}
+
+/**
+ * `SavedTabsUseCasesDeps` から presentation 層が必要とする port 群
+ * (`SavedTabsPresentationPorts`) へ投影する。
+ *
+ * presentation 層は永続化 repository を直接扱わず、use-case 経由で
+ * データを操作する。そのため composition 段階で use-case 構築に使った
+ * deps のうち、presentation が呼ぶ非永続 port だけを切り出して渡す。
+ */
+const toSavedTabsPresentationPorts = (
+  deps: SavedTabsUseCasesDeps,
+): SavedTabsPresentationPorts => ({
+  browserTabPort: deps.browserTabPort,
+  categoryAssignmentPort: deps.categoryAssignmentPort,
+  messagingPort: deps.messagingPort,
+  migrationPort: deps.migrationPort,
+  storageChangePort: deps.storageChangePort,
+})
+
+/**
+ * saved-tabs presentation 層が受け取る依存バンドルを一度に構築する。
+ *
+ * `SavedTabsRoute` の `createDeps` prop (`SavedTabsDepsFactory`) に
+ * 対する production 用 factory。infrastructure deps を 1 度だけ組み立て、
+ * そこから presentation ports と use-case 群を同時に生成して返す。
+ *
+ * 旧 `src/features/navigation/app/AppRouter` が
+ * `@/contexts/saved-tabs/application/createSavedTabsUseCases` へ直接
+ * 依存して wiring を行っていた箇所 (#588) を composition root へ集約し、
+ * legacy feature code が context 内部へ依存しないようにする。
+ *
+ * `options.resolveActive` を渡すと `BrowserTabPort` 配下のタブ open が
+ * 実行時に設定値を反映する。
+ */
+export const createSavedTabsPresentationComposition = (
+  options: CreateSavedTabsUseCasesDepsOptions = {},
+): {
+  readonly deps: SavedTabsPresentationPorts
+  readonly useCases: SavedTabsUseCases
+} => {
+  const deps = createSavedTabsUseCasesDeps(options)
+  return {
+    deps: toSavedTabsPresentationPorts(deps),
+    useCases: createApplicationSavedTabsUseCases(deps),
+  }
 }

--- a/src/contexts/saved-tabs/public-api.ts
+++ b/src/contexts/saved-tabs/public-api.ts
@@ -1,0 +1,15 @@
+/**
+ * `saved-tabs` context の公開 API。
+ *
+ * context 外のコード（legacy `src/features/**` や他の context）は
+ * domain / application / infrastructure の内部実装へ直接依存せず、
+ * このファイルが再公開する安定した面のみを参照する。
+ *
+ * 交差 context 依存もこのファイル経由のみを許可する
+ * (`.dependency-cruiser.cjs` の `no-*-to-other-context-internal` 規則)。
+ *
+ * 公開するのは純粋関数・型・不変値のみとし、repository / port の
+ * 実装詳細や branded entity の生成口は含めない。
+ */
+
+export { normalizeDomainString } from './domain/value-objects/DomainName'

--- a/src/features/navigation/app/AppRouter.tsx
+++ b/src/features/navigation/app/AppRouter.tsx
@@ -9,9 +9,7 @@ import {
   useNavigate,
 } from 'react-router-dom'
 
-import { createSavedTabsUseCasesDeps } from '@/app/composition/createSavedTabsUseCases'
-import { createSavedTabsUseCases } from '@/contexts/saved-tabs/application/createSavedTabsUseCases'
-import type { SavedTabsDepsFactory } from '@/contexts/saved-tabs/presentation/routes/SavedTabsRoute'
+import { createSavedTabsPresentationComposition } from '@/app/composition/createSavedTabsUseCases'
 import {
   getSavedTabsEntryRoute,
   getSavedTabsHrefForMode,
@@ -87,22 +85,6 @@ const SavedTabsRouteComponent = lazy(async () =>
   ),
 )
 
-const createSavedTabsPresentationDependencies: SavedTabsDepsFactory = (
-  options,
-) => {
-  const deps = createSavedTabsUseCasesDeps(options)
-  return {
-    deps: {
-      browserTabPort: deps.browserTabPort,
-      categoryAssignmentPort: deps.categoryAssignmentPort,
-      messagingPort: deps.messagingPort,
-      migrationPort: deps.migrationPort,
-      storageChangePort: deps.storageChangePort,
-    },
-    useCases: createSavedTabsUseCases(deps),
-  }
-}
-
 const SavedTabsRoutePage = () => {
   const routerLocation = useLocation()
   const navigate = useNavigate()
@@ -145,7 +127,7 @@ const SavedTabsRoutePage = () => {
   return (
     <Suspense fallback={null}>
       <SavedTabsRouteComponent
-        createDeps={createSavedTabsPresentationDependencies}
+        createDeps={createSavedTabsPresentationComposition}
         search={routerLocation.search}
         onViewModeNavigate={handleViewModeNavigate}
       />

--- a/src/features/options/lib/import-export/settings-merge.ts
+++ b/src/features/options/lib/import-export/settings-merge.ts
@@ -1,4 +1,4 @@
-import { normalizeDomainString } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
+import { normalizeDomainString } from '@/contexts/saved-tabs/public-api'
 import type { AiChatConversation } from '@/features/ai-chat/types'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
 import type { SavedAnalyticsView } from '@/lib/storage/analytics'

--- a/src/features/options/lib/import-export/url-conversion.ts
+++ b/src/features/options/lib/import-export/url-conversion.ts
@@ -1,4 +1,4 @@
-import { normalizeDomainString } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
+import { normalizeDomainString } from '@/contexts/saved-tabs/public-api'
 import {
   getBrowserUiLocale,
   getMessage,

--- a/src/lib/architecture/dependencyCruiserConfig.test.ts
+++ b/src/lib/architecture/dependencyCruiserConfig.test.ts
@@ -381,6 +381,35 @@ describe('dependency-cruiser architecture rules', () => {
           "import type { OtherContextEntity } from '../../bar/domain/entity'\nexport type FooEntity = OtherContextEntity\n",
       },
     },
+    {
+      name: 'legacy feature dependencies on context domain',
+      rule: 'no-legacy-features-to-context-internals',
+      files: {
+        'src/contexts/saved-tabs/domain/entity.ts': 'export const entity = 1\n',
+        'src/features/foo/bar.ts':
+          "import '../../contexts/saved-tabs/domain/entity'\n",
+      },
+    },
+    {
+      name: 'legacy feature dependencies on context application',
+      rule: 'no-legacy-features-to-context-internals',
+      files: {
+        'src/contexts/saved-tabs/application/useCase.ts':
+          'export const useCase = 1\n',
+        'src/features/foo/bar.ts':
+          "import '../../contexts/saved-tabs/application/useCase'\n",
+      },
+    },
+    {
+      name: 'legacy feature dependencies on context infrastructure',
+      rule: 'no-legacy-features-to-context-internals',
+      files: {
+        'src/contexts/saved-tabs/infrastructure/repo.ts':
+          'export const repo = 1\n',
+        'src/features/foo/bar.ts':
+          "import '../../contexts/saved-tabs/infrastructure/repo'\n",
+      },
+    },
   ])('rejects $name with $rule', ({ files, rule }) => {
     const result = cruise(removeUndefinedFiles(files))
 
@@ -402,6 +431,28 @@ describe('dependency-cruiser architecture rules', () => {
       'src/contexts/bar/public-api.ts': 'export const barApi = 1\n',
       'src/contexts/foo/application/useCase.ts':
         "import '../../bar/public-api'\n",
+    })
+
+    expect(result).toEqual({ status: 0, output: '' })
+  })
+
+  it('allows legacy feature dependencies on context public API', () => {
+    const result = cruise({
+      'src/contexts/saved-tabs/public-api.ts':
+        'export const savedTabsApi = 1\n',
+      'src/features/foo/bar.ts':
+        "import '../../contexts/saved-tabs/public-api'\n",
+    })
+
+    expect(result).toEqual({ status: 0, output: '' })
+  })
+
+  it('allows legacy feature dependencies on context presentation entry point', () => {
+    const result = cruise({
+      'src/contexts/saved-tabs/presentation/route.tsx':
+        'export const SavedTabsRoute = 1\n',
+      'src/features/foo/bar.ts':
+        "import '../../contexts/saved-tabs/presentation/route'\n",
     })
 
     expect(result).toEqual({ status: 0, output: '' })


### PR DESCRIPTION
## 変更内容

issue #588 の対応。DDD 移行中に legacy `src/features/**` から context 内部実装 (`src/contexts/*/(domain|application|infrastructure)`) への直接 import が混入するのを防ぐ。

### 1. dependency-cruiser 規則の追加

`.dependency-cruiser.cjs` に `no-legacy-features-to-context-internals` (severity: `error`) を追加した。`src/features/` から `src/contexts/{name}/(domain|application|infrastructure)/` への直接依存を禁止し、context 公開 API (`public-api.ts`) / facade / presentation entry point 経由に寄せる。

### 2. 既存違反の本質的解消

feature から context 内部へ直接依存していた 3 箇所を修正した。

- **`src/features/navigation/app/AppRouter.tsx`**
  - 修正前: `@/contexts/saved-tabs/application/createSavedTabsUseCases` を直接 import し、feature 内で deps + useCases の wiring を行っていた
  - 修正後: composition root (`src/app/composition/createSavedTabsUseCases.ts`) に `createSavedTabsPresentationComposition` を新設し、infrastructure deps を一度だけ構築して presentation ports と use-case 群を同時に返す。AppRouter は composition root 経由で受け取る（feature → composition root は context 内部ではないため許容）

- **`src/features/options/lib/import-export/url-conversion.ts` / `settings-merge.ts`**
  - 修正前: `@/contexts/saved-tabs/domain/value-objects/DomainName` の `normalizeDomainString` を直接 import
  - 修正後: `src/contexts/saved-tabs/public-api.ts`（交差 context 規則が既に想定する公開 API 面）経由に変更。domain 内部実装を隠蔽しつつ、純粋関数のみを公開

### 3. テスト

- `src/lib/architecture/dependencyCruiserConfig.test.ts` に新規則の negative case (domain / application / infrastructure 各層) と positive case (public-api / presentation 許容) を追加
- `src/app/composition/createSavedTabsUseCases.test.ts` に `createSavedTabsPresentationComposition` のテストを追加

Closes #588

## チェックリスト

- [x] ローカル環境でエラーになっていない (`bun run quality` / `bun run compile` / `bun run arch:check` 通過)
- [x] `bun run test` 全 3106 test 通過
- [x] `bun run arch:check` 通過 (新規則違反 0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened architectural boundaries by introducing an additional architecture rule to prevent legacy internal cross-context imports.
  * Added a stable public API entry for the Saved Tabs context to control what external code can use.
  * Refactored Saved Tabs dependency composition and updated router wiring to use the new presentation composition approach.
  * Updated domain normalization imports to use the Saved Tabs public API.
* **Tests**
  * Expanded coverage for Saved Tabs composition factories, including dependency ports and `resolveActive` behavior.
  * Added validation scenarios to confirm the architecture rule rejects/accepts the expected import paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->