### PR TITLE
eslint-plugin-testing-library を Oxlint jsPlugins 経由で導入

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -713,7 +713,9 @@
         "src/**/*.spec.ts",
         "src/**/*.spec.tsx",
         "src/test/**",
-        "src/**/testing/**"
+        "src/**/testing/**",
+        "tests/**/*.test.ts",
+        "tests/**/*.test.tsx"
       ],
       "rules": {
         "testing-library/await-async-events": "error",
@@ -723,7 +725,6 @@
         "testing-library/no-await-sync-queries": "error",
         "testing-library/prefer-screen-queries": "error",
         "testing-library/prefer-query-by-disappearance": "error",
-        "testing-library/prefer-query-matchers": "error",
         "testing-library/no-global-regexp-flag-in-query": "error",
         "testing-library/no-dom-import": "error",
         "testing-library/prefer-user-event-setup": "error",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -21,6 +21,10 @@
     {
       "name": "react-hooks-compiler",
       "specifier": "eslint-plugin-react-hooks"
+    },
+    {
+      "name": "testing-library",
+      "specifier": "eslint-plugin-testing-library"
     }
   ],
   "categories": {
@@ -700,6 +704,30 @@
             "message": "presentation 層は chrome.runtime を直接利用できません（MessagingPort 経由）"
           }
         ]
+      }
+    },
+    {
+      "files": [
+        "src/**/*.test.ts",
+        "src/**/*.test.tsx",
+        "src/**/*.spec.ts",
+        "src/**/*.spec.tsx",
+        "src/test/**",
+        "src/**/testing/**"
+      ],
+      "rules": {
+        "testing-library/await-async-events": "error",
+        "testing-library/await-async-queries": "error",
+        "testing-library/await-async-utils": "error",
+        "testing-library/no-await-sync-events": "error",
+        "testing-library/no-await-sync-queries": "error",
+        "testing-library/prefer-screen-queries": "error",
+        "testing-library/prefer-query-by-disappearance": "error",
+        "testing-library/prefer-query-matchers": "error",
+        "testing-library/no-global-regexp-flag-in-query": "error",
+        "testing-library/no-dom-import": "error",
+        "testing-library/prefer-user-event-setup": "error",
+        "testing-library/no-debugging-utils": "error"
       }
     }
   ]

--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
         "autoprefixer": "^10.5.0",
         "dependency-cruiser": "^17.4.3",
         "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-testing-library": "^7.16.2",
         "happy-dom": "^20.10.2",
         "html-validate": "^11.5.3",
         "jscpd": "^5.0.8",
@@ -1514,6 +1515,8 @@
     "eslint-plugin-react-web-api": ["eslint-plugin-react-web-api@5.9.5", "", { "dependencies": { "@eslint-react/ast": "5.9.5", "@eslint-react/core": "5.9.5", "@eslint-react/eslint": "5.9.5", "@eslint-react/shared": "5.9.5", "@eslint-react/var": "5.9.5", "@typescript-eslint/types": "^8.62.0", "@typescript-eslint/utils": "^8.62.0", "birecord": "^0.1.1", "ts-pattern": "^5.9.0" }, "peerDependencies": { "eslint": "*", "typescript": "*" } }, "sha512-QySgjUrlEifAZp0phtA+VzuJZdRYcIxTjFXPMaSY+QPKAsHZo3cJ3rjFcbtR9DS/kdGGf6p/Oa02Rqgk9cw2FQ=="],
 
     "eslint-plugin-react-x": ["eslint-plugin-react-x@5.9.5", "", { "dependencies": { "@eslint-react/ast": "5.9.5", "@eslint-react/core": "5.9.5", "@eslint-react/eslint": "5.9.5", "@eslint-react/jsx": "5.9.5", "@eslint-react/shared": "5.9.5", "@eslint-react/var": "5.9.5", "@typescript-eslint/scope-manager": "^8.62.0", "@typescript-eslint/type-utils": "^8.62.0", "@typescript-eslint/types": "^8.62.0", "@typescript-eslint/typescript-estree": "^8.62.0", "@typescript-eslint/utils": "^8.62.0", "compare-versions": "^6.1.1", "string-ts": "^2.3.1", "ts-api-utils": "^2.5.0", "ts-pattern": "^5.9.0" }, "peerDependencies": { "eslint": "*", "typescript": "*" } }, "sha512-GToujy4Aj5xs5h/yMG7gUWYlb52oyMTvk1KXqcXefMhYY31AY0xEN1385W/dGVGOMyobNrHDVzoZ2lBDF2cquw=="],
+
+    "eslint-plugin-testing-library": ["eslint-plugin-testing-library@7.16.2", "", { "dependencies": { "@typescript-eslint/scope-manager": "^8.56.0", "@typescript-eslint/utils": "^8.56.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0" } }, "sha512-8gleGnQXK2ZA3hHwjCwpYTZvM+9VsrJ+/9kDI8CjqAQGAdMQOdn/rJNu7ZySENuiWlGKQWyZJ4ZjEg2zamaRHw=="],
 
     "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "autoprefixer": "^10.5.0",
     "dependency-cruiser": "^17.4.3",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-testing-library": "^7.16.2",
     "happy-dom": "^20.10.2",
     "html-validate": "^11.5.3",
     "jscpd": "^5.0.8",


### PR DESCRIPTION
## 変更内容

`eslint-plugin-testing-library` を Oxlint の `jsPlugins` 経由で導入し、React Testing Library 向けルールをテストファイル限定で `error` として有効化する。

### 導入方式

issue の優先順位 1 (Oxlint `jsPlugins` 経由) を検証し、**正常に動作することを確認** したため採用した。これにより専用の ESLint script は不要で、既存の `bun run lint` (および `bun run quality`) に自然に組み込まれる。

- `.oxlintrc.json` の `jsPlugins` に `eslint-plugin-testing-library` を追加
- テストファイル限定の override を新設し、ルールを `error` で有効化
- e2e / tests-examples (Playwright) は対象外

### 対象ファイル

`src` 配下のテストファイル + `tests/**/*.test.{ts,tsx}` (例: `tests/profile/saved-tabs-profiler.test.ts` は `@testing-library/react` を利用するため対象に含む)。e2e / tests-examples は Playwright のため対象外。

### 採用ルール (11 件、すべて `error`、既存違反 0 件)

#### 非同期安全性
- `testing-library/await-async-events`
- `testing-library/await-async-queries`
- `testing-library/await-async-utils`
- `testing-library/no-await-sync-events`
- `testing-library/no-await-sync-queries`

#### query / assertion 品質
- `testing-library/prefer-screen-queries`
- `testing-library/prefer-query-by-disappearance`
- `testing-library/no-global-regexp-flag-in-query`

#### Testing Library の思想
- `testing-library/no-dom-import`
- `testing-library/prefer-user-event-setup`

#### デバッグ残り防止
- `testing-library/no-debugging-utils`

### 見送りルール (別 issue に分割 or 制約により見送り)

| ルール | 違反件数 | 扱い | 理由 |
| --- | --- | --- | --- |
| `prefer-user-event` | 669 | #616 | `fireEvent` → `userEvent` 変換は非同期イベント dispatch のタイミング・順序が変わりデグレリスクが高い。41 ファイル 669 件を一括変換せず段階移行する。 |
| `no-container` | 8 | #617 | 直接 DOM アクセスで CSS クラス・SVG 構造など実装詳細をアサーションしている。`no-node-access` と同一の懸念のためまとめて対応する。 |
| `no-node-access` | 124 | #617 | 同上。jsdom で視覚状態クラスを意味的 query で検証できないケースが多く、テスト方針の見直しを要する。 |
| `prefer-query-matchers` | 0 (no-op) | 見送り | Oxlint `jsPlugins` 経由では rule options (`validEntries`) がプラグインへ伝達されず、本ルールは必須オプションなしでは何も検査しない no-op になる。実機検証で `["error", {validEntries:[...]}]` 配列形式のオプションが無視されることを確認した。Oxlint の jsPlugin options 対応、または別途 ESLint script 導入時に再採用する。 |

見送りルールは `warn` には落とさず、`error` での採用を前提に別 issue / 刎期で段階導入する。

## `bun run quality` への組込み

`jsPlugins` 経由のため `bun run lint` に含まれ、`bun run quality` のパイプラインに自動的に組み込まれる。専用 script は不要。

## ローカル検証

- [x] `bun run lint` が通る
- [x] `bun run test` が通る (294 files / 3132 tests)
- [x] `bun run quality` が通る
- [x] `bun run knip` が通る (新規 devDependency は未使用扱いなし)
- [x] e2e / tests-examples に testing-library ルールが適用されていないことを確認
- [x] `tests/profile/saved-tabs-profiler.test.ts` が対象に含まれていることを確認

Closes #609
分割先: #616 #617


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added testing-library linting support to the project.
  * Introduced stricter lint rules for test/spec files to promote consistent async behavior and safer query/event usage.
  * Added the required linting package to development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->