### PR TITLE
[codex] 保存時のドメイン重複作成を防ぐ

### DIFF
--- a/src/lib/storage/migration.test.ts
+++ b/src/lib/storage/migration.test.ts
@@ -479,6 +479,57 @@ describe('migration storage facade', () => {
     ])
   })
 
+  it('saveTabs は hostname 形式の既存ドメインへ追加し schemeful の重複ドメインを作らない', async () => {
+    const state: StorageState = {
+      savedTabs: [
+        {
+          domain: 'existing.example.com',
+          id: 'existing-group',
+          parentCategoryId: 'category-1',
+          subCategories: ['docs'],
+          urlIds: ['old-url'],
+          urlSubCategories: {
+            'old-url': 'docs',
+          },
+        },
+      ],
+    }
+    mocks.getParentCategories.mockResolvedValue([
+      createCategory({
+        domains: ['existing-group'],
+        domainNames: ['existing.example.com'],
+        id: 'category-1',
+      }),
+    ])
+    globalThis.chrome = {
+      storage: {
+        local: createChromeStorageLocal(state),
+      },
+    } as unknown as typeof chrome
+
+    const { saveTabs } = await loadModule()
+
+    await saveTabs([
+      {
+        title: 'New Doc',
+        url: 'https://existing.example.com/new-doc',
+      },
+    ] as chrome.tabs.Tab[])
+
+    expect(state.savedTabs).toStrictEqual([
+      expect.objectContaining({
+        domain: 'existing.example.com',
+        id: 'existing-group',
+        parentCategoryId: 'category-1',
+        subCategories: ['docs'],
+        urlIds: ['old-url', 'id:https://existing.example.com/new-doc'],
+        urlSubCategories: {
+          'old-url': 'docs',
+        },
+      }),
+    ])
+  })
+
   it('saveTabs は空 domainNames を検出したら親カテゴリ移行後の値で分類する', async () => {
     const state: StorageState = {
       domainCategoryMappings: [],

--- a/src/lib/storage/migration.ts
+++ b/src/lib/storage/migration.ts
@@ -176,6 +176,29 @@ const buildGroupedTabsByDomain = (
   }
   return groupedTabs
 }
+const normalizeDomainLookupKey = (domain: string): string => {
+  const trimmedDomain = domain.trim().toLowerCase()
+  if (!trimmedDomain.includes('://')) {
+    return trimmedDomain
+  }
+  try {
+    return new URL(trimmedDomain).hostname
+  } catch {
+    return trimmedDomain
+  }
+}
+const buildGroupedTabsLookup = (
+  savedTabs: TabGroup[],
+): Map<string, TabGroup> => {
+  const groupedTabs = new Map<string, TabGroup>()
+  for (const group of savedTabs) {
+    const key = normalizeDomainLookupKey(group.domain)
+    if (!groupedTabs.has(key)) {
+      groupedTabs.set(key, group)
+    }
+  }
+  return groupedTabs
+}
 const getCategoryDomainNames = (category: {
   domainNames?: unknown
 }): string[] =>
@@ -215,7 +238,10 @@ const findCategoryByDomainMapping = (
   domainCategoryMappings: DomainParentCategoryMapping[],
   parentCategories: ParentCategory[],
 ): DomainCategoryMatch | null => {
-  const domainMapping = domainCategoryMappings.find((m) => m.domain === domain)
+  const domainKey = normalizeDomainLookupKey(domain)
+  const domainMapping = domainCategoryMappings.find(
+    (m) => normalizeDomainLookupKey(m.domain) === domainKey,
+  )
   if (!domainMapping) {
     return null
   }
@@ -237,6 +263,7 @@ const findCategoryByDomainNames = (
   domain: string,
   parentCategories: ParentCategory[],
 ): DomainCategoryMatch | null => {
+  const domainKey = normalizeDomainLookupKey(domain)
   for (const category of parentCategories) {
     if (!Array.isArray(category.domainNames)) {
       console.log(`カテゴリ「${category.name}」のdomainNamesが不正です`)
@@ -246,7 +273,11 @@ const findCategoryByDomainNames = (
       domainCount: category.domainNames.length,
       searchDomain: redactUrlForLog(domain),
     })
-    if (category.domainNames.some((d) => d === domain)) {
+    if (
+      category.domainNames.some(
+        (d) => normalizeDomainLookupKey(d) === domainKey,
+      )
+    ) {
       console.log(
         `ドメイン ${redactUrlForLog(domain)} は親カテゴリ「${category.name}」のdomainNamesに見つかりました`,
       )
@@ -391,6 +422,7 @@ const saveTabs = async (tabs: chrome.tabs.Tab[]) => {
   const { savedTabs = [] } = savedTabsResult
   const filteredTabs = filterItemsBySavableUrl(tabs, settings.excludePatterns)
   const groupedTabs = buildGroupedTabsByDomain(savedTabs)
+  const groupedTabsLookup = buildGroupedTabsLookup(savedTabs)
   console.log('既存タブグループ数:', savedTabs.length)
   console.log('重複除外済みタブグループ数:', groupedTabs.size)
   console.log('ドメインマッピング:', domainCategoryMappings)
@@ -399,10 +431,16 @@ const saveTabs = async (tabs: chrome.tabs.Tab[]) => {
   )
   logParentCategorySnapshot(parentCategories)
   const tabsWithDomains = getTabsWithDomains(filteredTabs)
+  const missingDomainKeys = new Set<string>()
   const missingDomainSet = tabsWithDomains.reduce<Set<string>>(
     (domains, { domain }) => {
-      if (!groupedTabs.has(domain)) {
+      const domainKey = normalizeDomainLookupKey(domain)
+      if (
+        !groupedTabsLookup.has(domainKey) &&
+        !missingDomainKeys.has(domainKey)
+      ) {
         domains.add(domain)
+        missingDomainKeys.add(domainKey)
       }
       return domains
     },
@@ -430,6 +468,7 @@ const saveTabs = async (tabs: chrome.tabs.Tab[]) => {
   }
   for (const { domain, group } of createdGroups) {
     groupedTabs.set(domain, group)
+    groupedTabsLookup.set(normalizeDomainLookupKey(domain), group)
   }
   const urlRecordByUrl = await createOrUpdateUrlRecordsBatch(
     tabsWithDomains.map(({ tab, url }) => ({
@@ -438,11 +477,12 @@ const saveTabs = async (tabs: chrome.tabs.Tab[]) => {
     })),
   )
   for (const { domain, url } of tabsWithDomains) {
-    const group = groupedTabs.get(domain)
+    const domainKey = normalizeDomainLookupKey(domain)
+    const group = groupedTabsLookup.get(domainKey)
     if (!group) {
       throw new Error(`Domain group not found: ${redactUrlForLog(domain)}`)
     }
-    if (!missingDomainSet.has(domain)) {
+    if (!missingDomainKeys.has(domainKey)) {
       console.log(`既存のドメインに追加: ${redactUrlForLog(domain)}`)
     }
     const urlRecord = urlRecordByUrl.get(url)
@@ -491,10 +531,10 @@ const saveTabsWithAutoCategory = async (tabs: chrome.tabs.Tab[]) => {
   const uniqueDomains = getUniqueDomainsFromTabs(filteredTabs)
 
   // 各ドメインで自動カテゴライズを実行
-  const groupByDomain = new Map(savedTabs.map((group) => [group.domain, group]))
+  const groupByDomain = buildGroupedTabsLookup(savedTabs)
   await Promise.all(
     [...uniqueDomains].flatMap((domain) => {
-      const group = groupByDomain.get(domain)
+      const group = groupByDomain.get(normalizeDomainLookupKey(domain))
       return group && (group.categoryKeywords?.length ?? 0) > 0
         ? [autoCategorizeTabs(group.id)]
         : []


### PR DESCRIPTION
## 変更内容
- 保存時のドメイン照合を hostname 正規化キーで行うようにしました
- `domainCategoryMappings` / `parentCategories.domainNames` の照合でも schemeful と hostname の差を吸収します
- hostname 形式の既存ドメインへ保存したときに schemeful の重複ドメインを作らない回帰テストを追加しました

## 背景
PR #600 後に domain entity 経由で既存データが `example.com` 形式へ正規化される一方、拡張ボタン保存側は `https://example.com` 形式で既存グループを探していました。そのため既存ドメインを見つけられず、新規ドメイングループが作られていました。

## 検証
- `rtk bun run test:node src/lib/storage/migration.test.ts`
- `rtk bun run compile`
- `rtk bun run check`
- `rtk bun run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain matching when saving tabs, so hostname-based URLs and scheme-less saved domains are handled consistently.
  * Prevented duplicate domain entries when adding new tabs to an existing saved group.
  * Preserved existing category and subcategory links while appending new saved URLs.
* **Tests**
  * Added coverage for saving tabs with hostname-style URLs to verify the updated matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->