### PR TITLE
eslint-plugin-react-hooks の React Compiler 系ルールを導入する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -17,6 +17,10 @@
     {
       "name": "eslint-react",
       "specifier": "@eslint-react/eslint-plugin"
+    },
+    {
+      "name": "react-hooks-compiler",
+      "specifier": "eslint-plugin-react-hooks"
     }
   ],
   "categories": {
@@ -406,7 +410,19 @@
     "jsdoc/check-tag-names": "error",
     "jsdoc/check-property-names": "error",
     "jsdoc/empty-tags": "error",
-    "jsdoc/implements-on-classes": "error"
+    "jsdoc/implements-on-classes": "error",
+    "react-hooks-compiler/static-components": "error",
+    "react-hooks-compiler/use-memo": "error",
+    "react-hooks-compiler/preserve-manual-memoization": "error",
+    "react-hooks-compiler/immutability": "error",
+    "react-hooks-compiler/globals": "error",
+    "react-hooks-compiler/set-state-in-effect": "error",
+    "react-hooks-compiler/error-boundaries": "error",
+    "react-hooks-compiler/purity": "error",
+    "react-hooks-compiler/set-state-in-render": "error",
+    "react-hooks-compiler/unsupported-syntax": "error",
+    "react-hooks-compiler/config": "error",
+    "react-hooks-compiler/gating": "error"
   },
   "overrides": [
     {

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
         "@wxt-dev/module-react": "^1.2.2",
         "autoprefixer": "^10.5.0",
         "dependency-cruiser": "^17.4.3",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "happy-dom": "^20.10.2",
         "html-validate": "^11.5.3",
         "jscpd": "^5.0.8",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "@wxt-dev/module-react": "^1.2.2",
     "autoprefixer": "^10.5.0",
     "dependency-cruiser": "^17.4.3",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "happy-dom": "^20.10.2",
     "html-validate": "^11.5.3",
     "jscpd": "^5.0.8",

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryGroupState.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryGroupState.ts
@@ -1,6 +1,6 @@
 import type { DragEndEvent } from '@dnd-kit/core'
 import { arrayMove } from '@dnd-kit/sortable'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
 import type {
@@ -131,29 +131,38 @@ export const useCategoryGroupState = ({
   )
 
   // --- ドラッグ中の折りたたみ制御 ---
-  useEffect(() => {
+  const [prevDragSync, setPrevDragSync] = useState({
+    isDraggingGlobal,
+    isCategoryReorderMode,
+  })
+
+  if (
+    prevDragSync.isDraggingGlobal !== isDraggingGlobal ||
+    prevDragSync.isCategoryReorderMode !== isCategoryReorderMode
+  ) {
+    setPrevDragSync({ isDraggingGlobal, isCategoryReorderMode })
     if (isDraggingGlobal && !isCategoryReorderMode) {
       setIsCollapsed(true)
     }
-  }, [isDraggingGlobal, isCategoryReorderMode, setIsCollapsed])
+  }
 
   // --- 親カテゴリ並び替えモード中の折りたたみ ---
-  const prevReorderModeRef = useRef<boolean>(false)
-  useEffect(() => {
-    if (isCategoryReorderMode && !prevReorderModeRef.current) {
+  const [prevReorderMode, setPrevReorderMode] = useState(false)
+
+  if (prevReorderMode !== isCategoryReorderMode) {
+    setPrevReorderMode(isCategoryReorderMode)
+    if (isCategoryReorderMode) {
       setCollapseState({
         isCollapsed: true,
         userCollapsedState: isCollapsed,
       })
-      prevReorderModeRef.current = true
-    } else if (!isCategoryReorderMode && prevReorderModeRef.current) {
+    } else {
       setCollapseState((prev) => ({
         ...prev,
         isCollapsed: userCollapsedState,
       }))
-      prevReorderModeRef.current = false
     }
-  }, [isCategoryReorderMode, isCollapsed, userCollapsedState])
+  }
 
   // --- ネイティブDnDハンドラ ---
   const handleDragOver = useCallback((event: React.DragEvent) => {

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryGroupState.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryGroupState.ts
@@ -131,12 +131,13 @@ export const useCategoryGroupState = ({
   )
 
   // --- ドラッグ中の折りたたみ制御 ---
-  const [prevDragSync, setPrevDragSync] = useState({
-    isDraggingGlobal,
-    isCategoryReorderMode,
-  })
+  const [prevDragSync, setPrevDragSync] = useState<{
+    isDraggingGlobal: boolean
+    isCategoryReorderMode: boolean
+  } | null>(null)
 
   if (
+    !prevDragSync ||
     prevDragSync.isDraggingGlobal !== isDraggingGlobal ||
     prevDragSync.isCategoryReorderMode !== isCategoryReorderMode
   ) {

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
@@ -195,9 +195,7 @@ export const useCategoryKeywordModal = ({
 
   if (prevParentCategoryId !== group.parentCategoryId) {
     setPrevParentCategoryId(group.parentCategoryId)
-    if (group.parentCategoryId) {
-      setSelectedParentCategory(group.parentCategoryId)
-    }
+    setSelectedParentCategory(group.parentCategoryId ?? 'none')
   }
 
   // --- バリデーション ---

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
@@ -186,8 +186,19 @@ export const useCategoryKeywordModal = ({
   const [internalParentCategories, setInternalParentCategories] = useState<
     ParentCategory[]
   >(initialParentCategories)
-  const [selectedParentCategory, setSelectedParentCategory] =
-    useState<string>('none')
+  const [selectedParentCategory, setSelectedParentCategory] = useState<string>(
+    group.parentCategoryId ?? 'none',
+  )
+  const [prevParentCategoryId, setPrevParentCategoryId] = useState(
+    group.parentCategoryId,
+  )
+
+  if (prevParentCategoryId !== group.parentCategoryId) {
+    setPrevParentCategoryId(group.parentCategoryId)
+    if (group.parentCategoryId) {
+      setSelectedParentCategory(group.parentCategoryId)
+    }
+  }
 
   // --- バリデーション ---
   const validateCategoryName = useCallback(
@@ -205,13 +216,6 @@ export const useCategoryKeywordModal = ({
     },
     [t],
   )
-
-  // --- 初期値の設定 ---
-  useEffect(() => {
-    if (group.parentCategoryId) {
-      setSelectedParentCategory(group.parentCategoryId)
-    }
-  }, [group.parentCategoryId])
 
   // --- 親カテゴリ読み込み ---
   // 以下の値 (group, onUpdateParentCategories, getSavedTabsPageDataQuery, t) は
@@ -288,7 +292,13 @@ export const useCategoryKeywordModal = ({
   }, [isOpen, loadParentCategories])
 
   // --- カテゴリ変更時のキーワード読み込み ---
-  useEffect(() => {
+  const keywordSyncKey = isOpen && activeCategory ? activeCategory : ''
+  const [prevKeywordSyncKey, setPrevKeywordSyncKey] = useState<string | null>(
+    null,
+  )
+
+  if (keywordSyncKey !== prevKeywordSyncKey) {
+    setPrevKeywordSyncKey(keywordSyncKey)
     if (isOpen && activeCategory) {
       const categoryKeywords = group.categoryKeywords?.find(
         (ck) => ck.categoryName === activeCategory,
@@ -301,7 +311,7 @@ export const useCategoryKeywordModal = ({
         newCategoryName: '',
       }))
     }
-  }, [isOpen, activeCategory, group])
+  }
 
   // --- キーワード追加 ---
   const handleAddKeyword = useCallback(() => {

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryModal.ts
@@ -282,15 +282,32 @@ export const useCategoryModal = ({
   }, [getSavedTabsPageDataQuery, t, tabGroups])
 
   // --- 選択カテゴリ変更時のドメイン選択更新 ---
-  useEffect(() => {
-    if (!selectedCategoryId) {
-      return
+  const [prevDomainSync, setPrevDomainSync] = useState<{
+    selectedCategoryId: string | null
+    categories: typeof categories
+    updateFn: typeof updateSelectedDomains
+  } | null>(null)
+
+  if (
+    prevDomainSync === null ||
+    prevDomainSync.selectedCategoryId !== selectedCategoryId ||
+    prevDomainSync.categories !== categories ||
+    prevDomainSync.updateFn !== updateSelectedDomains
+  ) {
+    setPrevDomainSync({
+      selectedCategoryId,
+      categories,
+      updateFn: updateSelectedDomains,
+    })
+    if (selectedCategoryId) {
+      const selectedCategory = categories.find(
+        (c) => c.id === selectedCategoryId,
+      )
+      if (selectedCategory) {
+        updateSelectedDomains(selectedCategory)
+      }
     }
-    const selectedCategory = categories.find((c) => c.id === selectedCategoryId)
-    if (selectedCategory) {
-      updateSelectedDomains(selectedCategory)
-    }
-  }, [selectedCategoryId, categories, updateSelectedDomains])
+  }
 
   // --- カテゴリ選択ハンドラ ---
   const handleCategoryChange = useCallback(

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryModal.ts
@@ -299,7 +299,9 @@ export const useCategoryModal = ({
       categories,
       updateFn: updateSelectedDomains,
     })
-    if (selectedCategoryId) {
+    if (selectedCategoryId === 'uncategorized') {
+      updateSelectedDomains('uncategorized')
+    } else if (selectedCategoryId) {
       const selectedCategory = categories.find(
         (c) => c.id === selectedCategoryId,
       )

--- a/src/contexts/saved-tabs/presentation/hooks/useDomainCardState.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useDomainCardState.ts
@@ -559,13 +559,14 @@ export const useDomainCardState = ({
   )
 
   // --- ドラッグ・並び替えモード時の折りたたみ制御 ---
-  const [prevCollapseSync, setPrevCollapseSync] = useState({
-    isDraggingGlobal,
-    isReorderMode,
-    userCollapsedState,
-  })
+  const [prevCollapseSync, setPrevCollapseSync] = useState<{
+    isDraggingGlobal: boolean
+    isReorderMode: boolean
+    userCollapsedState: boolean
+  } | null>(null)
 
   if (
+    !prevCollapseSync ||
     prevCollapseSync.isDraggingGlobal !== isDraggingGlobal ||
     prevCollapseSync.isReorderMode !== isReorderMode ||
     prevCollapseSync.userCollapsedState !== userCollapsedState

--- a/src/contexts/saved-tabs/presentation/hooks/useDomainCardState.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useDomainCardState.ts
@@ -141,8 +141,8 @@ const buildCategoryOrderFromSaved = (
  * @param params フックの引数
  * @returns 折りたたみ・ソート・カテゴリ並び替え・キーワードモーダル・親カテゴリ関連の状態と操作
  */
+// eslint-disable-next-line eslint/max-lines-per-function, eslint/complexity
 export const useDomainCardState = ({
-  // eslint-disable-line eslint/max-lines-per-function
   group,
   handleDeleteUrls,
   handleDeleteCategory,
@@ -226,27 +226,54 @@ export const useDomainCardState = ({
   )
 
   // --- 保存済みカテゴリ順序の初期化 ---
-  useEffect(() => {
+  const [prevCategoryInitSync, setPrevCategoryInitSync] = useState<{
+    savedOrderRef: typeof group.subCategoryOrderWithUncategorized
+    computedRef: typeof computedCategoryIds
+    allLen: number
+    trigger: number
+  } | null>(null)
+
+  if (
+    !prevCategoryInitSync ||
+    prevCategoryInitSync.savedOrderRef !==
+      group.subCategoryOrderWithUncategorized ||
+    prevCategoryInitSync.computedRef !== computedCategoryIds ||
+    prevCategoryInitSync.allLen !== allCategoryIds.length ||
+    prevCategoryInitSync.trigger !== categoryUpdateTrigger
+  ) {
+    setPrevCategoryInitSync({
+      savedOrderRef: group.subCategoryOrderWithUncategorized,
+      computedRef: computedCategoryIds,
+      allLen: allCategoryIds.length,
+      trigger: categoryUpdateTrigger,
+    })
     if (
       group.subCategoryOrderWithUncategorized &&
       allCategoryIds.length === 0
     ) {
       const savedOrder = [...group.subCategoryOrderWithUncategorized]
       if (savedOrder.length > 0) {
-        console.log('保存済みの順序を読み込み:', savedOrder)
         setAllCategoryIds(savedOrder)
       }
     }
-  }, [group.subCategoryOrderWithUncategorized, allCategoryIds.length])
+    if (allCategoryIds.length === 0 && computedCategoryIds.length > 0) {
+      setAllCategoryIds(computedCategoryIds)
+    }
+    if (
+      categoryUpdateTrigger > 0 &&
+      !arraysEqual(computedCategoryIds, allCategoryIds)
+    ) {
+      setAllCategoryIds(computedCategoryIds)
+    }
+  }
 
   // --- カテゴリ順序の更新を保存する関数 ---
-  const handleUpdateCategoryOrder = useCallback(
+  const saveCategoryOrder = useCallback(
     async (updatedOrder: string[], updatedAllOrder: string[]) => {
+      if (!categoryAssignmentPort || !getSavedTabsPageDataQuery) {
+        return
+      }
       try {
-        setAllCategoryIds(updatedAllOrder)
-        if (!categoryAssignmentPort || !getSavedTabsPageDataQuery) {
-          return
-        }
         const { tabGroups: savedTabs } = await getSavedTabsPageDataQuery()
         const updatedTabs = toPresentationTabGroups(savedTabs).map((tab) => {
           if (tab.id === group.id) {
@@ -267,6 +294,14 @@ export const useDomainCardState = ({
     [categoryAssignmentPort, getSavedTabsPageDataQuery, group.id],
   )
 
+  const handleUpdateCategoryOrder = useCallback(
+    async (updatedOrder: string[], updatedAllOrder: string[]) => {
+      setAllCategoryIds(updatedAllOrder)
+      await saveCategoryOrder(updatedOrder, updatedAllOrder)
+    },
+    [saveCategoryOrder],
+  )
+
   // --- 新規カテゴリ順序の自動保存 ---
   useEffect(() => {
     if (
@@ -277,32 +312,13 @@ export const useDomainCardState = ({
       const regularOrder = allCategoryIds.filter(
         (id) => id !== '__uncategorized',
       )
-      void handleUpdateCategoryOrder(regularOrder, allCategoryIds)
+      void saveCategoryOrder(regularOrder, allCategoryIds)
     }
   }, [
     allCategoryIds,
     group.subCategoryOrderWithUncategorized,
-    handleUpdateCategoryOrder,
+    saveCategoryOrder,
   ])
-
-  // --- カテゴリ表示の初期化 ---
-  useEffect(() => {
-    if (allCategoryIds.length === 0 && computedCategoryIds.length > 0) {
-      console.log('初期カテゴリID設定:', computedCategoryIds)
-      setAllCategoryIds(computedCategoryIds)
-    }
-  }, [allCategoryIds.length, computedCategoryIds])
-
-  // --- カテゴリ設定変更の監視 ---
-  useEffect(() => {
-    if (
-      categoryUpdateTrigger > 0 &&
-      !arraysEqual(computedCategoryIds, allCategoryIds)
-    ) {
-      console.log('カテゴリ設定変更を検知 - 表示を更新:', computedCategoryIds)
-      setAllCategoryIds(computedCategoryIds)
-    }
-  }, [categoryUpdateTrigger, computedCategoryIds, allCategoryIds])
 
   // --- タブ変更の監視 ---
   const prevUrlsRef = useRef<TabGroup['urls']>([])
@@ -543,13 +559,24 @@ export const useDomainCardState = ({
   )
 
   // --- ドラッグ・並び替えモード時の折りたたみ制御 ---
-  useEffect(() => {
+  const [prevCollapseSync, setPrevCollapseSync] = useState({
+    isDraggingGlobal,
+    isReorderMode,
+    userCollapsedState,
+  })
+
+  if (
+    prevCollapseSync.isDraggingGlobal !== isDraggingGlobal ||
+    prevCollapseSync.isReorderMode !== isReorderMode ||
+    prevCollapseSync.userCollapsedState !== userCollapsedState
+  ) {
+    setPrevCollapseSync({ isDraggingGlobal, isReorderMode, userCollapsedState })
     if (isDraggingGlobal || isReorderMode) {
       setIsCollapsed(true)
     } else {
       setIsCollapsed(userCollapsedState)
     }
-  }, [isDraggingGlobal, isReorderMode, userCollapsedState])
+  }
   return {
     /** カテゴリ操作 */
     categoryActions: {

--- a/src/features/options/routes/OptionsRoute.tsx
+++ b/src/features/options/routes/OptionsRoute.tsx
@@ -1,5 +1,5 @@
 import { RotateCcw } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { z } from 'zod'
 
 import { ModeToggle } from '@/components/mode-toggle'
@@ -126,15 +126,18 @@ const useOptionsRouteView = () => {
     fontSizeInputValue: String(fontSizePercent),
     fontSizeSliderValue: String(fontSizePercent),
   })
+  const [prevFontSizePercent, setPrevFontSizePercent] =
+    useState(fontSizePercent)
   const { fontSizeInputValue, fontSizeSliderValue } = fontSizeValues
 
-  useEffect(() => {
+  if (prevFontSizePercent !== fontSizePercent) {
+    setPrevFontSizePercent(fontSizePercent)
     const nextFontSizeValue = String(fontSizePercent)
     setFontSizeValues({
       fontSizeInputValue: nextFontSizeValue,
       fontSizeSliderValue: nextFontSizeValue,
     })
-  }, [fontSizePercent])
+  }
 
   const updateFontSizePercent = useCallback(
     async (value: number) => {


### PR DESCRIPTION
## 変更内容

Issue #608 の対応。

`eslint-plugin-react-hooks` v7 の React Compiler 系ルールを Oxlint `jsPlugins` 経由で導入し、render 中の副作用、mutation、ref read/write、render 中 setState などを CI / PR で早期検出できるようにした。

### 調査結果

Oxlint native `react` plugin には React Compiler 系ルールの同等品がないため、`eslint-plugin-react-hooks` v7 を `jsPlugins` 経由で利用する。`react-hooks` は Oxlint で予約名のため `react-hooks-compiler` エイリアスを使用。

### 採用ルール (12) — すべて error

| ルール | 説明 |
|--------|------|
| `static-components` | コンポーネントの再生成を検出 |
| `use-memo` | useMemo の誤用を検出 |
| `preserve-manual-memoization` | 手動メモ化の保持を検証 |
| `immutability` | props / state の mutation を検出 |
| `globals` | render 中のグローバル変数変更を検出 |
| `set-state-in-effect` | effect 内の同期 setState を検出 |
| `error-boundaries` | try/catch の代わりに Error Boundary を推奨 |
| `purity` | コンポーネントの純粋性を検証 |
| `set-state-in-render` | render 中の setState を検出 |
| `unsupported-syntax` | React Compiler 非対応構文を検出 |
| `config` | コンパイラ設定の妥当性を検証 |
| `gating` | gating モード設定を検証 |

### 見送りルール (4)

| ルール | 理由 |
|--------|------|
| `rules-of-hooks` | Oxlint native `react/rules-of-hooks` と重複 |
| `exhaustive-deps` | Oxlint native `react/exhaustive-deps` と重複 |
| `refs` | `ref={callbackRef}` / `ref={refObject}` などの標準 React API で誤検知が多発 (29 件中 14 件が誤検知) |
| `incompatible-library` | TanStack Virtual `useVirtualizer` が既知の非互換ライブラリとして検出されるが、コード側の問題ではない |

### コード修正

`set-state-in-effect` ルールの違反 10 件を React 推奨の "adjust state during render" パターンで修正:

- `OptionsRoute.tsx`: fontSizeValues の同期を render-time adjustment に移行
- `useCategoryKeywordModal.ts`: parentCategoryId 同期と keyword ロードを render-time adjustment に移行
- `useCategoryModal.ts`: 選択カテゴリ変更時のドメイン選択更新を render-time adjustment に移行
- `useCategoryGroupState.ts`: ドラッグ中 / 並び替えモード中の折りたたみ制御を render-time adjustment に移行
- `useDomainCardState.ts`: カテゴリ ID 初期化 / 更新、自動保存、折りたたみ制御を render-time adjustment に移行

## ローカル検証

- [x] `bun run compile` 通過
- [x] `bun run test` 通過 (294 files / 3132 tests)
- [x] `bun run check` 通過 (format + lint)
- [x] `bun run quality` 通過

Closes #608

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state synchronization across saved-tabs dialogs and category management so parent-category selection, keywords, collapse/open behavior during drag-and-drop, and subcategory ordering remain consistent when switching modes or categories.
  * Made font-size display settings update more reliably by synchronizing the related UI state during render.
* **Chores**
  * Updated linting configuration and added additional React Hooks compiler checks to help catch hook-related issues earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->