### PR TITLE
[DDD] public-api.ts の lint 例外を限定する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -439,6 +439,12 @@
       }
     },
     {
+      "files": ["src/contexts/*/public-api.ts"],
+      "rules": {
+        "oxc/no-barrel-file": "off"
+      }
+    },
+    {
       "files": [
         "**/*.test.ts",
         "**/*.test.tsx",

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -189,6 +189,20 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
     })
   })
 
+  describe('issue #590: public-api.ts の barrel 例外は最小範囲に限定する', () => {
+    it('src/contexts/*/public-api.ts のみ oxc/no-barrel-file を例外許可する', () => {
+      const override = config.overrides?.find((entry) =>
+        entry.files?.includes('src/contexts/*/public-api.ts'),
+      )
+
+      expect(override).toBeDefined()
+      expect(override?.files).toEqual(['src/contexts/*/public-api.ts'])
+      expect(override?.rules).toEqual({
+        'oxc/no-barrel-file': 'off',
+      })
+    })
+  })
+
   describe('domain 層', () => {
     const override = findOverride(config, 'domain')
 

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -191,15 +191,19 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
 
   describe('issue #590: public-api.ts の barrel 例外は最小範囲に限定する', () => {
     it('src/contexts/*/public-api.ts のみ oxc/no-barrel-file を例外許可する', () => {
-      const override = config.overrides?.find((entry) =>
-        entry.files?.includes('src/contexts/*/public-api.ts'),
-      )
+      const barrelFileOverrides =
+        config.overrides?.filter(
+          (entry) => entry.rules?.['oxc/no-barrel-file'] === 'off',
+        ) ?? []
 
-      expect(override).toBeDefined()
-      expect(override?.files).toEqual(['src/contexts/*/public-api.ts'])
-      expect(override?.rules).toEqual({
-        'oxc/no-barrel-file': 'off',
-      })
+      expect(barrelFileOverrides).toEqual([
+        {
+          files: ['src/contexts/*/public-api.ts'],
+          rules: {
+            'oxc/no-barrel-file': 'off',
+          },
+        },
+      ])
     })
   })
 


### PR DESCRIPTION
## 変更内容
- `src/contexts/*/public-api.ts` だけを `oxc/no-barrel-file` の例外対象に限定しました
- `src/contexts/saved-tabs/dddLayerGuard.test.ts` に guard test を追加し、例外範囲が広がらないよう固定しました

## 背景
- context 間 import を `public-api.ts` 経由に寄せる方針と barrel file 禁止ルールが衝突していました
- `oxc/no-barrel-file` を全面緩和せず、公開 API 用の最小例外として整合させています

## 確認
- `bun run check`
- `bun run quality`

Closes #590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the lint configuration to exempt targeted public API files from the barrel-file rule, reducing false positives.
* **Tests**
  * Added coverage to verify the lint override is applied exactly to the intended public API file pattern and not more broadly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->