### PR TITLE
storage 型の infrastructure 境界を整理し、presentation / application 層が storage 型を直接参照しないようにする

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -101,6 +101,22 @@ module.exports = {
       to: { path: '^src/types/storage(?:/|\\.)' },
     },
     {
+      name: 'no-application-to-storage-types',
+      comment:
+        'Application code must use application DTOs instead of shared storage persistence types',
+      severity: 'error',
+      from: { path: '^src/contexts/[^/]+/application/' },
+      to: { path: '^src/types/storage(?:/|.)' },
+    },
+    {
+      name: 'no-presentation-to-storage-types',
+      comment:
+        'Presentation code must use view models instead of shared storage persistence types',
+      severity: 'error',
+      from: { path: '^src/contexts/[^/]+/presentation/' },
+      to: { path: '^src/types/storage(?:/|.)' },
+    },
+    {
       name: 'no-domain-to-outer-layer',
       comment: 'Domain code must not depend on an outer context layer',
       severity: 'error',

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -106,7 +106,7 @@ module.exports = {
         'Application code must use application DTOs instead of shared storage persistence types',
       severity: 'error',
       from: { path: '^src/contexts/[^/]+/application/' },
-      to: { path: '^src/types/storage(?:/|.)' },
+      to: { path: '^src/types/storage(?:/|\\.)' },
     },
     {
       name: 'no-presentation-to-storage-types',
@@ -114,7 +114,7 @@ module.exports = {
         'Presentation code must use view models instead of shared storage persistence types',
       severity: 'error',
       from: { path: '^src/contexts/[^/]+/presentation/' },
-      to: { path: '^src/types/storage(?:/|.)' },
+      to: { path: '^src/types/storage(?:/|\\.)' },
     },
     {
       name: 'no-domain-to-outer-layer',

--- a/src/contexts/saved-tabs/application/commands/MoveDomainBetweenCategoriesCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/MoveDomainBetweenCategoriesCommand.ts
@@ -1,5 +1,3 @@
-import type { TabGroup } from '@/types/storage'
-
 /**
  * `MoveDomainBetweenCategoriesUseCase` の入力 (issue #525)。
  *
@@ -23,6 +21,8 @@ import type { TabGroup } from '@/types/storage'
  * }
  * ```
  */
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+
 export interface MoveDomainBetweenCategoriesCommand {
   /** 移動する `TabGroupId`（生文字列）。 */
   readonly domainId: string

--- a/src/contexts/saved-tabs/application/commands/RemoveSubCategoryFromTabGroupsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/RemoveSubCategoryFromTabGroupsCommand.ts
@@ -1,5 +1,3 @@
-import type { TabGroup } from '@/types/storage'
-
 /**
  * `RemoveSubCategoryFromTabGroupsUseCase` の入力 (issue #519)。
  *
@@ -15,6 +13,8 @@ import type { TabGroup } from '@/types/storage'
  * original の rich フィールドを保持してしまう) 既存問題を回避する
  * (issue #519 Codex レビュー P1)。
  */
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+
 export interface RemoveSubCategoryFromTabGroupsCommand {
   readonly groupId: string
   readonly categoryName: string

--- a/src/contexts/saved-tabs/application/commands/ReorderCustomProjectUrlsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/ReorderCustomProjectUrlsCommand.ts
@@ -1,5 +1,3 @@
-import type { CustomProject } from '@/types/storage'
-
 /**
  * `ReorderCustomProjectUrlsUseCase` の入力 (issue #539)。
  *
@@ -18,6 +16,8 @@ import type { CustomProject } from '@/types/storage'
  * }
  * ```
  */
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+
 export interface ReorderCustomProjectUrlsCommand {
   readonly projectId: string
   readonly urls: CustomProject['urls']

--- a/src/contexts/saved-tabs/application/commands/ReorderCustomProjectUrlsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/ReorderCustomProjectUrlsCommand.ts
@@ -20,5 +20,5 @@ import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/save
 
 export interface ReorderCustomProjectUrlsCommand {
   readonly projectId: string
-  readonly urls: NonNullable<CustomProject['urls']>
+  readonly urls: CustomProject['urls']
 }

--- a/src/contexts/saved-tabs/application/commands/ReorderCustomProjectUrlsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/ReorderCustomProjectUrlsCommand.ts
@@ -20,5 +20,5 @@ import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/save
 
 export interface ReorderCustomProjectUrlsCommand {
   readonly projectId: string
-  readonly urls: CustomProject['urls']
+  readonly urls: NonNullable<CustomProject['urls']>
 }

--- a/src/contexts/saved-tabs/application/commands/ReorderDomainsInCategoryCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/ReorderDomainsInCategoryCommand.ts
@@ -1,5 +1,3 @@
-import type { TabGroup } from '@/types/storage'
-
 /**
  * `ReorderDomainsInCategoryUseCase` の入力 (issue #525)。
  *
@@ -15,6 +13,8 @@ import type { TabGroup } from '@/types/storage'
  * }
  * ```
  */
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+
 export interface ReorderDomainsInCategoryCommand {
   /** 並び替え対象カテゴリの `ParentCategoryId`。 */
   readonly categoryId: string

--- a/src/contexts/saved-tabs/application/commands/ReorderParentCategoriesCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/ReorderParentCategoriesCommand.ts
@@ -1,5 +1,3 @@
-import type { ParentCategory } from '@/types/storage'
-
 /**
  * `ReorderParentCategoriesUseCase` の入力 (issue #519)。
  *
@@ -16,6 +14,8 @@ import type { ParentCategory } from '@/types/storage'
  * `ParentCategoryReorderService.buildReorderedCategoryOrder` 出力）
  * に委ねる方針。
  */
+import type { SavedTabsParentCategoryDto as ParentCategory } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+
 export interface ReorderParentCategoriesCommand {
   readonly categories: readonly ParentCategory[]
 }

--- a/src/contexts/saved-tabs/application/commands/UpdateCustomProjectKeywordsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/UpdateCustomProjectKeywordsCommand.ts
@@ -1,5 +1,3 @@
-import type { ProjectKeywordSettings } from '@/types/storage'
-
 /**
  * `UpdateCustomProjectKeywordsUseCase` の入力 (issue #539)。
  *
@@ -20,6 +18,8 @@ import type { ProjectKeywordSettings } from '@/types/storage'
  * }
  * ```
  */
+import type { SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+
 export interface UpdateCustomProjectKeywordsCommand {
   readonly projectId: string
   readonly projectKeywords: ProjectKeywordSettings

--- a/src/contexts/saved-tabs/application/dto/SavedTabsPresentationDto.ts
+++ b/src/contexts/saved-tabs/application/dto/SavedTabsPresentationDto.ts
@@ -6,6 +6,21 @@ export interface SavedTabsAiSystemPromptDto {
   readonly updatedAt: number
 }
 
+export interface SavedTabsProjectKeywordSettingsDto {
+  titleKeywords: string[]
+  urlKeywords: string[]
+  domainKeywords: string[]
+}
+
+export interface SavedTabsCustomProjectUrlDto {
+  id?: string
+  url: string
+  title: string
+  notes?: string
+  savedAt?: number
+  category?: string
+}
+
 export interface SavedTabsUserSettingsDto {
   language?: 'system' | 'ja' | 'en'
   removeTabAfterOpen: boolean
@@ -32,12 +47,16 @@ export interface SavedTabsUserSettingsDto {
 }
 
 export interface SavedTabsCustomProjectDto {
-  readonly id: string
-  readonly name: string
-  readonly urlIds: readonly string[]
-  readonly categories: readonly string[]
-  readonly createdAt: number
-  readonly updatedAt: number
+  id: string
+  name: string
+  urlIds?: string[]
+  categories: string[]
+  createdAt: number
+  updatedAt: number
+  projectKeywords?: SavedTabsProjectKeywordSettingsDto
+  urls?: SavedTabsCustomProjectUrlDto[]
+  urlMetadata?: Record<string, { notes?: string; category?: string }>
+  categoryOrder?: string[]
 }
 
 export interface SavedTabsParentCategoryDto {
@@ -48,21 +67,22 @@ export interface SavedTabsParentCategoryDto {
 }
 
 export interface SavedTabsCategoryKeywordDto {
-  readonly categoryName: string
-  readonly keywords: readonly string[]
+  categoryName: string
+  keywords: string[]
 }
 
 export interface SavedTabsTabGroupDto {
-  readonly id: string
-  readonly domain: string
-  readonly urlIds: readonly string[]
-  readonly urlSubCategories?: Readonly<Record<string, string>>
-  readonly subCategories?: readonly string[]
-  readonly categoryKeywords?: readonly SavedTabsCategoryKeywordDto[]
-  readonly subCategoryOrder?: readonly string[]
-  readonly subCategoryOrderWithUncategorized?: readonly string[]
-  readonly parentCategoryId?: string
-  readonly savedAt?: number
+  id: string
+  domain: string
+  urlIds?: string[]
+  urlSubCategories?: Record<string, string>
+  subCategories?: string[]
+  categoryKeywords?: SavedTabsCategoryKeywordDto[]
+  subCategoryOrder?: string[]
+  subCategoryOrderWithUncategorized?: string[]
+  parentCategoryId?: string
+  savedAt?: number
+  urls?: SavedTabsDisplayUrlDto[]
 }
 
 export interface SavedTabsDisplayUrlDto {

--- a/src/contexts/saved-tabs/application/mappers/SavedTabsDtosMapper.ts
+++ b/src/contexts/saved-tabs/application/mappers/SavedTabsDtosMapper.ts
@@ -1,17 +1,20 @@
-import type { DomainCategoryMappingDto } from '@/contexts/saved-tabs/domain/dto/DomainCategoryMappingDto'
-import type { DomainCategorySettingsDto } from '@/contexts/saved-tabs/domain/dto/DomainCategorySettingsDto'
+import type {
+  SavedTabsAiSystemPromptDto as AiSystemPromptPreset,
+  SavedTabsUserSettingsDto as UserSettings,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  DomainCategoryMappingDto as DomainParentCategoryMapping,
+  DomainCategoryMappingDto,
+} from '@/contexts/saved-tabs/domain/dto/DomainCategoryMappingDto'
+import type {
+  DomainCategorySettingsDto as DomainCategorySettings,
+  SubCategoryKeywordDto as SubCategoryKeyword,
+  DomainCategorySettingsDto,
+} from '@/contexts/saved-tabs/domain/dto/DomainCategorySettingsDto'
 import type {
   AiSystemPromptPresetDto,
   UserSettingsDto,
 } from '@/contexts/saved-tabs/domain/dto/UserSettingsDto'
-import type {
-  AiSystemPromptPreset,
-  DomainCategorySettings,
-  DomainParentCategoryMapping,
-  SubCategoryKeyword,
-  UserSettings,
-} from '@/types/storage'
-
 /**
  * `@/types/storage` 形 (chrome.storage 互換) と domain DTO 間の
  * 純変換を集約する application mapper (issue #511)。

--- a/src/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper.ts
+++ b/src/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper.ts
@@ -210,7 +210,5 @@ export const toCreateCustomProjectInput = (
   id: dto.id,
   name: dto.name,
   updatedAt: dto.updatedAt,
-  urlIds:
-    dto.urlIds ??
-    (dto.urls ? dto.urls.map((_, index) => `url-${index}`) : []),
+  urlIds: dto.urlIds ?? [],
 })

--- a/src/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper.ts
+++ b/src/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper.ts
@@ -7,9 +7,15 @@ import type {
   SavedTabsUserSettingsDto,
 } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { UserSettingsDto } from '@/contexts/saved-tabs/domain/dto/UserSettingsDto'
-import type { CustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
+import type {
+  createCustomProject,
+  CustomProject,
+} from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import type { ParentCategory } from '@/contexts/saved-tabs/domain/entities/ParentCategory'
-import type { TabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
+import type {
+  createTabGroup,
+  TabGroup,
+} from '@/contexts/saved-tabs/domain/entities/TabGroup'
 import type { UrlRecord } from '@/contexts/saved-tabs/domain/entities/UrlRecord'
 
 type Mutable<T> = { -readonly [Key in keyof T]: T[Key] }
@@ -124,7 +130,7 @@ export const toSavedTabsDisplayTabGroupDto = (
   return {
     domain: dto.domain,
     id: dto.id,
-    urlIds: [...dto.urlIds],
+    ...(dto.urlIds ? { urlIds: [...dto.urlIds] } : {}),
     ...(dto.parentCategoryId ? { parentCategoryId: dto.parentCategoryId } : {}),
     ...(dto.savedAt === undefined ? {} : { savedAt: dto.savedAt }),
     ...(dto.urlSubCategories
@@ -166,3 +172,43 @@ export const toSavedTabsUrlRecordDto = (
   }
   return dto
 }
+
+/**
+ * `SavedTabsTabGroupDto` から domain factory 入力へ変換する。
+ *
+ * application DTO は storage 互換で `urlIds` を省略可能にしているが、
+ * domain factory では必須なので未設定時は空配列に正規化する。
+ */
+export const toCreateTabGroupInput = (
+  dto: SavedTabsTabGroupDto,
+): Parameters<typeof createTabGroup>[0] => ({
+  categoryKeywords: dto.categoryKeywords,
+  domain: dto.domain,
+  id: dto.id,
+  parentCategoryId: dto.parentCategoryId,
+  savedAt: dto.savedAt,
+  subCategories: dto.subCategories,
+  subCategoryOrder: dto.subCategoryOrder,
+  subCategoryOrderWithUncategorized: dto.subCategoryOrderWithUncategorized,
+  urlIds: dto.urlIds ?? [],
+  urlSubCategories: dto.urlSubCategories,
+})
+
+/**
+ * `SavedTabsCustomProjectDto` から domain factory 入力へ変換する。
+ *
+ * application DTO は storage 互換で `urlIds` を省略可能にしているが、
+ * domain factory では必須なので未設定時は空配列に正規化する。
+ * storage 互換の rich フィールド (`urls` / `urlMetadata` /
+ * `projectKeywords` / `categoryOrder`) は domain 入力に不要なので無視する。
+ */
+export const toCreateCustomProjectInput = (
+  dto: SavedTabsCustomProjectDto,
+): Parameters<typeof createCustomProject>[0] => ({
+  categories: dto.categories,
+  createdAt: dto.createdAt,
+  id: dto.id,
+  name: dto.name,
+  updatedAt: dto.updatedAt,
+  urlIds: dto.urlIds ?? [],
+})

--- a/src/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper.ts
+++ b/src/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper.ts
@@ -210,5 +210,7 @@ export const toCreateCustomProjectInput = (
   id: dto.id,
   name: dto.name,
   updatedAt: dto.updatedAt,
-  urlIds: dto.urlIds ?? [],
+  urlIds:
+    dto.urlIds ??
+    (dto.urls ? dto.urls.map((_, index) => `url-${index}`) : []),
 })

--- a/src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.test.ts
+++ b/src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest' // eslint-disable-line
 
 import type { OpenedUrlsRestoreSnapshot } from '@/contexts/saved-tabs/application/commands/RestoreOpenedUrlsSnapshotCommand'
+import {
+  toSavedTabsCustomProjectDto,
+  toSavedTabsTabGroupDto,
+} from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
 import { createCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import { createParentCategory } from '@/contexts/saved-tabs/domain/entities/ParentCategory'
 import { createTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
@@ -168,13 +172,15 @@ describe('SavedTabsSnapshotMapper.getSnapshotSavedTabs', () => {
     const result = getSnapshotSavedTabs(
       buildSnapshot({
         savedTabs: [
-          createTabGroup({
-            domain: 'example.com',
-            id: 'group-1',
-            parentCategoryId: 'cat-1',
-            savedAt: 10,
-            urlIds: ['url-1'],
-          }),
+          toSavedTabsTabGroupDto(
+            createTabGroup({
+              domain: 'example.com',
+              id: 'group-1',
+              parentCategoryId: 'cat-1',
+              savedAt: 10,
+              urlIds: ['url-1'],
+            }),
+          ),
         ],
       }),
     )
@@ -269,14 +275,16 @@ describe('SavedTabsSnapshotMapper.toStorageCustomProjects', () => {
       toStorageCustomProjects(
         buildSnapshot({
           customProjects: [
-            createCustomProject({
-              categories: ['cat-1'],
-              createdAt: 1,
-              id: 'project-1',
-              name: 'Reading',
-              updatedAt: 2,
-              urlIds: ['url-1'],
-            }),
+            toSavedTabsCustomProjectDto(
+              createCustomProject({
+                categories: ['cat-1'],
+                createdAt: 1,
+                id: 'project-1',
+                name: 'Reading',
+                updatedAt: 2,
+                urlIds: ['url-1'],
+              }),
+            ),
           ],
         }),
       ),

--- a/src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.ts
+++ b/src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.ts
@@ -4,6 +4,9 @@ import type {
   RestoreOpenedUrlsSnapshotCommand,
 } from '@/contexts/saved-tabs/application/commands/RestoreOpenedUrlsSnapshotCommand'
 import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
   SavedTabsCustomProjectDto,
   SavedTabsDisplayTabGroupDto,
   SavedTabsParentCategoryDto,
@@ -16,10 +19,8 @@ import { createTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
 import type { TabGroup as DomainTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
 import type { CustomProjectRawSnapshot } from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
 import { normalizeDomainString } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
-import type { CustomProject, ParentCategory, TabGroup } from '@/types/storage'
 
 import { toSavedTabsTabGroupDto } from './SavedTabsPresentationMapper'
-
 /**
  * `BuildSavedTabsSnapshotUseCase` / `RestoreOpenedUrlsSnapshotUseCase` 由来の
  * domain entity 形 snapshot を presentation 層 (chrome.storage 互換の
@@ -52,7 +53,7 @@ export const toStorageCustomProject = (
   id: project.id,
   name: project.name,
   updatedAt: project.updatedAt,
-  urlIds: [...project.urlIds],
+  urlIds: project.urlIds ? [...project.urlIds] : [],
 })
 
 /** raw snapshot の rich 補助フィールドを保持したまま storage 形へ投影する。 */

--- a/src/contexts/saved-tabs/application/ports/CustomProjectsCommandService.ts
+++ b/src/contexts/saved-tabs/application/ports/CustomProjectsCommandService.ts
@@ -1,5 +1,3 @@
-import type { CustomProject, ProjectKeywordSettings } from '@/types/storage'
-
 /**
  * 旧 `src/lib/storage/projects` の高レベル操作を port として再公開する
  * DDD 境界 interface。
@@ -21,6 +19,11 @@ import type { CustomProject, ProjectKeywordSettings } from '@/types/storage'
  * あくまで互換層として lib/storage をラップする。`lib/storage` の
  * 全面 DDD 化は別 issue で段階的に行う。
  */
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+
 export interface CustomProjectsCommandService {
   /**
    * 旧 `addCategoryToProject` の port 版。カテゴリが既に存在する場合は

--- a/src/contexts/saved-tabs/application/ports/RemoveSubCategoryFromTabGroupPort.ts
+++ b/src/contexts/saved-tabs/application/ports/RemoveSubCategoryFromTabGroupPort.ts
@@ -20,11 +20,12 @@
  * `TabGroup` への正規化 (subCategory の `urlSubCategories` 引継ぎ等)
  * を行う責務を負う。
  */
-import type { TabGroup } from '@/types/storage'
 
 /**
  * `RemoveSubCategoryFromTabGroupPort` の関数定義。
  */
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+
 export interface RemoveSubCategoryFromTabGroupPort {
   /**
    * 指定 `groupId` の `TabGroup` から `categoryName` を 1 件削除し、

--- a/src/contexts/saved-tabs/application/ports/StorageChangePort.ts
+++ b/src/contexts/saved-tabs/application/ports/StorageChangePort.ts
@@ -38,13 +38,6 @@
  * ```
  */
 
-import type {
-  CustomProject,
-  ParentCategory,
-  TabGroup,
-  UserSettings,
-} from '@/types/storage'
-
 /**
  * saved-tabs context が同期対象とする storage キー。
  *
@@ -52,6 +45,13 @@ import type {
  * 列挙する。`urlRecords` のような domain 用語ではなく、実装のキー名
  * (`urls` など) を採用する。
  */
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettings,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+
 export type SavedTabsStorageChangeKey =
   | 'savedTabs'
   | 'urls'

--- a/src/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { UrlRecord } from '@/contexts/saved-tabs/domain/entities/UrlRecord'
 import type { CustomProjectRepository } from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
 import type { UrlRecordRepository } from '@/contexts/saved-tabs/domain/repositories/UrlRecordRepository'
 import { createSavedAt } from '@/contexts/saved-tabs/domain/value-objects/SavedAt'
 import { createUrl } from '@/contexts/saved-tabs/domain/value-objects/Url'
 import { createUrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/UrlRecordId'
-import type { CustomProject } from '@/types/storage'
 
 import { createGetProjectUrlsUseCase } from './GetProjectUrlsUseCase'
 

--- a/src/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase.ts
@@ -1,3 +1,4 @@
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { UrlRecord } from '@/contexts/saved-tabs/domain/entities/UrlRecord'
 import type {
   CustomProjectRawSnapshot,
@@ -5,7 +6,6 @@ import type {
 } from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
 import type { UrlRecordRepository } from '@/contexts/saved-tabs/domain/repositories/UrlRecordRepository'
 import { createUrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/UrlRecordId'
-import type { CustomProject } from '@/types/storage'
 
 /**
  * `GetProjectUrlsUseCase` の戻り値要素型。

--- a/src/contexts/saved-tabs/application/use-cases/MoveDomainBetweenCategoriesUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/MoveDomainBetweenCategoriesUseCase.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { createParentCategory } from '@/contexts/saved-tabs/domain/entities/ParentCategory'
 import type { ParentCategoryRepository } from '@/contexts/saved-tabs/domain/repositories/ParentCategoryRepository'
 import { createTabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabGroupId'
-import type { TabGroup } from '@/types/storage'
 
 import { createMoveDomainBetweenCategoriesUseCase } from './MoveDomainBetweenCategoriesUseCase'
 import type { MoveDomainBetweenCategoriesUseCaseDeps } from './MoveDomainBetweenCategoriesUseCase'

--- a/src/contexts/saved-tabs/application/use-cases/RemoveSubCategoryFromTabGroupsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveSubCategoryFromTabGroupsUseCase.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { RemoveSubCategoryFromTabGroupPort } from '@/contexts/saved-tabs/application/ports/RemoveSubCategoryFromTabGroupPort'
-import type { TabGroup } from '@/types/storage'
 
 import { createRemoveSubCategoryFromTabGroupsUseCase } from './RemoveSubCategoryFromTabGroupsUseCase'
 import type { RemoveSubCategoryFromTabGroupsUseCaseDeps } from './RemoveSubCategoryFromTabGroupsUseCase'

--- a/src/contexts/saved-tabs/application/use-cases/ReorderDomainsInCategoryUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderDomainsInCategoryUseCase.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { createParentCategory } from '@/contexts/saved-tabs/domain/entities/ParentCategory'
 import type { ParentCategoryRepository } from '@/contexts/saved-tabs/domain/repositories/ParentCategoryRepository'
 import { createTabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabGroupId'
-import type { TabGroup } from '@/types/storage'
 
 import { createReorderDomainsInCategoryUseCase } from './ReorderDomainsInCategoryUseCase'
 import type { ReorderDomainsInCategoryUseCaseDeps } from './ReorderDomainsInCategoryUseCase'

--- a/src/contexts/saved-tabs/application/use-cases/ReorderTabGroupsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderTabGroupsUseCase.test.ts
@@ -94,4 +94,27 @@ describe('ReorderTabGroupsUseCase', () => {
     expect(repositories.saveAllSpy).toHaveBeenCalledWith([])
     expect(repositories.tabGroups).toStrictEqual([])
   })
+
+  it('urlIds が未設定の DTO を渡された場合、repository へは urlIds: [] を持つ domain entity を保存する', async () => {
+    const repositories = createInMemoryRepositories()
+    const useCase = createReorderTabGroupsUseCase(repositories)
+
+    await useCase({
+      tabGroups: [
+        {
+          domain: 'legacy.com',
+          id: 'group-legacy',
+        },
+      ],
+    })
+
+    expect(repositories.saveAllSpy).toHaveBeenCalledTimes(1)
+    const savedGroups = repositories.saveAllSpy.mock.calls[0][0]
+    expect(savedGroups).toHaveLength(1)
+    expect(savedGroups[0]).toMatchObject({
+      domain: 'legacy.com',
+      id: 'group-legacy',
+      urlIds: [],
+    })
+  })
 })

--- a/src/contexts/saved-tabs/application/use-cases/ReorderTabGroupsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderTabGroupsUseCase.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { toSavedTabsTabGroupDto } from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
 import { createTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
 import type { TabGroupRepository } from '@/contexts/saved-tabs/domain/repositories/TabGroupRepository'
 
@@ -63,7 +64,9 @@ describe('ReorderTabGroupsUseCase', () => {
     })
     const useCase = createReorderTabGroupsUseCase(repositories)
 
-    await useCase({ tabGroups: [third, first, second] })
+    await useCase({
+      tabGroups: [third, first, second].map(toSavedTabsTabGroupDto),
+    })
 
     expect(repositories.saveAllSpy).toHaveBeenCalledTimes(1)
     expect(repositories.saveAllSpy).toHaveBeenCalledWith([third, first, second])

--- a/src/contexts/saved-tabs/application/use-cases/ReorderTabGroupsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderTabGroupsUseCase.ts
@@ -1,4 +1,5 @@
 import type { ReorderTabGroupsCommand } from '@/contexts/saved-tabs/application/commands/ReorderTabGroupsCommand'
+import { toCreateTabGroupInput } from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
 import { createTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
 import type { TabGroupRepository } from '@/contexts/saved-tabs/domain/repositories/TabGroupRepository'
 
@@ -38,6 +39,8 @@ export const createReorderTabGroupsUseCase = (
   deps: ReorderTabGroupsUseCaseDeps,
 ): ReorderTabGroupsUseCase => {
   return async (command) => {
-    await deps.tabGroupRepository.saveAll(command.tabGroups.map(createTabGroup))
+    await deps.tabGroupRepository.saveAll(
+      command.tabGroups.map(toCreateTabGroupInput).map(createTabGroup),
+    )
   }
 }

--- a/src/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
+import type { SavedTabsCustomProjectDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import { toCreateCustomProjectInput } from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
+import { createCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import type { CustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import type {
   CustomProjectRawSnapshot,
@@ -27,19 +30,14 @@ const makeRepository = (options: {
   }) as unknown as CustomProjectRepository
 
 describe('RestoreCustomProjectsSnapshotUseCase', () => {
-  const projects: CustomProject[] = [
+  const projects: SavedTabsCustomProjectDto[] = [
     {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      id: 'project-1' as never,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      name: 'Project A' as never,
+      id: 'project-1',
+      name: 'Project A',
       categories: [],
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      createdAt: 1 as never,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      updatedAt: 2 as never,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-      urlIds: ['url-a' as never],
+      createdAt: 1,
+      updatedAt: 2,
+      urlIds: ['url-a'],
     },
   ]
   const raws: CustomProjectRawSnapshot[] = [
@@ -102,7 +100,9 @@ describe('RestoreCustomProjectsSnapshotUseCase', () => {
       },
     })
 
-    expect(saveAll).toHaveBeenCalledWith(projects)
+    expect(saveAll).toHaveBeenCalledWith(
+      projects.map((p) => createCustomProject(toCreateCustomProjectInput(p))),
+    )
     expect(restoreAllRaw).not.toHaveBeenCalled()
     expect(saveOrder).toHaveBeenCalledWith(order)
   })
@@ -126,7 +126,9 @@ describe('RestoreCustomProjectsSnapshotUseCase', () => {
       },
     })
 
-    expect(saveAll).toHaveBeenCalledWith(projects)
+    expect(saveAll).toHaveBeenCalledWith(
+      projects.map((p) => createCustomProject(toCreateCustomProjectInput(p))),
+    )
     expect(saveOrder).toHaveBeenCalledWith(order)
   })
 

--- a/src/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase.test.ts
@@ -147,4 +147,35 @@ describe('RestoreCustomProjectsSnapshotUseCase', () => {
 
     expect(saveOrder).toHaveBeenCalledWith([])
   })
+
+  it('urlIds が未設定の SavedTabsCustomProjectDto を渡された場合、saveAll へは urlIds: [] を持つ domain project を渡す', async () => {
+    const saveAll = vi.fn().mockResolvedValue(undefined)
+    const customProjectRepository = makeRepository({ saveAll })
+    const useCase = createRestoreCustomProjectsSnapshotUseCase({
+      customProjectRepository,
+    })
+
+    await useCase({
+      payload: {
+        customProjects: [
+          {
+            id: 'project-legacy',
+            name: 'Legacy Project',
+            categories: ['test'],
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ],
+      },
+    })
+
+    expect(saveAll).toHaveBeenCalledTimes(1)
+    const savedProjects = saveAll.mock.calls[0][0]
+    expect(savedProjects).toHaveLength(1)
+    expect(savedProjects[0]).toMatchObject({
+      id: 'project-legacy',
+      name: 'Legacy Project',
+      urlIds: [],
+    })
+  })
 })

--- a/src/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase.ts
@@ -1,6 +1,7 @@
 import type { SavedTabsCustomProjectRawSnapshotDto } from '@/contexts/saved-tabs/application/dto/SavedTabsCustomProjectRawSnapshotDto'
 import type { SavedTabsCustomProjectDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { toCustomProjectRawSnapshot } from '@/contexts/saved-tabs/application/mappers/SavedTabsCustomProjectRawSnapshotMapper'
+import { toCreateCustomProjectInput } from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
 import { createCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import type { CustomProjectRepository } from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
 import { createCustomProjectId } from '@/contexts/saved-tabs/domain/value-objects/CustomProjectId'
@@ -84,7 +85,9 @@ export const createRestoreCustomProjectsSnapshotUseCase = (
       )
     } else {
       await deps.customProjectRepository.saveAll(
-        payload.customProjects.map(createCustomProject),
+        payload.customProjects
+          .map(toCreateCustomProjectInput)
+          .map(createCustomProject),
       )
     }
     const order = (payload.customProjectOrder ?? []).map(createCustomProjectId)

--- a/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import {
+  toSavedTabsCustomProjectDto,
+  toSavedTabsParentCategoryDto,
+  toSavedTabsTabGroupDto,
+  toSavedTabsUrlRecordDto,
+} from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
 import { createCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import { createParentCategory } from '@/contexts/saved-tabs/domain/entities/ParentCategory'
 import { createTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
@@ -163,17 +169,25 @@ describe('RestoreOpenedUrlsSnapshotUseCase', () => {
 
     const result = await useCase({
       snapshot: {
-        customProjects: [project],
-        parentCategories: [category],
-        savedTabs: [target],
-        urlRecords: [url],
+        customProjects: [toSavedTabsCustomProjectDto(project)],
+        parentCategories: [toSavedTabsParentCategoryDto(category)],
+        savedTabs: [toSavedTabsTabGroupDto(target)],
+        urlRecords: [toSavedTabsUrlRecordDto(url)],
       },
     })
 
-    expect(result.restoredTabGroups).toStrictEqual([target])
-    expect(result.restoredUrlRecords).toStrictEqual([url])
-    expect(result.restoredCustomProjects).toStrictEqual([project])
-    expect(result.restoredParentCategories).toStrictEqual([category])
+    expect(result.restoredTabGroups).toStrictEqual([
+      toSavedTabsTabGroupDto(target),
+    ])
+    expect(result.restoredUrlRecords).toStrictEqual([
+      toSavedTabsUrlRecordDto(url),
+    ])
+    expect(result.restoredCustomProjects).toStrictEqual([
+      toSavedTabsCustomProjectDto(project),
+    ])
+    expect(result.restoredParentCategories).toStrictEqual([
+      toSavedTabsParentCategoryDto(category),
+    ])
     expect(repos.tabGroups).toStrictEqual([target])
     expect(repos.urlRecords).toStrictEqual([url])
     expect(repos.customProjects).toStrictEqual([project])
@@ -194,7 +208,9 @@ describe('RestoreOpenedUrlsSnapshotUseCase', () => {
     const repos = createInMemoryRepositories({ tabGroups: [existing] })
     const useCase = createRestoreOpenedUrlsSnapshotUseCase(repos)
 
-    await useCase({ snapshot: { savedTabs: [restored] } })
+    await useCase({
+      snapshot: { savedTabs: [toSavedTabsTabGroupDto(restored)] },
+    })
 
     expect(repos.tabGroups.map((group) => group.id)).toStrictEqual([
       existing.id,
@@ -216,7 +232,9 @@ describe('RestoreOpenedUrlsSnapshotUseCase', () => {
     const repos = createInMemoryRepositories({ tabGroups: [existing] })
     const useCase = createRestoreOpenedUrlsSnapshotUseCase(repos)
 
-    await useCase({ snapshot: { savedTabs: [restored] } })
+    await useCase({
+      snapshot: { savedTabs: [toSavedTabsTabGroupDto(restored)] },
+    })
 
     expect(repos.tabGroups).toStrictEqual([restored])
   })
@@ -258,8 +276,8 @@ describe('RestoreOpenedUrlsSnapshotUseCase', () => {
 
     await useCase({
       snapshot: {
-        customProjects: [restoredProject],
-        urlRecords: [restoredUrl],
+        customProjects: [toSavedTabsCustomProjectDto(restoredProject)],
+        urlRecords: [toSavedTabsUrlRecordDto(restoredUrl)],
       },
     })
 

--- a/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.test.ts
@@ -335,4 +335,44 @@ describe('RestoreOpenedUrlsSnapshotUseCase', () => {
     expect(result.restoredCustomProjectOrder).toBeUndefined()
     expect(repos.customProjectOrder).toStrictEqual(initial)
   })
+
+  it('legacy snapshot で savedTabs[].urlIds / customProjects[].urlIds が省略されている場合、urlIds: [] を持つ entity へ正規化する', async () => {
+    const repos = createInMemoryRepositories()
+    const useCase = createRestoreOpenedUrlsSnapshotUseCase(repos)
+
+    const result = await useCase({
+      snapshot: {
+        savedTabs: [
+          {
+            domain: 'legacy-tabs.com',
+            id: 'group-legacy',
+          },
+        ],
+        customProjects: [
+          {
+            id: 'project-legacy',
+            name: 'Legacy Project',
+            categories: [],
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ],
+      },
+    })
+
+    expect(result.restoredTabGroups).toHaveLength(1)
+    expect(result.restoredCustomProjects).toHaveLength(1)
+    expect(repos.tabGroups).toHaveLength(1)
+    expect(repos.tabGroups[0]).toMatchObject({
+      domain: 'legacy-tabs.com',
+      id: 'group-legacy',
+      urlIds: [],
+    })
+    expect(repos.customProjects).toHaveLength(1)
+    expect(repos.customProjects[0]).toMatchObject({
+      id: 'project-legacy',
+      name: 'Legacy Project',
+      urlIds: [],
+    })
+  })
 })

--- a/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.ts
@@ -1,5 +1,9 @@
 import type { RestoreOpenedUrlsSnapshotCommand } from '@/contexts/saved-tabs/application/commands/RestoreOpenedUrlsSnapshotCommand'
 import type { RestoredSnapshotDto } from '@/contexts/saved-tabs/application/dto/RestoredSnapshotDto'
+import {
+  toCreateCustomProjectInput,
+  toCreateTabGroupInput,
+} from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
 import { createCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import { createParentCategory } from '@/contexts/saved-tabs/domain/entities/ParentCategory'
 import { createTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
@@ -93,10 +97,13 @@ export const createRestoreOpenedUrlsSnapshotUseCase = (
     const restoredCustomProjectOrder = normalizeCustomProjectOrder(
       snapshot.customProjectOrder,
     )
-    const restoredTabGroupEntities = restoredTabGroups.map(createTabGroup)
+    const restoredTabGroupEntities = restoredTabGroups
+      .map(toCreateTabGroupInput)
+      .map(createTabGroup)
     const restoredUrlRecordEntities = restoredUrlRecords.map(createUrlRecord)
-    const restoredCustomProjectEntities =
-      restoredCustomProjects.map(createCustomProject)
+    const restoredCustomProjectEntities = restoredCustomProjects
+      .map(toCreateCustomProjectInput)
+      .map(createCustomProject)
     const restoredParentCategoryEntities =
       restoredParentCategories.map(createParentCategory)
 

--- a/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotViewUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotViewUseCase.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { OpenedUrlsRestoreSnapshot } from '@/contexts/saved-tabs/application/commands/RestoreOpenedUrlsSnapshotCommand'
+import {
+  toSavedTabsCustomProjectDto,
+  toSavedTabsParentCategoryDto,
+  toSavedTabsTabGroupDto,
+} from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
 import { createCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import { createParentCategory } from '@/contexts/saved-tabs/domain/entities/ParentCategory'
 import { createTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
@@ -24,32 +29,38 @@ describe('RestoreOpenedUrlsSnapshotViewUseCase', () => {
 
     const snapshot: OpenedUrlsRestoreSnapshot = {
       customProjects: [
-        createCustomProject({
-          categories: ['cat-1'],
-          createdAt: 1,
-          id: 'project-1',
-          name: 'Reading',
-          updatedAt: 2,
-          urlIds: ['url-1'],
-        }),
+        toSavedTabsCustomProjectDto(
+          createCustomProject({
+            categories: ['cat-1'],
+            createdAt: 1,
+            id: 'project-1',
+            name: 'Reading',
+            updatedAt: 2,
+            urlIds: ['url-1'],
+          }),
+        ),
       ],
       customProjectOrder: ['project-1'],
       parentCategories: [
-        createParentCategory({
-          domains: ['group-1'],
-          domainNames: ['example.com'],
-          id: 'cat-1',
-          name: 'Reading',
-        }),
+        toSavedTabsParentCategoryDto(
+          createParentCategory({
+            domains: ['group-1'],
+            domainNames: ['example.com'],
+            id: 'cat-1',
+            name: 'Reading',
+          }),
+        ),
       ],
       savedTabs: [
-        createTabGroup({
-          domain: 'example.com',
-          id: 'group-1',
-          parentCategoryId: 'cat-1',
-          savedAt: 10,
-          urlIds: ['url-1'],
-        }),
+        toSavedTabsTabGroupDto(
+          createTabGroup({
+            domain: 'example.com',
+            id: 'group-1',
+            parentCategoryId: 'cat-1',
+            savedAt: 10,
+            urlIds: ['url-1'],
+          }),
+        ),
       ],
       urlRecords: [],
     }

--- a/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotViewUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotViewUseCase.ts
@@ -1,11 +1,15 @@
 import type { OpenedUrlsRestoreSnapshot } from '@/contexts/saved-tabs/application/commands/RestoreOpenedUrlsSnapshotCommand'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import {
   getSnapshotSavedTabs,
   toStorageCustomProjects,
   toStorageParentCategories,
   toRestoreOpenedUrlsSnapshotCommand,
 } from '@/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper'
-import type { CustomProject, ParentCategory, TabGroup } from '@/types/storage'
 
 import type { RestoreOpenedUrlsSnapshotUseCase } from './RestoreOpenedUrlsSnapshotUseCase'
 

--- a/src/contexts/saved-tabs/application/use-cases/SaveCustomProjectsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/SaveCustomProjectsUseCase.ts
@@ -1,4 +1,5 @@
 import type { SavedTabsCustomProjectDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import { toCreateCustomProjectInput } from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
 import { createCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import type { CustomProjectRepository } from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
 
@@ -51,7 +52,7 @@ export const createSaveCustomProjectsUseCase = (
 ): SaveCustomProjectsUseCase => {
   return async (command) => {
     await deps.customProjectRepository.saveAll(
-      command.projects.map(createCustomProject),
+      command.projects.map(toCreateCustomProjectInput).map(createCustomProject),
     )
   }
 }

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
@@ -12,14 +12,14 @@ import { useMemo, useRef } from 'react'
 import { toast } from 'sonner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type {
-  CustomProject,
-  ParentCategory,
-  TabGroup,
-  UrlRecord,
-  ViewMode,
-} from '@/types/storage'
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUrlRecordDto as UrlRecord,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 
 const commandServiceMock = vi.hoisted(() => {
   const addCategoryToProject = vi.fn()

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -10,7 +10,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Toaster } from '@/components/ui/sonner'
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/createSavedTabsUseCases'
 import { savedTabsDefaultUserSettings as defaultUserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDefaultsDto'
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { SavedTabsPresentationPorts } from '@/contexts/saved-tabs/application/ports/SavedTabsPresentationPorts'
 import {
   buildPresentationCategoryLookup,
@@ -29,9 +32,9 @@ import { useProjectManagement } from '@/contexts/saved-tabs/presentation/hooks/u
 import { useTabData } from '@/contexts/saved-tabs/presentation/hooks/useTabData'
 import { createCategorizedDisplayState } from '@/contexts/saved-tabs/presentation/lib/categorized-display'
 import { syncStorageChanges } from '@/contexts/saved-tabs/presentation/services/modeSyncService'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 import type { ResolveActiveRef } from '@/contexts/saved-tabs/presentation/types/ResolveActiveRef'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { TabGroup, ViewMode } from '@/types/storage'
 
 import { useProjectMoveHandlers } from './handlers/useProjectMoveHandlers'
 import { useTabGroupDeletionHandlers } from './handlers/useTabGroupDeletionHandlers'

--- a/src/contexts/saved-tabs/presentation/app/handlers/useProjectMoveHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/app/handlers/useProjectMoveHandlers.ts
@@ -3,10 +3,10 @@ import { useCallback } from 'react'
 import { toast } from 'sonner'
 
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/createSavedTabsUseCases'
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { moveCustomProjectUrlAndSyncState } from '@/contexts/saved-tabs/presentation/lib/custom-project-move'
 import type { TranslateFn } from '@/features/i18n/context/I18nProvider'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
-import type { CustomProject } from '@/types/storage'
 
 interface UseProjectMoveHandlersDeps {
   savedTabsUseCases: SavedTabsUseCases
@@ -46,9 +46,9 @@ export const useProjectMoveHandlers = ({
               id: project.id as unknown as string,
               name: project.name,
               updatedAt: project.updatedAt,
-              ...(project.urlIds.length > 0
+              ...((project.urlIds ?? []).length > 0
                 ? // eslint-disable-next-line typescript/no-unsafe-type-assertion, @typescript-eslint/no-unsafe-type-assertion -- domain UrlRecordId と storage 側の string 差 (issue #511 と同系統)
-                  { urlIds: [...project.urlIds] as unknown as string[] }
+                  { urlIds: [...(project.urlIds ?? [])] as unknown as string[] }
                 : {}),
             }))
           },

--- a/src/contexts/saved-tabs/presentation/app/handlers/useTabGroupDeletionHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/app/handlers/useTabGroupDeletionHandlers.ts
@@ -2,6 +2,11 @@ import type { Dispatch, SetStateAction } from 'react'
 import { useCallback } from 'react'
 
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/createSavedTabsUseCases'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { toStorageParentCategory } from '@/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper'
 import {
   countTabGroupUrls,
@@ -14,7 +19,6 @@ import {
 import type { OpenedUrlsStorageSnapshot } from '@/contexts/saved-tabs/presentation/app/savedTabsApp.helpers'
 import type { TranslateFn } from '@/features/i18n/context/I18nProvider'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
-import type { CustomProject, ParentCategory, TabGroup } from '@/types/storage'
 
 interface UseTabGroupDeletionHandlersDeps {
   isUncategorizedReorderMode: boolean

--- a/src/contexts/saved-tabs/presentation/app/handlers/useTabOpeningHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/app/handlers/useTabOpeningHandlers.ts
@@ -2,7 +2,12 @@ import type { Dispatch, SetStateAction } from 'react'
 import { useCallback } from 'react'
 
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/createSavedTabsUseCases'
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { SavedTabsPresentationPorts } from '@/contexts/saved-tabs/application/ports/SavedTabsPresentationPorts'
 import {
   showOpenedUrlsUndoToast,
@@ -10,7 +15,6 @@ import {
 } from '@/contexts/saved-tabs/presentation/app/savedTabsApp.helpers'
 import type { TranslateFn } from '@/features/i18n/context/I18nProvider'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
-import type { CustomProject, ParentCategory, TabGroup } from '@/types/storage'
 
 interface UseTabOpeningHandlersDeps {
   savedTabsUseCases: SavedTabsUseCases

--- a/src/contexts/saved-tabs/presentation/app/handlers/useUncategorizedReorderHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/app/handlers/useUncategorizedReorderHandlers.ts
@@ -5,10 +5,10 @@ import { useCallback } from 'react'
 import { toast } from 'sonner'
 
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/createSavedTabsUseCases'
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { toSavedTabsTabGroupDto } from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
 import { toDomainTabGroupsForReorder } from '@/contexts/saved-tabs/presentation/app/savedTabsApp.helpers'
 import type { TranslateFn } from '@/features/i18n/context/I18nProvider'
-import type { TabGroup } from '@/types/storage'
 
 interface UseUncategorizedReorderHandlersDeps {
   isUncategorizedReorderMode: boolean

--- a/src/contexts/saved-tabs/presentation/components/CategoryGroup.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryGroup.test.tsx
@@ -2,14 +2,17 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { AddDomainToParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/AddDomainToParentCategoryUseCase'
 import type { DeleteParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteParentCategoryUseCase'
 import type { RemoveDomainFromParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RemoveDomainFromParentCategoryUseCase'
 import type { RenameParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RenameParentCategoryUseCase'
 import type { ReorderTabGroupUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/ReorderTabGroupUrlsUseCase'
-import type { CategoryGroupProps } from '@/types/saved-tabs'
-import type { ParentCategory, TabGroup } from '@/types/storage'
+import type { CategoryGroupProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 
 const { categoryGroupRootSpy } = vi.hoisted(() => ({
   categoryGroupRootSpy: vi.fn(),

--- a/src/contexts/saved-tabs/presentation/components/CategoryGroup.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryGroup.tsx
@@ -6,7 +6,7 @@ import type {
   CategoryManagementModalDeps,
   CategoryManagementModalUseCases,
 } from '@/contexts/saved-tabs/presentation/components/CategoryManagementModal'
-import type { CategoryGroupProps } from '@/types/saved-tabs'
+import type { CategoryGroupProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 
 import { CategoryGroupActions } from './category-group/CategoryGroupActions'
 import { CategoryGroupContent } from './category-group/CategoryGroupContent'

--- a/src/contexts/saved-tabs/presentation/components/CategoryKeywordModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryKeywordModal.test.tsx
@@ -1,9 +1,12 @@
-// @vitest-environment jsdom
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { CategoryKeywordModalProps } from '@/types/saved-tabs'
-import type { ParentCategory, TabGroup } from '@/types/storage'
+// @vitest-environment jsdom
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type { CategoryKeywordModalProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 
 const { keywordModalRootSpy } = vi.hoisted(() => ({
   keywordModalRootSpy: vi.fn(),

--- a/src/contexts/saved-tabs/presentation/components/CategoryKeywordModal.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryKeywordModal.tsx
@@ -1,8 +1,8 @@
+import type { SavedTabsParentCategoryDto as ParentCategory } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { CategoryAssignmentPort } from '@/contexts/saved-tabs/application/ports/CategoryAssignmentPort'
 import type { StorageChangePort } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
-import type { CategoryKeywordModalProps } from '@/types/saved-tabs'
-import type { ParentCategory } from '@/types/storage'
+import type { CategoryKeywordModalProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 
 import { KeywordEditor } from './keyword-modal/KeywordEditor'
 import { KeywordModalRoot } from './keyword-modal/KeywordModalRoot'

--- a/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.test.tsx
@@ -17,7 +17,11 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 import { z } from 'zod'
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { AddDomainToParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/AddDomainToParentCategoryUseCase'
 import type { DeleteParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteParentCategoryUseCase'
 import type { RemoveDomainFromParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RemoveDomainFromParentCategoryUseCase'
@@ -27,7 +31,6 @@ import type {
   CategoryManagementModalUseCases,
 } from '@/contexts/saved-tabs/presentation/components/CategoryManagementModal'
 import { categoryNameSchema } from '@/contexts/saved-tabs/presentation/components/categoryNameSchema'
-import type { ParentCategory, TabGroup } from '@/types/storage'
 
 const categoryManagementModalI18nState = vi.hoisted(() => ({
   language: 'ja' as 'en' | 'ja',

--- a/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.tsx
@@ -19,13 +19,16 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Tooltip, TooltipTrigger } from '@/components/ui/tooltip'
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { DeleteEntityConfirmPanel } from '@/contexts/saved-tabs/presentation/components/shared/DeleteEntityConfirmPanel'
 import {
   SavedTabsResponsiveLabel,
   SavedTabsResponsiveTooltipContent,
 } from '@/contexts/saved-tabs/presentation/components/shared/SavedTabsResponsive'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { ParentCategory, TabGroup } from '@/types/storage'
 
 import type {
   CategoryManagementModalDeps,

--- a/src/contexts/saved-tabs/presentation/components/CategoryModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryModal.test.tsx
@@ -1,8 +1,8 @@
-// @vitest-environment jsdom
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { TabGroup } from '@/types/storage'
+// @vitest-environment jsdom
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 const { categoryModalRootSpy } = vi.hoisted(() => ({
   categoryModalRootSpy: vi.fn(),

--- a/src/contexts/saved-tabs/presentation/components/CategoryModal.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryModal.tsx
@@ -1,8 +1,8 @@
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
 import type { AssignDomainToCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/AssignDomainToCategoryUseCase'
 import type { CreateParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/CreateParentCategoryUseCase'
 import type { DeleteParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteParentCategoryUseCase'
-import type { TabGroup } from '@/types/storage'
 
 import { CategoryCreateSection } from './category-modal/CategoryCreateSection'
 import { CategoryModalRoot } from './category-modal/CategoryModalRoot'

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectSection.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectSection.tsx
@@ -33,9 +33,9 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { CustomProjectSectionProps } from '@/contexts/saved-tabs/presentation/types/CustomProjectSection.types'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { CustomProject } from '@/types/storage'
 
 import { CustomProjectCard } from './CustomProjectCard'
 import { DragHandlersContext } from './DragHandlersContext'

--- a/src/contexts/saved-tabs/presentation/components/Header.additional.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/Header.additional.test.tsx
@@ -2,8 +2,12 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
-import type { CustomProject, TabGroup, ViewMode } from '@/types/storage'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 
 const headerI18nState = vi.hoisted(() => ({
   language: 'ja' as 'en' | 'ja',

--- a/src/contexts/saved-tabs/presentation/components/Header.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/Header.test.tsx
@@ -2,8 +2,12 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
-import type { CustomProject, TabGroup, ViewMode } from '@/types/storage'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 
 const headerI18nState = vi.hoisted(() => ({
   language: 'ja' as 'en' | 'ja',

--- a/src/contexts/saved-tabs/presentation/components/Header.tsx
+++ b/src/contexts/saved-tabs/presentation/components/Header.tsx
@@ -11,12 +11,16 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipTrigger } from '@/components/ui/tooltip'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
 import type { AssignDomainToCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/AssignDomainToCategoryUseCase'
 import type { CreateParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/CreateParentCategoryUseCase'
 import type { DeleteParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteParentCategoryUseCase'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { CustomProject, TabGroup, ViewMode } from '@/types/storage'
 
 import { CategoryModal } from './CategoryModal'
 import {

--- a/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx
@@ -5,10 +5,12 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { useSavedTabsUseCases } from '@/contexts/saved-tabs/presentation/controllers/SavedTabsUseCasesContext'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { CustomProject } from '@/types/storage'
 
 import {
   getCategoryDisplayName,

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsContent.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsContent.test.tsx
@@ -9,7 +9,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
-import type { SortableCategorySectionProps } from '@/types/saved-tabs'
+import type { SortableCategorySectionProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 
 const { useSortableMock } = vi.hoisted(() => ({
   useSortableMock: vi.fn(),

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsContent.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsContent.tsx
@@ -13,8 +13,8 @@ import {
 } from '@/components/ui/alert-dialog'
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { getScopedNounActionLabel } from '@/contexts/saved-tabs/presentation/lib/accessibility'
+import type { SortableCategorySectionProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { SortableCategorySectionProps } from '@/types/saved-tabs'
 
 import { CategoryBulkActionButtons } from './shared/CategoryBulkActionButtons'
 import { OpenAllTabsConfirmDialog } from './shared/OpenAllTabsConfirmDialog'

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.tsx
@@ -9,8 +9,8 @@ import {
   isDevProfileEnabled,
 } from '@/contexts/saved-tabs/presentation/app/savedTabsProfiler'
 import type { UseSavedTabsControllerReturn } from '@/contexts/saved-tabs/presentation/controllers/useSavedTabsController'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 import type { ResolveActiveRef } from '@/contexts/saved-tabs/presentation/types/ResolveActiveRef'
-import type { ViewMode } from '@/types/storage'
 
 import { SavedTabsChatWidgetBridge } from './SavedTabsChatWidgetBridge'
 import { SavedTabsResponsiveLayoutProvider } from './SavedTabsResponsiveLayoutContext'

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsScrollControls.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsScrollControls.tsx
@@ -28,8 +28,8 @@ import type {
   ScrollDirection,
   ScrollTargetType,
 } from '@/contexts/saved-tabs/presentation/lib/scroll-controls'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 import { useI18nText } from '@/features/i18n/lib/useI18nText'
-import type { ViewMode } from '@/types/storage'
 
 const HIGHLIGHT_CLASS_NAME = 'saved-tabs-scroll-highlight'
 const HIGHLIGHT_DURATION_MS = 1200

--- a/src/contexts/saved-tabs/presentation/components/SortableCategorySection.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableCategorySection.test.tsx
@@ -10,7 +10,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
-import type { SortableCategorySectionProps } from '@/types/saved-tabs'
+import type { SortableCategorySectionProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 
 const { useSortableMock, dndMonitorHandlers, categorySectionSpy } = vi.hoisted(
   () => ({

--- a/src/contexts/saved-tabs/presentation/components/SortableCategorySection.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableCategorySection.tsx
@@ -29,8 +29,8 @@ import {
   getScopedObjectActionLabel,
   getScopedSortLabel,
 } from '@/contexts/saved-tabs/presentation/lib/accessibility'
+import type { SortableCategorySectionProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { SortableCategorySectionProps } from '@/types/saved-tabs'
 
 import { CategoryBulkActionButtons } from './shared/CategoryBulkActionButtons'
 import { SavedTabsResponsiveTooltipContent } from './shared/SavedTabsResponsive'

--- a/src/contexts/saved-tabs/presentation/components/SortableDomainCard.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableDomainCard.test.tsx
@@ -1,11 +1,13 @@
-// @vitest-environment jsdom
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+// @vitest-environment jsdom
+import type {
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { ReorderTabGroupUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/ReorderTabGroupUrlsUseCase'
-import type { SortableDomainCardProps } from '@/types/saved-tabs'
-import type { TabGroup } from '@/types/storage'
+import type { SortableDomainCardProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 
 const { domainCardRootSpy } = vi.hoisted(() => ({
   domainCardRootSpy: vi.fn(),

--- a/src/contexts/saved-tabs/presentation/components/SortableDomainCard.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableDomainCard.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo } from 'react'
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { ReorderTabGroupUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/ReorderTabGroupUrlsUseCase'
-import type { SortableDomainCardProps } from '@/types/saved-tabs'
+import type { SortableDomainCardProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 
 import { DomainCardActions } from './domain-card/DomainCardActions'
 import { DomainCardContent } from './domain-card/DomainCardContent'

--- a/src/contexts/saved-tabs/presentation/components/SortableUrlItem.additional.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableUrlItem.additional.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // esli
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { MessagingPort } from '@/contexts/saved-tabs/application/ports/MessagingPort'
-import type { SortableUrlItemProps } from '@/types/saved-tabs'
+import type { SortableUrlItemProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 
 const sortableUrlItemAdditionalI18nState = vi.hoisted(() => ({
   language: 'ja' as 'en' | 'ja',

--- a/src/contexts/saved-tabs/presentation/components/SortableUrlItem.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableUrlItem.tsx
@@ -5,8 +5,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { useSavedTabsUseCases } from '@/contexts/saved-tabs/presentation/controllers/SavedTabsUseCasesContext'
+import type { SortableUrlItemProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { SortableUrlItemProps } from '@/types/saved-tabs'
 import { TimeRemaining } from '@/utils/datetime'
 import { formatFixedDatetime as formatDatetime } from '@/utils/localDateTime'
 

--- a/src/contexts/saved-tabs/presentation/components/TimeRemaining.tsx
+++ b/src/contexts/saved-tabs/presentation/components/TimeRemaining.tsx
@@ -16,7 +16,7 @@ import {
 import { useCallback, useMemo, useState } from 'react'
 
 import type { ReorderTabGroupUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/ReorderTabGroupUrlsUseCase'
-import type { CategorySectionProps } from '@/types/saved-tabs'
+import type { CategorySectionProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 
 import { SortableUrlItem } from './SortableUrlItem'
 

--- a/src/contexts/saved-tabs/presentation/components/ViewModeToggle.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ViewModeToggle.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import {
   cleanup,
   fireEvent,
@@ -7,7 +8,6 @@ import {
 } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-// @vitest-environment jsdom
 import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 
 const viewModeI18nState = vi.hoisted(() => ({

--- a/src/contexts/saved-tabs/presentation/components/ViewModeToggle.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ViewModeToggle.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import {
   cleanup,
   fireEvent,
@@ -8,7 +7,8 @@ import {
 } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { ViewMode } from '@/types/storage'
+// @vitest-environment jsdom
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 
 const viewModeI18nState = vi.hoisted(() => ({
   language: 'ja' as 'en' | 'ja',

--- a/src/contexts/saved-tabs/presentation/components/ViewModeToggle.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ViewModeToggle.tsx
@@ -9,8 +9,8 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Tooltip, TooltipTrigger } from '@/components/ui/tooltip'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { ViewMode } from '@/types/storage'
 
 import {
   SavedTabsResponsiveLabel,

--- a/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupContent.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupContent.test.tsx
@@ -1,7 +1,7 @@
+// @vitest-environment jsdom
 import { cleanup, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-// @vitest-environment jsdom
 import type {
   SavedTabsTabGroupDto as TabGroup,
   SavedTabsUserSettingsDto as UserSettingsDto,

--- a/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupContent.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupContent.test.tsx
@@ -1,9 +1,11 @@
-// @vitest-environment jsdom
 import { cleanup, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
-import type { TabGroup } from '@/types/storage'
+// @vitest-environment jsdom
+import type {
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 const {
   sortableDomainCardSpy,

--- a/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupContext.ts
+++ b/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupContext.ts
@@ -3,8 +3,8 @@ import type { useSortable } from '@dnd-kit/sortable'
 import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { ReorderTabGroupUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/ReorderTabGroupUrlsUseCase'
 import type { useCategoryGroupState } from '@/contexts/saved-tabs/presentation/hooks/useCategoryGroupState'
+import type { CategoryGroupProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 import { createCompoundContext } from '@/lib/ui/createCompoundContext'
-import type { CategoryGroupProps } from '@/types/saved-tabs'
 
 /** CategoryGroup のコンテキスト型 */
 export interface CategoryGroupContextType {

--- a/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupRoot.tsx
@@ -11,8 +11,8 @@ import type {
 } from '@/contexts/saved-tabs/presentation/components/CategoryManagementModal'
 import { CategoryManagementModal } from '@/contexts/saved-tabs/presentation/components/CategoryManagementModal'
 import { useCategoryGroupState } from '@/contexts/saved-tabs/presentation/hooks/useCategoryGroupState'
+import type { CategoryGroupProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { CategoryGroupProps } from '@/types/saved-tabs'
 
 import { CategoryGroupContext } from './CategoryGroupContext'
 import type { CategoryGroupContextType } from './CategoryGroupContext'

--- a/src/contexts/saved-tabs/presentation/components/category-modal/CategoryModalContext.ts
+++ b/src/contexts/saved-tabs/presentation/components/category-modal/CategoryModalContext.ts
@@ -1,6 +1,6 @@
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { useCategoryModal } from '@/contexts/saved-tabs/presentation/hooks/useCategoryModal'
 import { createCompoundContext } from '@/lib/ui/createCompoundContext'
-import type { TabGroup } from '@/types/storage'
 
 /** CategoryModal のコンテキスト型 */
 export interface CategoryModalContextType {

--- a/src/contexts/saved-tabs/presentation/components/category-modal/CategoryModalRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-modal/CategoryModalRoot.tsx
@@ -6,13 +6,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
 import type { AssignDomainToCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/AssignDomainToCategoryUseCase'
 import type { CreateParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/CreateParentCategoryUseCase'
 import type { DeleteParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteParentCategoryUseCase'
 import { useCategoryModal } from '@/contexts/saved-tabs/presentation/hooks/useCategoryModal'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { TabGroup } from '@/types/storage'
 
 import { CategoryModalContext } from './CategoryModalContext'
 import type { CategoryModalContextType } from './CategoryModalContext'

--- a/src/contexts/saved-tabs/presentation/components/category-modal/DomainSelectionList.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-modal/DomainSelectionList.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { readFileSync } from 'node:fs'
 // eslint-disable-next-line eslint/no-unused-vars
 import { dirname, resolve } from 'node:path'
@@ -13,7 +14,6 @@ import {
 } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-// @vitest-environment jsdom
 import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 import { DomainSelectionList } from './DomainSelectionList'

--- a/src/contexts/saved-tabs/presentation/components/category-modal/DomainSelectionList.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-modal/DomainSelectionList.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { readFileSync } from 'node:fs'
 // eslint-disable-next-line eslint/no-unused-vars
 import { dirname, resolve } from 'node:path'
@@ -14,7 +13,8 @@ import {
 } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { TabGroup } from '@/types/storage'
+// @vitest-environment jsdom
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 import { DomainSelectionList } from './DomainSelectionList'
 

--- a/src/contexts/saved-tabs/presentation/components/category-modal/DomainSelectionList.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-modal/DomainSelectionList.tsx
@@ -4,8 +4,8 @@ import { useCallback, useMemo, useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { TabGroup } from '@/types/storage'
 
 import { useCategoryModalContext } from './CategoryModalContext'
 

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardContent.tsx
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardContent.tsx
@@ -14,12 +14,14 @@ import {
 import { useCallback } from 'react'
 
 import { CardContent } from '@/components/ui/card'
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { ReorderTabGroupUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/ReorderTabGroupUrlsUseCase'
 import { SortableCategorySection } from '@/contexts/saved-tabs/presentation/components/SortableCategorySection'
 import { CategorySection } from '@/contexts/saved-tabs/presentation/components/TimeRemaining'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { TabGroup } from '@/types/storage'
 
 import { useDomainCard } from './DomainCardContext'
 

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardContext.ts
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardContext.ts
@@ -3,8 +3,8 @@ import type { useSortable } from '@dnd-kit/sortable'
 import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { ReorderTabGroupUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/ReorderTabGroupUrlsUseCase'
 import type { useDomainCardState } from '@/contexts/saved-tabs/presentation/hooks/useDomainCardState'
+import type { SortableDomainCardProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 import { createCompoundContext } from '@/lib/ui/createCompoundContext'
-import type { SortableDomainCardProps } from '@/types/saved-tabs'
 
 /** DomainCard のコンテキスト型 */
 export interface DomainCardContextType {

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardRoot.tsx
@@ -6,7 +6,7 @@ import type { CSSProperties } from 'react'
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { useDomainCardState } from '@/contexts/saved-tabs/presentation/hooks/useDomainCardState'
-import type { SortableDomainCardProps } from '@/types/saved-tabs'
+import type { SortableDomainCardProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 
 import { DomainCardContext } from './DomainCardContext'
 import type { DomainCardContextType } from './DomainCardContext'

--- a/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordModalContext.ts
+++ b/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordModalContext.ts
@@ -1,6 +1,6 @@
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { useCategoryKeywordModal } from '@/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal'
 import { createCompoundContext } from '@/lib/ui/createCompoundContext'
-import type { TabGroup } from '@/types/storage'
 
 /** KeywordModal のコンテキスト型 */
 export interface KeywordModalContextType {

--- a/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordModalRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordModalRoot.tsx
@@ -10,8 +10,8 @@ import type { CategoryAssignmentPort } from '@/contexts/saved-tabs/application/p
 import type { StorageChangePort } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
 import { useCategoryKeywordModal } from '@/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal'
+import type { CategoryKeywordModalProps } from '@/contexts/saved-tabs/presentation/types/SavedTabsComponentProps'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { CategoryKeywordModalProps } from '@/types/saved-tabs'
 
 import { KeywordModalContext } from './KeywordModalContext'
 import type { KeywordModalContextType } from './KeywordModalContext'

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardContext.ts
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardContext.ts
@@ -1,8 +1,10 @@
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { useCustomProjectCard } from '@/contexts/saved-tabs/presentation/hooks/useCustomProjectCard'
 import type { CustomProjectCardProps } from '@/contexts/saved-tabs/presentation/types/CustomProjectCard.types'
 import { createCompoundContext } from '@/lib/ui/createCompoundContext'
-import type { CustomProject } from '@/types/storage'
 
 /** ProjectCard のコンテキスト型 */
 export interface ProjectCardContextType {

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { readFileSync } from 'node:fs'
 // eslint-disable-next-line eslint/no-unused-vars
 import { dirname, resolve } from 'node:path'
@@ -13,7 +14,6 @@ import {
 } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-// @vitest-environment jsdom
 import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 const projectManagementModalI18nState = vi.hoisted(() => ({

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { readFileSync } from 'node:fs'
 // eslint-disable-next-line eslint/no-unused-vars
 import { dirname, resolve } from 'node:path'
@@ -14,7 +13,8 @@ import {
 } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { CustomProject } from '@/types/storage'
+// @vitest-environment jsdom
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 const projectManagementModalI18nState = vi.hoisted(() => ({
   language: 'ja' as 'en' | 'ja',

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.tsx
@@ -13,13 +13,16 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Tooltip, TooltipTrigger } from '@/components/ui/tooltip'
 import { savedTabsUncategorizedProjectId as UNCATEGORIZED_PROJECT_ID } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDefaultsDto'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { DeleteEntityConfirmPanel } from '@/contexts/saved-tabs/presentation/components/shared/DeleteEntityConfirmPanel'
 import {
   SavedTabsResponsiveLabel,
   SavedTabsResponsiveTooltipContent,
 } from '@/contexts/saved-tabs/presentation/components/shared/SavedTabsResponsive'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { CustomProject, ProjectKeywordSettings } from '@/types/storage'
 
 import { useProjectModalState } from './useProjectModalState'
 import { createProjectNameSchema } from './useProjectNameSchema'

--- a/src/contexts/saved-tabs/presentation/components/project-card/useProjectModalState.test.ts
+++ b/src/contexts/saved-tabs/presentation/components/project-card/useProjectModalState.test.ts
@@ -1,8 +1,11 @@
-// @vitest-environment jsdom
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { CustomProject, ProjectKeywordSettings } from '@/types/storage'
+// @vitest-environment jsdom
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 import { useProjectModalState } from './useProjectModalState'
 import { createProjectNameSchema } from './useProjectNameSchema'

--- a/src/contexts/saved-tabs/presentation/components/project-card/useProjectModalState.test.ts
+++ b/src/contexts/saved-tabs/presentation/components/project-card/useProjectModalState.test.ts
@@ -1,7 +1,7 @@
+// @vitest-environment jsdom
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-// @vitest-environment jsdom
 import type {
   SavedTabsCustomProjectDto as CustomProject,
   SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings,

--- a/src/contexts/saved-tabs/presentation/components/project-card/useProjectModalState.ts
+++ b/src/contexts/saved-tabs/presentation/components/project-card/useProjectModalState.ts
@@ -1,7 +1,10 @@
 import { useRef, useState } from 'react'
 
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { CustomProject, ProjectKeywordSettings } from '@/types/storage'
 
 import { projectNameSchema } from './useProjectNameSchema'
 import type { ProjectNameSchema } from './useProjectNameSchema'

--- a/src/contexts/saved-tabs/presentation/components/useCategoryActions.ts
+++ b/src/contexts/saved-tabs/presentation/components/useCategoryActions.ts
@@ -1,7 +1,10 @@
 import { useCallback } from 'react'
 import { toast } from 'sonner'
 
-import type { ParentCategory, TabGroup } from '@/types/storage'
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 import type { CategoryManagementModalUseCases } from './CategoryManagementModal.types'
 

--- a/src/contexts/saved-tabs/presentation/containers/CustomModeContainer.test.tsx
+++ b/src/contexts/saved-tabs/presentation/containers/CustomModeContainer.test.tsx
@@ -1,9 +1,11 @@
-// @vitest-environment jsdom
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
-import type { CustomProject } from '@/types/storage'
+// @vitest-environment jsdom
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 vi.mock('@/features/i18n/context/I18nProvider', () => ({
   useI18n: () => ({

--- a/src/contexts/saved-tabs/presentation/containers/CustomModeContainer.test.tsx
+++ b/src/contexts/saved-tabs/presentation/containers/CustomModeContainer.test.tsx
@@ -1,7 +1,7 @@
+// @vitest-environment jsdom
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-// @vitest-environment jsdom
 import type {
   SavedTabsCustomProjectDto as CustomProject,
   SavedTabsUserSettingsDto as UserSettingsDto,

--- a/src/contexts/saved-tabs/presentation/containers/CustomModeContainer.tsx
+++ b/src/contexts/saved-tabs/presentation/containers/CustomModeContainer.tsx
@@ -1,8 +1,11 @@
 import { LoadingState } from '@/components/ui/loading-state'
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { GetProjectUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase'
 import { CustomProjectSection } from '@/contexts/saved-tabs/presentation/components/CustomProjectSection'
-import type { CustomProject, ProjectKeywordSettings } from '@/types/storage'
 
 interface CustomModeContainerProps {
   isLoading: boolean

--- a/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.test.tsx
+++ b/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.test.tsx
@@ -8,13 +8,16 @@ import {
 } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { AddDomainToParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/AddDomainToParentCategoryUseCase'
 import type { DeleteParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteParentCategoryUseCase'
 import type { RemoveDomainFromParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RemoveDomainFromParentCategoryUseCase'
 import type { RenameParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RenameParentCategoryUseCase'
 import type { ReorderTabGroupUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/ReorderTabGroupUrlsUseCase'
-import type { ParentCategory, TabGroup } from '@/types/storage'
 
 const domainModeI18nState = vi.hoisted(() => ({
   language: 'ja' as 'en' | 'ja',

--- a/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.tsx
+++ b/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.tsx
@@ -10,7 +10,11 @@ import { Button } from '@/components/ui/button'
 import { LoadingState } from '@/components/ui/loading-state'
 import { Tooltip, TooltipTrigger } from '@/components/ui/tooltip'
 import { savedTabsDefaultUserSettings as defaultUserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDefaultsDto'
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { RenameParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RenameParentCategoryUseCase'
 import type { ReorderTabGroupUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/ReorderTabGroupUrlsUseCase'
 import { CategoryGroup } from '@/contexts/saved-tabs/presentation/components/CategoryGroup'
@@ -26,7 +30,6 @@ import {
 import { SortableDomainCard } from '@/contexts/saved-tabs/presentation/components/SortableDomainCard'
 import { getScopedNounActionLabel } from '@/contexts/saved-tabs/presentation/lib/accessibility'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { ParentCategory, TabGroup } from '@/types/storage'
 
 const BULK_OPEN_THRESHOLD = 10
 const EMPTY_TAB_GROUPS: TabGroup[] = []

--- a/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.ts
@@ -74,12 +74,12 @@ export const useCustomModeController = (
         categories: [...project.categories],
         categoryOrder: project.categories,
         createdAt: project.createdAt,
-        displayUrlCount: project.urlIds.length,
-        hasUrls: project.urlIds.length > 0,
+        displayUrlCount: (project.urlIds ?? []).length,
+        hasUrls: (project.urlIds ?? []).length > 0,
         id: project.id,
         name: project.name,
         updatedAt: project.updatedAt,
-        urlIds: [...project.urlIds],
+        urlIds: [...(project.urlIds ?? [])],
         urls: [],
       }))
     }

--- a/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.ts
@@ -134,13 +134,13 @@ export const useDomainModeController = (
       parentViewModel.tabGroups.length === 0
     ) {
       return initialTabGroups.map((group) => ({
-        displayUrlCount: group.urlIds.length,
+        displayUrlCount: (group.urlIds ?? []).length,
         domain: group.domain,
-        hasUrls: group.urlIds.length > 0,
+        hasUrls: (group.urlIds ?? []).length > 0,
         id: group.id,
         parentCategoryId: group.parentCategoryId,
         subCategoryCount: 0,
-        urlIds: [...group.urlIds],
+        urlIds: [...(group.urlIds ?? [])],
         urls: [],
       }))
     }
@@ -159,12 +159,12 @@ export const useDomainModeController = (
         categories: [...project.categories],
         categoryOrder: project.categories,
         createdAt: project.createdAt,
-        displayUrlCount: project.urlIds.length,
-        hasUrls: project.urlIds.length > 0,
+        displayUrlCount: (project.urlIds ?? []).length,
+        hasUrls: (project.urlIds ?? []).length > 0,
         id: project.id,
         name: project.name,
         updatedAt: project.updatedAt,
-        urlIds: [...project.urlIds],
+        urlIds: [...(project.urlIds ?? [])],
         urls: [],
       }))
     }

--- a/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.ts
@@ -135,7 +135,7 @@ const toCustomProjectViewModelFromEntity = (
     id: project.id,
     name: project.name,
     updatedAt: project.updatedAt,
-    urlIds: [...project.urlIds],
+    urlIds: [...(project.urlIds ?? [])],
   })
 
 const toTabGroupViewModelFromEntity = (group: TabGroup): TabGroupViewModel =>
@@ -143,7 +143,7 @@ const toTabGroupViewModelFromEntity = (group: TabGroup): TabGroupViewModel =>
     domain: group.domain,
     id: group.id,
     parentCategoryId: group.parentCategoryId,
-    urlIds: [...group.urlIds],
+    urlIds: [...(group.urlIds ?? [])],
   })
 
 /**

--- a/src/contexts/saved-tabs/presentation/hooks/projectManagementDefaults.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/projectManagementDefaults.ts
@@ -6,6 +6,10 @@
 import type { Dispatch, RefObject, SetStateAction } from 'react'
 import { toast } from 'sonner'
 
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { toStorageCustomProjectFromRaw } from '@/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper'
 import type { GetCustomProjectOrderQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectOrderQuery'
 import type { GetCustomProjectRawsQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectRawsQuery'
@@ -32,11 +36,7 @@ import type { SetCustomProjectUrlCategoryUseCase } from '@/contexts/saved-tabs/a
 import type { UpdateCustomProjectCategoryOrderUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectCategoryOrderUseCase'
 import type { UpdateCustomProjectKeywordsUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectKeywordsUseCase'
 import type { UpdateCustomProjectNameUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectNameUseCase'
-import type {
-  CustomProject,
-  ProjectKeywordSettings,
-  ViewMode,
-} from '@/types/storage'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 
 const asyncNoopCreate: CreateCustomProjectUseCase = () => {
   throw new Error('createCustomProjectUseCase is not provided')
@@ -190,8 +190,8 @@ const showCustomProjectDeleteUndoToast = ({
                       name: project.name,
                       updatedAt: project.updatedAt,
                     }
-                    if (project.urlIds.length > 0) {
-                      result.urlIds = [...project.urlIds]
+                    if ((project.urlIds ?? []).length > 0) {
+                      result.urlIds = [...(project.urlIds ?? [])]
                     }
                     return result
                   }),

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryGroupState.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryGroupState.ts
@@ -3,9 +3,12 @@ import { arrayMove } from '@dnd-kit/sortable'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { RenameParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RenameParentCategoryUseCase'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { ParentCategory, TabGroup } from '@/types/storage'
 
 import { useSortOrder } from './useSortOrder'
 

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.test.tsx
@@ -1,15 +1,17 @@
-// @vitest-environment jsdom
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import type { ChangeEvent } from 'react'
 import { toast } from 'sonner'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type {
   StorageChangePort,
   TypedSavedTabsStorageChange,
 } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
-import type { ParentCategory, TabGroup } from '@/types/storage'
 
 import {
   renameCategoryInTab,

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { z } from 'zod'
 
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import {
   toPresentationTabGroups,
   toStorageParentCategory,
@@ -10,7 +14,6 @@ import type { CategoryAssignmentPort } from '@/contexts/saved-tabs/application/p
 import type { StorageChangePort } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { ParentCategory, TabGroup } from '@/types/storage'
 
 /** カテゴリ名のバリデーションスキーマ */
 const MAX_CATEGORY_NAME_LENGTH = 25

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryManagement.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryManagement.ts
@@ -1,12 +1,16 @@
-/**
- * @file useCategoryManagement.ts
- * @description 親カテゴリの CRUD・並び替えモード・ドメイン移動を担うカスタムフック。
- */
 import type { DragEndEvent } from '@dnd-kit/core'
 import { useCallback, useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { toast } from 'sonner'
 
+/**
+ * @file useCategoryManagement.ts
+ * @description 親カテゴリの CRUD・並び替えモード・ドメイン移動を担うカスタムフック。
+ */
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { toStorageParentCategory } from '@/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper'
 import { buildReorderedCategoryOrder } from '@/contexts/saved-tabs/application/services/ParentCategoryReorderService'
 import type { MoveDomainBetweenCategoriesUseCase } from '@/contexts/saved-tabs/application/use-cases/MoveDomainBetweenCategoriesUseCase'
@@ -15,7 +19,6 @@ import type { ReorderDomainsInCategoryUseCase } from '@/contexts/saved-tabs/appl
 import type { ReorderParentCategoriesUseCase } from '@/contexts/saved-tabs/application/use-cases/ReorderParentCategoriesUseCase'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
-import type { ParentCategory, TabGroup } from '@/types/storage'
 
 /** UseCategoryManagement フックの戻り値型 */
 interface UseCategoryManagementReturn {

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryModal.ts
@@ -3,13 +3,16 @@ import type { Dispatch, SetStateAction } from 'react'
 import { toast } from 'sonner'
 import { z } from 'zod'
 
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { toStorageParentCategory } from '@/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper'
 import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
 import type { AssignDomainToCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/AssignDomainToCategoryUseCase'
 import type { CreateParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/CreateParentCategoryUseCase'
 import type { DeleteParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/DeleteParentCategoryUseCase'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { ParentCategory, TabGroup } from '@/types/storage'
 
 /** UseCategoryModal フックの引数 */
 interface UseCategoryModalParams {

--- a/src/contexts/saved-tabs/presentation/hooks/useCustomProjectCard.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCustomProjectCard.ts
@@ -5,10 +5,13 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { toast } from 'sonner'
 
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsUrlRecordDto as UrlRecord,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { GetProjectUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { getMessage } from '@/features/i18n/lib/language'
-import type { CustomProject, UrlRecord } from '@/types/storage'
 
 import { useCategoryDnD } from './useCategoryDnD'
 

--- a/src/contexts/saved-tabs/presentation/hooks/useDomainCardState.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useDomainCardState.test.tsx
@@ -1,10 +1,10 @@
-// @vitest-environment jsdom
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
+// @vitest-environment jsdom
+import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { AssignDomainToCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/AssignDomainToCategoryUseCase'
 import type { CreateParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/CreateParentCategoryUseCase'
-import type { TabGroup } from '@/types/storage'
 
 import {
   arraysEqual,

--- a/src/contexts/saved-tabs/presentation/hooks/useDomainCardState.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useDomainCardState.test.tsx
@@ -1,7 +1,7 @@
+// @vitest-environment jsdom
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-// @vitest-environment jsdom
 import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { AssignDomainToCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/AssignDomainToCategoryUseCase'
 import type { CreateParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/CreateParentCategoryUseCase'

--- a/src/contexts/saved-tabs/presentation/hooks/useDomainCardState.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useDomainCardState.ts
@@ -2,6 +2,10 @@ import { arrayMove } from '@dnd-kit/sortable'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import {
   toPresentationTabGroups,
   toStorageParentCategory,
@@ -11,7 +15,6 @@ import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/applicatio
 import type { AssignDomainToCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/AssignDomainToCategoryUseCase'
 import type { CreateParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/CreateParentCategoryUseCase'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { ParentCategory, TabGroup } from '@/types/storage'
 
 /** UseDomainCardState フックの引数 */
 interface UseDomainCardStateParams {

--- a/src/contexts/saved-tabs/presentation/hooks/useFilteredCustomProjects.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useFilteredCustomProjects.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/createSavedTabsUseCases'
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { filterCustomProjectsByQuery } from '@/contexts/saved-tabs/presentation/lib/custom-project-search'
-import type { CustomProject } from '@/types/storage'
 
 /**
  * `customProjects` / `searchQuery` 変更時に `savedTabsUseCases.getProjectUrls` を

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectCategoryHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectCategoryHandlers.ts
@@ -2,7 +2,8 @@ import { useCallback, useEffect } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { toast } from 'sonner'
 
-import type { CustomProject, ViewMode } from '@/types/storage'
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 
 import { toRawStorageCustomProject } from './projectManagementDefaults'
 import type { ProjectManagementRefs } from './useProjectManagementRefs'

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectCrudHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectCrudHandlers.ts
@@ -3,12 +3,12 @@ import type { Dispatch, RefObject, SetStateAction } from 'react'
 import { toast } from 'sonner'
 
 import { savedTabsUncategorizedProjectId as UNCATEGORIZED_PROJECT_ID } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDefaultsDto'
-import { toStorageCustomProject } from '@/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper'
 import type {
-  CustomProject,
-  ProjectKeywordSettings,
-  ViewMode,
-} from '@/types/storage'
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import { toStorageCustomProject } from '@/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 
 import {
   showCustomProjectDeleteUndoToast,

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx
@@ -1,10 +1,12 @@
-// @vitest-environment jsdom
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { toast } from 'sonner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
-import type { CustomProject } from '@/types/storage'
+// @vitest-environment jsdom
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 import { useProjectManagement } from './useProjectManagement'
 

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.ts
@@ -14,7 +14,11 @@
 
 import { useEffect, useRef, useState } from 'react'
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { GetCustomProjectOrderQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectOrderQuery'
 import type { GetCustomProjectRawsQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectRawsQuery'
 import type { GetCustomProjectsQuery } from '@/contexts/saved-tabs/application/queries/GetCustomProjectsQuery'
@@ -34,8 +38,8 @@ import type { SetCustomProjectUrlCategoryUseCase } from '@/contexts/saved-tabs/a
 import type { UpdateCustomProjectCategoryOrderUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectCategoryOrderUseCase'
 import type { UpdateCustomProjectKeywordsUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectKeywordsUseCase'
 import type { UpdateCustomProjectNameUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectNameUseCase'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import type { CustomProject, TabGroup, ViewMode } from '@/types/storage'
 
 import type { UseProjectManagementReturn } from './projectManagementDefaults'
 import {
@@ -62,7 +66,6 @@ import {
 import { useProjectCategoryHandlers } from './useProjectCategoryHandlers'
 import { useProjectCrudHandlers } from './useProjectCrudHandlers'
 import { useProjectManagementRefs } from './useProjectManagementRefs'
-
 /**
  * issue #539 / #540 で `useProjectManagement` から application
  * use-case へ移設した 10 操作。

--- a/src/contexts/saved-tabs/presentation/hooks/useTabData.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useTabData.test.tsx
@@ -1,9 +1,11 @@
-// @vitest-environment jsdom
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
-import type { ParentCategory, TabGroup } from '@/types/storage'
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 import { useTabData } from './useTabData'
 

--- a/src/contexts/saved-tabs/presentation/hooks/useTabData.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useTabData.ts
@@ -7,7 +7,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { toPresentationTabGroups } from '@/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper'
 import type { MigrationPort } from '@/contexts/saved-tabs/application/ports/MigrationPort'
 import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
@@ -18,8 +22,6 @@ import type {
   RepairTabGroupParentCategoryIdsUseCase,
 } from '@/contexts/saved-tabs/application/use-cases/RepairTabGroupParentCategoryIdsUseCase'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
-import type { ParentCategory, TabGroup } from '@/types/storage'
-
 /** UseTabData フックの引数 */
 interface UseTabDataParams {
   /** URL 解決用 use-case。presentation 層が `loadTabGroupsWithUrls` 相当の操作で `@/lib/storage/tabs` を直接呼ばないようにするための依存注入ポイント。 */

--- a/src/contexts/saved-tabs/presentation/lib/categorized-display.test.ts
+++ b/src/contexts/saved-tabs/presentation/lib/categorized-display.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import type { CustomProject, TabGroup } from '@/types/storage'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 import { createCategorizedDisplayState } from './categorized-display'
 

--- a/src/contexts/saved-tabs/presentation/lib/categorized-display.ts
+++ b/src/contexts/saved-tabs/presentation/lib/categorized-display.ts
@@ -1,4 +1,8 @@
-import type { CustomProject, TabGroup, ViewMode } from '@/types/storage'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 
 import { buildDisplayTabGroup, getDisplayUrlCount } from './display-tab-group'
 import { shouldShowUncategorizedHeader } from './uncategorized-display'

--- a/src/contexts/saved-tabs/presentation/lib/custom-project-move.test.ts
+++ b/src/contexts/saved-tabs/presentation/lib/custom-project-move.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
-import type { CustomProject } from '@/types/storage'
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 import { moveCustomProjectUrlAndSyncState } from './custom-project-move'
 

--- a/src/contexts/saved-tabs/presentation/lib/custom-project-move.ts
+++ b/src/contexts/saved-tabs/presentation/lib/custom-project-move.ts
@@ -1,8 +1,8 @@
 import type { Dispatch, SetStateAction } from 'react'
 
 import type { MoveUrlBetweenCustomProjectsCommand } from '@/contexts/saved-tabs/application/commands/MoveUrlBetweenCustomProjectsCommand'
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { MoveUrlBetweenCustomProjectsUseCase } from '@/contexts/saved-tabs/application/use-cases/MoveUrlBetweenCustomProjectsUseCase'
-import type { CustomProject } from '@/types/storage'
 
 interface MoveCustomProjectUrlAndSyncStateParams {
   sourceProjectId: string

--- a/src/contexts/saved-tabs/presentation/lib/custom-project-search.test.ts
+++ b/src/contexts/saved-tabs/presentation/lib/custom-project-search.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { GetProjectUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase'
-import type { CustomProject } from '@/types/storage'
 
 import { filterCustomProjectsByQuery } from './custom-project-search'
 

--- a/src/contexts/saved-tabs/presentation/lib/custom-project-search.ts
+++ b/src/contexts/saved-tabs/presentation/lib/custom-project-search.ts
@@ -1,10 +1,10 @@
 import Fuse from 'fuse.js'
 
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type {
   GetProjectUrlsUseCase,
   ProjectUrlEntry,
 } from '@/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase'
-import type { CustomProject } from '@/types/storage'
 
 type ProjectUrlItem = ProjectUrlEntry
 

--- a/src/contexts/saved-tabs/presentation/lib/display-tab-group.test.ts
+++ b/src/contexts/saved-tabs/presentation/lib/display-tab-group.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import type { CustomProject, TabGroup } from '@/types/storage'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 import { buildDisplayTabGroup, getDisplayUrlCount } from './display-tab-group'
 

--- a/src/contexts/saved-tabs/presentation/lib/display-tab-group.ts
+++ b/src/contexts/saved-tabs/presentation/lib/display-tab-group.ts
@@ -1,5 +1,3 @@
-import type { CustomProject, TabGroup } from '@/types/storage'
-
 /**
  * 描画用に「表示対象」とみなせる URL 数を返す。
  *
@@ -16,6 +14,11 @@ import type { CustomProject, TabGroup } from '@/types/storage'
  * getDisplayUrlCount({ id: 'g1', domain: 'a' })                  // 0
  * ```
  */
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+
 export const getDisplayUrlCount = (group: TabGroup): number =>
   (group.urls ?? group.urlIds ?? []).length
 

--- a/src/contexts/saved-tabs/presentation/lib/project-state.test.ts
+++ b/src/contexts/saved-tabs/presentation/lib/project-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest' // eslint-disable-line
 
-import type { CustomProject } from '@/types/storage'
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 import { moveUrlBetweenProjectsState } from './project-state'
 

--- a/src/contexts/saved-tabs/presentation/lib/project-state.ts
+++ b/src/contexts/saved-tabs/presentation/lib/project-state.ts
@@ -1,6 +1,6 @@
 import { produce } from 'immer'
 
-import type { CustomProject } from '@/types/storage'
+import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 type ProjectUrl = NonNullable<CustomProject['urls']>[number]
 

--- a/src/contexts/saved-tabs/presentation/lib/tab-group-state.ts
+++ b/src/contexts/saved-tabs/presentation/lib/tab-group-state.ts
@@ -1,8 +1,10 @@
-import type { SavedTabsParentCategoryDto as ParentCategoryDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUrlRecordDto as UrlRecord,
+  SavedTabsParentCategoryDto as ParentCategoryDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { PresentationCategoryLookup } from '@/contexts/saved-tabs/application/services/SavedTabsCategorizationService'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
-import type { TabGroup, UrlRecord } from '@/types/storage'
-
 /**
  * `tabGroup` 内の表示用 URL 件数を数える。
  *

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
@@ -14,10 +14,10 @@ import {
 import { SavedTabsUseCasesProvider } from '@/contexts/saved-tabs/presentation/controllers/SavedTabsUseCasesContext'
 import { useSavedTabsController } from '@/contexts/saved-tabs/presentation/controllers/useSavedTabsController'
 import type { UseSavedTabsControllerReturn } from '@/contexts/saved-tabs/presentation/controllers/useSavedTabsController'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 import type { ResolveActiveRef } from '@/contexts/saved-tabs/presentation/types/ResolveActiveRef'
 import type { SavedTabsViewModel } from '@/contexts/saved-tabs/presentation/view-models/SavedTabsViewModel'
 import { getSavedTabsModeFromLocation } from '@/features/navigation/lib/pageNavigation'
-import type { ViewMode } from '@/types/storage'
 
 export type { ResolveActiveRef } from '@/contexts/saved-tabs/presentation/types/ResolveActiveRef'
 

--- a/src/contexts/saved-tabs/presentation/routes/SavedTabsRoute.tsx
+++ b/src/contexts/saved-tabs/presentation/routes/SavedTabsRoute.tsx
@@ -4,8 +4,8 @@ import type { SavedTabsPresentationPorts } from '@/contexts/saved-tabs/applicati
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/SavedTabsUseCases'
 import { SavedTabsPage } from '@/contexts/saved-tabs/presentation/pages/SavedTabsPage'
 import type { ResolveActiveRef } from '@/contexts/saved-tabs/presentation/pages/SavedTabsPage'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 import { getSavedTabsModeFromLocation } from '@/features/navigation/lib/pageNavigation'
-import type { ViewMode } from '@/types/storage'
 
 export type SavedTabsDepsFactory = (options: {
   readonly resolveActive: () => boolean

--- a/src/contexts/saved-tabs/presentation/services/modeSyncService.test.ts
+++ b/src/contexts/saved-tabs/presentation/services/modeSyncService.test.ts
@@ -1,14 +1,14 @@
 import type { RefObject, SetStateAction } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
-import type { TypedSavedTabsStorageChange } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import type {
-  CustomProject,
-  ParentCategory,
-  TabGroup,
-  ViewMode,
-} from '@/types/storage'
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type { TypedSavedTabsStorageChange } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 
 import { syncStorageChanges } from './modeSyncService'
 

--- a/src/contexts/saved-tabs/presentation/services/modeSyncService.ts
+++ b/src/contexts/saved-tabs/presentation/services/modeSyncService.ts
@@ -1,14 +1,16 @@
 import type { Dispatch, RefObject, SetStateAction } from 'react'
 
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
-import type { TypedSavedTabsStorageChange } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
-import type { ModeSyncEvent } from '@/contexts/saved-tabs/presentation/types/mode'
 import type {
-  CustomProject,
-  ParentCategory,
-  TabGroup,
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type { TypedSavedTabsStorageChange } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
+import type {
   ViewMode,
-} from '@/types/storage'
+  ModeSyncEvent,
+} from '@/contexts/saved-tabs/presentation/types/mode'
 
 interface SyncStorageChangesParams {
   changes: readonly TypedSavedTabsStorageChange[]

--- a/src/contexts/saved-tabs/presentation/services/savedTabsUndoNotificationService.ts
+++ b/src/contexts/saved-tabs/presentation/services/savedTabsUndoNotificationService.ts
@@ -4,10 +4,14 @@ import { toast } from 'sonner'
 import type { OpenedUrlsRestoreSnapshot } from '@/contexts/saved-tabs/application/commands/RestoreOpenedUrlsSnapshotCommand'
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/createSavedTabsUseCases'
 import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
   RestoredSnapshotViewDto,
   RestoreOpenedUrlsSnapshotViewUseCase,
 } from '@/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotViewUseCase'
-import type { CustomProject, ParentCategory, TabGroup } from '@/types/storage'
 
 /**
  * `SavedTabsUndoNotificationService` 群が共通で必要とする presenter 依存。

--- a/src/contexts/saved-tabs/presentation/services/viewModeNavigationService.ts
+++ b/src/contexts/saved-tabs/presentation/services/viewModeNavigationService.ts
@@ -1,5 +1,5 @@
+import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 import { getPageHref } from '@/features/navigation/lib/pageNavigation'
-import type { ViewMode } from '@/types/storage'
 
 /**
  * view mode に対応する href を解決する。

--- a/src/contexts/saved-tabs/presentation/types/CustomProjectCard.types.ts
+++ b/src/contexts/saved-tabs/presentation/types/CustomProjectCard.types.ts
@@ -1,6 +1,9 @@
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { GetProjectUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase'
-import type { CustomProject, ProjectKeywordSettings } from '@/types/storage'
 
 export interface CustomProjectCardProps {
   project: CustomProject

--- a/src/contexts/saved-tabs/presentation/types/CustomProjectCategory.types.ts
+++ b/src/contexts/saved-tabs/presentation/types/CustomProjectCategory.types.ts
@@ -1,6 +1,8 @@
 // Filepath: contexts/saved-tabs/presentation/types/CustomProjectCategory.types.ts
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
-import type { CustomProject } from '@/types/storage'
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 export interface CustomProjectCategoryProps {
   projectId: string

--- a/src/contexts/saved-tabs/presentation/types/CustomProjectSection.types.ts
+++ b/src/contexts/saved-tabs/presentation/types/CustomProjectSection.types.ts
@@ -1,7 +1,9 @@
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
-// Filepath: contexts/saved-tabs/presentation/types/CustomProjectSection.types.ts
+import type {
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings,
+  SavedTabsUserSettingsDto as UserSettingsDto,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { GetProjectUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase'
-import type { CustomProject, ProjectKeywordSettings } from '@/types/storage'
 
 export interface CustomProjectSectionProps {
   projects: CustomProject[]

--- a/src/contexts/saved-tabs/presentation/types/SavedTabsComponentProps.ts
+++ b/src/contexts/saved-tabs/presentation/types/SavedTabsComponentProps.ts
@@ -1,4 +1,16 @@
-import type { ParentCategory, TabGroup, UserSettings } from './storage'
+/**
+ * SavedTabs 表示コンポーネント間で共有する props 型。
+ *
+ * これらは presentation 層の型であり、storage 型を直接参照しない。
+ * 必要な DTO は `SavedTabsPresentationDto` から再エクスポートして使う
+ * (issue #589)。
+ */
+
+import type {
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+  SavedTabsUserSettingsDto as UserSettings,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 export interface DomainCardActionHandlers {
   handleOpenAllTabs: (urls: { url: string; title: string }[]) => void

--- a/src/contexts/saved-tabs/presentation/types/mode.ts
+++ b/src/contexts/saved-tabs/presentation/types/mode.ts
@@ -1,10 +1,11 @@
-import type { SavedTabsUserSettingsDto as UserSettingsDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type {
-  CustomProject,
-  ParentCategory,
-  TabGroup,
-  ViewMode,
-} from '@/types/storage'
+  SavedTabsUserSettingsDto as UserSettingsDto,
+  SavedTabsCustomProjectDto as CustomProject,
+  SavedTabsParentCategoryDto as ParentCategory,
+  SavedTabsTabGroupDto as TabGroup,
+} from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
+
+export type ViewMode = 'domain' | 'custom'
 
 export type ModeSyncEventType =
   | 'savedTabsUpdated'

--- a/src/contexts/saved-tabs/presentation/view-models/CustomProjectViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/CustomProjectViewModel.ts
@@ -10,7 +10,7 @@ export interface CustomProjectViewModel {
   readonly name: string
   readonly urlIds: readonly string[]
   readonly urls: readonly {
-    readonly id: string
+    readonly id?: string
     readonly url: string
     readonly title: string
     readonly category?: string
@@ -36,7 +36,7 @@ export const toCustomProjectViewModel = (project: {
   name: string
   urlIds?: readonly string[]
   urls?: readonly {
-    id: string
+    id?: string
     url: string
     title: string
     category?: string

--- a/src/contexts/saved-tabs/presentation/view-models/TabGroupViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/TabGroupViewModel.ts
@@ -17,7 +17,7 @@ export interface TabGroupViewModel {
   readonly parentCategoryId: string | undefined
   readonly urlIds: readonly string[]
   readonly urls: readonly {
-    readonly id: string
+    readonly id?: string
     readonly url: string
     readonly title: string
     readonly subCategory?: string
@@ -44,7 +44,7 @@ export const toTabGroupViewModel = (group: {
   parentCategoryId?: string
   urlIds?: readonly string[]
   urls?: readonly {
-    id: string
+    id?: string
     url: string
     title: string
     subCategory?: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,4 @@
 // ストレージ関連の型定義
 
 // Saved-tabs関連の型定義（既存のファイルがあれば再エクスポート）
-export type * from './saved-tabs'
 export type * from './storage'


### PR DESCRIPTION
## 概要

Issue #589 に対応。

- presentation / application 層が `@/types/storage` の storage 型を直接参照しないよう、対象の型を `SavedTabsPresentationDto` や presentation 層の型へ移行
- `src/types/saved-tabs.ts` を `src/contexts/saved-tabs/presentation/types/SavedTabsComponentProps.ts` へ移動し、component props 型を presentation 層に閉じる
- `.dependency-cruiser.cjs` に `no-application-to-storage-types` / `no-presentation-to-storage-types` ルールを追加
- 移行中に壊れたテストファイルの import / mock / lint ディレクティブを復元

## ローカル検証

- [x] `bun run compile` 通過
- [x] `bun run test` 通過（292 files / 3111 tests）
- [x] `bun run check` 通過
- [x] `bun run quality` 通過

Closes #589


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved saved tabs save/restore/reorder behavior when project/tab data is partial or missing `urlIds`, including legacy snapshots.
  * Increased resilience for view rendering when nested URL entry IDs are optional.

* **Refactor**
  * Unified saved-tabs data contracts across commands, mappers, and UI so data shapes stay consistent.

* **Tests**
  * Expanded automated coverage for DTO normalization and legacy/partial snapshot restoration.

* **Chores**
  * Added architecture validation to prevent incorrect saved-tabs layering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->