### PR TITLE
prefer-user-event ルールを有効化し fireEvent を userEvent に移行する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -83,14 +83,8 @@
     "eslint/func-style": "off",
     "eslint/id-length": "off",
     "eslint/init-declarations": "off",
-    "eslint/complexity": [
-      "error",
-      15
-    ],
-    "eslint/max-depth": [
-      "error",
-      3
-    ],
+    "eslint/complexity": ["error", 15],
+    "eslint/max-depth": ["error", 3],
     "eslint/max-lines": [
       "error",
       {
@@ -107,18 +101,9 @@
         "skipComments": true
       }
     ],
-    "eslint/max-nested-callbacks": [
-      "error",
-      3
-    ],
-    "eslint/max-params": [
-      "error",
-      4
-    ],
-    "eslint/max-statements": [
-      "error",
-      60
-    ],
+    "eslint/max-nested-callbacks": ["error", 3],
+    "eslint/max-params": ["error", 4],
+    "eslint/max-statements": ["error", 60],
     "eslint/new-cap": "off",
     "eslint/no-continue": "off",
     "eslint/no-duplicate-imports": "off",
@@ -139,12 +124,7 @@
     "eslint/no-magic-numbers": [
       "error",
       {
-        "ignore": [
-          -1,
-          0,
-          1,
-          2
-        ],
+        "ignore": [-1, 0, 1, 2],
         "ignoreArrayIndexes": true,
         "ignoreDefaultValues": true,
         "detectObjects": false,
@@ -164,10 +144,7 @@
     "eslint/no-promise-executor-return": "off",
     "eslint/default-case-last": "error",
     "eslint/default-param-last": "error",
-    "eslint/eqeqeq": [
-      "error",
-      "always"
-    ],
+    "eslint/eqeqeq": ["error", "always"],
     "eslint/guard-for-in": "error",
     "eslint/no-await-in-loop": "error",
     "eslint/no-debugger": "error",
@@ -497,10 +474,7 @@
             "skipComments": true
           }
         ],
-        "eslint/max-statements": [
-          "error",
-          100
-        ],
+        "eslint/max-statements": ["error", 100],
         "eslint/max-params": "off"
       }
     },
@@ -514,9 +488,7 @@
       }
     },
     {
-      "files": [
-        "src/contexts/*/public-api.ts"
-      ],
+      "files": ["src/contexts/*/public-api.ts"],
       "rules": {
         "oxc/no-barrel-file": "off"
       }
@@ -555,18 +527,9 @@
             "skipComments": true
           }
         ],
-        "eslint/max-statements": [
-          "error",
-          200
-        ],
-        "eslint/complexity": [
-          "error",
-          20
-        ],
-        "eslint/max-depth": [
-          "error",
-          5
-        ],
+        "eslint/max-statements": ["error", 200],
+        "eslint/complexity": ["error", 20],
+        "eslint/max-depth": ["error", 5],
         "eslint/max-params": "off",
         "import/first": "off",
         "eslint/max-nested-callbacks": "off",
@@ -620,14 +583,8 @@
             "skipComments": true
           }
         ],
-        "eslint/max-statements": [
-          "error",
-          100
-        ],
-        "eslint/complexity": [
-          "error",
-          20
-        ],
+        "eslint/max-statements": ["error", 100],
+        "eslint/complexity": ["error", 20],
         "react-perf/jsx-no-jsx-as-prop": "off",
         "react-perf/jsx-no-new-function-as-prop": "off",
         "react-perf/jsx-no-new-object-as-prop": "off",
@@ -650,9 +607,7 @@
       }
     },
     {
-      "files": [
-        "src/contexts/*/domain/**/*.{ts,tsx}"
-      ],
+      "files": ["src/contexts/*/domain/**/*.{ts,tsx}"],
       "rules": {
         "eslint/no-restricted-globals": [
           "error",
@@ -718,9 +673,7 @@
       }
     },
     {
-      "files": [
-        "src/contexts/*/application/**/*.{ts,tsx}"
-      ],
+      "files": ["src/contexts/*/application/**/*.{ts,tsx}"],
       "rules": {
         "eslint/no-restricted-properties": [
           "error",
@@ -753,9 +706,7 @@
       }
     },
     {
-      "files": [
-        "src/contexts/*/presentation/**/*.{ts,tsx}"
-      ],
+      "files": ["src/contexts/*/presentation/**/*.{ts,tsx}"],
       "rules": {
         "eslint/no-restricted-properties": [
           "error",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -83,8 +83,14 @@
     "eslint/func-style": "off",
     "eslint/id-length": "off",
     "eslint/init-declarations": "off",
-    "eslint/complexity": ["error", 15],
-    "eslint/max-depth": ["error", 3],
+    "eslint/complexity": [
+      "error",
+      15
+    ],
+    "eslint/max-depth": [
+      "error",
+      3
+    ],
     "eslint/max-lines": [
       "error",
       {
@@ -101,9 +107,18 @@
         "skipComments": true
       }
     ],
-    "eslint/max-nested-callbacks": ["error", 3],
-    "eslint/max-params": ["error", 4],
-    "eslint/max-statements": ["error", 60],
+    "eslint/max-nested-callbacks": [
+      "error",
+      3
+    ],
+    "eslint/max-params": [
+      "error",
+      4
+    ],
+    "eslint/max-statements": [
+      "error",
+      60
+    ],
     "eslint/new-cap": "off",
     "eslint/no-continue": "off",
     "eslint/no-duplicate-imports": "off",
@@ -124,7 +139,12 @@
     "eslint/no-magic-numbers": [
       "error",
       {
-        "ignore": [-1, 0, 1, 2],
+        "ignore": [
+          -1,
+          0,
+          1,
+          2
+        ],
         "ignoreArrayIndexes": true,
         "ignoreDefaultValues": true,
         "detectObjects": false,
@@ -144,7 +164,10 @@
     "eslint/no-promise-executor-return": "off",
     "eslint/default-case-last": "error",
     "eslint/default-param-last": "error",
-    "eslint/eqeqeq": ["error", "always"],
+    "eslint/eqeqeq": [
+      "error",
+      "always"
+    ],
     "eslint/guard-for-in": "error",
     "eslint/no-await-in-loop": "error",
     "eslint/no-debugger": "error",
@@ -201,7 +224,12 @@
     "react/no-react-children": "off",
     "react/hook-use-state": "error",
     "react/jsx-handler-names": "error",
-    "react/jsx-max-depth": ["error", { "max": 5 }],
+    "react/jsx-max-depth": [
+      "error",
+      {
+        "max": 5
+      }
+    ],
     "react/jsx-no-constructed-context-values": "error",
     "react/jsx-props-no-spreading": "off",
     "react/react-in-jsx-scope": "off",
@@ -444,7 +472,10 @@
         "vitest.workspace.ts",
         "src/entrypoints/**"
       ],
-      "env": { "node": true, "es2024": true },
+      "env": {
+        "node": true,
+        "es2024": true
+      },
       "rules": {
         "import/no-default-export": "off",
         "import/no-anonymous-default-export": "off",
@@ -452,13 +483,24 @@
         "unicorn/no-abusive-eslint-disable": "off",
         "eslint/max-lines": [
           "error",
-          { "max": 800, "skipBlankLines": true, "skipComments": true }
+          {
+            "max": 800,
+            "skipBlankLines": true,
+            "skipComments": true
+          }
         ],
         "eslint/max-lines-per-function": [
           "error",
-          { "max": 250, "skipBlankLines": true, "skipComments": true }
+          {
+            "max": 250,
+            "skipBlankLines": true,
+            "skipComments": true
+          }
         ],
-        "eslint/max-statements": ["error", 100],
+        "eslint/max-statements": [
+          "error",
+          100
+        ],
         "eslint/max-params": "off"
       }
     },
@@ -472,7 +514,9 @@
       }
     },
     {
-      "files": ["src/contexts/*/public-api.ts"],
+      "files": [
+        "src/contexts/*/public-api.ts"
+      ],
       "rules": {
         "oxc/no-barrel-file": "off"
       }
@@ -497,15 +541,32 @@
         "eslint/no-magic-numbers": "off",
         "eslint/max-lines": [
           "error",
-          { "max": 5000, "skipBlankLines": true, "skipComments": true }
+          {
+            "max": 5000,
+            "skipBlankLines": true,
+            "skipComments": true
+          }
         ],
         "eslint/max-lines-per-function": [
           "error",
-          { "max": 2000, "skipBlankLines": true, "skipComments": true }
+          {
+            "max": 2000,
+            "skipBlankLines": true,
+            "skipComments": true
+          }
         ],
-        "eslint/max-statements": ["error", 200],
-        "eslint/complexity": ["error", 20],
-        "eslint/max-depth": ["error", 5],
+        "eslint/max-statements": [
+          "error",
+          200
+        ],
+        "eslint/complexity": [
+          "error",
+          20
+        ],
+        "eslint/max-depth": [
+          "error",
+          5
+        ],
         "eslint/max-params": "off",
         "import/first": "off",
         "eslint/max-nested-callbacks": "off",
@@ -545,14 +606,28 @@
         "eslint/no-magic-numbers": "off",
         "eslint/max-lines": [
           "error",
-          { "max": 800, "skipBlankLines": true, "skipComments": true }
+          {
+            "max": 800,
+            "skipBlankLines": true,
+            "skipComments": true
+          }
         ],
         "eslint/max-lines-per-function": [
           "error",
-          { "max": 300, "skipBlankLines": true, "skipComments": true }
+          {
+            "max": 300,
+            "skipBlankLines": true,
+            "skipComments": true
+          }
         ],
-        "eslint/max-statements": ["error", 100],
-        "eslint/complexity": ["error", 20],
+        "eslint/max-statements": [
+          "error",
+          100
+        ],
+        "eslint/complexity": [
+          "error",
+          20
+        ],
         "react-perf/jsx-no-jsx-as-prop": "off",
         "react-perf/jsx-no-new-function-as-prop": "off",
         "react-perf/jsx-no-new-object-as-prop": "off",
@@ -575,7 +650,9 @@
       }
     },
     {
-      "files": ["src/contexts/*/domain/**/*.{ts,tsx}"],
+      "files": [
+        "src/contexts/*/domain/**/*.{ts,tsx}"
+      ],
       "rules": {
         "eslint/no-restricted-globals": [
           "error",
@@ -641,7 +718,9 @@
       }
     },
     {
-      "files": ["src/contexts/*/application/**/*.{ts,tsx}"],
+      "files": [
+        "src/contexts/*/application/**/*.{ts,tsx}"
+      ],
       "rules": {
         "eslint/no-restricted-properties": [
           "error",
@@ -674,7 +753,9 @@
       }
     },
     {
-      "files": ["src/contexts/*/presentation/**/*.{ts,tsx}"],
+      "files": [
+        "src/contexts/*/presentation/**/*.{ts,tsx}"
+      ],
       "rules": {
         "eslint/no-restricted-properties": [
           "error",
@@ -728,7 +809,8 @@
         "testing-library/no-global-regexp-flag-in-query": "error",
         "testing-library/no-dom-import": "error",
         "testing-library/prefer-user-event-setup": "error",
-        "testing-library/no-debugging-utils": "error"
+        "testing-library/no-debugging-utils": "error",
+        "testing-library/prefer-user-event": "error"
       }
     }
   ]

--- a/src/components/theme-provider.test.tsx
+++ b/src/components/theme-provider.test.tsx
@@ -2,12 +2,12 @@
 import {
   act,
   cleanup,
-  fireEvent,
   render,
   renderHook,
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
@@ -270,6 +270,7 @@ describe('ThemeProvider', () => {
   })
 
   it('user テーマの色適用と userSettings 変更イベントを反映する', async () => {
+    const user = userEvent.setup()
     storageValues.userSettings = {
       colors: {
         accent: '#111111',
@@ -298,7 +299,7 @@ describe('ThemeProvider', () => {
     })
     expect(document.documentElement.style.getPropertyValue('--accent')).toBe('')
 
-    fireEvent.click(screen.getByRole('button', { name: 'set-user' }))
+    await user.click(screen.getByRole('button', { name: 'set-user' }))
 
     await waitFor(() => {
       expect(screen.getByTestId('theme').textContent).toBe('user')

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
@@ -1,12 +1,6 @@
 /* eslint-disable max-lines-per-function, typescript/consistent-type-imports, typescript/no-misused-promises, typescript/require-await -- vi.importActual の typeof import および mock interface の sync 実装 */
 // @vitest-environment jsdom
-import {
-  act,
-  cleanup,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useMemo, useRef } from 'react'
 import { toast } from 'sonner'

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
@@ -3,11 +3,11 @@
 import {
   act,
   cleanup,
-  fireEvent,
   render,
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { useMemo, useRef } from 'react'
 import { toast } from 'sonner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
@@ -992,11 +992,11 @@ describe('SavedTabsApp custom search', () => {
   })
 
   it('プロジェクト名一致で対象プロジェクトだけを表示する', async () => {
+    const user = userEvent.setup()
     render(<SavedTabsApp />)
 
-    fireEvent.change(screen.getByLabelText('search'), {
-      target: { value: 'Reading' },
-    })
+    await user.clear(screen.getByLabelText('search'))
+    await user.type(screen.getByLabelText('search'), 'Reading')
 
     await waitFor(() => {
       expect(screen.getByText('project:Reading List')).toBeTruthy()
@@ -1007,11 +1007,11 @@ describe('SavedTabsApp custom search', () => {
   })
 
   it('URL 一致で対象プロジェクトに絞り込み、一致した URL を表示する', async () => {
+    const user = userEvent.setup()
     render(<SavedTabsApp />)
 
-    fireEvent.change(screen.getByLabelText('search'), {
-      target: { value: 'docker-cmd' },
-    })
+    await user.clear(screen.getByLabelText('search'))
+    await user.type(screen.getByLabelText('search'), 'docker-cmd')
 
     await waitFor(() => {
       expect(
@@ -1027,11 +1027,11 @@ describe('SavedTabsApp custom search', () => {
   })
 
   it('タイトル一致で対象プロジェクトに絞り込み、一致したタブを表示する', async () => {
+    const user = userEvent.setup()
     render(<SavedTabsApp />)
 
-    fireEvent.change(screen.getByLabelText('search'), {
-      target: { value: 'Meeting notes' },
-    })
+    await user.clear(screen.getByLabelText('search'))
+    await user.type(screen.getByLabelText('search'), 'Meeting notes')
 
     await waitFor(() => {
       expect(
@@ -1101,6 +1101,7 @@ describe('SavedTabsApp custom search', () => {
   })
 
   it('ドメインモードでは親カテゴリ名検索で一致したグループを保持する', async () => {
+    const user = userEvent.setup()
     const group: TabGroup = {
       id: 'group-1',
       domain: 'example.com',
@@ -1129,9 +1130,8 @@ describe('SavedTabsApp custom search', () => {
 
     render(<SavedTabsApp initialViewMode='domain' />)
 
-    fireEvent.change(screen.getByLabelText('search'), {
-      target: { value: 'Reading' },
-    })
+    await user.clear(screen.getByLabelText('search'))
+    await user.type(screen.getByLabelText('search'), 'Reading')
 
     await waitFor(() => {
       expect(mocked.domainModeContainerSpy).toHaveBeenLastCalledWith(
@@ -1143,6 +1143,7 @@ describe('SavedTabsApp custom search', () => {
   })
 
   it('parentCategoryId が直接指す親カテゴリ名でも検索一致する', async () => {
+    const user = userEvent.setup()
     const group: TabGroup = {
       domain: 'example.com',
       id: 'group-1',
@@ -1171,9 +1172,8 @@ describe('SavedTabsApp custom search', () => {
 
     render(<SavedTabsApp initialViewMode='domain' />)
 
-    fireEvent.change(screen.getByLabelText('search'), {
-      target: { value: 'Reading' },
-    })
+    await user.clear(screen.getByLabelText('search'))
+    await user.type(screen.getByLabelText('search'), 'Reading')
 
     await waitFor(() => {
       expect(mocked.domainModeContainerSpy).toHaveBeenLastCalledWith(
@@ -1189,6 +1189,7 @@ describe('SavedTabsApp custom search', () => {
   })
 
   it('検索時に URL 一覧が空のグループとカテゴリ未一致ログ分岐を扱う', async () => {
+    const user = userEvent.setup()
     const emptyGroup: TabGroup = {
       domain: 'empty.example.com',
       id: 'group-empty',
@@ -1213,9 +1214,8 @@ describe('SavedTabsApp custom search', () => {
 
     render(<SavedTabsApp initialViewMode='domain' />)
 
-    fireEvent.change(screen.getByLabelText('search'), {
-      target: { value: 'missing' },
-    })
+    await user.clear(screen.getByLabelText('search'))
+    await user.type(screen.getByLabelText('search'), 'missing')
 
     await waitFor(() => {
       expect(mocked.domainModeContainerSpy).toHaveBeenLastCalledWith(
@@ -2617,6 +2617,7 @@ describe('SavedTabsApp custom search', () => {
   })
 
   it('未分類ドメインの並び替えを確定/キャンセルできる', async () => {
+    const user = userEvent.setup()
     const group1: TabGroup = {
       domain: 'a.example.com',
       id: 'group-1',
@@ -2666,9 +2667,7 @@ describe('SavedTabsApp custom search', () => {
       }) => void
     }
 
-    fireEvent.change(screen.getByLabelText('search'), {
-      target: { value: '' },
-    })
+    await user.clear(screen.getByLabelText('search'))
 
     act(() => {
       domainProps.handleUncategorizedDragEnd({
@@ -2780,6 +2779,7 @@ describe('SavedTabsApp custom search', () => {
   })
 
   it('親カテゴリ検索は missing parent と URL 部分一致の絞り込みを処理する', async () => {
+    const user = userEvent.setup()
     const group: TabGroup = {
       domain: 'example.com',
       id: 'group-1',
@@ -2813,9 +2813,8 @@ describe('SavedTabsApp custom search', () => {
 
     render(<SavedTabsApp initialViewMode='domain' />)
 
-    fireEvent.change(screen.getByLabelText('search'), {
-      target: { value: 'alpha' },
-    })
+    await user.clear(screen.getByLabelText('search'))
+    await user.type(screen.getByLabelText('search'), 'alpha')
 
     await waitFor(() => {
       expect(mocked.domainModeContainerSpy).toHaveBeenLastCalledWith(

--- a/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.test.tsx
@@ -14,6 +14,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 import { z } from 'zod'
 
@@ -412,6 +413,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('開いたときに初期化して利用可能ドメインを読み込み、通常時は閉じられる', async () => {
+    const user = userEvent.setup()
     const onClose = vi.fn()
     const { deps, useCases, getSavedTabsPageDataQuery } = setupMocks()
     render(
@@ -432,7 +434,7 @@ describe('CategoryManagementModal', () => {
     expect(screen.getByTestId('select-item-g2')).toBeTruthy()
     expect(getSavedTabsPageDataQuery).toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-close' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-close' }))
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
@@ -459,6 +461,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('リネーム開始時に input を focus/select し Escape でキャンセルする', async () => {
+    const user = userEvent.setup()
     let rafCallback: FrameRequestCallback | undefined
     ;(
       globalThis.requestAnimationFrame as unknown as ReturnType<typeof vi.fn>
@@ -479,7 +482,7 @@ describe('CategoryManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
     const input = (await screen.findByPlaceholderText(
       '例: ビジネスツール、技術情報',
     )) as HTMLInputElement
@@ -490,13 +493,14 @@ describe('CategoryManagementModal', () => {
     expect(focusSpy).toHaveBeenCalled()
     expect(selectSpy).toHaveBeenCalled()
 
-    fireEvent.keyDown(input, { key: 'Escape' })
+    await user.type(input, '{Escape}')
     expect(
       screen.queryByPlaceholderText('例: ビジネスツール、技術情報'),
     ).toBeNull()
   })
 
   it('リネーム時の Enter/Blur 分岐（変更なし・バリデーション失敗・処理中・キャンセル）を処理する', async () => {
+    const user = userEvent.setup()
     // eslint-disable-next-line typescript/no-invalid-void-type
     const deferredRename = createDeferred<void>()
     const renameParentCategory = vi.fn(
@@ -527,13 +531,13 @@ describe('CategoryManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
     let input = await screen.findByPlaceholderText(
       '例: ビジネスツール、技術情報',
     )
 
     // 変更なし Enter -> 早期 return
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.type(input, '{Enter}')
     expect(
       screen.getByPlaceholderText('例: ビジネスツール、技術情報'),
     ).toBeTruthy()
@@ -543,10 +547,11 @@ describe('CategoryManagementModal', () => {
     expect(
       screen.queryByPlaceholderText('例: ビジネスツール、技術情報'),
     ).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
     input = await screen.findByPlaceholderText('例: ビジネスツール、技術情報')
-    fireEvent.change(input, { target: { value: '12345678901234567890123456' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.clear(input)
+    await user.type(input, '12345678901234567890123456')
+    await user.type(input, '{Enter}')
     expect(
       screen.getByText('新規親カテゴリ名は25文字以下にしてください'),
     ).toBeTruthy()
@@ -557,10 +562,11 @@ describe('CategoryManagementModal', () => {
     expect(focusSpy).toHaveBeenCalled()
 
     // Tab key -> Enter/Escape どちらでもない分岐
-    fireEvent.keyDown(input, { key: 'Tab' })
+    await user.type(input, '{Tab}')
 
     // valid blur -> 保存開始
-    fireEvent.change(input, { target: { value: 'BlurSave' } })
+    await user.clear(input)
+    await user.type(input, 'BlurSave')
     fireEvent.blur(input)
     await waitFor(() => {
       expect(renameParentCategory).toHaveBeenCalledWith(
@@ -572,7 +578,7 @@ describe('CategoryManagementModal', () => {
     })
 
     // 処理中 Enter/Blur は早期 return
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.type(input, '{Enter}')
     fireEvent.blur(input)
 
     await act(async () => {
@@ -584,9 +590,10 @@ describe('CategoryManagementModal', () => {
     })
 
     // 再度開いて同名 blur -> キャンセル
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
     input = await screen.findByPlaceholderText('例: ビジネスツール、技術情報')
-    fireEvent.change(input, { target: { value: 'BlurSave' } })
+    await user.clear(input)
+    await user.type(input, 'BlurSave')
     fireEvent.blur(input)
     expect(
       screen.queryByPlaceholderText('例: ビジネスツール、技術情報'),
@@ -594,6 +601,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('リネーム開始/バリデーション/成功保存/closeガード（isRenaming）を処理する', async () => {
+    const user = userEvent.setup()
     const onClose = vi.fn()
     const renameParentCategory = vi.fn(
       async (command: { categoryId: string; newName: string }) => {
@@ -621,25 +629,27 @@ describe('CategoryManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
     const input = await screen.findByPlaceholderText(
       '例: ビジネスツール、技術情報',
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-close' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-close' }))
     expect(onClose).not.toHaveBeenCalled()
 
-    fireEvent.change(input, { target: { value: '' } })
+    await user.clear(input)
     fireEvent.blur(input)
     expect(screen.getByText('新規親カテゴリ名を入力してください')).toBeTruthy()
 
-    fireEvent.change(input, { target: { value: '12345678901234567890123456' } })
+    await user.clear(input)
+    await user.type(input, '12345678901234567890123456')
     expect(
       screen.getByText('新規親カテゴリ名は25文字以下にしてください'),
     ).toBeTruthy()
 
-    fireEvent.change(input, { target: { value: '新しいカテゴリ' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.clear(input)
+    await user.type(input, '新しいカテゴリ')
+    await user.type(input, '{Enter}')
 
     await waitFor(() => {
       expect(renameParentCategory).toHaveBeenCalledWith(
@@ -657,6 +667,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('リネーム失敗時（use-case throw / 確認失敗）に toast.error を出す', async () => {
+    const user = userEvent.setup()
     // Sub-test 1: renameParentCategory use-case が throw する
     {
       const renameParentCategory = vi.fn(async () => {
@@ -676,14 +687,15 @@ describe('CategoryManagementModal', () => {
         />,
       )
 
-      fireEvent.click(
+      await user.click(
         screen.getByRole('button', { name: /親カテゴリ名を変更/ }),
       )
       const input = await screen.findByPlaceholderText(
         '例: ビジネスツール、技術情報',
       )
-      fireEvent.change(input, { target: { value: '失敗1' } })
-      fireEvent.keyDown(input, { key: 'Enter' })
+      await user.clear(input)
+    await user.type(input, '失敗1')
+      await user.type(input, '{Enter}')
 
       await waitFor(() => {
         expect(toastErrorSpy).toHaveBeenCalledWith(
@@ -714,14 +726,15 @@ describe('CategoryManagementModal', () => {
         />,
       )
 
-      fireEvent.click(
+      await user.click(
         screen.getByRole('button', { name: /親カテゴリ名を変更/ }),
       )
       const input = await screen.findByPlaceholderText(
         '例: ビジネスツール、技術情報',
       )
-      fireEvent.change(input, { target: { value: '更新未反映' } })
-      fireEvent.keyDown(input, { key: 'Enter' })
+      await user.clear(input)
+    await user.type(input, '更新未反映')
+      await user.type(input, '{Enter}')
 
       await waitFor(() => {
         expect(toastErrorSpy).toHaveBeenCalledWith(
@@ -732,6 +745,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('リネーム use-case 戻り値が更新を反映しない場合にエラーとして処理する', async () => {
+    const user = userEvent.setup()
     // issue #518 で `parentCategoryRepository.findById` による最終確認は
     // 撤廃され、use-case 戻り値検証 (1次検証) のみが残る。use-case が
     // 状態 (mockStateRef) を更新しない (古い name のまま返す) シナリオで
@@ -764,12 +778,13 @@ describe('CategoryManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
     const input = await screen.findByPlaceholderText(
       '例: ビジネスツール、技術情報',
     )
-    fireEvent.change(input, { target: { value: '更新後' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.clear(input)
+    await user.type(input, '更新後')
+    await user.type(input, '{Enter}')
 
     await waitFor(() => {
       expect(renameParentCategory).toHaveBeenCalled()
@@ -780,6 +795,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('リネーム保存で non-Error を投げた場合も stack なしでハンドリングする', async () => {
+    const user = userEvent.setup()
     const renameParentCategory = vi.fn(async () => {
       // eslint-disable-next-line eslint/no-throw-literal
       throw 'string-error'
@@ -799,12 +815,13 @@ describe('CategoryManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
     const input = await screen.findByPlaceholderText(
       '例: ビジネスツール、技術情報',
     )
-    fireEvent.change(input, { target: { value: 'string fail' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.clear(input)
+    await user.type(input, 'string fail')
+    await user.type(input, '{Enter}')
 
     await waitFor(() => {
       expect(
@@ -822,6 +839,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('リネーム保存時に validateCategoryName が false を返した場合は処理を中止する', async () => {
+    const user = userEvent.setup()
     const renameParentCategory =
       vi.fn() as unknown as RenameParentCategoryUseCase
     const { deps, useCases } = setupMocks({
@@ -839,11 +857,12 @@ describe('CategoryManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリ名を変更/ }))
     const input = await screen.findByPlaceholderText(
       '例: ビジネスツール、技術情報',
     )
-    fireEvent.change(input, { target: { value: 'valid-name' } })
+    await user.clear(input)
+    await user.type(input, 'valid-name')
 
     using _safeParseSpy = vi
       .spyOn(categoryNameSchema, 'safeParse')
@@ -861,7 +880,7 @@ describe('CategoryManagementModal', () => {
           }) as ReturnType<typeof z.ZodString.prototype.safeParse>,
       )
 
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.type(input, '{Enter}')
     await waitFor(() => {
       expect(screen.getByText('カテゴリ名が無効です')).toBeTruthy()
     })
@@ -869,6 +888,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('親カテゴリ削除の成功/失敗を処理する', async () => {
+    const user = userEvent.setup()
     const onClose = vi.fn()
     const { deps, useCases, parentCategoryRepository } = setupMocks()
     const { rerender } = render(
@@ -882,8 +902,8 @@ describe('CategoryManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリを削除/ }))
-    fireEvent.click(screen.getByRole('button', { name: /^削除$/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリを削除/ }))
+    await user.click(screen.getByRole('button', { name: /^削除$/ }))
 
     await waitFor(() => {
       // `deleteParentCategory` use-case 経由で削除される (issue #518)。
@@ -915,8 +935,8 @@ describe('CategoryManagementModal', () => {
         useCases={useCases}
       />,
     )
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリを削除/ }))
-    fireEvent.click(screen.getByRole('button', { name: /^削除$/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリを削除/ }))
+    await user.click(screen.getByRole('button', { name: /^削除$/ }))
 
     await waitFor(() => {
       expect(toastErrorSpy).toHaveBeenCalledWith('カテゴリの削除に失敗しました')
@@ -924,6 +944,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('親カテゴリ削除確認のキャンセル・関連ドメインなし表示・処理中の再入防止を処理する', async () => {
+    const user = userEvent.setup()
     // eslint-disable-next-line typescript/no-invalid-void-type
     const deferredRemove = createDeferred<void>()
     const deleteParentCategory = vi.fn(
@@ -958,13 +979,13 @@ describe('CategoryManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリを削除/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリを削除/ }))
     expect(screen.queryByText(/件のドメインが関連付けられています/)).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }))
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }))
     expect(screen.queryByRole('button', { name: /^削除$/ })).toBeNull()
 
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリを削除/ }))
-    fireEvent.click(screen.getByRole('button', { name: /^削除$/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリを削除/ }))
+    await user.click(screen.getByRole('button', { name: /^削除$/ }))
 
     await waitFor(() => {
       expect(deleteParentCategory).toHaveBeenCalledTimes(1)
@@ -985,6 +1006,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('ドメイン追加の成功/重複エラーを処理する', async () => {
+    const user = userEvent.setup()
     const [currentDomain] = createDomains()
     expect(currentDomain).toBeTruthy()
     if (!currentDomain) {
@@ -1012,7 +1034,7 @@ describe('CategoryManagementModal', () => {
       if (!plusButton) {
         throw new Error('plusButton not found')
       }
-      fireEvent.click(plusButton)
+      await user.click(plusButton)
 
       await waitFor(() => {
         // eslint-disable-next-line no-console
@@ -1070,7 +1092,7 @@ describe('CategoryManagementModal', () => {
       if (!secondPlusButton) {
         throw new Error('secondPlusButton not found')
       }
-      fireEvent.click(secondPlusButton)
+      await user.click(secondPlusButton)
 
       await waitFor(() => {
         expect(toastErrorSpy).toHaveBeenCalledWith(
@@ -1081,6 +1103,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('ドメイン追加の残件選択・カテゴリ更新分岐・処理中再入防止を処理する', async () => {
+    const user = userEvent.setup()
     const domains3: TabGroup[] = [
       { id: 'g1', domain: 'a.com', urls: [] },
       { id: 'g2', domain: 'b.com', urls: [] },
@@ -1155,7 +1178,7 @@ describe('CategoryManagementModal', () => {
       throw new Error('plusButton not found')
     }
 
-    fireEvent.click(plusButton)
+    await user.click(plusButton)
     await waitFor(() => {
       expect(addDomainToParentCategory).toHaveBeenCalledTimes(1)
     })
@@ -1225,6 +1248,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('ドメイン追加でカテゴリ不存在・選択ドメイン情報不存在をハンドリングする', async () => {
+    const user = userEvent.setup()
     const [currentDomain] = createDomains()
     expect(currentDomain).toBeTruthy()
     if (!currentDomain) {
@@ -1254,7 +1278,7 @@ describe('CategoryManagementModal', () => {
       if (!plusButton) {
         throw new Error('plusButton not found')
       }
-      fireEvent.click(plusButton)
+      await user.click(plusButton)
       await waitFor(() => {
         expect(toastErrorSpy).toHaveBeenCalledWith(
           'カテゴリの設定に失敗しました',
@@ -1310,7 +1334,7 @@ describe('CategoryManagementModal', () => {
         return originalFind.call(context, predicate, thisArg)
       })
 
-      fireEvent.click(plusButton)
+      await user.click(plusButton)
       await waitFor(() => {
         expect(toastErrorSpy).toHaveBeenCalledWith(
           'カテゴリの設定に失敗しました',
@@ -1320,6 +1344,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('ドメイン削除の成功/失敗と closeガード（loading中）を処理する', async () => {
+    const user = userEvent.setup()
     const originalReadyState = document.readyState
     const removeDomainFromParentCategory = vi.fn(
       async () => mockStateRef.current.parentCategories,
@@ -1347,7 +1372,7 @@ describe('CategoryManagementModal', () => {
     if (!firstRemoveButton) {
       throw new Error('firstRemoveButton not found')
     }
-    fireEvent.click(firstRemoveButton)
+    await user.click(firstRemoveButton)
     await waitFor(() => {
       expect(toastSuccessSpy).toHaveBeenCalledWith(
         'ドメイン a.com を「仕事」から削除しました',
@@ -1368,7 +1393,7 @@ describe('CategoryManagementModal', () => {
     if (!nextRemoveButton) {
       throw new Error('nextRemoveButton not found')
     }
-    fireEvent.click(nextRemoveButton)
+    await user.click(nextRemoveButton)
     await waitFor(() => {
       expect(toastErrorSpy).toHaveBeenCalledWith('カテゴリの削除に失敗しました')
     })
@@ -1377,7 +1402,7 @@ describe('CategoryManagementModal', () => {
       configurable: true,
       get: () => 'loading',
     })
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-close' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-close' }))
 
     Object.defineProperty(document, 'readyState', {
       configurable: true,
@@ -1386,6 +1411,7 @@ describe('CategoryManagementModal', () => {
   })
 
   it('ドメイン削除のカテゴリ更新分岐・処理中再入防止・関連データ不足を処理する', async () => {
+    const user = userEvent.setup()
     // eslint-disable-next-line typescript/no-invalid-void-type
     const deferredRemove = createDeferred<void>()
     const removeDomainFromParentCategory = vi.fn(
@@ -1452,7 +1478,7 @@ describe('CategoryManagementModal', () => {
     if (!removeButton) {
       throw new Error('removeButton not found')
     }
-    fireEvent.click(removeButton)
+    await user.click(removeButton)
 
     await waitFor(() => {
       expect(removeDomainFromParentCategory).toHaveBeenCalledTimes(1)
@@ -1502,7 +1528,7 @@ describe('CategoryManagementModal', () => {
       />,
     )
     removeButtons = screen.getAllByRole('button', { name: 'ドメインを削除' })
-    fireEvent.click(removeButtons[0] as HTMLButtonElement)
+    await user.click(removeButtons[0] as HTMLButtonElement)
     await waitFor(() => {
       expect(toastErrorSpy).toHaveBeenCalledWith('カテゴリの削除に失敗しました')
     })
@@ -1527,7 +1553,7 @@ describe('CategoryManagementModal', () => {
       />,
     )
     removeButtons = screen.getAllByRole('button', { name: 'ドメインを削除' })
-    fireEvent.click(removeButtons[0] as HTMLButtonElement)
+    await user.click(removeButtons[0] as HTMLButtonElement)
     await waitFor(() => {
       expect(toastErrorSpy).toHaveBeenCalledWith('カテゴリの削除に失敗しました')
     })

--- a/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.test.tsx
@@ -694,7 +694,7 @@ describe('CategoryManagementModal', () => {
         '例: ビジネスツール、技術情報',
       )
       await user.clear(input)
-    await user.type(input, '失敗1')
+      await user.type(input, '失敗1')
       await user.type(input, '{Enter}')
 
       await waitFor(() => {
@@ -733,7 +733,7 @@ describe('CategoryManagementModal', () => {
         '例: ビジネスツール、技術情報',
       )
       await user.clear(input)
-    await user.type(input, '更新未反映')
+      await user.type(input, '更新未反映')
       await user.type(input, '{Enter}')
 
       await waitFor(() => {

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.additional.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.additional.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 import {
   cleanup,
-  fireEvent,
   render,
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -134,6 +134,7 @@ describe('CustomProjectCategory additional', () => {
   })
 
   it('handleDeleteUrlsFromProject があれば一括削除でそちらを使う', async () => {
+    const user = userEvent.setup()
     const handleDeleteUrlsFromProject = vi.fn().mockResolvedValue(undefined)
 
     render(
@@ -144,7 +145,7 @@ describe('CustomProjectCategory additional', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'すべて削除' }))
+    await user.click(screen.getByRole('button', { name: 'すべて削除' }))
 
     await waitFor(() => {
       expect(handleDeleteUrlsFromProject).toHaveBeenCalledWith('project-1', [

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.additional.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.additional.test.tsx
@@ -1,10 +1,5 @@
 // @vitest-environment jsdom
-import {
-  cleanup,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -260,6 +261,7 @@ describe('CustomProjectCategory', () => {
   })
 
   it('カテゴリURLをフィルタして描画し、折りたたみ・ソート・即時一括操作を処理する', async () => {
+    const user = userEvent.setup()
     const handleOpenAllUrls = vi.fn()
     const handleDeleteUrl = vi.fn(async () => {})
     render(
@@ -283,33 +285,35 @@ describe('CustomProjectCategory', () => {
     )
 
     const collapseButton = screen.getByRole('button', { name: '折りたたむ' })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.pointerDown(collapseButton)
-    fireEvent.click(collapseButton)
+    await user.click(collapseButton)
     expect(screen.queryByTestId('card-content')).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: '展開' }))
+    await user.click(screen.getByRole('button', { name: '展開' }))
     expect(screen.getByTestId('card-content')).toBeTruthy()
 
     const sortButton = screen.getByRole('button', { name: 'デフォルト' })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.pointerDown(sortButton)
-    fireEvent.click(sortButton)
+    await user.click(sortButton)
     expect(screen.getByRole('button', { name: '保存日時の昇順' })).toBeTruthy()
     expect(screen.getAllByTestId('project-url-item')[0]?.textContent).toContain(
       'https://c.com',
     )
 
-    fireEvent.click(screen.getByRole('button', { name: '保存日時の昇順' }))
+    await user.click(screen.getByRole('button', { name: '保存日時の昇順' }))
     expect(screen.getByRole('button', { name: '保存日時の降順' })).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: '保存日時の降順' }))
+    await user.click(screen.getByRole('button', { name: '保存日時の降順' }))
     expect(screen.getByRole('button', { name: 'デフォルト' })).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'すべて開く' }))
+    await user.click(screen.getByRole('button', { name: 'すべて開く' }))
     expect(handleOpenAllUrls).toHaveBeenCalledWith(
       expect.arrayContaining([
         { url: 'https://b.com', title: 'B', category: 'Work', savedAt: 2 },
       ]),
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'すべて削除' }))
+    await user.click(screen.getByRole('button', { name: 'すべて削除' }))
     await waitFor(() => {
       expect(handleDeleteUrl).toHaveBeenCalledTimes(3)
     })
@@ -355,6 +359,7 @@ describe('CustomProjectCategory', () => {
   })
 
   it('10件以上の一括開く確認ダイアログで handleOpenAllUrls 未指定時は window.open にフォールバックする', async () => {
+    const user = userEvent.setup()
     using openSpy = vi.spyOn(window, 'open')
     render(
       <CustomProjectCategory
@@ -370,8 +375,8 @@ describe('CustomProjectCategory', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'すべて開く' }))
-    fireEvent.click(await screen.findByRole('button', { name: '開く' }))
+    await user.click(screen.getByRole('button', { name: 'すべて開く' }))
+    await user.click(await screen.findByRole('button', { name: '開く' }))
 
     expect(openSpy).toHaveBeenCalledTimes(10)
     expect(openSpy).toHaveBeenCalledWith(
@@ -382,6 +387,7 @@ describe('CustomProjectCategory', () => {
   })
 
   it('confirmDeleteAll=true では一括削除確認ダイアログを表示し未分類名も表示する', async () => {
+    const user = userEvent.setup()
     const handleDeleteUrl = vi.fn(async () => {})
     render(
       <CustomProjectCategory
@@ -397,17 +403,18 @@ describe('CustomProjectCategory', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'すべて削除' }))
+    await user.click(screen.getByRole('button', { name: 'すべて削除' }))
     expect(screen.getByText('タブをすべて削除しますか？')).toBeTruthy()
     expect(screen.getByText(/未分類/)).toBeTruthy()
-    fireEvent.click(await screen.findByRole('button', { name: '削除' }))
+    await user.click(await screen.findByRole('button', { name: '削除' }))
 
     await waitFor(() => {
       expect(handleDeleteUrl).toHaveBeenCalledWith('project-1', 'https://u.com')
     })
   })
 
-  it('カテゴリ管理ダイアログで rename / delete の分岐とイベント停止を処理する', () => {
+  it('カテゴリ管理ダイアログで rename / delete の分岐とイベント停止を処理する', async () => {
+    const user = userEvent.setup()
     const handleRenameCategory = vi.fn()
     const handleDeleteCategory = vi.fn()
     render(
@@ -419,37 +426,42 @@ describe('CustomProjectCategory', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'カテゴリ管理' }))
+    await user.click(screen.getByRole('button', { name: 'カテゴリ管理' }))
     expect(screen.getByRole('heading', { name: 'カテゴリ管理' })).toBeTruthy()
 
     const dialogContent = screen.getByTestId('dialog-content')
     const stopPropagation = vi.fn()
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(dialogContent, { key: 'Enter', stopPropagation })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(dialogContent, { key: ' ', stopPropagation })
 
     const renameInput = screen.getByLabelText('カテゴリ名')
-    fireEvent.change(renameInput, { target: { value: '   ' } })
+    await user.clear(renameInput)
+    await user.type(renameInput, '   ')
     fireEvent.blur(renameInput)
     expect(screen.getByText('カテゴリ名を入力してください')).toBeTruthy()
 
-    fireEvent.change(renameInput, { target: { value: 'Work' } })
+    await user.clear(renameInput)
+    await user.type(renameInput, 'Work')
     fireEvent.blur(renameInput)
     expect(handleRenameCategory).not.toHaveBeenCalled()
 
-    fireEvent.change(renameInput, { target: { value: 'Work2' } })
-    fireEvent.keyDown(renameInput, { key: 'Enter' })
+    await user.clear(renameInput)
+    await user.type(renameInput, 'Work2')
+    await user.type(renameInput, '{Enter}')
     expect(handleRenameCategory).toHaveBeenCalledWith(
       'project-1',
       'Work',
       'Work2',
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'カテゴリを削除' }))
-    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }))
+    await user.click(screen.getByRole('button', { name: 'カテゴリを削除' }))
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }))
     expect(screen.queryByRole('button', { name: '削除' })).toBeNull()
 
-    fireEvent.click(screen.getByRole('button', { name: 'カテゴリを削除' }))
-    fireEvent.click(screen.getByRole('button', { name: '削除' }))
+    await user.click(screen.getByRole('button', { name: 'カテゴリを削除' }))
+    await user.click(screen.getByRole('button', { name: '削除' }))
     expect(handleDeleteCategory).toHaveBeenCalledWith('project-1', 'Work')
     expect(screen.queryByRole('heading', { name: 'カテゴリ管理' })).toBeNull()
   })
@@ -550,7 +562,8 @@ describe('CustomProjectCategory', () => {
     ).toBe(true)
   })
 
-  it('savedAt 未指定のソートと、管理ダイアログの未設定ハンドラ/イベント分岐を処理する', () => {
+  it('savedAt 未指定のソートと、管理ダイアログの未設定ハンドラ/イベント分岐を処理する', async () => {
+    const user = userEvent.setup()
     const handleDeleteCategory = vi.fn()
     const { rerender } = render(
       <CustomProjectCategory
@@ -565,10 +578,10 @@ describe('CustomProjectCategory', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'デフォルト' }))
+    await user.click(screen.getByRole('button', { name: 'デフォルト' }))
     expect(screen.getByRole('button', { name: '保存日時の昇順' })).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'カテゴリ管理' }))
+    await user.click(screen.getByRole('button', { name: 'カテゴリ管理' }))
     const dialogContent = screen.getByTestId('dialog-content')
     const pointerStopPropagation = vi.fn()
     const pointerDownEvent = new Event('pointerdown', {
@@ -592,13 +605,14 @@ describe('CustomProjectCategory', () => {
     expect(keyStopPropagation).not.toHaveBeenCalled()
 
     const renameInput = screen.getByLabelText('カテゴリ名')
-    fireEvent.keyDown(renameInput, { key: 'Escape' })
-    fireEvent.change(renameInput, { target: { value: 'Renamed' } })
-    fireEvent.keyDown(renameInput, { key: 'Enter' })
+    await user.type(renameInput, '{Escape}')
+    await user.clear(renameInput)
+    await user.type(renameInput, 'Renamed')
+    await user.type(renameInput, '{Enter}')
     expect(handleDeleteCategory).not.toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole('button', { name: 'カテゴリを削除' }))
-    fireEvent.click(screen.getByRole('button', { name: '削除' }))
+    await user.click(screen.getByRole('button', { name: 'カテゴリを削除' }))
+    await user.click(screen.getByRole('button', { name: '削除' }))
     expect(handleDeleteCategory).toHaveBeenCalledWith('project-1', 'Work')
 
     const handleRenameCategory = vi.fn()
@@ -612,14 +626,14 @@ describe('CustomProjectCategory', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'カテゴリ管理' }))
+    await user.click(screen.getByRole('button', { name: 'カテゴリ管理' }))
     const deleteCategoryButton = screen.queryByRole('button', {
       name: 'カテゴリを削除',
     })
     if (deleteCategoryButton) {
-      fireEvent.click(deleteCategoryButton)
+      await user.click(deleteCategoryButton)
     }
-    fireEvent.click(screen.getByRole('button', { name: '削除' }))
+    await user.click(screen.getByRole('button', { name: '削除' }))
     expect(screen.queryByRole('heading', { name: 'カテゴリ管理' })).toBeNull()
   })
 

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectSection.additional.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectSection.additional.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -279,7 +280,8 @@ describe('CustomProjectSection additional', () => {
     cleanup()
   })
 
-  it('create dialog の close と Enter 以外のキー分岐を処理する', () => {
+  it('create dialog の close と Enter 以外のキー分岐を処理する', async () => {
+    const user = userEvent.setup()
     const handleCreateProject = vi.fn()
 
     render(
@@ -290,13 +292,14 @@ describe('CustomProjectSection additional', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-open' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-open' }))
     const nameInput = screen.getByLabelText('プロジェクト名 *')
-    fireEvent.change(nameInput, { target: { value: 'Created Project' } })
-    fireEvent.keyDown(nameInput, { key: 'Escape' })
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Created Project')
+    await user.type(nameInput, '{Escape}')
     expect(handleCreateProject).not.toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-close' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-close' }))
     expect(screen.queryByText('新規プロジェクト作成')).toBeNull()
   })
 

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectSection.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectSection.test.tsx
@@ -1,11 +1,5 @@
 // @vitest-environment jsdom
-import {
-  act,
-  cleanup,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
@@ -341,7 +335,10 @@ describe('CustomProjectSection', () => {
     await user.click(screen.getByRole('button', { name: 'dialog-open' }))
 
     await user.clear(screen.getByLabelText('プロジェクト名 *'))
-    await user.type(screen.getByLabelText('プロジェクト名 *'), 'Enter Created Project')
+    await user.type(
+      screen.getByLabelText('プロジェクト名 *'),
+      'Enter Created Project',
+    )
 
     await user.type(screen.getByLabelText('プロジェクト名 *'), '{Enter}')
 

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectSection.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectSection.test.tsx
@@ -2,11 +2,11 @@
 import {
   act,
   cleanup,
-  fireEvent,
   render,
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -268,6 +268,7 @@ describe('CustomProjectSection', () => {
   })
 
   it('作成ダイアログで空入力・重複・成功・キャンセルの分岐を処理する', async () => {
+    const user = userEvent.setup()
     const handleCreateProject = vi.fn()
     render(
       <CustomProjectSection
@@ -277,31 +278,28 @@ describe('CustomProjectSection', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-open' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-open' }))
     expect(screen.getByTestId('dialog-content')).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: '作成' }))
+    await user.click(screen.getByRole('button', { name: '作成' }))
     await waitFor(() => {
       expect(screen.getByText('プロジェクト名を入力してください')).toBeTruthy()
     })
 
-    fireEvent.change(screen.getByLabelText('プロジェクト名 *'), {
-      target: { value: '   ' },
-    })
+    await user.clear(screen.getByLabelText('プロジェクト名 *'))
+    await user.type(screen.getByLabelText('プロジェクト名 *'), '   ')
 
-    fireEvent.change(screen.getByLabelText('プロジェクト名 *'), {
-      target: { value: 'Project One' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: '作成' }))
+    await user.clear(screen.getByLabelText('プロジェクト名 *'))
+    await user.type(screen.getByLabelText('プロジェクト名 *'), 'Project One')
+    await user.click(screen.getByRole('button', { name: '作成' }))
     await waitFor(() => {
       expect(
         screen.getByText('プロジェクト名「Project One」は既に使用されています'),
       ).toBeTruthy()
     })
 
-    fireEvent.change(screen.getByLabelText('プロジェクト名 *'), {
-      target: { value: 'New Project' },
-    })
+    await user.clear(screen.getByLabelText('プロジェクト名 *'))
+    await user.type(screen.getByLabelText('プロジェクト名 *'), 'New Project')
     await waitFor(() => {
       expect(
         screen.queryByText(
@@ -310,7 +308,7 @@ describe('CustomProjectSection', () => {
       ).toBeNull()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: '作成' }))
+    await user.click(screen.getByRole('button', { name: '作成' }))
 
     await waitFor(() => {
       expect(handleCreateProject).toHaveBeenCalledWith('New Project')
@@ -319,18 +317,18 @@ describe('CustomProjectSection', () => {
       expect(screen.queryByTestId('dialog-content')).toBeNull()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-open' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-open' }))
     expect(screen.queryByLabelText('説明（オプション）')).toBeNull()
-    fireEvent.change(screen.getByLabelText('プロジェクト名 *'), {
-      target: { value: 'Tmp' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }))
+    await user.clear(screen.getByLabelText('プロジェクト名 *'))
+    await user.type(screen.getByLabelText('プロジェクト名 *'), 'Tmp')
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }))
     await waitFor(() => {
       expect(screen.queryByTestId('dialog-content')).toBeNull()
     })
   })
 
   it('プロジェクト名入力で Enter を押すと作成を実行する', async () => {
+    const user = userEvent.setup()
     const handleCreateProject = vi.fn()
     render(
       <CustomProjectSection
@@ -340,16 +338,12 @@ describe('CustomProjectSection', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-open' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-open' }))
 
-    fireEvent.change(screen.getByLabelText('プロジェクト名 *'), {
-      target: { value: 'Enter Created Project' },
-    })
+    await user.clear(screen.getByLabelText('プロジェクト名 *'))
+    await user.type(screen.getByLabelText('プロジェクト名 *'), 'Enter Created Project')
 
-    fireEvent.keyDown(screen.getByLabelText('プロジェクト名 *'), {
-      key: 'Enter',
-      code: 'Enter',
-    })
+    await user.type(screen.getByLabelText('プロジェクト名 *'), '{Enter}')
 
     await waitFor(() => {
       expect(handleCreateProject).toHaveBeenCalledWith('Enter Created Project')
@@ -357,6 +351,7 @@ describe('CustomProjectSection', () => {
   })
 
   it('Enter以外のキーでは送信せず、ダイアログcloseイベントでフォームをリセットする', async () => {
+    const user = userEvent.setup()
     const handleCreateProject = vi.fn()
     render(
       <CustomProjectSection
@@ -366,20 +361,16 @@ describe('CustomProjectSection', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-open' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-open' }))
 
-    fireEvent.change(screen.getByLabelText('プロジェクト名 *'), {
-      target: { value: 'Temporary Name' },
-    })
-    fireEvent.keyDown(screen.getByLabelText('プロジェクト名 *'), {
-      key: 'Escape',
-      code: 'Escape',
-    })
+    await user.clear(screen.getByLabelText('プロジェクト名 *'))
+    await user.type(screen.getByLabelText('プロジェクト名 *'), 'Temporary Name')
+    await user.type(screen.getByLabelText('プロジェクト名 *'), '{Escape}')
 
     expect(handleCreateProject).not.toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-close' }))
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-open' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-close' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-open' }))
 
     await waitFor(() => {
       expect(

--- a/src/contexts/saved-tabs/presentation/components/Footer.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/Footer.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import { CategoryReorderFooter } from './Footer'
@@ -46,7 +47,8 @@ describe('CategoryReorderFooterコンポーネント', () => {
     footerI18nState.language = 'ja'
   })
 
-  it('キャンセル/確認ボタンをクリックするとハンドラを呼び出す', () => {
+  it('キャンセル/確認ボタンをクリックするとハンドラを呼び出す', async () => {
+    const user = userEvent.setup()
     const onConfirm = vi.fn()
     const onCancel = vi.fn()
 
@@ -57,10 +59,10 @@ describe('CategoryReorderFooterコンポーネント', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: '親カテゴリの並び替えをキャンセル' }),
     )
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: '親カテゴリの並び替えを確定' }),
     )
 
@@ -68,13 +70,14 @@ describe('CategoryReorderFooterコンポーネント', () => {
     expect(onConfirm).toHaveBeenCalledTimes(1)
   })
 
-  it('ハンドラなしでも描画できる', () => {
+  it('ハンドラなしでも描画できる', async () => {
+    const user = userEvent.setup()
     render(<CategoryReorderFooter />)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: '親カテゴリの並び替えをキャンセル' }),
     )
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: '親カテゴリの並び替えを確定' }),
     )
 

--- a/src/contexts/saved-tabs/presentation/components/Header.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/Header.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type {
@@ -188,7 +189,8 @@ describe('Header', () => {
     vi.restoreAllMocks()
   })
 
-  it('検索入力変更・クリア・件数表示を処理する', () => {
+  it('検索入力変更・クリア・件数表示を処理する', async () => {
+    const user = userEvent.setup()
     const onSearchChange = vi.fn()
 
     render(
@@ -201,13 +203,14 @@ describe('Header', () => {
       />,
     )
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(screen.getByPlaceholderText('検索'), {
       target: { value: 'next' },
     })
     expect(onSearchChange).toHaveBeenCalledWith('next')
 
     const clearButton = screen.getByRole('button', { name: '検索をクリア' })
-    fireEvent.click(clearButton)
+    await user.click(clearButton)
     expect(onSearchChange).toHaveBeenCalledWith('')
 
     expect(screen.getByText('タブ:2')).toBeTruthy()
@@ -328,7 +331,8 @@ describe('Header', () => {
     expect(screen.getByText('プロジェクト:1')).toBeTruthy()
   })
 
-  it('domain モードで親カテゴリ管理モーダルを開閉し ViewModeToggle を描画する', () => {
+  it('domain モードで親カテゴリ管理モーダルを開閉し ViewModeToggle を描画する', async () => {
+    const user = userEvent.setup()
     render(<Header {...createProps()} />)
 
     expect(viewModeToggleSpy).toHaveBeenCalledWith(
@@ -337,7 +341,7 @@ describe('Header', () => {
       }),
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /親カテゴリ管理/ }))
+    await user.click(screen.getByRole('button', { name: /親カテゴリ管理/ }))
     expect(screen.getByTestId('category-modal')).toBeTruthy()
     expect(categoryModalSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -345,13 +349,14 @@ describe('Header', () => {
       }),
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'close-category-modal' }),
     )
     expect(screen.queryByTestId('category-modal')).toBeNull()
   })
 
-  it('custom モードでプロジェクト追加ダイアログの Enter 分岐（空/重複/成功）を処理する', () => {
+  it('custom モードでプロジェクト追加ダイアログの Enter 分岐（空/重複/成功）を処理する', async () => {
+    const user = userEvent.setup()
     const onCreateProject = vi.fn()
     const customProjects = createCustomProjects()
 
@@ -365,22 +370,24 @@ describe('Header', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /プロジェクト追加/ }))
+    await user.click(screen.getByRole('button', { name: /プロジェクト追加/ }))
     const input = screen.getByPlaceholderText('例: 仕事、調査、後で読む')
 
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.type(input, '{Enter}')
     expect(toastErrorSpy).toHaveBeenCalledWith(
       'プロジェクト名を入力してください',
     )
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: 'Project A' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.type(input, '{Enter}')
     expect(toastErrorSpy).toHaveBeenCalledWith(
       '同じプロジェクト名は追加できません',
     )
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: '新プロジェクト' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.type(input, '{Enter}')
 
     expect(onCreateProject).toHaveBeenCalledTimes(1)
     expect(onCreateProject).toHaveBeenCalledWith('新プロジェクト')
@@ -390,7 +397,8 @@ describe('Header', () => {
     expect(screen.queryByTestId('dialog-content')).toBeNull()
   })
 
-  it('IME 変換中の Enter ではプロジェクト追加しない', () => {
+  it('IME 変換中の Enter ではプロジェクト追加しない', async () => {
+    const user = userEvent.setup()
     const onCreateProject = vi.fn()
 
     render(
@@ -402,9 +410,11 @@ describe('Header', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /プロジェクト追加/ }))
+    await user.click(screen.getByRole('button', { name: /プロジェクト追加/ }))
     const input = screen.getByPlaceholderText('例: 仕事、調査、後で読む')
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: '新プロジェクト' } })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(input, {
       key: 'Enter',
       isComposing: true,
@@ -415,7 +425,8 @@ describe('Header', () => {
     expect(toastSuccessSpy).not.toHaveBeenCalled()
   })
 
-  it('customProjects が空でもプロジェクト追加できる', () => {
+  it('customProjects が空でもプロジェクト追加できる', async () => {
+    const user = userEvent.setup()
     const onCreateProject = vi.fn()
 
     render(
@@ -428,16 +439,18 @@ describe('Header', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /プロジェクト追加/ }))
+    await user.click(screen.getByRole('button', { name: /プロジェクト追加/ }))
     const input = screen.getByPlaceholderText('例: 仕事、調査、後で読む')
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: '新プロジェクト' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.type(input, '{Enter}')
 
     expect(onCreateProject).toHaveBeenCalledTimes(1)
     expect(onCreateProject).toHaveBeenCalledWith('新プロジェクト')
   })
 
-  it('Dialog の onOpenChange で custom プロジェクトダイアログを閉じる', () => {
+  it('Dialog の onOpenChange で custom プロジェクトダイアログを閉じる', async () => {
+    const user = userEvent.setup()
     render(
       <Header
         {...createProps({
@@ -446,14 +459,15 @@ describe('Header', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: /プロジェクト追加/ }))
+    await user.click(screen.getByRole('button', { name: /プロジェクト追加/ }))
     expect(screen.getByTestId('dialog-content')).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-close' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-close' }))
     expect(screen.queryByTestId('dialog-content')).toBeNull()
   })
 
-  it('Enter 以外のキーでは追加せず、onCreateProject 未指定時のデフォルト関数でも成功分岐を通る', () => {
+  it('Enter 以外のキーでは追加せず、onCreateProject 未指定時のデフォルト関数でも成功分岐を通る', async () => {
+    const user = userEvent.setup()
     render(
       <Header
         {...(createProps({
@@ -485,14 +499,15 @@ describe('Header', () => {
     expect(screen.getByText('タブ:0')).toBeTruthy()
     expect(screen.getByText('プロジェクト:2')).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: /プロジェクト追加/ }))
+    await user.click(screen.getByRole('button', { name: /プロジェクト追加/ }))
     const input = screen.getByPlaceholderText('例: 仕事、調査、後で読む')
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: 'プロジェクトX' } })
-    fireEvent.keyDown(input, { key: 'Escape' })
+    await user.type(input, '{Escape}')
     expect(toastSuccessSpy).not.toHaveBeenCalled()
 
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.type(input, '{Enter}')
     expect(toastSuccessSpy).toHaveBeenCalledWith(
       'プロジェクト「プロジェクトX」を追加しました',
     )

--- a/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -169,7 +170,8 @@ describe('ProjectUrlItem', () => {
   })
 
   // eslint-disable-next-line eslint/complexity
-  it('未分類URLを描画しリンククリックと即時削除を処理する', () => {
+  it('未分類URLを描画しリンククリックと即時削除を処理する', async () => {
+    const user = userEvent.setup()
     const handleOpenUrl = vi.fn()
     const handleDeleteUrl = vi.fn()
     const item = {
@@ -212,10 +214,10 @@ describe('ProjectUrlItem', () => {
     const titleLabel = link.querySelector('span')
     expect(titleLabel?.className).toContain('min-w-0')
     expect(titleLabel?.className).toContain('truncate')
-    fireEvent.click(link)
+    await user.click(link)
     expect(handleOpenUrl).toHaveBeenCalledWith(item.url)
 
-    fireEvent.click(screen.getByRole('button', { name: 'タブを削除' }))
+    await user.click(screen.getByRole('button', { name: 'タブを削除' }))
     expect(handleDeleteUrl).toHaveBeenCalledWith('project-1', item.url)
 
     expect(useSortableMock).toHaveBeenCalledWith(
@@ -241,6 +243,7 @@ describe('ProjectUrlItem', () => {
   })
 
   it('サブカテゴリ付きURLを描画し確認ダイアログ経由で削除する', async () => {
+    const user = userEvent.setup()
     useSortableMock.mockReturnValueOnce({
       attributes: { 'data-attr': 'x' },
       listeners: { onPointerDown: vi.fn() },
@@ -283,11 +286,11 @@ describe('ProjectUrlItem', () => {
     expect(screen.getByText('Child')).toBeTruthy()
     expect(screen.getByRole('button', { name: /Doc/ })).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'タブを削除' }))
+    await user.click(screen.getByRole('button', { name: 'タブを削除' }))
     const confirmButton = await screen.findByRole('button', {
       name: '削除',
     })
-    fireEvent.click(confirmButton)
+    await user.click(confirmButton)
 
     expect(handleDeleteUrl).toHaveBeenCalledWith('project-1', item.url)
 

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsContent.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsContent.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 import {
   cleanup,
-  fireEvent,
   render,
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -239,6 +239,7 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
   })
 
   it('renders English category controls when the display language is en', async () => {
+    const user = userEvent.setup()
     savedTabsContentI18nState.language = 'en'
 
     render(
@@ -256,7 +257,7 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
         name: getOpenAllButtonName('__uncategorized'),
       }),
     ).toBeTruthy()
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: getDeleteAllButtonName('__uncategorized'),
       }),
@@ -264,7 +265,8 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
     await expect(screen.findByText('Delete all tabs?')).resolves.toBeTruthy()
   })
 
-  it('isDragging スタイルと urls 未指定時のフォールバックを処理する', () => {
+  it('isDragging スタイルと urls 未指定時のフォールバックを処理する', async () => {
+    const user = userEvent.setup()
     useSortableMock.mockReturnValue({
       attributes: {},
       listeners: {},
@@ -288,13 +290,14 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
     expect(container.innerHTML.includes('shadow-lg')).toBe(true)
     expect(container.innerHTML.includes('cursor-grabbing')).toBe(true)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: getOpenAllButtonName('news') }),
     )
     expect(handleOpenAllTabs).toHaveBeenCalledWith([])
   })
 
   it('すべて開くボタンは件数が少ない場合に即時実行し、多い場合は確認ダイアログを経由する', async () => {
+    const user = userEvent.setup()
     const handleOpenAllTabs = vi.fn()
     const { rerender } = render(
       <SavedTabsContentComponent
@@ -305,7 +308,7 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: getOpenAllButtonName('news') }),
     )
     expect(handleOpenAllTabs).toHaveBeenCalledWith([
@@ -324,14 +327,14 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: getOpenAllButtonName('news') }),
     )
     await expect(
       screen.findByText('10個以上のタブを開こうとしています。続行しますか？'),
     ).resolves.toBeTruthy()
     const openButton = await screen.findByRole('button', { name: '開く' })
-    fireEvent.click(openButton)
+    await user.click(openButton)
 
     expect(handleOpenAllTabs).toHaveBeenCalledWith(
       expect.arrayContaining([{ url: 'https://example.com/0', title: '0' }]),
@@ -339,6 +342,7 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
   })
 
   it('削除ボタンがない場合は描画せず、ある場合は確認ダイアログを開く', async () => {
+    const user = userEvent.setup()
     const { rerender } = render(
       <SavedTabsContentComponent {...createProps()} />,
     )
@@ -354,7 +358,7 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: getDeleteAllButtonName('news') }),
     )
     await expect(
@@ -363,6 +367,7 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
   })
 
   it('カテゴリ全削除確認で handleDeleteAllTabs を 1 回だけ呼ぶ', async () => {
+    const user = userEvent.setup()
     const handleDeleteAllTabs = vi.fn().mockResolvedValue(undefined)
 
     render(
@@ -373,10 +378,10 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: getDeleteAllButtonName('news') }),
     )
-    fireEvent.click(await screen.findByRole('button', { name: '削除' }))
+    await user.click(await screen.findByRole('button', { name: '削除' }))
 
     await waitFor(() => {
       expect(handleDeleteAllTabs).toHaveBeenCalledWith([
@@ -389,6 +394,7 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
   })
 
   it('削除処理で例外時でも落ちずに終了する', async () => {
+    const user = userEvent.setup()
     const handleDeleteAllTabs = vi.fn().mockRejectedValueOnce(new Error('boom'))
 
     const { rerender } = render(
@@ -399,10 +405,10 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: getDeleteAllButtonName('news') }),
     )
-    fireEvent.click(await screen.findByRole('button', { name: '削除' }))
+    await user.click(await screen.findByRole('button', { name: '削除' }))
 
     await screen.findByRole('button', { name: getDeleteAllButtonName('news') })
 
@@ -415,12 +421,12 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: getDeleteAllButtonName('error-case'),
       }),
     )
-    fireEvent.click(await screen.findByRole('button', { name: '削除' }))
+    await user.click(await screen.findByRole('button', { name: '削除' }))
 
     await waitFor(() => {
       expect(console.error).toHaveBeenCalled()
@@ -428,6 +434,7 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
   })
 
   it('削除確認の二重実行を防ぐ', async () => {
+    const user = userEvent.setup()
     let resolveUpdate: (() => void) | undefined
     const handleDeleteAllTabs = vi.fn().mockImplementationOnce(
       async () =>
@@ -444,13 +451,13 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: getDeleteAllButtonName('news') }),
     )
     const confirmButton = await screen.findByRole('button', {
       name: '削除',
     })
-    fireEvent.click(confirmButton)
+    await user.click(confirmButton)
     await waitFor(() => {
       expect(
         screen
@@ -458,7 +465,7 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
           .hasAttribute('disabled'),
       ).toBe(true)
     })
-    fireEvent.click(confirmButton)
+    await user.click(confirmButton)
 
     await waitFor(() => {
       expect(handleDeleteAllTabs).toHaveBeenCalledTimes(1)

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsContent.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsContent.test.tsx
@@ -1,10 +1,5 @@
 // @vitest-environment jsdom
-import {
-  cleanup,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsScrollControls.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsScrollControls.test.tsx
@@ -296,7 +296,9 @@ describe('contexts/SavedTabsScrollControls', () => {
     scrollControlState.getRelativeScrollTarget.mockReturnValue(targetEl)
     const container = renderWithContainer('domain')
     expect(container).not.toBeNull()
-    await user.click(screen.getByLabelText('Scroll to previous parent category'))
+    await user.click(
+      screen.getByLabelText('Scroll to previous parent category'),
+    )
     expect(scrollControlState.scrollContainerToTarget).toHaveBeenCalled()
   })
 
@@ -318,7 +320,9 @@ describe('contexts/SavedTabsScrollControls', () => {
     const user = userEvent.setup()
     scrollControlState.getRelativeScrollTarget.mockReturnValue(null)
     renderWithContainer('domain')
-    await user.click(screen.getByLabelText('Scroll to previous parent category'))
+    await user.click(
+      screen.getByLabelText('Scroll to previous parent category'),
+    )
     expect(scrollControlState.scrollContainerToTarget).not.toHaveBeenCalled()
   })
 
@@ -357,7 +361,9 @@ describe('contexts/SavedTabsScrollControls', () => {
 
     await user.click(screen.getByLabelText('Scroll to top'))
     await user.click(screen.getByLabelText('Scroll to bottom'))
-    await user.click(screen.getByLabelText('Scroll to previous parent category'))
+    await user.click(
+      screen.getByLabelText('Scroll to previous parent category'),
+    )
 
     expect(scrollControlState.scrollContainerToTarget).not.toHaveBeenCalled()
   })

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsScrollControls.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsScrollControls.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -173,15 +174,21 @@ describe('contexts/SavedTabsScrollControls', () => {
   it('alt + ArrowUp / ArrowDown / PageUp / PageDown キーボードショートカットを受ける', () => {
     renderWithContainer('domain')
     act(() => {
+      // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.keyDown(window, { altKey: true, key: 'ArrowUp' })
+      // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.keyDown(window, { altKey: true, key: 'ArrowDown' })
+      // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.keyDown(window, { altKey: true, key: 'PageUp' })
+      // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.keyDown(window, { altKey: true, key: 'PageDown' })
+      // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.keyDown(window, {
         altKey: true,
         key: 'ArrowUp',
         shiftKey: true,
       })
+      // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.keyDown(window, {
         altKey: true,
         key: 'ArrowDown',
@@ -194,6 +201,7 @@ describe('contexts/SavedTabsScrollControls', () => {
   it('alt キー無しの keyDown は無視される', () => {
     renderWithContainer('domain')
     act(() => {
+      // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.keyDown(window, { altKey: false, key: 'ArrowUp' })
     })
     expect(screen.getAllByRole('button').length).toBeGreaterThan(0)
@@ -202,7 +210,9 @@ describe('contexts/SavedTabsScrollControls', () => {
   it('metaKey / ctrlKey 併用時は alt + 矢印でも無視される', () => {
     renderWithContainer('domain')
     act(() => {
+      // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.keyDown(window, { altKey: true, key: 'ArrowUp', metaKey: true })
+      // eslint-disable-next-line testing-library/prefer-user-event
       fireEvent.keyDown(window, { altKey: true, key: 'ArrowUp', ctrlKey: true })
     })
     expect(screen.getAllByRole('button').length).toBeGreaterThan(0)
@@ -210,6 +220,7 @@ describe('contexts/SavedTabsScrollControls', () => {
 
   it('alt + 未知 key は無視される', () => {
     renderWithContainer('domain')
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(window, { altKey: true, key: 'Home' })
     expect(scrollControlState.getRelativeScrollTarget).not.toHaveBeenCalled()
   })
@@ -224,7 +235,8 @@ describe('contexts/SavedTabsScrollControls', () => {
     expect(() => render(<Probe />)).not.toThrow()
   })
 
-  it('custom モードの上下プロジェクトボタンを押下しても例外を投げない', () => {
+  it('custom モードの上下プロジェクトボタンを押下しても例外を投げない', async () => {
+    const user = userEvent.setup()
     renderWithContainer('custom')
     const buttons = screen.getAllByRole('button')
     const previousProject = buttons.find(
@@ -237,14 +249,13 @@ describe('contexts/SavedTabsScrollControls', () => {
     )
     expect(previousProject).toBeDefined()
     expect(nextProject).toBeDefined()
-    act(() => {
-      fireEvent.click(previousProject as HTMLElement)
-      fireEvent.click(nextProject as HTMLElement)
-    })
+    await user.click(previousProject as HTMLElement)
+    await user.click(nextProject as HTMLElement)
     expect(buttons.length).toBeGreaterThan(0)
   })
 
-  it('Scroll to top ボタン押下で container.scrollTo({ top: 0, behavior: "smooth" }) を呼ぶ', () => {
+  it('Scroll to top ボタン押下で container.scrollTo({ top: 0, behavior: "smooth" }) を呼ぶ', async () => {
+    const user = userEvent.setup()
     const container = renderWithContainer('domain')
     expect(container).not.toBeNull()
     const scrollTo = vi.fn()
@@ -252,14 +263,15 @@ describe('contexts/SavedTabsScrollControls', () => {
       configurable: true,
       value: scrollTo,
     })
-    fireEvent.click(screen.getByLabelText('Scroll to top'))
+    await user.click(screen.getByLabelText('Scroll to top'))
     expect(scrollTo).toHaveBeenCalledWith({
       behavior: 'smooth',
       top: 0,
     })
   })
 
-  it('Scroll to bottom ボタン押下で container.scrollTo({ top: container.scrollHeight, behavior: "smooth" }) を呼ぶ', () => {
+  it('Scroll to bottom ボタン押下で container.scrollTo({ top: container.scrollHeight, behavior: "smooth" }) を呼ぶ', async () => {
+    const user = userEvent.setup()
     const container = renderWithContainer('domain')
     expect(container).not.toBeNull()
     const scrollTo = vi.fn()
@@ -267,14 +279,15 @@ describe('contexts/SavedTabsScrollControls', () => {
       configurable: true,
       value: scrollTo,
     })
-    fireEvent.click(screen.getByLabelText('Scroll to bottom'))
+    await user.click(screen.getByLabelText('Scroll to bottom'))
     expect(scrollTo).toHaveBeenCalledWith({
       behavior: 'smooth',
       top: container?.scrollHeight,
     })
   })
 
-  it('getRelativeScrollTarget が target を返すと highlight / scrollTo / announce / updateAvailability を順に呼ぶ', () => {
+  it('getRelativeScrollTarget が target を返すと highlight / scrollTo / announce / updateAvailability を順に呼ぶ', async () => {
+    const user = userEvent.setup()
     const targetEl = document.createElement('div')
     targetEl.classList.add('saved-tabs-scroll-target')
     targetEl.setAttribute('data-saved-tabs-scroll-target', 'parent')
@@ -283,26 +296,29 @@ describe('contexts/SavedTabsScrollControls', () => {
     scrollControlState.getRelativeScrollTarget.mockReturnValue(targetEl)
     const container = renderWithContainer('domain')
     expect(container).not.toBeNull()
-    fireEvent.click(screen.getByLabelText('Scroll to previous parent category'))
+    await user.click(screen.getByLabelText('Scroll to previous parent category'))
     expect(scrollControlState.scrollContainerToTarget).toHaveBeenCalled()
   })
 
-  it('highlight は timeout 後に解除される', () => {
+  it('highlight は timeout 後に解除される', async () => {
     vi.useFakeTimers()
     const target = document.createElement('div')
     scrollControlState.getRelativeScrollTarget.mockReturnValue(target)
     renderWithContainer('domain')
 
+    // userEvent is incompatible with fake timers; use fireEvent here
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.click(screen.getByLabelText('Scroll to previous parent category'))
     expect(target.classList.contains('saved-tabs-scroll-highlight')).toBe(true)
     void act(() => vi.advanceTimersByTime(1_200))
     expect(target.classList.contains('saved-tabs-scroll-highlight')).toBe(false)
   })
 
-  it('getRelativeScrollTarget が null を返す場合 updateAvailability だけ呼んで早期 return', () => {
+  it('getRelativeScrollTarget が null を返す場合 updateAvailability だけ呼んで早期 return', async () => {
+    const user = userEvent.setup()
     scrollControlState.getRelativeScrollTarget.mockReturnValue(null)
     renderWithContainer('domain')
-    fireEvent.click(screen.getByLabelText('Scroll to previous parent category'))
+    await user.click(screen.getByLabelText('Scroll to previous parent category'))
     expect(scrollControlState.scrollContainerToTarget).not.toHaveBeenCalled()
   })
 
@@ -315,7 +331,8 @@ describe('contexts/SavedTabsScrollControls', () => {
     expect(scrollControlState.getScrollControlAvailability).toHaveBeenCalled()
   })
 
-  it('container が null の状態で container が必要な関数を呼んでも例外を投げない', () => {
+  it('container が null の状態で container が必要な関数を呼んでも例外を投げない', async () => {
+    const user = userEvent.setup()
     const container = renderWithContainer('domain')
     const scrollTo = vi.fn()
     // ref.current を取り出せないシナリオで Scroll to top をクリック
@@ -324,11 +341,12 @@ describe('contexts/SavedTabsScrollControls', () => {
       configurable: true,
       value: scrollTo,
     })
-    fireEvent.click(screen.getByLabelText('Scroll to top'))
+    await user.click(screen.getByLabelText('Scroll to top'))
     expect(scrollTo).toHaveBeenCalled()
   })
 
-  it('描画後に ref が null になった top/bottom/relative 操作は no-op', () => {
+  it('描画後に ref が null になった top/bottom/relative 操作は no-op', async () => {
+    const user = userEvent.setup()
     const ref: { current: HTMLDivElement | null } = {
       current: document.createElement('div'),
     }
@@ -337,9 +355,9 @@ describe('contexts/SavedTabsScrollControls', () => {
     )
     ref.current = null
 
-    fireEvent.click(screen.getByLabelText('Scroll to top'))
-    fireEvent.click(screen.getByLabelText('Scroll to bottom'))
-    fireEvent.click(screen.getByLabelText('Scroll to previous parent category'))
+    await user.click(screen.getByLabelText('Scroll to top'))
+    await user.click(screen.getByLabelText('Scroll to bottom'))
+    await user.click(screen.getByLabelText('Scroll to previous parent category'))
 
     expect(scrollControlState.scrollContainerToTarget).not.toHaveBeenCalled()
   })
@@ -355,8 +373,10 @@ describe('contexts/SavedTabsScrollControls', () => {
     })
     const topButton = screen.getByLabelText('Scroll to top')
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.mouseDown(topButton)
     void act(() => vi.advanceTimersByTime(700))
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.mouseUp(topButton)
     const callsAfterMouseUp = scrollTo.mock.calls.length
     void act(() => vi.advanceTimersByTime(500))

--- a/src/contexts/saved-tabs/presentation/components/SortableCategorySection.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableCategorySection.test.tsx
@@ -2,11 +2,11 @@
 import {
   act,
   cleanup,
-  fireEvent,
   render,
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -222,7 +222,8 @@ describe('SortableCategorySection', () => {
     vi.restoreAllMocks()
   })
 
-  it('カテゴリ名表示・折りたたみ・ソート切替・即時でのすべて開くを処理する', () => {
+  it('カテゴリ名表示・折りたたみ・ソート切替・即時でのすべて開くを処理する', async () => {
+    const user = userEvent.setup()
     const handleOpenAllTabs = vi.fn()
     render(
       <SortableCategorySection
@@ -240,7 +241,7 @@ describe('SortableCategorySection', () => {
       'https://b.com,https://a.com,https://c.com',
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: '「未分類」の並び順: デフォルト' }),
     )
     expect(
@@ -252,7 +253,7 @@ describe('SortableCategorySection', () => {
       'https://c.com,https://a.com,https://b.com',
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類」の並び順: 保存日時の昇順',
       }),
@@ -266,7 +267,7 @@ describe('SortableCategorySection', () => {
       'https://b.com,https://a.com,https://c.com',
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類」の並び順: 保存日時の降順',
       }),
@@ -275,14 +276,14 @@ describe('SortableCategorySection', () => {
       screen.getByRole('button', { name: '「未分類」の並び順: デフォルト' }),
     ).toBeTruthy()
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: '「未分類」を折りたたむ' }),
     )
     expect(screen.queryByTestId('category-section')).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: '「未分類」を展開' }))
+    await user.click(screen.getByRole('button', { name: '「未分類」を展開' }))
     expect(screen.getByTestId('category-section')).toBeTruthy()
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類」のすべてのタブを開く',
       }),
@@ -295,6 +296,7 @@ describe('SortableCategorySection', () => {
   })
 
   it('10件以上は開く確認ダイアログを経由する', async () => {
+    const user = userEvent.setup()
     const handleOpenAllTabs = vi.fn()
     render(
       <SortableCategorySection
@@ -309,12 +311,12 @@ describe('SortableCategorySection', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類」のすべてのタブを開く',
       }),
     )
-    fireEvent.click(await screen.findByRole('button', { name: '開く' }))
+    await user.click(await screen.findByRole('button', { name: '開く' }))
 
     expect(handleOpenAllTabs).toHaveBeenCalledWith(
       expect.arrayContaining([
@@ -323,7 +325,8 @@ describe('SortableCategorySection', () => {
     )
   })
 
-  it('urls 未指定時の件数/一括開くフォールバックと savedAt 未指定ソートを処理する', () => {
+  it('urls 未指定時の件数/一括開くフォールバックと savedAt 未指定ソートを処理する', async () => {
+    const user = userEvent.setup()
     const handleOpenAllTabs = vi.fn()
     const { rerender } = render(
       <SortableCategorySection
@@ -335,7 +338,7 @@ describe('SortableCategorySection', () => {
     )
 
     expect(screen.getByText('0')).toBeTruthy()
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類」のすべてのタブを開く',
       }),
@@ -352,7 +355,7 @@ describe('SortableCategorySection', () => {
         })}
       />,
     )
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: '「未分類」の並び順: デフォルト' }),
     )
     expect(
@@ -363,10 +366,12 @@ describe('SortableCategorySection', () => {
   })
 
   it('削除ボタンは handler がある時のみ描画され、confirmDeleteAll=false では即時削除し二重実行を防ぐ', async () => {
+    const user = userEvent.setup({ delay: null })
+    let resolveDelete: () => void = () => {}
     const handleDeleteAllTabs = vi.fn(
       async () =>
         new Promise<void>((resolve) => {
-          setTimeout(resolve, 0)
+          resolveDelete = resolve
         }),
     )
     const { rerender } = render(<SortableCategorySection {...createProps()} />)
@@ -386,7 +391,7 @@ describe('SortableCategorySection', () => {
     const deleteButton = screen.getByRole('button', {
       name: '「未分類」のすべてのタブを削除',
     })
-    fireEvent.click(deleteButton)
+    await user.click(deleteButton)
     expect(handleDeleteAllTabs).toHaveBeenCalledTimes(1)
     expect(screen.getByText('削除中...')).toBeTruthy()
     expect(
@@ -397,12 +402,14 @@ describe('SortableCategorySection', () => {
         .hasAttribute('disabled'),
     ).toBe(true)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類」のすべてのタブを削除',
       }),
     )
     expect(handleDeleteAllTabs).toHaveBeenCalledTimes(1)
+
+    resolveDelete()
 
     await waitFor(() => {
       expect(
@@ -414,6 +421,7 @@ describe('SortableCategorySection', () => {
   })
 
   it('confirmDeleteAll=true の削除確認ダイアログとエラーハンドリングを処理する', async () => {
+    const user = userEvent.setup()
     const handleDeleteAllTabs = vi.fn(async () => {
       throw new Error('boom')
     })
@@ -428,13 +436,13 @@ describe('SortableCategorySection', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「news」のすべてのタブを削除',
       }),
     )
     expect(screen.getByText('タブを削除')).toBeTruthy()
-    fireEvent.click(await screen.findByRole('button', { name: '削除' }))
+    await user.click(await screen.findByRole('button', { name: '削除' }))
 
     await waitFor(() => {
       expect(handleDeleteAllTabs).toHaveBeenCalledWith(
@@ -447,11 +455,12 @@ describe('SortableCategorySection', () => {
   })
 
   it('DnD monitor によるドラッグ中の自動折りたたみと復元を処理する', async () => {
+    const user = userEvent.setup()
     render(<SortableCategorySection {...createProps()} />)
 
     expect(screen.getByTestId('category-section')).toBeTruthy()
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: '「未分類」を折りたたむ' }),
     )
     expect(screen.queryByTestId('category-section')).toBeNull()
@@ -477,6 +486,7 @@ describe('SortableCategorySection', () => {
   })
 
   it('並び替えモード中は折りたたみボタン無効・自動折りたたみ、isDragging スタイルも適用される', async () => {
+    const user = userEvent.setup()
     useSortableMock.mockReturnValue({
       attributes: {},
       listeners: {},
@@ -503,7 +513,7 @@ describe('SortableCategorySection', () => {
     expect(container.querySelector('.top-20')).toBeTruthy()
     expect(container.innerHTML.includes('shadow-lg')).toBe(true)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: '「未分類」の並び順: デフォルト' }),
     )
     expect(

--- a/src/contexts/saved-tabs/presentation/components/SortableCategorySection.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableCategorySection.test.tsx
@@ -1,11 +1,5 @@
 // @vitest-environment jsdom
-import {
-  act,
-  cleanup,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 

--- a/src/contexts/saved-tabs/presentation/components/SortableUrlItem.additional.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableUrlItem.additional.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -230,7 +231,8 @@ describe('SortableUrlItem additional', () => {
     })
   })
 
-  it('confirmDeleteEach が true の場合は確認後に削除する', () => {
+  it('confirmDeleteEach が true の場合は確認後に削除する', async () => {
+    const user = userEvent.setup()
     const props = createProps()
     const handleDeleteUrl = vi.fn()
     renderWithMessagingPort(
@@ -241,10 +243,10 @@ describe('SortableUrlItem additional', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'タブを削除' }))
+    await user.click(screen.getByRole('button', { name: 'タブを削除' }))
     expect(handleDeleteUrl).not.toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole('button', { name: '削除' }))
+    await user.click(screen.getByRole('button', { name: '削除' }))
     expect(handleDeleteUrl).toHaveBeenCalledWith(
       'group-1',
       'https://example.com',

--- a/src/contexts/saved-tabs/presentation/components/SortableUrlItem.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableUrlItem.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -88,7 +89,8 @@ describe('SortableUrlItem', () => {
     cleanup()
   })
 
-  it('長いタイトルでも縮小可能なclassを維持し、クリックと削除を処理する', () => {
+  it('長いタイトルでも縮小可能なclassを維持し、クリックと削除を処理する', async () => {
+    const user = userEvent.setup()
     const handleOpenTab = vi.fn()
     const handleDeleteUrl = vi.fn()
 
@@ -126,12 +128,12 @@ describe('SortableUrlItem', () => {
     expect(screen.getByText('2026/06/02 12:34')).toBeTruthy()
     expect(screen.getByTestId('time-remaining')).toBeTruthy()
 
-    fireEvent.click(openButton)
+    await user.click(openButton)
     expect(handleOpenTab).toHaveBeenCalledWith(
       'https://example.com/really/long/path/that/should/not/stretch/the/card',
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'タブを削除' }))
+    await user.click(screen.getByRole('button', { name: 'タブを削除' }))
     expect(handleDeleteUrl).toHaveBeenCalledWith(
       'group-1',
       'https://example.com/really/long/path/that/should/not/stretch/the/card',

--- a/src/contexts/saved-tabs/presentation/components/ViewModeToggle.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ViewModeToggle.test.tsx
@@ -1,10 +1,5 @@
 // @vitest-environment jsdom
-import {
-  cleanup,
-  render,
-  screen,
-  within,
-} from '@testing-library/react'
+import { cleanup, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 

--- a/src/contexts/saved-tabs/presentation/components/ViewModeToggle.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ViewModeToggle.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 import {
   cleanup,
-  fireEvent,
   render,
   screen,
   within,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
@@ -106,7 +106,8 @@ describe('ViewModeToggle', () => {
     viewModeI18nState.language = 'ja'
   })
 
-  it('domain モードの選択表示と tooltip/menu を描画し onChange を呼ぶ', () => {
+  it('domain モードの選択表示と tooltip/menu を描画し onChange を呼ぶ', async () => {
+    const user = userEvent.setup()
     const onChange = vi.fn()
 
     render(<ViewModeToggle currentMode='domain' onChange={onChange} />)
@@ -119,7 +120,7 @@ describe('ViewModeToggle', () => {
     expect(screen.getByTestId('select-item-domain')).toBeTruthy()
     expect(screen.getByTestId('select-item-custom')).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'emit-custom' }))
+    await user.click(screen.getByRole('button', { name: 'emit-custom' }))
 
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChange).toHaveBeenCalledWith('custom')

--- a/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupActions.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupActions.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 import {
   cleanup,
-  fireEvent,
   render,
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 const { cardGroupActionsSpy, useCategoryGroupMock } = vi.hoisted(() => ({
@@ -99,6 +99,7 @@ describe('CategoryGroupActions', () => {
   })
 
   it('検索中のすべて削除は表示中URLだけを group ごとに削除する', async () => {
+    const user = userEvent.setup()
     const handleDeleteUrls = vi.fn().mockResolvedValue(undefined)
     const handleDeleteGroup = vi.fn()
     const handleDeleteGroups = vi.fn()
@@ -139,7 +140,7 @@ describe('CategoryGroupActions', () => {
 
     render(<CategoryGroupActions />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'すべて削除' }))
+    await user.click(screen.getByRole('button', { name: 'すべて削除' }))
 
     await waitFor(() => {
       expect(handleDeleteUrls).toHaveBeenNthCalledWith(1, 'group-1', [
@@ -155,6 +156,7 @@ describe('CategoryGroupActions', () => {
   })
 
   it('未検索時のすべて削除は既存の group 削除を使う', async () => {
+    const user = userEvent.setup()
     const handleDeleteUrls = vi.fn().mockResolvedValue(undefined)
     const handleDeleteGroups = vi.fn().mockResolvedValue(undefined)
 
@@ -186,7 +188,7 @@ describe('CategoryGroupActions', () => {
 
     render(<CategoryGroupActions />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'すべて削除' }))
+    await user.click(screen.getByRole('button', { name: 'すべて削除' }))
 
     await waitFor(() => {
       expect(handleDeleteGroups).toHaveBeenCalledWith(['group-1', 'group-2'])
@@ -240,7 +242,8 @@ describe('CategoryGroupActions', () => {
     )
   })
 
-  it('管理と一括 open を handler へ委譲する', () => {
+  it('管理と一括 open を handler へ委譲する', async () => {
+    const user = userEvent.setup()
     const setIsModalOpen = vi.fn()
     const handleOpenAllTabs = vi.fn()
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
@@ -273,8 +276,8 @@ describe('CategoryGroupActions', () => {
     })
 
     render(<CategoryGroupActions />)
-    fireEvent.click(screen.getByRole('button', { name: '管理' }))
-    fireEvent.click(screen.getByRole('button', { name: 'すべて開く' }))
+    await user.click(screen.getByRole('button', { name: '管理' }))
+    await user.click(screen.getByRole('button', { name: 'すべて開く' }))
 
     expect(setIsModalOpen).toHaveBeenCalledWith(true)
     expect(handleOpenAllTabs).toHaveBeenCalledWith(domains[0]?.urls)
@@ -282,6 +285,7 @@ describe('CategoryGroupActions', () => {
   })
 
   it('bulk delete handler が無ければ各 group を削除する', async () => {
+    const user = userEvent.setup()
     const handleDeleteGroup = vi.fn()
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     const domains = [
@@ -310,7 +314,7 @@ describe('CategoryGroupActions', () => {
     })
 
     render(<CategoryGroupActions />)
-    fireEvent.click(screen.getByRole('button', { name: 'すべて削除' }))
+    await user.click(screen.getByRole('button', { name: 'すべて削除' }))
 
     await waitFor(() => {
       expect(handleDeleteGroup).toHaveBeenNthCalledWith(1, 'group-1')
@@ -320,6 +324,7 @@ describe('CategoryGroupActions', () => {
   })
 
   it('検索中の空 URL group は削除処理を呼ばない', async () => {
+    const user = userEvent.setup()
     const handleDeleteUrls = vi.fn()
     useCategoryGroupMock.mockReturnValue({
       state: {
@@ -349,7 +354,7 @@ describe('CategoryGroupActions', () => {
       onDeleteAll: expect.any(Function),
       onOpenAll: undefined,
     })
-    fireEvent.click(screen.getByRole('button', { name: 'すべて削除' }))
+    await user.click(screen.getByRole('button', { name: 'すべて削除' }))
     await waitFor(() => expect(handleDeleteUrls).not.toHaveBeenCalled())
   })
 })

--- a/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupActions.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupActions.test.tsx
@@ -1,10 +1,5 @@
 // @vitest-environment jsdom
-import {
-  cleanup,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 

--- a/src/contexts/saved-tabs/presentation/components/category-modal/DomainSelectionList.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-modal/DomainSelectionList.test.tsx
@@ -5,12 +5,7 @@ import { dirname, resolve } from 'node:path'
 // eslint-disable-next-line eslint/no-unused-vars
 import { fileURLToPath } from 'node:url'
 
-import {
-  cleanup,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 

--- a/src/contexts/saved-tabs/presentation/components/category-modal/DomainSelectionList.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-modal/DomainSelectionList.test.tsx
@@ -7,11 +7,11 @@ import { fileURLToPath } from 'node:url'
 
 import {
   cleanup,
-  fireEvent,
   render,
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -274,6 +274,7 @@ describe('DomainSelectionList', () => {
   })
 
   it('チェックボックス操作でドメイン選択トグルを呼び出す', async () => {
+    const user = userEvent.setup()
     const tabGroups = createTabGroups(1)
     const toggleDomainSelection = vi.fn()
 
@@ -292,7 +293,7 @@ describe('DomainSelectionList', () => {
       expect(screen.getByRole('checkbox')).toBeTruthy()
     })
 
-    fireEvent.click(screen.getByRole('checkbox'))
+    await user.click(screen.getByRole('checkbox'))
 
     expect(toggleDomainSelection).toHaveBeenCalledWith('group-0')
   })

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardActions.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardActions.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 import {
   cleanup,
-  fireEvent,
   render,
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 const { handleSaveKeywordsMock, useDomainCardMock, useSavedTabsUseCasesMock } =
@@ -179,6 +179,7 @@ describe('DomainCardActions', () => {
   })
 
   it('検索中のすべて削除は表示中URLだけを削除する', async () => {
+    const user = userEvent.setup()
     const handleDeleteUrls = vi.fn().mockResolvedValue(undefined)
     const handleDeleteGroup = vi.fn()
 
@@ -216,7 +217,7 @@ describe('DomainCardActions', () => {
 
     render(<DomainCardActions />)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「example.com」のすべてのタブを削除',
       }),
@@ -231,7 +232,8 @@ describe('DomainCardActions', () => {
     expect(handleDeleteGroup).not.toHaveBeenCalled()
   })
 
-  it('未検索時のすべて削除は group 削除を使う', () => {
+  it('未検索時のすべて削除は group 削除を使う', async () => {
+    const user = userEvent.setup()
     const handleDeleteUrls = vi.fn().mockResolvedValue(undefined)
     const handleDeleteGroup = vi.fn()
 
@@ -269,7 +271,7 @@ describe('DomainCardActions', () => {
 
     render(<DomainCardActions />)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「example.com」のすべてのタブを削除',
       }),
@@ -331,7 +333,8 @@ describe('DomainCardActions', () => {
     ).toBeTruthy()
   })
 
-  it('子カテゴリ管理ボタンで keyword modal を toggle する', () => {
+  it('子カテゴリ管理ボタンで keyword modal を toggle する', async () => {
+    const user = userEvent.setup()
     const setShowKeywordModal = vi.fn()
     useDomainCardMock.mockReturnValue(
       createContext({
@@ -341,14 +344,15 @@ describe('DomainCardActions', () => {
     )
 
     render(<DomainCardActions />)
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: '「example.com」の子カテゴリ管理' }),
     )
 
     expect(setShowKeywordModal).toHaveBeenCalledWith(true)
   })
 
-  it('少数 URL は即時に開き、並び替えモードではログを残す', () => {
+  it('少数 URL は即時に開き、並び替えモードではログを残す', async () => {
+    const user = userEvent.setup()
     const handleOpenAllTabs = vi.fn()
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     const urls = [{ title: 'Docs', url: 'https://example.com/docs' }]
@@ -357,7 +361,7 @@ describe('DomainCardActions', () => {
     )
 
     render(<DomainCardActions />)
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「example.com」のすべてのタブを開く',
       }),
@@ -367,7 +371,8 @@ describe('DomainCardActions', () => {
     expect(log).toHaveBeenCalled()
   })
 
-  it('大量 URL は確認後に開く', () => {
+  it('大量 URL は確認後に開く', async () => {
+    const user = userEvent.setup()
     const handleOpenAllTabs = vi.fn()
     const urls = Array.from({ length: 10 }, (_, index) => ({
       title: `Tab ${index}`,
@@ -379,17 +384,18 @@ describe('DomainCardActions', () => {
     vi.spyOn(console, 'log').mockImplementation(() => undefined)
 
     render(<DomainCardActions />)
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「example.com」のすべてのタブを開く',
       }),
     )
-    fireEvent.click(screen.getByRole('button', { name: '開く' }))
+    await user.click(screen.getByRole('button', { name: '開く' }))
 
     expect(handleOpenAllTabs).toHaveBeenCalledWith(urls)
   })
 
-  it('削除確認後に group を削除し、並び替えモードではログを残す', () => {
+  it('削除確認後に group を削除し、並び替えモードではログを残す', async () => {
+    const user = userEvent.setup()
     const handleDeleteGroup = vi.fn()
     useDomainCardMock.mockReturnValue(
       createContext({
@@ -402,25 +408,26 @@ describe('DomainCardActions', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
 
     render(<DomainCardActions />)
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「example.com」のすべてのタブを削除',
       }),
     )
-    fireEvent.click(screen.getByRole('button', { name: '削除' }))
+    await user.click(screen.getByRole('button', { name: '削除' }))
 
     expect(handleDeleteGroup).toHaveBeenCalledWith('group-1')
     expect(log).toHaveBeenCalled()
   })
 
-  it('検索中でも URL が無ければ group 削除へ fallback する', () => {
+  it('検索中でも URL が無ければ group 削除へ fallback する', async () => {
+    const user = userEvent.setup()
     const handleDeleteGroup = vi.fn()
     useDomainCardMock.mockReturnValue(
       createContext({ handleDeleteGroup, searchQuery: 'docs', urls: [] }),
     )
 
     render(<DomainCardActions />)
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「example.com」のすべてのタブを削除',
       }),
@@ -429,7 +436,8 @@ describe('DomainCardActions', () => {
     expect(handleDeleteGroup).toHaveBeenCalledWith('group-1')
   })
 
-  it('use-case context がある場合だけ keyword 保存を委譲する', () => {
+  it('use-case context がある場合だけ keyword 保存を委譲する', async () => {
+    const user = userEvent.setup()
     const useCases = { getSavedTabsPageData: vi.fn() }
     useSavedTabsUseCasesMock.mockReturnValue({
       deps: { categoryAssignmentPort: {} },
@@ -440,7 +448,7 @@ describe('DomainCardActions', () => {
     )
 
     render(<DomainCardActions />)
-    fireEvent.click(screen.getByRole('button', { name: 'save keywords' }))
+    await user.click(screen.getByRole('button', { name: 'save keywords' }))
 
     expect(handleSaveKeywordsMock).toHaveBeenCalledWith(
       useCases,

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardActions.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardActions.test.tsx
@@ -1,10 +1,5 @@
 // @vitest-environment jsdom
-import {
-  cleanup,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 

--- a/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordEditor.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordEditor.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 import { useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 const keywordEditorI18nState = vi.hoisted(() => ({
   language: 'ja' as 'en' | 'ja',

--- a/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordEditor.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordEditor.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
+import { useState } from 'react'
 
 const keywordEditorI18nState = vi.hoisted(() => ({
   language: 'ja' as 'en' | 'ja',
@@ -99,21 +101,32 @@ describe('KeywordEditor', () => {
     expect(container.childElementCount).toBe(0)
   })
 
-  it('入力変更を state setter へ渡す', () => {
+  it('入力変更を state setter へ渡す', async () => {
+    const user = userEvent.setup()
     const setNewKeyword = vi.fn()
-    useKeywordModalMock.mockReturnValue(
-      createKeywordModalValue({ setNewKeyword }),
-    )
-    render(<KeywordEditor />)
 
-    fireEvent.change(screen.getByRole('textbox'), {
-      target: { value: 'guide' },
-    })
+    function Harness() {
+      const [keywordValue, setKeywordValue] = useState('')
+      useKeywordModalMock.mockImplementation(() =>
+        createKeywordModalValue({
+          setNewKeyword: vi.fn((value: string) => {
+            setNewKeyword(value)
+            setKeywordValue(value)
+          }),
+          newKeyword: keywordValue,
+        }),
+      )
+      return <KeywordEditor />
+    }
+
+    render(<Harness />)
+    await user.type(screen.getByRole('textbox'), 'guide')
 
     expect(setNewKeyword).toHaveBeenCalledWith('guide')
   })
 
-  it('Enter で追加し、それ以外の key では追加しない', () => {
+  it('Enter で追加し、それ以外の key では追加しない', async () => {
+    const user = userEvent.setup()
     const handleAddKeyword = vi.fn()
     useKeywordModalMock.mockReturnValue(
       createKeywordModalValue({ handleAddKeyword }),
@@ -121,9 +134,9 @@ describe('KeywordEditor', () => {
     render(<KeywordEditor />)
     const input = screen.getByRole('textbox')
 
-    fireEvent.keyDown(input, { key: 'Escape' })
+    await user.type(input, '{Escape}')
     expect(handleAddKeyword).not.toHaveBeenCalled()
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.type(input, '{Enter}')
     expect(handleAddKeyword).toHaveBeenCalledOnce()
   })
 
@@ -148,7 +161,8 @@ describe('KeywordEditor', () => {
     expect(filledAdd).toHaveBeenCalledOnce()
   })
 
-  it('keyword badge の削除を委譲し、rename 中は操作を無効化する', () => {
+  it('keyword badge の削除を委譲し、rename 中は操作を無効化する', async () => {
+    const user = userEvent.setup()
     const handleRemoveKeyword = vi.fn()
     useKeywordModalMock.mockReturnValue(
       createKeywordModalValue({
@@ -158,7 +172,7 @@ describe('KeywordEditor', () => {
     )
     const { rerender } = render(<KeywordEditor />)
 
-    fireEvent.click(screen.getByRole('button'))
+    await user.click(screen.getByRole('button'))
     expect(handleRemoveKeyword).toHaveBeenCalledWith('guide')
 
     useKeywordModalMock.mockReturnValue(

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardRoot.additional.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardRoot.additional.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -240,6 +241,7 @@ describe('ProjectCardRoot additional', () => {
   })
 
   it('open all と管理モーダル close を処理する', async () => {
+    const user = userEvent.setup()
     const handleOpenAllUrls = vi.fn()
 
     render(
@@ -254,7 +256,7 @@ describe('ProjectCardRoot additional', () => {
       </ProjectCardRoot>,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'すべてのタブを開く' }))
+    await user.click(screen.getByRole('button', { name: 'すべてのタブを開く' }))
     expect(handleOpenAllUrls).toHaveBeenCalledWith([
       {
         url: 'https://example.com/one',
@@ -266,11 +268,11 @@ describe('ProjectCardRoot additional', () => {
       },
     ])
 
-    fireEvent.click(screen.getByRole('button', { name: '管理' }))
+    await user.click(screen.getByRole('button', { name: '管理' }))
     expect(
       screen.getByRole('button', { name: 'close-management-modal' }),
     ).toBeTruthy()
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'close-management-modal' }),
     )
     await act(async () => {})
@@ -280,7 +282,7 @@ describe('ProjectCardRoot additional', () => {
   })
 
   it('一括削除は project handler があればそれを使い、なければ hook handler を順に呼ぶ', async () => {
-    vi.useFakeTimers()
+    const user = userEvent.setup()
 
     const handleDeleteUrlsFromProject = vi.fn().mockResolvedValue(undefined)
     const hookDeleteUrl = vi.fn()
@@ -303,12 +305,13 @@ describe('ProjectCardRoot additional', () => {
       </ProjectCardRoot>,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'すべて削除' }))
-    await act(async () => {})
-    expect(handleDeleteUrlsFromProject).toHaveBeenCalledWith('project-1', [
-      'https://example.com/one',
-      'https://example.com/two',
-    ])
+    await user.click(screen.getByRole('button', { name: 'すべて削除' }))
+    await waitFor(() => {
+      expect(handleDeleteUrlsFromProject).toHaveBeenCalledWith('project-1', [
+        'https://example.com/one',
+        'https://example.com/two',
+      ])
+    })
 
     rerender(
       <ProjectCardRoot
@@ -328,23 +331,19 @@ describe('ProjectCardRoot additional', () => {
       </ProjectCardRoot>,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'すべて削除' }))
+    await user.click(screen.getByRole('button', { name: 'すべて削除' }))
 
-    await act(async () => {
-      vi.runAllTimers()
+    await waitFor(() => {
+      expect(hookDeleteUrl).toHaveBeenNthCalledWith(
+        1,
+        'project-1',
+        'https://example.com/one',
+      )
+      expect(hookDeleteUrl).toHaveBeenNthCalledWith(
+        2,
+        'project-1',
+        'https://example.com/two',
+      )
     })
-
-    expect(hookDeleteUrl).toHaveBeenNthCalledWith(
-      1,
-      'project-1',
-      'https://example.com/one',
-    )
-    expect(hookDeleteUrl).toHaveBeenNthCalledWith(
-      2,
-      'project-1',
-      'https://example.com/two',
-    )
-
-    vi.useRealTimers()
   })
 })

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardRoot.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardRoot.test.tsx
@@ -258,7 +258,7 @@ describe('ProjectCardRoot', () => {
     expect(dragHandle).toBeTruthy()
     if (dragHandle) {
       // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.pointerDown(dragHandle)
+      fireEvent.pointerDown(dragHandle)
     }
     expect(projectDragListenerMock).toHaveBeenCalled()
 

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardRoot.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardRoot.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsUserSettingsDto as UserSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -233,7 +234,7 @@ describe('ProjectCardRoot', () => {
     cleanup()
   })
 
-  it('プロジェクト名とドラッグハンドルを表示し、DnD コールバックを呼び出す', () => {
+  it('プロジェクト名とドラッグハンドルを表示し、DnD コールバックを呼び出す', async () => {
     const props = createProps()
     const hookState = createHookState()
     useCustomProjectCardMock.mockReturnValue(hookState)
@@ -256,7 +257,8 @@ describe('ProjectCardRoot', () => {
       .closest('div[data-sortable-attr="project"]')
     expect(dragHandle).toBeTruthy()
     if (dragHandle) {
-      fireEvent.pointerDown(dragHandle)
+      // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.pointerDown(dragHandle)
     }
     expect(projectDragListenerMock).toHaveBeenCalled()
 
@@ -455,7 +457,8 @@ describe('ProjectCardRoot', () => {
     expect(screen.queryByText('children')).toBeNull()
   })
 
-  it('折りたたみボタンで表示を切り替え、並び替えボタンでソート順を循環できる', () => {
+  it('折りたたみボタンで表示を切り替え、並び替えボタンでソート順を循環できる', async () => {
+    const user = userEvent.setup()
     render(
       <ProjectCardRoot {...createProps()}>
         <div>children</div>
@@ -463,16 +466,16 @@ describe('ProjectCardRoot', () => {
     )
 
     const collapseButton = screen.getByRole('button', { name: '折りたたむ' })
-    fireEvent.click(collapseButton)
+    await user.click(collapseButton)
     expect(screen.queryByText('children')).toBeNull()
 
-    fireEvent.click(screen.getByRole('button', { name: '展開' }))
+    await user.click(screen.getByRole('button', { name: '展開' }))
     expect(screen.getByText('children')).toBeTruthy()
 
     const sortButton = screen.getByRole('button', { name: 'デフォルト' })
-    fireEvent.click(sortButton)
+    await user.click(sortButton)
     expect(screen.getByRole('button', { name: '保存日時の昇順' })).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: '保存日時の昇順' }))
+    await user.click(screen.getByRole('button', { name: '保存日時の昇順' }))
     expect(screen.getByRole('button', { name: '保存日時の降順' })).toBeTruthy()
   })
 })

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardUncategorizedArea.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardUncategorizedArea.test.tsx
@@ -5,7 +5,8 @@ import { dirname, resolve } from 'node:path'
 // eslint-disable-next-line eslint/no-unused-vars
 import { fileURLToPath } from 'node:url'
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 const projectCardI18nState = vi.hoisted(() => ({
@@ -161,7 +162,8 @@ describe('ProjectCardUncategorizedArea', () => {
     expect(screen.queryByText('未分類のタブ')).toBeNull()
   })
 
-  it('空の未分類エリアで選択中 URL が projectUrls にあれば未分類へ戻す', () => {
+  it('空の未分類エリアで選択中 URL が projectUrls にあれば未分類へ戻す', async () => {
+    const user = userEvent.setup()
     const handleSetUrlCategory = vi.fn()
     vi.spyOn(window, 'getSelection').mockReturnValue({
       toString: () => 'https://example.com',
@@ -181,7 +183,7 @@ describe('ProjectCardUncategorizedArea', () => {
     )
 
     render(<ProjectCardUncategorizedArea />)
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: 'タブをここにドロップして未分類に移動',
       }),
@@ -194,7 +196,8 @@ describe('ProjectCardUncategorizedArea', () => {
     )
   })
 
-  it('空の未分類エリアで選択中 URL が projectUrls にない場合は no-op', () => {
+  it('空の未分類エリアで選択中 URL が projectUrls にない場合は no-op', async () => {
+    const user = userEvent.setup()
     const handleSetUrlCategory = vi.fn()
     vi.spyOn(window, 'getSelection').mockReturnValue({
       toString: () => 'https://other.example.com',
@@ -215,7 +218,7 @@ describe('ProjectCardUncategorizedArea', () => {
     )
 
     render(<ProjectCardUncategorizedArea />)
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: 'タブをここにドロップして未分類に移動',
       }),

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.test.tsx
@@ -12,6 +12,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
@@ -181,6 +182,7 @@ describe('ProjectManagementModal', () => {
   })
 
   it('リネーム入力のバリデーションと blur 保存を処理する', async () => {
+    const user = userEvent.setup()
     const onRenameProject = vi.fn().mockResolvedValue(undefined)
 
     render(
@@ -192,7 +194,7 @@ describe('ProjectManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: '名前を変更' }))
+    await user.click(screen.getByRole('button', { name: '名前を変更' }))
     flushAnimationFrames()
 
     const initialFocusCalls = vi.mocked(HTMLInputElement.prototype.focus).mock
@@ -202,6 +204,7 @@ describe('ProjectManagementModal', () => {
     expect(HTMLInputElement.prototype.select).toHaveBeenCalledTimes(1)
 
     const input = screen.getByPlaceholderText('例: ウェブサイトリニューアル')
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: '   ' } })
     expect(screen.getByText('プロジェクト名を入力してください')).toBeTruthy()
 
@@ -211,6 +214,7 @@ describe('ProjectManagementModal', () => {
       initialFocusCalls + 1,
     )
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: 'Project Beta' } })
     fireEvent.blur(input)
 
@@ -224,28 +228,33 @@ describe('ProjectManagementModal', () => {
   })
 
   it('Escape でリネームをキャンセルし、未設定ハンドラではエラーを握る', async () => {
+    const user = userEvent.setup()
     render(
       <ProjectManagementModal isOpen onClose={vi.fn()} project={project} />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Project Alpha' }))
+    await user.click(screen.getByRole('button', { name: 'Project Alpha' }))
     const input = screen.getByPlaceholderText('例: ウェブサイトリニューアル')
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(input, { key: 'Escape' })
     expect(screen.getByRole('button', { name: 'Project Alpha' })).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Project Alpha' }))
+    await user.click(screen.getByRole('button', { name: 'Project Alpha' }))
     const emptyInput = screen.getByPlaceholderText(
       '例: ウェブサイトリニューアル',
     )
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(emptyInput, { target: { value: 'Project Alpha' } })
     fireEvent.blur(emptyInput)
     expect(screen.getByRole('button', { name: 'Project Alpha' })).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: '名前を変更' }))
+    await user.click(screen.getByRole('button', { name: '名前を変更' }))
     const secondInput = screen.getByPlaceholderText(
       '例: ウェブサイトリニューアル',
     )
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(secondInput, { target: { value: 'Project Gamma' } })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(secondInput, { key: 'Enter' })
 
     await waitFor(() => {
@@ -257,6 +266,7 @@ describe('ProjectManagementModal', () => {
   })
 
   it('削除確認のキャンセルと削除成功を処理する', async () => {
+    const user = userEvent.setup()
     const onDeleteProject = vi.fn().mockResolvedValue(undefined)
     const onClose = vi.fn()
 
@@ -269,18 +279,18 @@ describe('ProjectManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'プロジェクトを削除' }))
+    await user.click(screen.getByRole('button', { name: 'プロジェクトを削除' }))
     expect(
       screen.getByText(
         /このプロジェクトに含まれるすべてのタブとの紐付けも解除されます/,
       ),
     ).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }))
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }))
     expect(screen.queryByText('削除')).toBeNull()
 
-    fireEvent.click(screen.getByRole('button', { name: 'プロジェクトを削除' }))
-    fireEvent.click(screen.getByRole('button', { name: '削除' }))
+    await user.click(screen.getByRole('button', { name: 'プロジェクトを削除' }))
+    await user.click(screen.getByRole('button', { name: '削除' }))
 
     await waitFor(() => {
       expect(onDeleteProject).toHaveBeenCalledWith('project-1')
@@ -289,6 +299,7 @@ describe('ProjectManagementModal', () => {
   })
 
   it('onOpenChange は loading 中や document loading 中は閉じない', async () => {
+    const user = userEvent.setup()
     let resolveRename: (() => void) | undefined
     const onClose = vi.fn()
     const onRenameProject = vi.fn(
@@ -307,11 +318,13 @@ describe('ProjectManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: '名前を変更' }))
+    await user.click(screen.getByRole('button', { name: '名前を変更' }))
     const input = screen.getByPlaceholderText('例: ウェブサイトリニューアル')
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: 'Project Delta' } })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(input, { key: 'Enter' })
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-close' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-close' }))
     expect(onClose).not.toHaveBeenCalled()
 
     resolveRename?.()
@@ -323,18 +336,19 @@ describe('ProjectManagementModal', () => {
       configurable: true,
       get: () => 'loading',
     })
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-close' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-close' }))
     expect(onClose).not.toHaveBeenCalled()
 
     Object.defineProperty(document, 'readyState', {
       configurable: true,
       get: () => 'complete',
     })
-    fireEvent.click(screen.getByRole('button', { name: 'dialog-close' }))
+    await user.click(screen.getByRole('button', { name: 'dialog-close' }))
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
   it('プロジェクトキーワードを blur で保存する', async () => {
+    const user = userEvent.setup()
     const onUpdateProjectKeywords = vi.fn().mockResolvedValue(undefined)
 
     render(
@@ -350,23 +364,22 @@ describe('ProjectManagementModal', () => {
     const urlInput = screen.getByLabelText('URLキーワード')
     const domainInput = screen.getByLabelText('ドメインキーワード')
 
-    fireEvent.change(titleInput, {
-      target: { value: 'release' },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(titleInput, { target: { value: 'release' } })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(titleInput, { key: 'Enter' })
-    fireEvent.change(urlInput, {
-      target: { value: 'spec' },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(urlInput, { target: { value: 'spec' } })
     fireEvent.blur(urlInput)
-    fireEvent.change(domainInput, {
-      target: { value: 'github.com' },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(domainInput, { target: { value: 'github.com' } })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(domainInput, { key: 'Enter' })
 
     const deleteButtons = screen.getAllByRole('button', {
       name: 'キーワードを削除',
     })
-    fireEvent.click(deleteButtons[0])
+    await user.click(deleteButtons[0])
 
     fireEvent.blur(domainInput)
 
@@ -380,6 +393,7 @@ describe('ProjectManagementModal', () => {
   })
 
   it('各 keyword input の Enter/blur と URL/domain 削除を処理する', async () => {
+    const user = userEvent.setup()
     const onUpdateProjectKeywords = vi.fn().mockResolvedValue(undefined)
     render(
       <ProjectManagementModal
@@ -393,10 +407,14 @@ describe('ProjectManagementModal', () => {
     const urlInput = screen.getByLabelText('URLキーワード')
     const domainInput = screen.getByLabelText('ドメインキーワード')
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(titleInput, { target: { value: 'release' } })
     fireEvent.blur(titleInput)
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(urlInput, { target: { value: 'spec' } })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(urlInput, { key: 'Enter' })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(domainInput, { target: { value: 'github.com' } })
     fireEvent.blur(domainInput)
 
@@ -406,14 +424,14 @@ describe('ProjectManagementModal', () => {
     if (!urlDeleteButton) {
       throw new Error('URL keyword delete button not found')
     }
-    fireEvent.click(urlDeleteButton)
+    await user.click(urlDeleteButton)
     const domainDeleteButton = screen
       .getByText('example.com')
       .parentElement?.querySelector('button')
     if (!domainDeleteButton) {
       throw new Error('domain keyword delete button not found')
     }
-    fireEvent.click(domainDeleteButton)
+    await user.click(domainDeleteButton)
 
     await waitFor(() => {
       expect(onUpdateProjectKeywords).toHaveBeenCalledWith(
@@ -427,7 +445,8 @@ describe('ProjectManagementModal', () => {
     })
   })
 
-  it('未分類プロジェクト名の click は rename を開始しない', () => {
+  it('未分類プロジェクト名の click は rename を開始しない', async () => {
+    const user = userEvent.setup()
     render(
       <ProjectManagementModal
         isOpen
@@ -436,18 +455,19 @@ describe('ProjectManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByText('未分類'))
+    await user.click(screen.getByText('未分類'))
 
     expect(screen.queryByRole('textbox', { name: 'プロジェクト名' })).toBeNull()
   })
 
   it('削除ハンドラ未設定でも例外で落とさない', async () => {
+    const user = userEvent.setup()
     render(
       <ProjectManagementModal isOpen onClose={vi.fn()} project={project} />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'プロジェクトを削除' }))
-    fireEvent.click(screen.getByRole('button', { name: '削除' }))
+    await user.click(screen.getByRole('button', { name: 'プロジェクトを削除' }))
+    await user.click(screen.getByRole('button', { name: '削除' }))
 
     await waitFor(() => {
       expect(console.error).toHaveBeenCalledWith(
@@ -458,6 +478,7 @@ describe('ProjectManagementModal', () => {
   })
 
   it('処理中は onBlur と削除ボタンを再実行しない', async () => {
+    const user = userEvent.setup()
     let resolveRename: (() => void) | undefined
     let resolveDelete: (() => void) | undefined
     const onRenameProject = vi.fn(
@@ -482,11 +503,13 @@ describe('ProjectManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: '名前を変更' }))
+    await user.click(screen.getByRole('button', { name: '名前を変更' }))
     const renameInput = screen.getByPlaceholderText(
       '例: ウェブサイトリニューアル',
     )
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(renameInput, { target: { value: 'Project Busy' } })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(renameInput, { key: 'Enter' })
     fireEvent.blur(renameInput)
 
@@ -506,9 +529,9 @@ describe('ProjectManagementModal', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'プロジェクトを削除' }))
-    fireEvent.click(screen.getByRole('button', { name: '削除' }))
-    fireEvent.click(screen.getByRole('button', { name: '削除' }))
+    await user.click(screen.getByRole('button', { name: 'プロジェクトを削除' }))
+    await user.click(screen.getByRole('button', { name: '削除' }))
+    await user.click(screen.getByRole('button', { name: '削除' }))
 
     expect(onDeleteProject).toHaveBeenCalledTimes(1)
 

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.test.tsx
@@ -204,6 +204,7 @@ describe('ProjectManagementModal', () => {
     expect(HTMLInputElement.prototype.select).toHaveBeenCalledTimes(1)
 
     const input = screen.getByPlaceholderText('例: ウェブサイトリニューアル')
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: '   ' } })
     expect(screen.getByText('プロジェクト名を入力してください')).toBeTruthy()
@@ -214,6 +215,7 @@ describe('ProjectManagementModal', () => {
       initialFocusCalls + 1,
     )
 
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: 'Project Beta' } })
     fireEvent.blur(input)
@@ -235,6 +237,7 @@ describe('ProjectManagementModal', () => {
 
     await user.click(screen.getByRole('button', { name: 'Project Alpha' }))
     const input = screen.getByPlaceholderText('例: ウェブサイトリニューアル')
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(input, { key: 'Escape' })
     expect(screen.getByRole('button', { name: 'Project Alpha' })).toBeTruthy()
@@ -243,6 +246,7 @@ describe('ProjectManagementModal', () => {
     const emptyInput = screen.getByPlaceholderText(
       '例: ウェブサイトリニューアル',
     )
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(emptyInput, { target: { value: 'Project Alpha' } })
     fireEvent.blur(emptyInput)
@@ -252,8 +256,10 @@ describe('ProjectManagementModal', () => {
     const secondInput = screen.getByPlaceholderText(
       '例: ウェブサイトリニューアル',
     )
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(secondInput, { target: { value: 'Project Gamma' } })
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(secondInput, { key: 'Enter' })
 
@@ -320,8 +326,10 @@ describe('ProjectManagementModal', () => {
 
     await user.click(screen.getByRole('button', { name: '名前を変更' }))
     const input = screen.getByPlaceholderText('例: ウェブサイトリニューアル')
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: 'Project Delta' } })
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(input, { key: 'Enter' })
     await user.click(screen.getByRole('button', { name: 'dialog-close' }))
@@ -364,15 +372,20 @@ describe('ProjectManagementModal', () => {
     const urlInput = screen.getByLabelText('URLキーワード')
     const domainInput = screen.getByLabelText('ドメインキーワード')
 
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(titleInput, { target: { value: 'release' } })
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(titleInput, { key: 'Enter' })
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(urlInput, { target: { value: 'spec' } })
     fireEvent.blur(urlInput)
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(domainInput, { target: { value: 'github.com' } })
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(domainInput, { key: 'Enter' })
 
@@ -407,13 +420,17 @@ describe('ProjectManagementModal', () => {
     const urlInput = screen.getByLabelText('URLキーワード')
     const domainInput = screen.getByLabelText('ドメインキーワード')
 
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(titleInput, { target: { value: 'release' } })
     fireEvent.blur(titleInput)
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(urlInput, { target: { value: 'spec' } })
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(urlInput, { key: 'Enter' })
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(domainInput, { target: { value: 'github.com' } })
     fireEvent.blur(domainInput)
@@ -507,8 +524,10 @@ describe('ProjectManagementModal', () => {
     const renameInput = screen.getByPlaceholderText(
       '例: ウェブサイトリニューアル',
     )
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(renameInput, { target: { value: 'Project Busy' } })
+    // Radix Dialog focus trap prevents userEvent from focusing inputs
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyDown(renameInput, { key: 'Enter' })
     fireEvent.blur(renameInput)

--- a/src/contexts/saved-tabs/presentation/components/shared/CardControls.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/CardControls.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
@@ -47,7 +48,8 @@ afterEach(() => {
 })
 
 describe('CardSortControl', () => {
-  it('default -> asc -> desc -> default でソート順を切り替える', () => {
+  it('default -> asc -> desc -> default でソート順を切り替える', async () => {
+    const user = userEvent.setup()
     const Harness = () => {
       const [sortOrder, setSortOrder] = useState<SortOrder>('default')
       return (
@@ -60,25 +62,26 @@ describe('CardSortControl', () => {
 
     render(<Harness />)
 
-    const clickSortButton = (name: string) => {
-      fireEvent.click(screen.getByRole('button', { name }))
+    const clickSortButton = async (name: string) => {
+      await user.click(screen.getByRole('button', { name }))
     }
 
     expect(screen.getByTestId('sort-order').textContent).toBe('default')
 
-    clickSortButton('デフォルト')
+    await clickSortButton('デフォルト')
     expect(screen.getByTestId('sort-order').textContent).toBe('asc')
 
-    clickSortButton('保存日時の昇順')
+    await clickSortButton('保存日時の昇順')
     expect(screen.getByTestId('sort-order').textContent).toBe('desc')
 
-    clickSortButton('保存日時の降順')
+    await clickSortButton('保存日時の降順')
     expect(screen.getByTestId('sort-order').textContent).toBe('default')
   })
 })
 
 describe('CardCollapseControl', () => {
-  it('有効時に折りたたみ状態とユーザー状態を更新する', () => {
+  it('有効時に折りたたみ状態とユーザー状態を更新する', async () => {
+    const user = userEvent.setup()
     const Harness = () => {
       const [isCollapsed, setIsCollapsed] = useState(false)
       const [userCollapsedState, setUserCollapsedState] = useState(false)
@@ -98,16 +101,17 @@ describe('CardCollapseControl', () => {
 
     render(<Harness />)
 
-    fireEvent.click(screen.getByRole('button', { name: '折りたたむ' }))
+    await user.click(screen.getByRole('button', { name: '折りたたむ' }))
     expect(screen.getByTestId('collapsed').textContent).toBe('true')
     expect(screen.getByTestId('user-collapsed').textContent).toBe('true')
 
-    fireEvent.click(screen.getByRole('button', { name: '展開' }))
+    await user.click(screen.getByRole('button', { name: '展開' }))
     expect(screen.getByTestId('collapsed').textContent).toBe('false')
     expect(screen.getByTestId('user-collapsed').textContent).toBe('false')
   })
 
-  it('無効時はクリックしても状態を更新しない', () => {
+  it('無効時はクリックしても状態を更新しない', async () => {
+    const user = userEvent.setup()
     const setIsCollapsed = vi.fn()
     const setUserCollapsedState = vi.fn()
 
@@ -124,7 +128,7 @@ describe('CardCollapseControl', () => {
     const button = screen.getByRole('button', { name: '折りたたむ' })
     expect(button.getAttribute('disabled')).not.toBeNull()
 
-    fireEvent.click(button)
+    await user.click(button)
     expect(setIsCollapsed).not.toHaveBeenCalled()
     expect(setUserCollapsedState).not.toHaveBeenCalled()
     expect(screen.getByText('並び替えモード中')).toBeTruthy()
@@ -154,7 +158,8 @@ describe('CardReorderControls', () => {
     expect(container.textContent).toBe('')
   })
 
-  it('並び替えモード時に確定/キャンセル操作を実行する', () => {
+  it('並び替えモード時に確定/キャンセル操作を実行する', async () => {
+    const user = userEvent.setup()
     const onCancel = vi.fn()
     const onConfirm = vi.fn()
 
@@ -166,10 +171,10 @@ describe('CardReorderControls', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: '並び替えをキャンセル' }),
     )
-    fireEvent.click(screen.getByRole('button', { name: '並び替えを確定' }))
+    await user.click(screen.getByRole('button', { name: '並び替えを確定' }))
 
     expect(onCancel).toHaveBeenCalledTimes(1)
     expect(onConfirm).toHaveBeenCalledTimes(1)

--- a/src/contexts/saved-tabs/presentation/components/shared/CardGroupActions.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/CardGroupActions.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 const cardGroupActionsI18nState = vi.hoisted(() => ({
@@ -87,7 +88,8 @@ describe('CardGroupActions', () => {
     cardGroupActionsI18nState.language = 'ja'
   })
 
-  it('確認なしの操作では即時に各ハンドラを呼ぶ', () => {
+  it('確認なしの操作では即時に各ハンドラを呼ぶ', async () => {
+    const user = userEvent.setup()
     const onManage = vi.fn()
     const onOpenAll = vi.fn()
     const onDeleteAll = vi.fn()
@@ -101,9 +103,9 @@ describe('CardGroupActions', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: '設定' }))
-    fireEvent.click(screen.getByRole('button', { name: 'すべてのタブを開く' }))
-    fireEvent.click(screen.getByRole('button', { name: 'すべて削除' }))
+    await user.click(screen.getByRole('button', { name: '設定' }))
+    await user.click(screen.getByRole('button', { name: 'すべてのタブを開く' }))
+    await user.click(screen.getByRole('button', { name: 'すべて削除' }))
 
     expect(onManage).toHaveBeenCalledTimes(1)
     expect(onOpenAll).toHaveBeenCalledTimes(1)
@@ -118,7 +120,8 @@ describe('CardGroupActions', () => {
     ).toContain('bg-secondary')
   })
 
-  it('確認が必要な場合はダイアログを開いてから実行する', () => {
+  it('確認が必要な場合はダイアログを開いてから実行する', async () => {
+    const user = userEvent.setup()
     const onOpenAll = vi.fn()
     const onDeleteAll = vi.fn()
 
@@ -134,23 +137,24 @@ describe('CardGroupActions', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'すべてのタブを開く' }))
+    await user.click(screen.getByRole('button', { name: 'すべてのタブを開く' }))
     expect(
       screen.getByText('20個以上のタブを開こうとしています。続行しますか？'),
     ).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: '開く' }))
+    await user.click(screen.getByRole('button', { name: '開く' }))
     expect(onOpenAll).toHaveBeenCalledTimes(1)
 
-    fireEvent.click(screen.getByRole('button', { name: 'すべて削除' }))
+    await user.click(screen.getByRole('button', { name: 'すべて削除' }))
     expect(screen.getByText('URLをすべて削除しますか？')).toBeTruthy()
     expect(screen.getByText('すべて削除します')).toBeTruthy()
     const confirmDeleteButton = screen.getByRole('button', { name: '削除' })
     expect(confirmDeleteButton.getAttribute('data-variant')).toBe('destructive')
-    fireEvent.click(confirmDeleteButton)
+    await user.click(confirmDeleteButton)
     expect(onDeleteAll).toHaveBeenCalledTimes(1)
   })
 
-  it('対象名付きの aria-label と確認文言を受け取れる', () => {
+  it('対象名付きの aria-label と確認文言を受け取れる', async () => {
+    const user = userEvent.setup()
     const onOpenAll = vi.fn()
     const onDeleteAll = vi.fn()
 
@@ -170,7 +174,7 @@ describe('CardGroupActions', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類のドメイン」のすべてのタブを開く',
       }),
@@ -181,7 +185,7 @@ describe('CardGroupActions', () => {
       ),
     ).toBeTruthy()
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類のドメイン」のすべてのタブを削除',
       }),

--- a/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.test.tsx
+++ b/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 import {
   cleanup,
-  fireEvent,
   render,
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type {
@@ -266,7 +266,8 @@ describe('DomainModeContainer', () => {
     ).toBeTruthy()
   })
 
-  it('未分類ヘッダーのすべて開くは表示中の未分類タブだけを開く', () => {
+  it('未分類ヘッダーのすべて開くは表示中の未分類タブだけを開く', async () => {
+    const user = userEvent.setup()
     const handleOpenAllTabs = vi.fn()
 
     render(
@@ -283,7 +284,7 @@ describe('DomainModeContainer', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類のドメイン」のすべてのタブを開く',
       }),
@@ -297,6 +298,7 @@ describe('DomainModeContainer', () => {
   })
 
   it('未分類ヘッダーのすべて削除は一括削除ハンドラがなければ単体削除にフォールバックする', async () => {
+    const user = userEvent.setup()
     const handleDeleteGroup = vi.fn()
 
     render(
@@ -314,7 +316,7 @@ describe('DomainModeContainer', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類のドメイン」のすべてのタブを削除',
       }),
@@ -327,6 +329,7 @@ describe('DomainModeContainer', () => {
   })
 
   it('検索中の未分類ヘッダーのすべて削除は表示中URLだけを group 単位で削除する', async () => {
+    const user = userEvent.setup()
     const handleDeleteUrls = vi.fn().mockResolvedValue(undefined)
     const handleDeleteGroup = vi.fn()
     const handleDeleteGroups = vi.fn()
@@ -359,7 +362,7 @@ describe('DomainModeContainer', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類のドメイン」のすべてのタブを削除',
       }),
@@ -379,6 +382,7 @@ describe('DomainModeContainer', () => {
   })
 
   it('検索中の未分類一括削除は URL がない group をスキップする', async () => {
+    const user = userEvent.setup()
     const handleDeleteUrls = vi.fn().mockResolvedValue(undefined)
 
     render(
@@ -406,7 +410,7 @@ describe('DomainModeContainer', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類のドメイン」のすべてのタブを削除',
       }),
@@ -455,6 +459,7 @@ describe('DomainModeContainer', () => {
   })
 
   it('未分類ヘッダーのすべて削除は一括削除ハンドラを優先する', async () => {
+    const user = userEvent.setup()
     const handleDeleteGroups = vi.fn().mockResolvedValue(undefined)
     const handleDeleteGroup = vi.fn()
 
@@ -473,7 +478,7 @@ describe('DomainModeContainer', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '「未分類のドメイン」のすべてのタブを削除',
       }),
@@ -486,6 +491,7 @@ describe('DomainModeContainer', () => {
   })
 
   it('カテゴリあり表示では空カテゴリを飛ばし、移動ハンドラに tabGroups を渡す', async () => {
+    const user = userEvent.setup()
     const handleMoveDomainToCategory = vi.fn()
     const domainGroups: TabGroup[] = [
       {
@@ -540,7 +546,7 @@ describe('DomainModeContainer', () => {
     expect(screen.getByText('category-group:Category 1')).toBeTruthy()
     expect(screen.queryByText('category-group:Empty')).toBeNull()
 
-    fireEvent.click(screen.getByText('move-domain'))
+    await user.click(screen.getByText('move-domain'))
 
     expect(handleMoveDomainToCategory).toHaveBeenCalledWith(
       'domain-1',
@@ -551,6 +557,7 @@ describe('DomainModeContainer', () => {
   })
 
   it('未分類リストと並び替え確定/取消ボタンを表示して操作できる', async () => {
+    const user = userEvent.setup()
     const handleCancelUncategorizedReorder = vi.fn()
     const handleConfirmUncategorizedReorder = vi.fn()
 
@@ -573,12 +580,12 @@ describe('DomainModeContainer', () => {
     expect(screen.getByText('sortable-domain-card:example.com')).toBeTruthy()
     expect(screen.getByText('sortable-domain-card:sample.com')).toBeTruthy()
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: '親カテゴリの並び替えをキャンセル',
       }),
     )
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: '親カテゴリの並び替えを確定' }),
     )
 

--- a/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.test.tsx
+++ b/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.test.tsx
@@ -1,10 +1,5 @@
 // @vitest-environment jsdom
-import {
-  cleanup,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 

--- a/src/entrypoints/options/main.behavior.test.tsx
+++ b/src/entrypoints/options/main.behavior.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createElement } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
@@ -401,35 +402,37 @@ describe('options route behavior', () => {
     expect(screen.queryByText('Loading...')).toBeNull()
   })
 
-  it('clickBehavior の select を変更すると updateSetting が呼ばれる', () => {
+  it('clickBehavior の select を変更すると updateSetting が呼ばれる', async () => {
+    const user = userEvent.setup()
     render(createElement(OptionsPage))
 
     expect(screen.queryByText('Current value')).toBeNull()
 
-    fireEvent.click(screen.getAllByTestId('mock-select-change')[0])
+    await user.click(screen.getAllByTestId('mock-select-change')[0])
     expect(mocked.updateSetting).toHaveBeenCalledWith(
       'clickBehavior',
       'saveWindowTabs',
     )
   })
 
-  it('auto delete 系の checkbox を変更すると updateSetting が呼ばれる', () => {
+  it('auto delete 系の checkbox を変更すると updateSetting が呼ばれる', async () => {
+    const user = userEvent.setup()
     render(createElement(OptionsPage))
 
-    fireEvent.click(
+    await user.click(
       screen.getByLabelText('Delete automatically after opening a saved tab'),
     )
-    fireEvent.click(
+    await user.click(
       screen.getByLabelText(
         'Delete automatically after dropping into another browser',
       ),
     )
-    fireEvent.click(screen.getByLabelText('Exclude pinned tabs'))
-    fireEvent.click(screen.getByLabelText('Open in background tabs'))
-    fireEvent.click(screen.getByLabelText('Open all tabs in a new window'))
-    fireEvent.click(screen.getByLabelText('Show saved time'))
-    fireEvent.click(screen.getByLabelText('Confirm before deleting tabs'))
-    fireEvent.click(screen.getByLabelText('Confirm before deleting all'))
+    await user.click(screen.getByLabelText('Exclude pinned tabs'))
+    await user.click(screen.getByLabelText('Open in background tabs'))
+    await user.click(screen.getByLabelText('Open all tabs in a new window'))
+    await user.click(screen.getByLabelText('Show saved time'))
+    await user.click(screen.getByLabelText('Confirm before deleting tabs'))
+    await user.click(screen.getByLabelText('Confirm before deleting all'))
 
     expect(mocked.updateSetting).toHaveBeenCalledWith(
       'removeTabAfterOpen',
@@ -453,24 +456,24 @@ describe('options route behavior', () => {
     expect(mocked.updateSetting).toHaveBeenCalledWith('confirmDeleteAll', true)
   })
 
-  it('exclude pattern を blur / Add ボタン / Enter / Remove ボタンで追加・削除できる', () => {
+  it('exclude pattern を blur / Add ボタン / Enter / Remove ボタンで追加・削除できる', async () => {
+    const user = userEvent.setup()
     render(createElement(OptionsPage))
 
     const excludeInput = screen.getByPlaceholderText('e.g. chrome-extension://')
-    fireEvent.change(excludeInput, {
-      target: { value: 'https://example.com' },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(excludeInput, { target: { value: 'https://example.com' } })
     expect(mocked.handleExcludePatternInputChange).toHaveBeenCalledTimes(1)
     fireEvent.blur(excludeInput)
     expect(mocked.addExcludePattern).toHaveBeenCalledTimes(1)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    await user.click(screen.getByRole('button', { name: 'Add' }))
     expect(mocked.addExcludePattern).toHaveBeenCalledTimes(2)
 
-    fireEvent.keyDown(excludeInput, { key: 'Enter' })
+    await user.type(excludeInput, '{Enter}')
     expect(mocked.addExcludePattern).toHaveBeenCalledTimes(3)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: 'Remove exclude pattern chrome://',
       }),
@@ -478,41 +481,42 @@ describe('options route behavior', () => {
     expect(mocked.removeExcludePattern).toHaveBeenCalledWith('chrome://')
   })
 
-  it('font size slider / input / Reset ボタンでフォントサイズを変更できる', () => {
+  it('font size slider / input / Reset ボタンでフォントサイズを変更できる', async () => {
+    const user = userEvent.setup()
     render(createElement(OptionsPage))
 
     const resetButtons = screen.getAllByRole('button', { name: 'Reset' })
 
-    fireEvent.click(resetButtons[0])
+    await user.click(resetButtons[0])
     expect(mocked.updateSetting).toHaveBeenCalledWith('fontSizePercent', 100)
 
     const fontSizeSlider = screen.getByLabelText('Font size slider')
     const updateSettingCallCount = mocked.updateSetting.mock.calls.length
 
-    fireEvent.change(fontSizeSlider, {
-      target: { value: '125' },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(fontSizeSlider, { target: { value: '125' } })
     expect(mocked.updateSetting).toHaveBeenCalledTimes(updateSettingCallCount)
     expect(
       (screen.getByLabelText('Font size percentage') as HTMLInputElement).value,
     ).toBe('125')
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.mouseUp(fontSizeSlider)
     expect(mocked.updateSetting).toHaveBeenCalledWith('fontSizePercent', 125)
 
-    fireEvent.change(screen.getByLabelText('Font size percentage'), {
-      target: { value: '501' },
-    })
+    await user.clear(screen.getByLabelText('Font size percentage'))
+    await user.type(screen.getByLabelText('Font size percentage'), '501')
     fireEvent.blur(screen.getByLabelText('Font size percentage'))
     expect(mocked.updateSetting).toHaveBeenCalledWith('fontSizePercent', 500)
   })
 
-  it('color input / hex input / Reset colors ボタンで色を変更できる', () => {
+  it('color input / hex input / Reset colors ボタンで色を変更できる', async () => {
+    const user = userEvent.setup()
     render(createElement(OptionsPage))
 
     const resetButtons = screen.getAllByRole('button', { name: 'Reset' })
 
-    fireEvent.click(resetButtons[1])
+    await user.click(resetButtons[1])
     expect(mocked.handleResetColors).toHaveBeenCalledTimes(1)
 
     const colorInput = document.querySelector('input[type="color"]')
@@ -520,18 +524,22 @@ describe('options route behavior', () => {
     if (!colorInput) {
       throw new Error('color input not found')
     }
-    fireEvent.input(colorInput, { target: { value: '#ffffff' } })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(colorInput, { target: { value: '#ffffff' } })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(colorInput, { target: { value: '#ffffff' } })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(hexInput, { target: { value: '#000000' } })
 
     expect(mocked.handleColorChange).toHaveBeenCalled()
   })
 
-  it('Contact / Release Notes の外部リンクを noopener,noreferrer 付きで window.open する', () => {
+  it('Contact / Release Notes の外部リンクを noopener,noreferrer 付きで window.open する', async () => {
+    const user = userEvent.setup()
     render(createElement(OptionsPage))
 
-    fireEvent.click(screen.getByRole('button', { name: 'Contact' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Release Notes' }))
+    await user.click(screen.getByRole('button', { name: 'Contact' }))
+    await user.click(screen.getByRole('button', { name: 'Release Notes' }))
 
     expect(window.open).toHaveBeenCalledWith(
       'https://forms.gle/c9gBiF2TmgXaeU7J6',
@@ -545,14 +553,13 @@ describe('options route behavior', () => {
     )
   })
 
-  it('Enter 以外のキー入力では除外パターンを追加しない', () => {
+  it('Enter 以外のキー入力では除外パターンを追加しない', async () => {
+    const user = userEvent.setup()
     render(createElement(OptionsPage))
 
-    fireEvent.keyDown(
+    await user.type(
       screen.getAllByPlaceholderText('e.g. chrome-extension://')[0],
-      {
-        key: 'Escape',
-      },
+      '{Escape}',
     )
 
     expect(mocked.addExcludePattern).not.toHaveBeenCalled()

--- a/src/features/ai-chat/components/OllamaErrorNotice.test.tsx
+++ b/src/features/ai-chat/components/OllamaErrorNotice.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { readFileSync } from 'node:fs'
 // eslint-disable-next-line eslint/no-unused-vars
 import { dirname, resolve } from 'node:path'
@@ -6,11 +7,11 @@ import { fileURLToPath } from 'node:url'
 
 import {
   cleanup,
-  fireEvent,
   render,
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import { OllamaErrorNotice } from './OllamaErrorNotice'
@@ -138,6 +139,13 @@ describe('OllamaErrorNotice', () => {
   })
 
   it('can copy the macOS command row', async () => {
+    const user = userEvent.setup()
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: mocked.writeClipboardText,
+      },
+    })
     render(
       <OllamaErrorNotice
         error={{
@@ -150,7 +158,7 @@ describe('OllamaErrorNotice', () => {
 
     const copyButton = screen.getByRole('button', { name: 'Copy command' })
 
-    fireEvent.click(copyButton)
+    await user.click(copyButton)
     await Promise.resolve()
 
     expect(mocked.writeClipboardText).toHaveBeenCalledWith(
@@ -173,6 +181,13 @@ describe('OllamaErrorNotice', () => {
   })
 
   it('can copy the Windows value row', async () => {
+    const user = userEvent.setup()
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: mocked.writeClipboardText,
+      },
+    })
     render(
       <OllamaErrorNotice
         error={{
@@ -183,7 +198,7 @@ describe('OllamaErrorNotice', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy value' }))
+    await user.click(screen.getByRole('button', { name: 'Copy value' }))
 
     await waitFor(() => {
       expect(mocked.writeClipboardText).toHaveBeenCalledWith(
@@ -193,6 +208,13 @@ describe('OllamaErrorNotice', () => {
   })
 
   it('can copy the check command row', async () => {
+    const user = userEvent.setup()
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: mocked.writeClipboardText,
+      },
+    })
     render(
       <OllamaErrorNotice
         error={{
@@ -203,7 +225,7 @@ describe('OllamaErrorNotice', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy check command' }))
+    await user.click(screen.getByRole('button', { name: 'Copy check command' }))
 
     await waitFor(() => {
       expect(mocked.writeClipboardText).toHaveBeenCalledWith(
@@ -213,6 +235,13 @@ describe('OllamaErrorNotice', () => {
   })
 
   it('shows an error toast when the clipboard API is unavailable', async () => {
+    const user = userEvent.setup()
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: mocked.writeClipboardText,
+      },
+    })
     render(
       <OllamaErrorNotice
         error={{
@@ -228,7 +257,7 @@ describe('OllamaErrorNotice', () => {
       value: undefined,
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy value' }))
+    await user.click(screen.getByRole('button', { name: 'Copy value' }))
 
     await waitFor(() => {
       expect(mocked.toastError).toHaveBeenCalledWith(
@@ -238,6 +267,13 @@ describe('OllamaErrorNotice', () => {
   })
 
   it('shows an error toast when clipboard write fails', async () => {
+    const user = userEvent.setup()
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: mocked.writeClipboardText,
+      },
+    })
     mocked.writeClipboardText.mockRejectedValueOnce(new Error('failed'))
 
     render(
@@ -250,7 +286,7 @@ describe('OllamaErrorNotice', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy check command' }))
+    await user.click(screen.getByRole('button', { name: 'Copy check command' }))
 
     await waitFor(() => {
       expect(mocked.toastError).toHaveBeenCalledWith(

--- a/src/features/ai-chat/components/OllamaErrorNotice.test.tsx
+++ b/src/features/ai-chat/components/OllamaErrorNotice.test.tsx
@@ -5,12 +5,7 @@ import { dirname, resolve } from 'node:path'
 // eslint-disable-next-line eslint/no-unused-vars
 import { fileURLToPath } from 'node:url'
 
-import {
-  cleanup,
-  render,
-  screen,
-  waitFor,
-} from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
@@ -59,6 +54,14 @@ const baseError = {
   faqUrl: 'https://docs.ollama.com/faq#how-do-i-configure-ollama-server',
   tagsUrl: 'http://localhost:11434/api/tags',
 } as const
+const restoreClipboardMock = () => {
+  Object.defineProperty(window.navigator, 'clipboard', {
+    configurable: true,
+    value: {
+      writeText: mocked.writeClipboardText,
+    },
+  })
+}
 
 describe('OllamaErrorNotice', () => {
   beforeEach(() => {
@@ -66,12 +69,7 @@ describe('OllamaErrorNotice', () => {
     mocked.toastError.mockReset()
     mocked.toastSuccess.mockReset()
     mocked.writeClipboardText.mockReset()
-    Object.defineProperty(window.navigator, 'clipboard', {
-      configurable: true,
-      value: {
-        writeText: mocked.writeClipboardText,
-      },
-    })
+    restoreClipboardMock()
   })
 
   afterEach(() => {
@@ -140,12 +138,7 @@ describe('OllamaErrorNotice', () => {
 
   it('can copy the macOS command row', async () => {
     const user = userEvent.setup()
-    Object.defineProperty(window.navigator, 'clipboard', {
-      configurable: true,
-      value: {
-        writeText: mocked.writeClipboardText,
-      },
-    })
+    restoreClipboardMock()
     render(
       <OllamaErrorNotice
         error={{
@@ -182,12 +175,7 @@ describe('OllamaErrorNotice', () => {
 
   it('can copy the Windows value row', async () => {
     const user = userEvent.setup()
-    Object.defineProperty(window.navigator, 'clipboard', {
-      configurable: true,
-      value: {
-        writeText: mocked.writeClipboardText,
-      },
-    })
+    restoreClipboardMock()
     render(
       <OllamaErrorNotice
         error={{
@@ -209,12 +197,7 @@ describe('OllamaErrorNotice', () => {
 
   it('can copy the check command row', async () => {
     const user = userEvent.setup()
-    Object.defineProperty(window.navigator, 'clipboard', {
-      configurable: true,
-      value: {
-        writeText: mocked.writeClipboardText,
-      },
-    })
+    restoreClipboardMock()
     render(
       <OllamaErrorNotice
         error={{
@@ -236,12 +219,7 @@ describe('OllamaErrorNotice', () => {
 
   it('shows an error toast when the clipboard API is unavailable', async () => {
     const user = userEvent.setup()
-    Object.defineProperty(window.navigator, 'clipboard', {
-      configurable: true,
-      value: {
-        writeText: mocked.writeClipboardText,
-      },
-    })
+    restoreClipboardMock()
     render(
       <OllamaErrorNotice
         error={{
@@ -268,12 +246,7 @@ describe('OllamaErrorNotice', () => {
 
   it('shows an error toast when clipboard write fails', async () => {
     const user = userEvent.setup()
-    Object.defineProperty(window.navigator, 'clipboard', {
-      configurable: true,
-      value: {
-        writeText: mocked.writeClipboardText,
-      },
-    })
+    restoreClipboardMock()
     mocked.writeClipboardText.mockRejectedValueOnce(new Error('failed'))
 
     render(

--- a/src/features/ai-chat/components/OllamaModelSelector.test.tsx
+++ b/src/features/ai-chat/components/OllamaModelSelector.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 vi.mock('@/components/ui/button', () => ({
@@ -117,7 +118,8 @@ describe('OllamaModelSelector', () => {
     expect(screen.queryByText('Loading model list...')).toBeNull()
   })
 
-  it('fetches models when opening the select in fetchOnOpen mode', () => {
+  it('fetches models when opening the select in fetchOnOpen mode', async () => {
+    const user = userEvent.setup()
     const onFetchModels = vi.fn()
 
     render(
@@ -130,7 +132,7 @@ describe('OllamaModelSelector', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'open-select' }))
+    await user.click(screen.getByRole('button', { name: 'open-select' }))
 
     expect(onFetchModels).toHaveBeenCalledTimes(1)
   })

--- a/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
@@ -211,7 +211,6 @@ const restoreClipboardMock = () => {
   })
 }
 
-
 describe('SavedTabsChatWidget', () => {
   beforeEach(() => {
     storageListeners.length = 0
@@ -894,7 +893,10 @@ describe('SavedTabsChatWidget', () => {
     )
 
     await user.clear(await screen.findByLabelText('Ask AI'))
-    await user.type(await screen.findByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.type(
+      await screen.findByLabelText('Ask AI'),
+      'Show me the tabs I added this month',
+    )
     await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
@@ -973,7 +975,10 @@ describe('SavedTabsChatWidget', () => {
     await user.clear(screen.getByLabelText('Prompt name'))
     await user.type(screen.getByLabelText('Prompt name'), 'Research notes')
     await user.clear(screen.getByLabelText('System prompt body'))
-    await user.type(screen.getByLabelText('System prompt body'), 'Analyze saved-tab patterns.')
+    await user.type(
+      screen.getByLabelText('System prompt body'),
+      'Analyze saved-tab patterns.',
+    )
 
     await user.click(screen.getByRole('button', { name: 'Duplicate' }))
     await user.click(screen.getByRole('button', { name: 'Save' }))
@@ -1072,7 +1077,10 @@ describe('SavedTabsChatWidget', () => {
     )
 
     await user.clear(screen.getByLabelText('Ask AI'))
-    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.type(
+      screen.getByLabelText('Ask AI'),
+      'Show me the tabs I added this month',
+    )
     await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await expect(screen.findByText('First response')).resolves.toBeTruthy()
@@ -1164,7 +1172,10 @@ describe('SavedTabsChatWidget', () => {
     expect(saveButton.hasAttribute('disabled')).toBe(true)
 
     await user.clear(screen.getByLabelText('System prompt body'))
-    await user.type(screen.getByLabelText('System prompt body'), 'Give me more comparison angles for saved tabs.')
+    await user.type(
+      screen.getByLabelText('System prompt body'),
+      'Give me more comparison angles for saved tabs.',
+    )
     await user.click(screen.getByText('Research'))
     await user.clear(screen.getByLabelText('Prompt name'))
     await user.type(screen.getByLabelText('Prompt name'), 'Default')
@@ -1314,7 +1325,10 @@ describe('SavedTabsChatWidget', () => {
     )
 
     await user.clear(screen.getByLabelText('Ask AI'))
-    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.type(
+      screen.getByLabelText('Ask AI'),
+      'Show me the tabs I added this month',
+    )
     await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
@@ -1414,7 +1428,10 @@ describe('SavedTabsChatWidget', () => {
     )
 
     await user.clear(screen.getByLabelText('Ask AI'))
-    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.type(
+      screen.getByLabelText('Ask AI'),
+      'Show me the tabs I added this month',
+    )
     await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await expect(screen.findByText('First response')).resolves.toBeTruthy()
@@ -1451,7 +1468,10 @@ describe('SavedTabsChatWidget', () => {
     )
 
     await user.clear(screen.getByLabelText('Ask AI'))
-    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.type(
+      screen.getByLabelText('Ask AI'),
+      'Show me the tabs I added this month',
+    )
     await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
@@ -1497,7 +1517,10 @@ describe('SavedTabsChatWidget', () => {
     )
 
     await user.clear(screen.getByLabelText('Ask AI'))
-    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.type(
+      screen.getByLabelText('Ask AI'),
+      'Show me the tabs I added this month',
+    )
     await user.click(
       screen.getByRole('button', {
         name: 'Submit',
@@ -1653,7 +1676,10 @@ describe('SavedTabsChatWidget', () => {
     )
 
     await user.clear(screen.getByLabelText('Ask AI'))
-    await user.type(screen.getByLabelText('Ask AI'), 'What kinds of content do I save most often?')
+    await user.type(
+      screen.getByLabelText('Ask AI'),
+      'What kinds of content do I save most often?',
+    )
     await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
@@ -1740,7 +1766,10 @@ describe('SavedTabsChatWidget', () => {
     )
 
     await user.clear(screen.getByLabelText('Ask AI'))
-    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I saved recently')
+    await user.type(
+      screen.getByLabelText('Ask AI'),
+      'Show me the tabs I saved recently',
+    )
     await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
@@ -1853,7 +1882,10 @@ describe('SavedTabsChatWidget', () => {
     )
 
     await user.clear(screen.getByLabelText('Ask AI'))
-    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.type(
+      screen.getByLabelText('Ask AI'),
+      'Show me the tabs I added this month',
+    )
     await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
@@ -1995,7 +2027,10 @@ describe('SavedTabsChatWidget', () => {
     )
 
     await user.clear(screen.getByLabelText('Ask AI'))
-    await user.type(screen.getByLabelText('Ask AI'), 'What kinds of content do I save most often?')
+    await user.type(
+      screen.getByLabelText('Ask AI'),
+      'What kinds of content do I save most often?',
+    )
     await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await expect(
@@ -2033,7 +2068,10 @@ describe('SavedTabsChatWidget', () => {
     )
 
     await user.clear(screen.getByLabelText('Ask AI'))
-    await user.type(screen.getByLabelText('Ask AI'), 'What kinds of content do I save most often?')
+    await user.type(
+      screen.getByLabelText('Ask AI'),
+      'What kinds of content do I save most often?',
+    )
     await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
@@ -2243,8 +2281,13 @@ describe('SavedTabsChatWidget', () => {
     )
 
     const uploadInput = screen.getByLabelText('Upload files')
+    // user.upload fails on hidden inputs with pointer-events: none
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(uploadInput, { target: { files: [new File(['Hello'], 'memo.txt', { type: 'text/plain' })] } })
+    fireEvent.change(uploadInput, {
+      target: {
+        files: [new File(['Hello'], 'memo.txt', { type: 'text/plain' })],
+      },
+    })
 
     await expect(screen.findByText('memo.txt')).resolves.toBeTruthy()
 

--- a/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
@@ -14,6 +14,7 @@ import {
   waitFor,
   within,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import { getAiChatToolDefinitions } from '@/constants/aiChatTools'
@@ -201,6 +202,15 @@ const buildConfiguredSettings = (): UserSettings =>
     removeTabAfterOpen: true,
     showSavedTime: false,
   }) as UserSettings
+const restoreClipboardMock = () => {
+  Object.defineProperty(window.navigator, 'clipboard', {
+    configurable: true,
+    value: {
+      writeText: mocked.writeClipboardText,
+    },
+  })
+}
+
 
 describe('SavedTabsChatWidget', () => {
   beforeEach(() => {
@@ -223,12 +233,7 @@ describe('SavedTabsChatWidget', () => {
         unobserve() {}
       },
     )
-    Object.defineProperty(window.navigator, 'clipboard', {
-      configurable: true,
-      value: {
-        writeText: mocked.writeClipboardText,
-      },
-    })
+    restoreClipboardMock()
     ;(globalThis as unknown as { chrome: typeof chrome }).chrome =
       createChromeMock()
     Element.prototype.scrollIntoView = vi.fn()
@@ -270,12 +275,14 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('opens the sidebar from the bottom-right launcher', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     const onOpenChange = vi.fn()
 
     render(<SavedTabsChatWidget onOpenChange={onOpenChange} />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -288,12 +295,14 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('renders Japanese copy when the display language is ja', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.language = 'ja'
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'AIチャットを開く',
       }),
@@ -303,7 +312,7 @@ describe('SavedTabsChatWidget', () => {
     expect(screen.getByText('チャット')).toBeTruthy()
     expect(screen.getByText('今月追加したタブを教えて')).toBeTruthy()
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'システムプロンプト設定を開く' }),
     )
 
@@ -313,12 +322,14 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('closes with the sidebar X button', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     const onOpenChange = vi.fn()
 
     render(<SavedTabsChatWidget onOpenChange={onOpenChange} />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -326,13 +337,15 @@ describe('SavedTabsChatWidget', () => {
 
     expect(screen.getByLabelText('AI chat sidebar')).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Close AI chat' }))
+    await user.click(screen.getByRole('button', { name: 'Close AI chat' }))
 
     expect(screen.queryByLabelText('AI chat sidebar')).toBeNull()
     expect(onOpenChange).toHaveBeenLastCalledWith(false)
   })
 
   it('drags the sidebar width and restores it on the next render', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,
@@ -342,7 +355,7 @@ describe('SavedTabsChatWidget', () => {
 
     const { unmount } = render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -353,8 +366,11 @@ describe('SavedTabsChatWidget', () => {
 
     expect(sidebar.style.width).toBe('420px')
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.pointerDown(resizeHandle, { clientX: 780 })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.pointerMove(window, { clientX: 700 })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.pointerUp(window)
 
     expect(sidebar.style.width).toBe('500px')
@@ -366,7 +382,7 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -376,11 +392,13 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('renders the resize handle as a full-height sidebar boundary', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -393,12 +411,14 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('shows a text send button at narrow widths while keeping the input UI', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     window.localStorage.setItem('tabbin-ai-chat-sidebar-width', '320')
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -412,11 +432,13 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('keeps the intro copy and suggested prompts near the input on first render', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -436,11 +458,13 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('anchors the input area as a bottom dock', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -452,12 +476,14 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('renders ConversationScrollButton in the conversation area', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     mocked.conversationScrollButtonVisible = true
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -467,17 +493,19 @@ describe('SavedTabsChatWidget', () => {
       name: 'Jump to latest message',
     })
 
-    fireEvent.click(scrollButton)
+    await user.click(scrollButton)
 
     expect(mocked.conversationScrollButtonClick).toHaveBeenCalledTimes(1)
   })
 
   it('contains overscroll in the conversation scroll area', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -490,11 +518,13 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('keeps the chat shell as an independent scroll region', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -509,11 +539,13 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('does not show a model-name badge in the header', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -523,11 +555,13 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('centers the header title in the sidebar', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -541,11 +575,13 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('shows the system prompt settings icon and selector on the left of the header', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -558,6 +594,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('places the history button to the left of system prompt settings and triggers sidebar-toggle', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     const onToggleHistory = vi.fn()
 
@@ -581,12 +619,14 @@ describe('SavedTabsChatWidget', () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy()
 
-    fireEvent.click(historyButton)
+    await user.click(historyButton)
 
     expect(onToggleHistory).toHaveBeenCalledTimes(1)
   })
 
   it('opens the list from the dropdown history button and calls the conversation select callback', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     const onSelectHistoryItem = vi.fn()
 
@@ -612,7 +652,7 @@ describe('SavedTabsChatWidget', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Recent conversations',
       }),
@@ -645,7 +685,7 @@ describe('SavedTabsChatWidget', () => {
     expect(preview?.className).toContain('wrap-anywhere')
     expect(preview?.className).toContain('overflow-hidden')
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: /Another conversation/ }),
     )
 
@@ -653,6 +693,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('deletes a conversation after confirming from the dropdown history menu', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     const onDeleteHistoryItem = vi.fn()
     const onSelectHistoryItem = vi.fn()
@@ -680,13 +722,13 @@ describe('SavedTabsChatWidget', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Recent conversations',
       }),
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: 'Delete Another conversation',
       }),
@@ -694,13 +736,15 @@ describe('SavedTabsChatWidget', () => {
 
     expect(screen.getByText('Delete this conversation?')).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
 
     expect(onDeleteHistoryItem).toHaveBeenCalledWith('conversation-2')
     expect(onSelectHistoryItem).not.toHaveBeenCalled()
   })
 
   it('reflects userSettings changes from chrome.storage.onChanged without reloading', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     const initialSettings = buildConfiguredSettings()
     const importedSettings = {
       ...buildConfiguredSettings(),
@@ -721,7 +765,7 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -825,6 +869,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('notifies onMessagesChange only at conversation start and completion, not during stream steps', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     const onMessagesChange = vi.fn()
     let handlePortMessage: ((message: unknown) => void) | undefined
@@ -847,12 +893,9 @@ describe('SavedTabsChatWidget', () => {
       <SavedTabsChatWidget defaultOpen onMessagesChange={onMessagesChange} />,
     )
 
-    fireEvent.change(await screen.findByLabelText('Ask AI'), {
-      target: {
-        value: 'Show me the tabs I added this month',
-      },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await user.clear(await screen.findByLabelText('Ask AI'))
+    await user.type(await screen.findByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
       expect(onMessagesChange).toHaveBeenCalledTimes(1)
@@ -905,17 +948,19 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('opens the system prompt modal and can create, duplicate, and save', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Open system prompt settings' }),
     )
 
@@ -923,17 +968,15 @@ describe('SavedTabsChatWidget', () => {
       screen.findByRole('dialog', { name: 'System prompt manager' }),
     ).resolves.toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'New prompt' }))
+    await user.click(screen.getByRole('button', { name: 'New prompt' }))
 
-    fireEvent.change(screen.getByLabelText('Prompt name'), {
-      target: { value: 'Research notes' },
-    })
-    fireEvent.change(screen.getByLabelText('System prompt body'), {
-      target: { value: 'Analyze saved-tab patterns.' },
-    })
+    await user.clear(screen.getByLabelText('Prompt name'))
+    await user.type(screen.getByLabelText('Prompt name'), 'Research notes')
+    await user.clear(screen.getByLabelText('System prompt body'))
+    await user.type(screen.getByLabelText('System prompt body'), 'Analyze saved-tab patterns.')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await user.click(screen.getByRole('button', { name: 'Duplicate' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
       expect(mocked.saveUserSettings).toHaveBeenCalledWith(
@@ -953,20 +996,22 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('最後の system prompt を削除したら直前の prompt を選択する', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Open system prompt settings' }),
     )
-    fireEvent.click(await screen.findByRole('button', { name: 'Research' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await user.click(await screen.findByRole('button', { name: 'Research' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
 
     await waitFor(() => {
       expect(screen.getByLabelText<HTMLInputElement>('Prompt name').value).toBe(
@@ -976,17 +1021,19 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('shows the available tools list in the system prompt manager', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Open system prompt settings' }),
     )
 
@@ -1007,6 +1054,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('saves the active preset and resets the conversation when switching the selector', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     mocked.sendRuntimeMessage.mockResolvedValue({
       answer: 'First response',
@@ -1016,22 +1065,22 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.change(screen.getByLabelText('Ask AI'), {
-      target: {
-        value: 'Show me the tabs I added this month',
-      },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await user.clear(screen.getByLabelText('Ask AI'))
+    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await expect(screen.findByText('First response')).resolves.toBeTruthy()
 
+    // Radix UI Select does not work with userEvent in jsdom
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.click(screen.getByRole('combobox', { name: 'Default' }))
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.click(await screen.findByRole('option', { name: 'Research' }))
 
     await waitFor(() => {
@@ -1047,6 +1096,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('disables create and duplicate when there are 50 system prompts', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue({
       ...buildConfiguredSettings(),
       activeAiSystemPromptId: 'prompt-1',
@@ -1061,13 +1112,13 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Open system prompt settings' }),
     )
 
@@ -1082,17 +1133,19 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('disables saving when the system prompt name or body is empty or duplicated', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Open system prompt settings' }),
     )
 
@@ -1100,35 +1153,27 @@ describe('SavedTabsChatWidget', () => {
 
     expect(saveButton.hasAttribute('disabled')).toBe(false)
 
-    fireEvent.change(screen.getByLabelText('Prompt name'), {
-      target: { value: '' },
-    })
+    await user.clear(screen.getByLabelText('Prompt name'))
 
     expect(saveButton.hasAttribute('disabled')).toBe(true)
 
-    fireEvent.change(screen.getByLabelText('Prompt name'), {
-      target: { value: 'Default' },
-    })
-    fireEvent.change(screen.getByLabelText('System prompt body'), {
-      target: { value: '' },
-    })
+    await user.clear(screen.getByLabelText('Prompt name'))
+    await user.type(screen.getByLabelText('Prompt name'), 'Default')
+    await user.clear(screen.getByLabelText('System prompt body'))
 
     expect(saveButton.hasAttribute('disabled')).toBe(true)
 
-    fireEvent.change(screen.getByLabelText('System prompt body'), {
-      target: { value: 'Give me more comparison angles for saved tabs.' },
-    })
-    fireEvent.click(screen.getByText('Research'))
-    fireEvent.change(screen.getByLabelText('Prompt name'), {
-      target: { value: 'Default' },
-    })
+    await user.clear(screen.getByLabelText('System prompt body'))
+    await user.type(screen.getByLabelText('System prompt body'), 'Give me more comparison angles for saved tabs.')
+    await user.click(screen.getByText('Research'))
+    await user.clear(screen.getByLabelText('Prompt name'))
+    await user.type(screen.getByLabelText('Prompt name'), 'Default')
 
     expect(saveButton.hasAttribute('disabled')).toBe(true)
     expect(mocked.saveUserSettings).not.toHaveBeenCalled()
 
-    fireEvent.change(screen.getByLabelText('Prompt name'), {
-      target: { value: 'Research details' },
-    })
+    await user.clear(screen.getByLabelText('Prompt name'))
+    await user.type(screen.getByLabelText('Prompt name'), 'Research details')
 
     expect(saveButton.hasAttribute('disabled')).toBe(false)
 
@@ -1137,25 +1182,26 @@ describe('SavedTabsChatWidget', () => {
 
     expect(nameInput.maxLength).toBe(25)
 
-    fireEvent.change(nameInput, {
-      target: { value: 'a'.repeat(26) },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(nameInput, { target: { value: 'a'.repeat(26) } })
 
     expect(saveButton.hasAttribute('disabled')).toBe(true)
   })
 
   it('shows duplicate and delete actions to the right of the prompt name input', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Open system prompt settings' }),
     )
 
@@ -1169,6 +1215,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('truncates long names in the system prompt list', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     const longName =
       'A very long system prompt name that should be truncated in the list view'
     const normalizedLongName = longName.slice(0, 25)
@@ -1192,13 +1240,13 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Open system prompt settings' }),
     )
 
@@ -1214,11 +1262,13 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('shows new conversation as an icon button with a tooltip label', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -1236,6 +1286,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('copies the whole conversation from the header button', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     let handlePortMessage: ((message: unknown) => void) | undefined
     const port = {
@@ -1255,18 +1307,15 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.change(screen.getByLabelText('Ask AI'), {
-      target: {
-        value: 'Show me the tabs I added this month',
-      },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await user.clear(screen.getByLabelText('Ask AI'))
+    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
       expect(port.postMessage).toHaveBeenCalledWith({
@@ -1295,7 +1344,7 @@ describe('SavedTabsChatWidget', () => {
 
     const copyButton = screen.getByRole('button', { name: 'Copy conversation' })
 
-    fireEvent.click(copyButton)
+    await user.click(copyButton)
 
     await waitFor(() => {
       expect(mocked.writeClipboardText).toHaveBeenCalledWith(
@@ -1313,6 +1362,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('clipboard API がない場合は copy error を表示する', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     Object.defineProperty(window.navigator, 'clipboard', {
       configurable: true,
@@ -1332,7 +1383,7 @@ describe('SavedTabsChatWidget', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', { name: 'Copy conversation' }),
     )
 
@@ -1345,6 +1396,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('resets history and returns to the initial state when new conversation is clicked', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     mocked.sendRuntimeMessage.mockResolvedValue({
       answer: 'First response',
@@ -1354,22 +1407,19 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.change(screen.getByLabelText('Ask AI'), {
-      target: {
-        value: 'Show me the tabs I added this month',
-      },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await user.clear(screen.getByLabelText('Ask AI'))
+    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await expect(screen.findByText('First response')).resolves.toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'New conversation' }))
+    await user.click(screen.getByRole('button', { name: 'New conversation' }))
 
     expect(screen.queryByText('First response')).toBeNull()
     expect(screen.getByTestId('ai-chat-intro')).toBeTruthy()
@@ -1377,6 +1427,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('disconnects the active stream when new conversation is clicked', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     const port = {
       disconnect: vi.fn(),
@@ -1392,18 +1444,15 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.change(screen.getByLabelText('Ask AI'), {
-      target: {
-        value: 'Show me the tabs I added this month',
-      },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await user.clear(screen.getByLabelText('Ask AI'))
+    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
       expect(port.postMessage).toHaveBeenCalledWith({
@@ -1413,13 +1462,15 @@ describe('SavedTabsChatWidget', () => {
       })
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'New conversation' }))
+    await user.click(screen.getByRole('button', { name: 'New conversation' }))
 
     expect(port.disconnect).toHaveBeenCalled()
     expect(screen.getByTestId('ai-chat-intro')).toBeTruthy()
   })
 
   it('renders the assistant response after submitting a question', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     let handlePortMessage: ((message: unknown) => void) | undefined
     const port = {
@@ -1439,18 +1490,15 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.change(screen.getByLabelText('Ask AI'), {
-      target: {
-        value: 'Show me the tabs I added this month',
-      },
-    })
-    fireEvent.click(
+    await user.clear(screen.getByLabelText('Ask AI'))
+    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.click(
       screen.getByRole('button', {
         name: 'Submit',
       }),
@@ -1497,7 +1545,7 @@ describe('SavedTabsChatWidget', () => {
       name: '1 source',
     })
     expect(sourcesTrigger).toBeTruthy()
-    fireEvent.click(sourcesTrigger)
+    await user.click(sourcesTrigger)
     await expect(
       screen.findByRole('link', {
         name: 'https://react.dev/learn',
@@ -1516,7 +1564,7 @@ describe('SavedTabsChatWidget', () => {
     ).resolves.not.toHaveLength(0)
     expect(screen.queryByText('Parameters')).toBeNull()
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: /Saved tabs list/,
       }),
@@ -1577,6 +1625,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('renders charts directly under the assistant message when present', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     let handlePortMessage: ((message: unknown) => void) | undefined
     const port = {
@@ -1596,18 +1646,15 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.change(screen.getByLabelText('Ask AI'), {
-      target: {
-        value: 'What kinds of content do I save most often?',
-      },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await user.clear(screen.getByLabelText('Ask AI'))
+    await user.type(screen.getByLabelText('Ask AI'), 'What kinds of content do I save most often?')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
       expect(port.postMessage).toHaveBeenCalledWith({
@@ -1665,6 +1712,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('deduplicates source URLs across tool traces', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     let handlePortMessage: ((message: unknown) => void) | undefined
     const port = {
@@ -1684,18 +1733,15 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.change(screen.getByLabelText('Ask AI'), {
-      target: {
-        value: 'Show me the tabs I saved recently',
-      },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await user.clear(screen.getByLabelText('Ask AI'))
+    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I saved recently')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
       expect(port.postMessage).toHaveBeenCalledWith({
@@ -1763,7 +1809,7 @@ describe('SavedTabsChatWidget', () => {
     const sourcesTrigger = await screen.findByRole('button', {
       name: '2 sources',
     })
-    fireEvent.click(sourcesTrigger)
+    await user.click(sourcesTrigger)
 
     const sourcesGroup =
       // eslint-disable-next-line typescript/no-unnecessary-type-assertion
@@ -1783,6 +1829,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('keeps the input editable but disables send while waiting for a reply', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     const port = {
       disconnect: vi.fn(),
@@ -1798,18 +1846,15 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.change(screen.getByLabelText('Ask AI'), {
-      target: {
-        value: 'Show me the tabs I added this month',
-      },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await user.clear(screen.getByLabelText('Ask AI'))
+    await user.type(screen.getByLabelText('Ask AI'), 'Show me the tabs I added this month')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
       expect(port.postMessage).toHaveBeenCalledWith({
@@ -1826,20 +1871,19 @@ describe('SavedTabsChatWidget', () => {
     expect(textarea.disabled).toBe(false)
     expect((submitButton as HTMLButtonElement).disabled).toBe(true)
 
-    fireEvent.change(textarea, {
-      target: {
-        value: 'Another question to ask',
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(textarea, { target: { value: 'Another question to ask' } })
 
     expect(textarea.value).toBe('Another question to ask')
 
-    fireEvent.click(submitButton)
+    await user.click(submitButton)
 
     expect(port.postMessage).toHaveBeenCalledTimes(1)
   })
 
   it('loads the Ollama model list when the footer selector is opened', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     mocked.sendRuntimeMessage.mockResolvedValue({
       models: [
@@ -1853,12 +1897,14 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
+    // Radix UI Select does not work with userEvent in jsdom
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.click(screen.getByRole('combobox', { name: 'llama3.2' }))
 
     await waitFor(() => {
@@ -1874,6 +1920,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('sends immediately when a suggestion is clicked and passes history on the second send', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     mocked.sendRuntimeMessage
       .mockResolvedValueOnce({
@@ -1889,13 +1937,13 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.click(screen.getByText('Show me the tabs I added this month'))
+    await user.click(screen.getByText('Show me the tabs I added this month'))
 
     await waitFor(() => {
       expect(mocked.sendRuntimeMessage).toHaveBeenNthCalledWith(1, {
@@ -1908,10 +1956,9 @@ describe('SavedTabsChatWidget', () => {
 
     await expect(screen.findByText('First response')).resolves.toBeTruthy()
 
-    fireEvent.change(screen.getByLabelText('Ask AI'), {
-      target: { value: 'Tell me more' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await user.clear(screen.getByLabelText('Ask AI'))
+    await user.type(screen.getByLabelText('Ask AI'), 'Tell me more')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
       expect(mocked.sendRuntimeMessage).toHaveBeenNthCalledWith(2, {
@@ -1932,6 +1979,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('shows the fallback error as an assistant message when the response fails', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     mocked.sendRuntimeMessage.mockResolvedValue({
       status: 'error',
@@ -1939,18 +1988,15 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.change(screen.getByLabelText('Ask AI'), {
-      target: {
-        value: 'What kinds of content do I save most often?',
-      },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await user.clear(screen.getByLabelText('Ask AI'))
+    await user.type(screen.getByLabelText('Ask AI'), 'What kinds of content do I save most often?')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await expect(
       screen.findAllByText('Could not get a response from AI.'),
@@ -1958,6 +2004,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('shows macOS setup guidance and the FAQ link for Ollama 403 stream errors', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     mocked.platformOs = 'mac'
     let handlePortMessage: ((message: unknown) => void) | undefined
@@ -1978,18 +2026,15 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
-    fireEvent.change(screen.getByLabelText('Ask AI'), {
-      target: {
-        value: 'What kinds of content do I save most often?',
-      },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await user.clear(screen.getByLabelText('Ask AI'))
+    await user.type(screen.getByLabelText('Ask AI'), 'What kinds of content do I save most often?')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
       expect(port.postMessage).toHaveBeenCalledWith({
@@ -2048,11 +2093,13 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('treats settings fetch failures as unconfigured and closes with the close button', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockRejectedValue(new Error('failed to load'))
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -2060,11 +2107,13 @@ describe('SavedTabsChatWidget', () => {
 
     expect(screen.getByRole('heading', { name: 'Select a model' })).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Close AI chat' }))
+    await user.click(screen.getByRole('button', { name: 'Close AI chat' }))
     expect(screen.queryByText('Chat')).toBeNull()
   })
 
   it('shows a centered guide and no suggestions when no model is selected', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue({
       ...buildConfiguredSettings(),
       ollamaModel: '',
@@ -2072,7 +2121,7 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -2089,11 +2138,13 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('does not send when the input is empty', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -2109,11 +2160,13 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('inserts a newline on Enter instead of sending', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -2122,17 +2175,11 @@ describe('SavedTabsChatWidget', () => {
     // eslint-disable-next-line typescript/no-unnecessary-type-assertion
     const textarea = screen.getByLabelText('Ask AI') as HTMLTextAreaElement
 
-    fireEvent.change(textarea, {
-      target: {
-        value: 'first',
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(textarea, { target: { value: 'first' } })
     textarea.focus()
     textarea.setSelectionRange(5, 5)
-    fireEvent.keyDown(textarea, {
-      code: 'Enter',
-      key: 'Enter',
-    })
+    await user.type(textarea, '{Enter}')
 
     await waitFor(() => {
       expect(textarea.value).toBe('first\n')
@@ -2141,6 +2188,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('sends on Ctrl+Enter', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     mocked.sendRuntimeMessage.mockResolvedValue({
       answer: 'Ctrl submit response',
@@ -2150,7 +2199,7 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -2159,16 +2208,9 @@ describe('SavedTabsChatWidget', () => {
     // eslint-disable-next-line typescript/no-unnecessary-type-assertion
     const textarea = screen.getByLabelText('Ask AI') as HTMLTextAreaElement
 
-    fireEvent.change(textarea, {
-      target: {
-        value: 'Ctrl submit',
-      },
-    })
-    fireEvent.keyDown(textarea, {
-      code: 'Enter',
-      ctrlKey: true,
-      key: 'Enter',
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(textarea, { target: { value: 'Ctrl submit' } })
+    await user.type(textarea, '{Control>}{Enter}{/Control}')
 
     await waitFor(() => {
       expect(mocked.sendRuntimeMessage).toHaveBeenCalledWith({
@@ -2183,6 +2225,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('sends text attachments in the conversation payload when selected from the bottom-left picker', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     mocked.sendRuntimeMessage.mockResolvedValue({
       answer: 'I read the attachment',
@@ -2192,27 +2236,21 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
     const uploadInput = screen.getByLabelText('Upload files')
-    fireEvent.change(uploadInput, {
-      target: {
-        files: [new File(['Hello'], 'memo.txt', { type: 'text/plain' })],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(uploadInput, { target: { files: [new File(['Hello'], 'memo.txt', { type: 'text/plain' })] } })
 
     await expect(screen.findByText('memo.txt')).resolves.toBeTruthy()
 
-    fireEvent.change(screen.getByLabelText('Ask AI'), {
-      target: {
-        value: 'Summarize the attachment',
-      },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await user.clear(screen.getByLabelText('Ask AI'))
+    await user.type(screen.getByLabelText('Ask AI'), 'Summarize the attachment')
+    await user.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => {
       expect(mocked.sendRuntimeMessage).toHaveBeenCalledWith({
@@ -2236,6 +2274,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('can select and save a model from inside the chat when none is set', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue({
       ...buildConfiguredSettings(),
       ollamaModel: '',
@@ -2252,7 +2292,7 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
@@ -2263,6 +2303,8 @@ describe('SavedTabsChatWidget', () => {
 
     expect(screen.queryByRole('button', { name: 'Load models' })).toBeNull()
 
+    // Radix UI Select does not work with userEvent in jsdom
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.click(screen.getByRole('combobox', { name: 'Select a model' }))
 
     await waitFor(() => {
@@ -2271,6 +2313,7 @@ describe('SavedTabsChatWidget', () => {
       })
     })
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.click(
       await screen.findByRole('option', { name: 'llama3.2 (8B)' }),
     )
@@ -2292,6 +2335,8 @@ describe('SavedTabsChatWidget', () => {
   })
 
   it('shows Windows guidance and download links for Ollama connection errors while fetching the model list', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     mocked.platformOs = 'win'
     mocked.sendRuntimeMessage.mockResolvedValue({
@@ -2309,12 +2354,14 @@ describe('SavedTabsChatWidget', () => {
 
     render(<SavedTabsChatWidget />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', {
         name: 'Open AI chat',
       }),
     )
 
+    // Radix UI Select does not work with userEvent in jsdom
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.click(screen.getByRole('combobox', { name: 'llama3.2' }))
 
     await waitFor(() => {

--- a/src/features/ai-chat/routes/AiChatRoute.test.tsx
+++ b/src/features/ai-chat/routes/AiChatRoute.test.tsx
@@ -99,11 +99,14 @@ describe('AiChatRoute', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.stubGlobal('ResizeObserver', class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    })
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    )
     mocked.useSharedAiChatHistory.mockReturnValue({
       activeConversation: {
         createdAt: 1,

--- a/src/features/ai-chat/routes/AiChatRoute.test.tsx
+++ b/src/features/ai-chat/routes/AiChatRoute.test.tsx
@@ -6,6 +6,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createElement } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
@@ -98,6 +99,11 @@ describe('AiChatRoute', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    })
     mocked.useSharedAiChatHistory.mockReturnValue({
       activeConversation: {
         createdAt: 1,
@@ -141,6 +147,7 @@ describe('AiChatRoute', () => {
 
   afterEach(() => {
     cleanup()
+    vi.unstubAllGlobals()
   })
 
   it('履歴一覧の操作に shared ui button を使い、生の button 要素を残さない', () => {
@@ -160,14 +167,15 @@ describe('AiChatRoute', () => {
     expect(screen.getByText('history-variant:sidebar-toggle')).toBeTruthy()
   })
 
-  it('履歴項目クリックで会話を選択し、breakpoint 跨ぎの resize で履歴表示を切り替える', () => {
+  it('履歴項目クリックで会話を選択し、breakpoint 跨ぎの resize で履歴表示を切り替える', async () => {
+    const user = userEvent.setup()
     render(createElement(AiChatRoute))
 
     window.innerWidth = 1100
     fireEvent(window, new Event('resize'))
     expect(screen.getByText('Recent conversations')).toBeTruthy()
 
-    fireEvent.click(
+    await user.click(
       // eslint-disable-next-line typescript/non-nullable-type-assertion-style
       screen
         .getAllByRole('button', { name: /別の会話/ })
@@ -232,12 +240,13 @@ describe('AiChatRoute', () => {
     expect(widgetShell?.className.includes('overflow-hidden')).toBe(true)
   })
 
-  it('狭い画面でも履歴ボタンで左履歴を再表示できる', () => {
+  it('狭い画面でも履歴ボタンで左履歴を再表示できる', async () => {
+    const user = userEvent.setup()
     window.innerWidth = 800
 
     render(createElement(AiChatRoute))
 
-    fireEvent.click(screen.getByText('toggle-history'))
+    await user.click(screen.getByText('toggle-history'))
 
     expect(screen.getByText('Recent conversations')).toBeTruthy()
   })
@@ -275,10 +284,11 @@ describe('AiChatRoute', () => {
     expect(screen.getByRole('status')).toBeTruthy()
   })
 
-  it('履歴削除ボタンから確認モーダルを開き、削除を実行できる', () => {
+  it('履歴削除ボタンから確認モーダルを開き、削除を実行できる', async () => {
+    const user = userEvent.setup()
     render(createElement(AiChatRoute))
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: 'Delete 最初の会話',
       }),
@@ -286,15 +296,16 @@ describe('AiChatRoute', () => {
 
     expect(screen.getByText('Delete this conversation?')).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
 
     expect(mocked.deleteConversation).toHaveBeenCalledWith('conversation-1')
   })
 
-  it('履歴削除確認はキャンセルできる', () => {
+  it('履歴削除確認はキャンセルできる', async () => {
+    const user = userEvent.setup()
     render(createElement(AiChatRoute))
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: 'Delete 最初の会話',
       }),
@@ -302,21 +313,22 @@ describe('AiChatRoute', () => {
 
     expect(screen.getByText('Delete this conversation?')).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
     expect(screen.queryByText('Delete this conversation?')).toBeNull()
     expect(mocked.deleteConversation).not.toHaveBeenCalled()
   })
 
-  it('履歴削除確認はキャンセルで削除されない', () => {
+  it('履歴削除確認はキャンセルで削除されない', async () => {
+    const user = userEvent.setup()
     render(createElement(AiChatRoute))
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', {
         name: 'Delete 最初の会話',
       }),
     )
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
     expect(mocked.deleteConversation).not.toHaveBeenCalled()
   })

--- a/src/features/analytics/routes/AnalyticsRoute.test.tsx
+++ b/src/features/analytics/routes/AnalyticsRoute.test.tsx
@@ -692,11 +692,14 @@ describe('AnalyticsRoute', () => {
       shouldAdvanceTime: true,
     })
     vi.setSystemTime(new Date(Date.UTC(2026, 2, 14, 0, 0, 0)))
-    vi.stubGlobal('ResizeObserver', class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    })
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    )
 
     analyticsRouteMocks.language = 'en'
     analyticsRouteMocks.deleteViewMock.mockReset()
@@ -1732,7 +1735,9 @@ describe('AnalyticsRoute', () => {
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
 
-    await user.click(screen.getByRole('button', { name: 'emit-empty-messages' }))
+    await user.click(
+      screen.getByRole('button', { name: 'emit-empty-messages' }),
+    )
     await user.click(screen.getByRole('button', { name: 'emit-user-only' }))
 
     expect(screen.getByText('Saved count by domain')).toBeTruthy()
@@ -1845,7 +1850,10 @@ describe('AnalyticsRoute', () => {
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
 
-    await user.selectOptions(screen.getByLabelText('Group by'), 'parentCategory')
+    await user.selectOptions(
+      screen.getByLabelText('Group by'),
+      'parentCategory',
+    )
     await user.click(
       screen.getByRole('button', { name: 'emit-uncategorized-click' }),
     )

--- a/src/features/analytics/routes/AnalyticsRoute.test.tsx
+++ b/src/features/analytics/routes/AnalyticsRoute.test.tsx
@@ -13,6 +13,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { Children, isValidElement } from 'react'
 import type { ReactNode } from 'react'
 import { toast } from 'sonner'
@@ -691,6 +692,11 @@ describe('AnalyticsRoute', () => {
       shouldAdvanceTime: true,
     })
     vi.setSystemTime(new Date(Date.UTC(2026, 2, 14, 0, 0, 0)))
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    })
 
     analyticsRouteMocks.language = 'en'
     analyticsRouteMocks.deleteViewMock.mockReset()
@@ -763,6 +769,7 @@ describe('AnalyticsRoute', () => {
   afterEach(() => {
     cleanup()
     vi.useRealTimers()
+    vi.unstubAllGlobals()
   })
 
   it('analytics helper が trace と fallback label を正規化する', () => {
@@ -1334,25 +1341,24 @@ describe('AnalyticsRoute', () => {
   })
 
   it('左側の手動フィルタ変更でチャートを更新する', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
 
-    fireEvent.change(screen.getByLabelText('Group by'), {
-      target: { value: 'project' },
-    })
+    await user.selectOptions(screen.getByLabelText('Group by'), 'project')
 
     expect(await screen.findByText('Saved count by project')).toBeTruthy()
   })
 
   it('チャート種別・表示件数・リセット操作で分析条件を更新する', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
 
-    fireEvent.change(screen.getByLabelText('Chart type'), {
-      target: { value: 'pie' },
-    })
+    await user.selectOptions(screen.getByLabelText('Chart type'), 'pie')
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(screen.getByLabelText('Top count'), {
       target: { value: '0' },
     })
@@ -1360,7 +1366,7 @@ describe('AnalyticsRoute', () => {
     const limitInput = screen.getByLabelText('Top count') as HTMLInputElement
     expect(limitInput.value).toBe('1')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Reset' }))
+    await user.click(screen.getByRole('button', { name: 'Reset' }))
 
     expect(limitInput.value).toBe('8')
   })
@@ -1379,6 +1385,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('保存済みビューの旧 time は時系列（直近）として読み込む', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadViewsMock.mockResolvedValue([
       {
         createdAt: 1,
@@ -1418,7 +1425,7 @@ describe('AnalyticsRoute', () => {
       await screen.findByRole('button', { name: 'Legacy Time View' }),
     ).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Legacy Time View' }))
+    await user.click(screen.getByRole('button', { name: 'Legacy Time View' }))
 
     await waitFor(() => {
       expect(
@@ -1431,13 +1438,15 @@ describe('AnalyticsRoute', () => {
   })
 
   it('現在の条件を保存できる', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(screen.getByLabelText('View name'), {
       target: { value: 'My Analytics' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
       expect(analyticsRouteMocks.saveViewsMock).toHaveBeenCalledTimes(1)
@@ -1445,16 +1454,16 @@ describe('AnalyticsRoute', () => {
   })
 
   it('保存成功後にビュー名をクリアする', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     await screen.findByText('Analysis conditions')
 
     const viewNameInput = screen.getByLabelText('View name') as HTMLInputElement
 
-    fireEvent.change(viewNameInput, {
-      target: { value: 'My Analytics' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(viewNameInput, { target: { value: 'My Analytics' } })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
       expect(analyticsRouteMocks.saveViewsMock).toHaveBeenCalledTimes(1)
@@ -1464,27 +1473,28 @@ describe('AnalyticsRoute', () => {
   })
 
   it('ビュー名が空のまま保存するとエラーを表示する', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     await screen.findByText('Analysis conditions')
 
     const viewNameInput = screen.getByLabelText('View name')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
 
     expect(analyticsRouteMocks.saveViewsMock).not.toHaveBeenCalled()
     expect(viewNameInput.getAttribute('aria-invalid')).toBe('true')
     expect(screen.getByText('Enter a view name')).toBeTruthy()
 
-    fireEvent.change(viewNameInput, {
-      target: { value: 'My Analytics' },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(viewNameInput, { target: { value: 'My Analytics' } })
 
     expect(viewNameInput.getAttribute('aria-invalid')).toBe('false')
     expect(screen.queryByText('Enter a view name')).toBeNull()
   })
 
   it('既存ビューと同名では保存できず重複エラーを表示する', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadViewsMock.mockResolvedValue([
       {
         createdAt: 1,
@@ -1524,10 +1534,9 @@ describe('AnalyticsRoute', () => {
 
     const viewNameInput = screen.getByLabelText('View name')
 
-    fireEvent.change(viewNameInput, {
-      target: { value: '  My Analytics  ' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(viewNameInput, { target: { value: '  My Analytics  ' } })
+    await user.click(screen.getByRole('button', { name: 'Save' }))
 
     expect(analyticsRouteMocks.saveViewsMock).not.toHaveBeenCalled()
     expect(viewNameInput.getAttribute('aria-invalid')).toBe('true')
@@ -1535,9 +1544,8 @@ describe('AnalyticsRoute', () => {
       screen.getByText('A view with this name already exists'),
     ).toBeTruthy()
 
-    fireEvent.change(viewNameInput, {
-      target: { value: 'My Analytics 2' },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(viewNameInput, { target: { value: 'My Analytics 2' } })
 
     expect(viewNameInput.getAttribute('aria-invalid')).toBe('false')
     expect(
@@ -1546,6 +1554,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('大文字小文字だけが異なるビュー名は別名として保存できる', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadViewsMock.mockResolvedValue([
       {
         createdAt: 1,
@@ -1583,10 +1592,11 @@ describe('AnalyticsRoute', () => {
 
     await screen.findByRole('button', { name: 'My Analytics' })
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(screen.getByLabelText('View name'), {
       target: { value: 'my analytics' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await user.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(() => {
       expect(analyticsRouteMocks.saveViewsMock).toHaveBeenCalledTimes(1)
@@ -1597,6 +1607,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('保存済みビューを読み込み、削除できる', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadViewsMock.mockResolvedValue([
       {
         createdAt: 1,
@@ -1635,7 +1646,7 @@ describe('AnalyticsRoute', () => {
     expect(
       await screen.findByRole('button', { name: 'Delete Saved View' }),
     ).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Delete Saved View' }))
+    await user.click(screen.getByRole('button', { name: 'Delete Saved View' }))
 
     await waitFor(() => {
       expect(analyticsRouteMocks.deleteViewMock).toHaveBeenCalledWith('view-1')
@@ -1643,6 +1654,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('保存済みビューを読み込んでもモードは両方固定になる', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadViewsMock.mockResolvedValue([
       {
         createdAt: 1,
@@ -1682,7 +1694,7 @@ describe('AnalyticsRoute', () => {
       await screen.findByRole('button', { name: 'Delete Domain Only View' }),
     ).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Domain Only View' }))
+    await user.click(screen.getByRole('button', { name: 'Domain Only View' }))
 
     await waitFor(() => {
       expect(
@@ -1694,41 +1706,45 @@ describe('AnalyticsRoute', () => {
   })
 
   it('AIチャットから渡されたチャートを左側に反映する', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-ai-chart' }))
+    await user.click(screen.getByRole('button', { name: 'emit-ai-chart' }))
 
     expect(await screen.findByText('AI-generated chart')).toBeTruthy()
     expect(analyticsRouteMocks.updateMessagesMock).toHaveBeenCalledTimes(1)
   })
 
   it('分析クエリが無い AI チャートでも左側に反映する', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-only' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-only' }))
 
     expect(await screen.findByText('AI chart without query')).toBeTruthy()
   })
 
   it('AI メッセージに有効なチャートがない場合は現在のチャートを維持する', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
 
-    fireEvent.click(screen.getByRole('button', { name: 'emit-empty-messages' }))
-    fireEvent.click(screen.getByRole('button', { name: 'emit-user-only' }))
+    await user.click(screen.getByRole('button', { name: 'emit-empty-messages' }))
+    await user.click(screen.getByRole('button', { name: 'emit-user-only' }))
 
     expect(screen.getByText('Saved count by domain')).toBeTruthy()
     expect(analyticsRouteMocks.updateMessagesMock).toHaveBeenCalledTimes(2)
   })
 
   it('AI ツール出力の query が不正でもチャートだけを反映する', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'emit-invalid-query-chart' }),
     )
 
@@ -1736,10 +1752,11 @@ describe('AnalyticsRoute', () => {
   })
 
   it('チャートクリックで項目に含まれる保存タブを表示する', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
 
     expect(await screen.findByText('Saved tabs in this item')).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull()
@@ -1774,6 +1791,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('ドリルダウンは現在の分析条件で絞り込まれた保存タブだけを表示する', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadRecordsMock.mockResolvedValue([
       ...records,
       {
@@ -1793,8 +1811,8 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-ai-chart' }))
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(screen.getByRole('button', { name: 'emit-ai-chart' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
 
     expect(await screen.findByText('Saved tabs in this item')).toBeTruthy()
     expect(screen.getByText('Example Docs')).toBeTruthy()
@@ -1802,10 +1820,11 @@ describe('AnalyticsRoute', () => {
   })
 
   it('空ラベルのドリルダウンは一致なし表示にする', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'emit-empty-chart-click' }),
     )
 
@@ -1821,37 +1840,33 @@ describe('AnalyticsRoute', () => {
   })
 
   it('親カテゴリ・子カテゴリ・プロジェクト条件で未分類ドリルダウンを表示する', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
 
-    fireEvent.change(screen.getByLabelText('Group by'), {
-      target: { value: 'parentCategory' },
-    })
-    fireEvent.click(
+    await user.selectOptions(screen.getByLabelText('Group by'), 'parentCategory')
+    await user.click(
       screen.getByRole('button', { name: 'emit-uncategorized-click' }),
     )
 
     expect(await screen.findByText('News Entry')).toBeTruthy()
 
-    fireEvent.change(screen.getByLabelText('Group by'), {
-      target: { value: 'subCategory' },
-    })
-    fireEvent.click(
+    await user.selectOptions(screen.getByLabelText('Group by'), 'subCategory')
+    await user.click(
       screen.getByRole('button', { name: 'emit-uncategorized-click' }),
     )
 
     expect(await screen.findByText('News Entry')).toBeTruthy()
 
-    fireEvent.change(screen.getByLabelText('Group by'), {
-      target: { value: 'project' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'emit-inbox-click' }))
+    await user.selectOptions(screen.getByLabelText('Group by'), 'project')
+    await user.click(screen.getByRole('button', { name: 'emit-inbox-click' }))
 
     expect(await screen.findByText('News Entry')).toBeTruthy()
   })
 
   it('時系列とプロジェクトカテゴリ条件でドリルダウンラベルを解決する', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadViewsMock.mockResolvedValue([
       {
         createdAt: 1,
@@ -1891,22 +1906,21 @@ describe('AnalyticsRoute', () => {
       await screen.findByRole('button', { name: 'Project Category View' }),
     ).toBeTruthy()
 
-    fireEvent.change(screen.getByLabelText('Group by'), {
-      target: { value: 'timeRecent' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'emit-time-click' }))
+    await user.selectOptions(screen.getByLabelText('Group by'), 'timeRecent')
+    await user.click(screen.getByRole('button', { name: 'emit-time-click' }))
 
     expect(await screen.findByText('Example Docs')).toBeTruthy()
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Project Category View' }),
     )
-    fireEvent.click(screen.getByRole('button', { name: 'emit-catchup-click' }))
+    await user.click(screen.getByRole('button', { name: 'emit-catchup-click' }))
 
     expect(await screen.findByText('News Entry')).toBeTruthy()
   })
 
   it('モード比較ドリルダウンは seriesKey に合う保存元だけを残す', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadViewsMock.mockResolvedValue([
       {
         createdAt: 1,
@@ -1942,10 +1956,10 @@ describe('AnalyticsRoute', () => {
 
     render(<AnalyticsRoute />)
 
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', { name: 'Compare Mode View' }),
     )
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'emit-domain-series-news-click' }),
     )
 
@@ -1953,13 +1967,13 @@ describe('AnalyticsRoute', () => {
       await screen.findByText('No matching saved tabs were found.'),
     ).toBeTruthy()
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'emit-custom-series-news-click' }),
     )
 
     expect(await screen.findByText('News Entry')).toBeTruthy()
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'emit-other-series-news-click' }),
     )
 
@@ -1967,6 +1981,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('長いタイトルでもドリルダウンの操作列が見切れないレイアウトを使う', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadRecordsMock.mockResolvedValue([
       {
         ...records[0],
@@ -1979,7 +1994,7 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
 
     const openLink = await screen.findByRole('link', {
       name: 'Open Extremely long analytics drilldown title that should never push the action area out of view even when the canvas is narrow',
@@ -2001,10 +2016,11 @@ describe('AnalyticsRoute', () => {
   })
 
   it('ドリルダウン各行に削除ボタンを表示する', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
 
     expect(
       await screen.findByRole('button', { name: 'Delete tab' }),
@@ -2012,10 +2028,11 @@ describe('AnalyticsRoute', () => {
   })
 
   it('ドリルダウン見出しにすべて開く・すべて削除ボタンを表示する', async () => {
+    const user = userEvent.setup()
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
 
     expect(
       await screen.findByRole('button', { name: 'Open all tabs in this item' }),
@@ -2026,6 +2043,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('ドリルダウンのすべて開くで対象URLを一括で開く', async () => {
+    const user = userEvent.setup()
     const openSpy = vi
       .spyOn(window, 'open')
       .mockImplementation(vi.fn() as never)
@@ -2033,9 +2051,9 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
     openSpy.mockClear()
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', { name: 'Open all tabs in this item' }),
     )
 
@@ -2048,6 +2066,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('ドリルダウンのすべて開くは10件以上で確認ダイアログを経由する', async () => {
+    const user = userEvent.setup()
     const manyRecords = Array.from({ length: 10 }, (_, index) => ({
       ...records[0],
       id: `docs-${index}`,
@@ -2066,21 +2085,22 @@ describe('AnalyticsRoute', () => {
         'Created Saved count by domain from 10 saved records.',
       ),
     ).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
     openSpy.mockClear()
-    fireEvent.click(
+    await user.click(
       await screen.findByRole('button', { name: 'Open all tabs in this item' }),
     )
 
     expect(await screen.findByText('Open all tabs?')).toBeTruthy()
     expect(openSpy).not.toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open' }))
+    await user.click(screen.getByRole('button', { name: 'Open' }))
 
     expect(openSpy).toHaveBeenCalledTimes(10)
   })
 
   it('confirmDeleteAll=false のときドリルダウンのすべて削除で対象URL IDを一括削除する', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadRecordsMock
       .mockResolvedValueOnce(bulkDeleteRecords)
       .mockResolvedValueOnce([records[1]])
@@ -2088,8 +2108,8 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
-    fireEvent.click(
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(
       await screen.findByRole('button', {
         name: 'Delete all tabs in this item',
       }),
@@ -2116,6 +2136,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('confirmDeleteAll=true のときドリルダウンのすべて削除は確認ダイアログを経由する', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadSettingsMock.mockResolvedValue({
       ...defaultSettings,
       confirmDeleteAll: true,
@@ -2127,8 +2148,8 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
-    fireEvent.click(
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(
       await screen.findByRole('button', {
         name: 'Delete all tabs in this item',
       }),
@@ -2137,7 +2158,7 @@ describe('AnalyticsRoute', () => {
     expect(await screen.findByText('Delete all tabs?')).toBeTruthy()
     expect(analyticsRouteMocks.sendMessageMock).not.toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
 
     await waitFor(() => {
       expect(analyticsRouteMocks.sendMessageMock).toHaveBeenCalledWith(
@@ -2152,6 +2173,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('一括削除確認はキャンセルできる', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadSettingsMock.mockResolvedValue({
       ...defaultSettings,
       confirmDeleteAll: true,
@@ -2161,15 +2183,15 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
-    fireEvent.click(
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(
       await screen.findByRole('button', {
         name: 'Delete all tabs in this item',
       }),
     )
 
     expect(await screen.findByText('Delete all tabs?')).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
     await waitFor(() => {
       expect(screen.queryByText('Delete all tabs?')).toBeNull()
@@ -2178,6 +2200,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('confirmDeleteEach=false のとき即時削除して一覧を再読込する', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadRecordsMock
       .mockResolvedValueOnce(records)
       .mockResolvedValueOnce([records[1]])
@@ -2185,8 +2208,8 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'Delete tab' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(await screen.findByRole('button', { name: 'Delete tab' }))
 
     await waitFor(() => {
       expect(analyticsRouteMocks.sendMessageMock).toHaveBeenCalledWith(
@@ -2229,6 +2252,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('削除 Undo の復元失敗はトーストで通知する', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadRecordsMock
       .mockResolvedValueOnce(records)
       .mockResolvedValueOnce([records[1]])
@@ -2239,8 +2263,8 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'Delete tab' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(await screen.findByRole('button', { name: 'Delete tab' }))
 
     await waitFor(() => {
       expect(toast.info).toHaveBeenCalled()
@@ -2259,6 +2283,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('単体削除失敗時はエラートーストを表示してドリルダウンを維持する', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.sendMessageMock.mockImplementation(
       (
         message: unknown,
@@ -2277,8 +2302,8 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'Delete tab' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(await screen.findByRole('button', { name: 'Delete tab' }))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to delete the tab')
@@ -2292,6 +2317,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('単体削除失敗時は background error が空でも fallback エラーを扱う', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.sendMessageMock.mockImplementation(
       (message: unknown, callback?: (response: { status: string }) => void) => {
         const action = (message as { action?: string })?.action
@@ -2307,8 +2333,8 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'Delete tab' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(await screen.findByRole('button', { name: 'Delete tab' }))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to delete the tab')
@@ -2316,6 +2342,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('一括削除失敗時はエラートーストを表示して確認ダイアログを閉じる', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadSettingsMock.mockResolvedValue({
       ...defaultSettings,
       confirmDeleteAll: true,
@@ -2339,15 +2366,15 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
-    fireEvent.click(
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(
       await screen.findByRole('button', {
         name: 'Delete all tabs in this item',
       }),
     )
 
     expect(await screen.findByText('Delete all tabs?')).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to delete the tabs')
@@ -2362,6 +2389,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('一括削除失敗時は background error が空でも fallback エラーを扱う', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadSettingsMock.mockResolvedValue({
       ...defaultSettings,
       confirmDeleteAll: true,
@@ -2382,13 +2410,13 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
-    fireEvent.click(
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(
       await screen.findByRole('button', {
         name: 'Delete all tabs in this item',
       }),
     )
-    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+    await user.click(await screen.findByRole('button', { name: 'Delete' }))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to delete the tabs')
@@ -2396,6 +2424,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('削除 Undo snapshot が非配列なら空 payload を復元する', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.storageGetMock.mockResolvedValue({
       customProjectOrder: { invalid: true },
       customProjects: { invalid: true },
@@ -2410,8 +2439,8 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'Delete tab' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(await screen.findByRole('button', { name: 'Delete tab' }))
 
     await waitFor(() => {
       expect(toast.info).toHaveBeenCalled()
@@ -2430,6 +2459,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('confirmDeleteEach=true のとき確認ダイアログ経由で削除する', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadSettingsMock.mockResolvedValue({
       ...defaultSettings,
       confirmDeleteEach: true,
@@ -2441,13 +2471,13 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'Delete tab' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(await screen.findByRole('button', { name: 'Delete tab' }))
 
     expect(await screen.findByText('Delete this tab?')).toBeTruthy()
     expect(analyticsRouteMocks.sendMessageMock).not.toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
 
     await waitFor(() => {
       expect(analyticsRouteMocks.sendMessageMock).toHaveBeenCalledTimes(1)
@@ -2455,6 +2485,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('単体削除確認はキャンセルできる', async () => {
+    const user = userEvent.setup()
     analyticsRouteMocks.loadSettingsMock.mockResolvedValue({
       ...defaultSettings,
       confirmDeleteEach: true,
@@ -2463,11 +2494,11 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
-    fireEvent.click(await screen.findByRole('button', { name: 'Delete tab' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(await screen.findByRole('button', { name: 'Delete tab' }))
 
     expect(await screen.findByText('Delete this tab?')).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
 
     await waitFor(() => {
       expect(screen.queryByText('Delete this tab?')).toBeNull()
@@ -2476,6 +2507,7 @@ describe('AnalyticsRoute', () => {
   })
 
   it('削除中は二重送信しない', async () => {
+    const user = userEvent.setup()
     let resolveRemoval: ((value: { status: string }) => void) | undefined
     analyticsRouteMocks.sendMessageMock.mockImplementation(
       (
@@ -2489,13 +2521,13 @@ describe('AnalyticsRoute', () => {
     render(<AnalyticsRoute />)
 
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
-    fireEvent.click(screen.getByRole('button', { name: 'emit-chart-click' }))
+    await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
 
     const deleteButton = await screen.findByRole('button', {
       name: 'Delete tab',
     })
-    fireEvent.click(deleteButton)
-    fireEvent.click(deleteButton)
+    await user.click(deleteButton)
+    await user.click(deleteButton)
 
     await waitFor(() => {
       expect(analyticsRouteMocks.sendMessageMock).toHaveBeenCalledTimes(1)

--- a/src/features/i18n/components/LanguageSelect.test.tsx
+++ b/src/features/i18n/components/LanguageSelect.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import { I18nProvider, useI18n } from '@/features/i18n/context/I18nProvider'
@@ -66,6 +67,7 @@ const MessageProbe = () => {
 
 describe('LanguageSelect', () => {
   it('選択変更で表示言語を切り替え、設定を保存する', async () => {
+    const user = userEvent.setup()
     mockedSettings.getUserSettings.mockResolvedValue({
       ...defaultSettings,
       language: 'system',
@@ -87,9 +89,7 @@ describe('LanguageSelect', () => {
       expect(screen.getByText('チャット')).toBeTruthy()
     })
 
-    fireEvent.change(screen.getByLabelText('language-select'), {
-      target: { value: 'en' },
-    })
+    await user.selectOptions(screen.getByLabelText('language-select'), 'en')
 
     await waitFor(() => {
       expect(screen.getByText('Chat')).toBeTruthy()

--- a/src/features/navigation/app/AppRouter.test.tsx
+++ b/src/features/navigation/app/AppRouter.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 const routeModuleLoads = vi.hoisted(() => ({
@@ -120,6 +121,7 @@ describe('AppRouter', () => {
   })
 
   it('サイドバークリックで SPA 遷移する', async () => {
+    const user = userEvent.setup()
     render(<AppRouter initialEntries={['/saved-tabs?mode=domain']} />)
 
     const analyticsLink = screen.getAllByRole('link', {
@@ -129,15 +131,16 @@ describe('AppRouter', () => {
       throw new Error('分析リンクが見つかりません')
     }
 
-    fireEvent.click(analyticsLink)
+    await user.click(analyticsLink)
 
     await expect(screen.findByText('analytics-route')).resolves.toBeTruthy()
   })
 
-  it('router context では内部リンクが app.html ではなく route を指す', () => {
+  it('router context では内部リンクが app.html ではなく route を指す', async () => {
+    const user = userEvent.setup()
     render(<AppRouter initialEntries={['/saved-tabs?mode=custom']} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'サイドバーを開く' }))
+    await user.click(screen.getByRole('button', { name: 'サイドバーを開く' }))
 
     expect(
       screen
@@ -181,10 +184,11 @@ describe('AppRouter', () => {
   })
 
   it('SavedTabsRoute から別 mode を選ぶと replace navigate する', async () => {
+    const user = userEvent.setup()
     render(<AppRouter initialEntries={['/saved-tabs?mode=domain']} />)
 
     await screen.findByText('saved-tabs-route:?mode=domain')
-    fireEvent.click(screen.getByRole('button', { name: 'navigate-custom' }))
+    await user.click(screen.getByRole('button', { name: 'navigate-custom' }))
 
     await expect(
       screen.findByText('saved-tabs-route:?mode=custom'),
@@ -192,10 +196,11 @@ describe('AppRouter', () => {
   })
 
   it('SavedTabsRoute から同じ mode を選んだ場合は再 navigate しない', async () => {
+    const user = userEvent.setup()
     render(<AppRouter initialEntries={['/saved-tabs?mode=domain']} />)
 
     await screen.findByText('saved-tabs-route:?mode=domain')
-    fireEvent.click(screen.getByRole('button', { name: 'navigate-domain' }))
+    await user.click(screen.getByRole('button', { name: 'navigate-domain' }))
 
     await expect(
       screen.findByText('saved-tabs-route:?mode=domain'),

--- a/src/features/navigation/components/ExtensionSidebar.test.tsx
+++ b/src/features/navigation/components/ExtensionSidebar.test.tsx
@@ -7,11 +7,11 @@ import { fileURLToPath } from 'node:url'
 
 import {
   cleanup,
-  fireEvent,
   render,
   screen,
   within,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 const sidebarContextValue = {
@@ -253,7 +253,8 @@ describe('ExtensionSidebar', () => {
     sidebarContextValue.sidebarWidth = 256
   })
 
-  it('縮小ヘッダーの開くボタンは固定でサイドバーを開いて幅を通常幅へ戻す', () => {
+  it('縮小ヘッダーの開くボタンは固定でサイドバーを開いて幅を通常幅へ戻す', async () => {
+    const user = userEvent.setup()
     sidebarContextValue.sidebarWidth = 48
     sidebarContextValue.open = true
 
@@ -266,7 +267,7 @@ describe('ExtensionSidebar', () => {
       />,
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'サイドバーを開く' }))
+    await user.click(screen.getByRole('button', { name: 'サイドバーを開く' }))
 
     expect(sidebarContextValue.setSidebarWidth).toHaveBeenCalledWith(256)
     expect(sidebarContextValue.setOpen).toHaveBeenCalledWith(true)
@@ -299,7 +300,8 @@ describe('ExtensionSidebar', () => {
     )
   })
 
-  it('通常幅ヘッダーの縮小ボタンは icon rail 幅まで戻す', () => {
+  it('通常幅ヘッダーの縮小ボタンは icon rail 幅まで戻す', async () => {
+    const user = userEvent.setup()
     sidebarContextValue.sidebarWidth = 256
 
     render(
@@ -311,7 +313,7 @@ describe('ExtensionSidebar', () => {
       />,
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'サイドバーを小さくする' }),
     )
 

--- a/src/features/navigation/components/ExtensionSidebar.test.tsx
+++ b/src/features/navigation/components/ExtensionSidebar.test.tsx
@@ -5,12 +5,7 @@ import { dirname, resolve } from 'node:path'
 // eslint-disable-next-line eslint/no-unused-vars
 import { fileURLToPath } from 'node:url'
 
-import {
-  cleanup,
-  render,
-  screen,
-  within,
-} from '@testing-library/react'
+import { cleanup, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 

--- a/src/features/options/ImportExportSettings.test.tsx
+++ b/src/features/options/ImportExportSettings.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import { ImportExportSettings } from './ImportExportSettings'
@@ -185,6 +186,11 @@ const getDropzoneFileInput = (container: HTMLElement): HTMLInputElement => {
 describe('ImportExportSettingsコンポーネント', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubGlobal('ResizeObserver', class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    })
     vi.spyOn(console, 'error').mockImplementation(() => {})
     readerMode = 'success'
     readerContent = '{"import":"payload"}'
@@ -217,9 +223,11 @@ describe('ImportExportSettingsコンポーネント', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it('データをエクスポートしてバックアップファイルをダウンロードする', async () => {
+    const user = userEvent.setup()
     vi.mocked(exportSettings).mockResolvedValue({
       version: '1.0.0',
       timestamp: '2026-02-16T00:00:00.000Z',
@@ -242,7 +250,7 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     render(<ImportExportSettings />)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Export settings and tab data' }),
     )
 
@@ -269,11 +277,12 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('エクスポート失敗時にエラートーストを表示する', async () => {
+    const user = userEvent.setup()
     vi.mocked(exportSettings).mockRejectedValue(new Error('export failed'))
 
     render(<ImportExportSettings />)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Export settings and tab data' }),
     )
 
@@ -285,6 +294,7 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('マージ設定を切り替えるとインポート時に mergeData=false を渡す', async () => {
+    const user = userEvent.setup()
     vi.mocked(importSettings).mockResolvedValue({
       success: true,
       message: 'ok',
@@ -292,11 +302,11 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Import settings and tab data' }),
     )
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('checkbox', {
         name: 'Merge with existing data (recommended)',
       }),
@@ -306,13 +316,8 @@ describe('ImportExportSettingsコンポーネント', () => {
       screen.getByText('Warning: all existing data will be replaced.'),
     ).toBeTruthy()
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(
@@ -320,7 +325,7 @@ describe('ImportExportSettingsコンポーネント', () => {
       ).toBeTruthy()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm Import' }))
 
     await waitFor(() => {
       expect(importSettings).toHaveBeenCalledWith(
@@ -334,6 +339,7 @@ describe('ImportExportSettingsコンポーネント', () => {
   it('ファイル未選択時は file change イベントを無視する', async () => {
     const { container } = render(<ImportExportSettings />)
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(getHiddenFileInput(container), {
       target: { files: [] },
     })
@@ -344,6 +350,7 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('dropzone input 経由（onDrop 経路）でファイルを処理する', async () => {
+    const user = userEvent.setup()
     vi.mocked(importSettings).mockResolvedValue({
       success: true,
       message: 'ok',
@@ -351,17 +358,12 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Import settings and tab data' }),
     )
 
-    fireEvent.change(getDropzoneFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'dropzone.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getDropzoneFileInput(container), { target: { files: [new File(['dummy'], 'dropzone.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(
@@ -369,7 +371,7 @@ describe('ImportExportSettingsコンポーネント', () => {
       ).toBeTruthy()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm Import' }))
 
     await waitFor(() => {
       expect(importSettings).toHaveBeenCalledWith(
@@ -381,9 +383,10 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('dropzone 上でドラッグ中にドラッグアクティブラベルを表示する', async () => {
+    const user = userEvent.setup()
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Import settings and tab data' }),
     )
 
@@ -406,9 +409,10 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('受け入れファイルがない drop イベントは処理しない', async () => {
+    const user = userEvent.setup()
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Import settings and tab data' }),
     )
 
@@ -431,19 +435,15 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('戻るボタンをクリックすると選択ステップに戻る', async () => {
+    const user = userEvent.setup()
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.click(
+    await user.click(
       screen.getByRole('button', { name: 'Import settings and tab data' }),
     )
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(
@@ -451,7 +451,7 @@ describe('ImportExportSettingsコンポーネント', () => {
       ).toBeTruthy()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    await user.click(screen.getByRole('button', { name: 'Back' }))
 
     await waitFor(() => {
       expect(
@@ -464,11 +464,8 @@ describe('ImportExportSettingsコンポーネント', () => {
   it('読み込み前に JSON 以外のファイルを拒否する', async () => {
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [new File(['dummy'], 'backup.txt', { type: 'text/plain' })],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.txt', { type: 'text/plain' })] } })
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Please select a JSON file')
@@ -479,6 +476,7 @@ describe('ImportExportSettingsコンポーネント', () => {
   it('10MB を超える JSON ファイルは読み込み前に拒否する', async () => {
     const { container } = render(<ImportExportSettings />)
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(getHiddenFileInput(container), {
       target: {
         files: [
@@ -505,13 +503,8 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Preview failed')
@@ -526,13 +519,8 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to read the file')
@@ -560,13 +548,8 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(screen.getByText('Yes')).toBeTruthy()
@@ -574,6 +557,7 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('JSON ファイルを正常にインポートして background に通知する', async () => {
+    const user = userEvent.setup()
     vi.mocked(importSettings).mockResolvedValue({
       success: true,
       message: 'Import successful',
@@ -581,13 +565,8 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(
@@ -595,7 +574,7 @@ describe('ImportExportSettingsコンポーネント', () => {
       ).toBeTruthy()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm Import' }))
 
     await waitFor(() => {
       expect(importSettings).toHaveBeenCalledWith(
@@ -612,6 +591,7 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('インポート結果が失敗時は importSettings の失敗メッセージを表示する', async () => {
+    const user = userEvent.setup()
     vi.mocked(importSettings).mockResolvedValue({
       success: false,
       message: 'Validation error',
@@ -619,13 +599,8 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(
@@ -633,7 +608,7 @@ describe('ImportExportSettingsコンポーネント', () => {
       ).toBeTruthy()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm Import' }))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Validation error')
@@ -643,17 +618,13 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('インポートで例外発生時に汎用エラーを表示する', async () => {
+    const user = userEvent.setup()
     vi.mocked(importSettings).mockRejectedValue(new Error('import failed'))
 
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(
@@ -661,7 +632,7 @@ describe('ImportExportSettingsコンポーネント', () => {
       ).toBeTruthy()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm Import' }))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
@@ -671,15 +642,11 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('確定時にファイル内容が空なら読み込みエラーを表示する', async () => {
+    const user = userEvent.setup()
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(
@@ -688,7 +655,7 @@ describe('ImportExportSettingsコンポーネント', () => {
     })
 
     readerMode = 'empty'
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm Import' }))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to read the file')
@@ -696,15 +663,11 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('確定時の FileReader.onerror で読み込みエラーを表示する', async () => {
+    const user = userEvent.setup()
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(
@@ -713,7 +676,7 @@ describe('ImportExportSettingsコンポーネント', () => {
     })
 
     readerMode = 'error'
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm Import' }))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to read the file')
@@ -721,15 +684,11 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('確定時に FileReader 作成が失敗したら汎用エラーを表示する', async () => {
+    const user = userEvent.setup()
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(
@@ -745,7 +704,7 @@ describe('ImportExportSettingsコンポーネント', () => {
     ;(globalThis as Record<string, unknown>).FileReader =
       ThrowingFileReader as unknown as typeof FileReader
 
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm Import' }))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
@@ -759,13 +718,8 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to read the file')
@@ -778,13 +732,8 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to read the file')
@@ -793,6 +742,7 @@ describe('ImportExportSettingsコンポーネント', () => {
   })
 
   it('アンマウント後の非同期 onload を null の file input ref に触れず処理する', async () => {
+    const user = userEvent.setup()
     readerMode = 'success'
     readerAsync = true
     vi.mocked(importSettings).mockResolvedValue({
@@ -802,13 +752,8 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container, unmount } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     await waitFor(() => {
       expect(
@@ -816,7 +761,7 @@ describe('ImportExportSettingsコンポーネント', () => {
       ).toBeTruthy()
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm Import' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm Import' }))
 
     unmount()
 
@@ -831,13 +776,8 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container, unmount } = render(<ImportExportSettings />)
 
-    fireEvent.change(getHiddenFileInput(container), {
-      target: {
-        files: [
-          new File(['dummy'], 'backup.json', { type: 'application/json' }),
-        ],
-      },
-    })
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
 
     unmount()
 

--- a/src/features/options/ImportExportSettings.test.tsx
+++ b/src/features/options/ImportExportSettings.test.tsx
@@ -186,11 +186,14 @@ const getDropzoneFileInput = (container: HTMLElement): HTMLInputElement => {
 describe('ImportExportSettingsコンポーネント', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.stubGlobal('ResizeObserver', class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    })
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    )
     vi.spyOn(console, 'error').mockImplementation(() => {})
     readerMode = 'success'
     readerContent = '{"import":"payload"}'
@@ -316,8 +319,15 @@ describe('ImportExportSettingsコンポーネント', () => {
       screen.getByText('Warning: all existing data will be replaced.'),
     ).toBeTruthy()
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(
@@ -339,6 +349,7 @@ describe('ImportExportSettingsコンポーネント', () => {
   it('ファイル未選択時は file change イベントを無視する', async () => {
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(getHiddenFileInput(container), {
       target: { files: [] },
@@ -362,8 +373,15 @@ describe('ImportExportSettingsコンポーネント', () => {
       screen.getByRole('button', { name: 'Import settings and tab data' }),
     )
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getDropzoneFileInput(container), { target: { files: [new File(['dummy'], 'dropzone.json', { type: 'application/json' })] } })
+    fireEvent.change(getDropzoneFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'dropzone.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(
@@ -442,8 +460,15 @@ describe('ImportExportSettingsコンポーネント', () => {
       screen.getByRole('button', { name: 'Import settings and tab data' }),
     )
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(
@@ -464,8 +489,13 @@ describe('ImportExportSettingsコンポーネント', () => {
   it('読み込み前に JSON 以外のファイルを拒否する', async () => {
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.txt', { type: 'text/plain' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [new File(['dummy'], 'backup.txt', { type: 'text/plain' })],
+      },
+    })
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Please select a JSON file')
@@ -476,6 +506,7 @@ describe('ImportExportSettingsコンポーネント', () => {
   it('10MB を超える JSON ファイルは読み込み前に拒否する', async () => {
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(getHiddenFileInput(container), {
       target: {
@@ -503,8 +534,15 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Preview failed')
@@ -519,8 +557,15 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to read the file')
@@ -548,8 +593,15 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(screen.getByText('Yes')).toBeTruthy()
@@ -565,8 +617,15 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(
@@ -599,8 +658,15 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(
@@ -623,8 +689,15 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(
@@ -645,8 +718,15 @@ describe('ImportExportSettingsコンポーネント', () => {
     const user = userEvent.setup()
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(
@@ -666,8 +746,15 @@ describe('ImportExportSettingsコンポーネント', () => {
     const user = userEvent.setup()
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(
@@ -687,8 +774,15 @@ describe('ImportExportSettingsコンポーネント', () => {
     const user = userEvent.setup()
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(
@@ -718,8 +812,15 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to read the file')
@@ -732,8 +833,15 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to read the file')
@@ -752,8 +860,15 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container, unmount } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     await waitFor(() => {
       expect(
@@ -776,8 +891,15 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     const { container, unmount } = render(<ImportExportSettings />)
 
+    // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getHiddenFileInput(container), { target: { files: [new File(['dummy'], 'backup.json', { type: 'application/json' })] } })
+    fireEvent.change(getHiddenFileInput(container), {
+      target: {
+        files: [
+          new File(['dummy'], 'backup.json', { type: 'application/json' }),
+        ],
+      },
+    })
 
     unmount()
 

--- a/src/features/options/SubCategoryKeywordManager.test.tsx
+++ b/src/features/options/SubCategoryKeywordManager.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type { TabGroup } from '@/types/storage'
@@ -101,8 +102,8 @@ const renderManager = (
   return render(<SubCategoryKeywordManager tabGroup={tabGroup} />)
 }
 
-const selectCategory = (name: string) => {
-  fireEvent.click(screen.getByRole('button', { name }))
+const selectCategory = async (user: ReturnType<typeof userEvent.setup>, name: string) => {
+  await user.click(screen.getByRole('button', { name }))
 }
 
 const getLastSavedTab = () =>
@@ -170,7 +171,8 @@ describe('SubCategoryKeywordManager', () => {
     await expect(updateTabGroup(tabGroup)).resolves.toBe(false)
   })
 
-  it('重複したキーワード追加では toast.error を表示する', () => {
+  it('重複したキーワード追加では toast.error を表示する', async () => {
+    const user = userEvent.setup()
     renderManager(
       createTabGroup({
         categoryKeywords: [{ categoryName: 'Docs', keywords: ['Guide'] }],
@@ -180,12 +182,11 @@ describe('SubCategoryKeywordManager', () => {
       }),
     )
 
-    selectCategory('Docs')
+    await selectCategory(user, 'Docs')
 
-    fireEvent.change(screen.getByPlaceholderText('Enter keyword'), {
-      target: { value: 'guide' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Add keyword' }))
+    await user.clear(screen.getByPlaceholderText('Enter keyword'))
+    await user.type(screen.getByPlaceholderText('Enter keyword'), 'guide')
+    await user.click(screen.getByRole('button', { name: 'Add keyword' }))
 
     expect(toast.error).toHaveBeenCalledWith('Duplicate keyword')
     expect(setCategoryKeywords).not.toHaveBeenCalled()
@@ -206,7 +207,8 @@ describe('SubCategoryKeywordManager', () => {
     expect(screen.queryByText('Keyword manager')).toBeNull()
   })
 
-  it('カテゴリにキーワード設定がない場合は空のキーワード一覧を表示する', () => {
+  it('カテゴリにキーワード設定がない場合は空のキーワード一覧を表示する', async () => {
+    const user = userEvent.setup()
     renderManager(
       createTabGroup({
         categoryKeywords: undefined,
@@ -214,12 +216,13 @@ describe('SubCategoryKeywordManager', () => {
       }),
     )
 
-    selectCategory('Docs')
+    await selectCategory(user, 'Docs')
 
     expect(screen.getByText('No keywords')).not.toBeNull()
   })
 
   it('キーワード追加で setCategoryKeywords に保存する', async () => {
+    const user = userEvent.setup()
     renderManager(
       createTabGroup({
         categoryKeywords: [{ categoryName: 'Docs', keywords: ['Guide'] }],
@@ -229,12 +232,11 @@ describe('SubCategoryKeywordManager', () => {
       }),
     )
 
-    selectCategory('Docs')
+    await selectCategory(user, 'Docs')
 
-    fireEvent.change(screen.getByPlaceholderText('Enter keyword'), {
-      target: { value: 'API' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Add keyword' }))
+    await user.clear(screen.getByPlaceholderText('Enter keyword'))
+    await user.type(screen.getByPlaceholderText('Enter keyword'), 'API')
+    await user.click(screen.getByRole('button', { name: 'Add keyword' }))
 
     await waitFor(() => {
       expect(setCategoryKeywords).toHaveBeenCalledWith('group-1', 'Docs', [
@@ -245,6 +247,7 @@ describe('SubCategoryKeywordManager', () => {
   })
 
   it('キーワード入力で Enter を押すと追加処理を実行する', async () => {
+    const user = userEvent.setup()
     renderManager(
       createTabGroup({
         categoryKeywords: [{ categoryName: 'Docs', keywords: ['Guide'] }],
@@ -254,14 +257,11 @@ describe('SubCategoryKeywordManager', () => {
       }),
     )
 
-    selectCategory('Docs')
+    await selectCategory(user, 'Docs')
 
-    fireEvent.change(screen.getByPlaceholderText('Enter keyword'), {
-      target: { value: 'API' },
-    })
-    fireEvent.keyDown(screen.getByPlaceholderText('Enter keyword'), {
-      key: 'Enter',
-    })
+    await user.clear(screen.getByPlaceholderText('Enter keyword'))
+    await user.type(screen.getByPlaceholderText('Enter keyword'), 'API')
+    await user.type(screen.getByPlaceholderText('Enter keyword'), '{Enter}')
 
     await waitFor(() => {
       expect(setCategoryKeywords).toHaveBeenCalledWith('group-1', 'Docs', [
@@ -272,6 +272,7 @@ describe('SubCategoryKeywordManager', () => {
   })
 
   it('キーワード追加の保存失敗ではエラーを記録する', async () => {
+    const user = userEvent.setup()
     vi.mocked(setCategoryKeywords).mockRejectedValueOnce(
       new Error('save failed'),
     )
@@ -285,12 +286,11 @@ describe('SubCategoryKeywordManager', () => {
       }),
     )
 
-    selectCategory('Docs')
+    await selectCategory(user, 'Docs')
 
-    fireEvent.change(screen.getByPlaceholderText('Enter keyword'), {
-      target: { value: 'API' },
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Add keyword' }))
+    await user.clear(screen.getByPlaceholderText('Enter keyword'))
+    await user.type(screen.getByPlaceholderText('Enter keyword'), 'API')
+    await user.click(screen.getByRole('button', { name: 'Add keyword' }))
 
     await waitFor(() => {
       expect(console.error).toHaveBeenCalledWith(
@@ -301,6 +301,7 @@ describe('SubCategoryKeywordManager', () => {
   })
 
   it('キーワード削除で setCategoryKeywords に保存する', async () => {
+    const user = userEvent.setup()
     renderManager(
       createTabGroup({
         categoryKeywords: [{ categoryName: 'Docs', keywords: ['Guide'] }],
@@ -310,9 +311,9 @@ describe('SubCategoryKeywordManager', () => {
       }),
     )
 
-    selectCategory('Docs')
+    await selectCategory(user, 'Docs')
 
-    fireEvent.click(screen.getByLabelText('Delete keyword Guide'))
+    await user.click(screen.getByLabelText('Delete keyword Guide'))
 
     await waitFor(() => {
       expect(setCategoryKeywords).toHaveBeenCalledWith('group-1', 'Docs', [])
@@ -320,6 +321,7 @@ describe('SubCategoryKeywordManager', () => {
   })
 
   it('キーワード削除の保存失敗では toast.error を表示する', async () => {
+    const user = userEvent.setup()
     vi.mocked(setCategoryKeywords).mockRejectedValueOnce(
       new Error('save failed'),
     )
@@ -333,8 +335,8 @@ describe('SubCategoryKeywordManager', () => {
       }),
     )
 
-    selectCategory('Docs')
-    fireEvent.click(screen.getByLabelText('Delete keyword Guide'))
+    await selectCategory(user, 'Docs')
+    await user.click(screen.getByLabelText('Delete keyword Guide'))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to update keywords')
@@ -342,6 +344,7 @@ describe('SubCategoryKeywordManager', () => {
   })
 
   it('サブカテゴリ作成で savedTabs を更新する', async () => {
+    const user = userEvent.setup()
     renderManager(
       createTabGroup({
         categoryKeywords: [{ categoryName: 'Docs', keywords: ['Guide'] }],
@@ -351,12 +354,9 @@ describe('SubCategoryKeywordManager', () => {
       }),
     )
 
-    fireEvent.change(screen.getByLabelText('Subcategory name'), {
-      target: { value: 'News' },
-    })
-    fireEvent.keyDown(screen.getByLabelText('Subcategory name'), {
-      key: 'Enter',
-    })
+    await user.clear(screen.getByLabelText('Subcategory name'))
+    await user.type(screen.getByLabelText('Subcategory name'), 'News')
+    await user.type(screen.getByLabelText('Subcategory name'), '{Enter}')
 
     await waitFor(() => {
       expect(getLastSavedTab()?.subCategories).toStrictEqual(['Docs', 'News'])
@@ -367,32 +367,26 @@ describe('SubCategoryKeywordManager', () => {
     })
   })
 
-  it('対象外キーと空入力では追加・rename を実行しない', () => {
+  it('対象外キーと空入力では追加・rename を実行しない', async () => {
+    const user = userEvent.setup()
     renderManager(createTabGroup())
 
-    fireEvent.keyDown(screen.getByLabelText('Subcategory name'), {
-      key: 'Tab',
-    })
+    await user.type(screen.getByLabelText('Subcategory name'), '{Tab}')
     fireEvent.blur(screen.getByLabelText('Subcategory name'))
     expect(storageLocalSet).not.toHaveBeenCalled()
 
-    selectCategory('Docs')
-    fireEvent.keyDown(screen.getByPlaceholderText('Enter keyword'), {
-      key: 'Tab',
-    })
-    fireEvent.keyDown(screen.getByPlaceholderText('Enter keyword'), {
-      key: 'Enter',
-    })
+    await selectCategory(user, 'Docs')
+    await user.type(screen.getByPlaceholderText('Enter keyword'), '{Tab}')
+    await user.type(screen.getByPlaceholderText('Enter keyword'), '{Enter}')
     expect(setCategoryKeywords).not.toHaveBeenCalled()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
-    fireEvent.keyDown(screen.getByLabelText('Rename subcategory'), {
-      key: 'Tab',
-    })
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+    await user.type(screen.getByLabelText('Rename subcategory'), '{Tab}')
     expect(screen.getByLabelText('Rename subcategory')).not.toBeNull()
   })
 
   it('空状態の blur でもサブカテゴリを作成し不足配列を補完する', async () => {
+    const user = userEvent.setup()
     const tabGroup = createTabGroup({
       categoryKeywords: undefined,
       subCategories: undefined,
@@ -403,9 +397,8 @@ describe('SubCategoryKeywordManager', () => {
 
     renderManager(tabGroup, [structuredClone(tabGroup)])
 
-    fireEvent.change(screen.getByLabelText('Subcategory name'), {
-      target: { value: 'News' },
-    })
+    await user.clear(screen.getByLabelText('Subcategory name'))
+    await user.type(screen.getByLabelText('Subcategory name'), 'News')
     fireEvent.blur(screen.getByLabelText('Subcategory name'))
 
     await waitFor(() => {
@@ -417,6 +410,7 @@ describe('SubCategoryKeywordManager', () => {
   })
 
   it('サブカテゴリ作成の保存失敗ではエラーを記録して保存しない', async () => {
+    const user = userEvent.setup()
     renderManager(
       createTabGroup({
         categoryKeywords: [{ categoryName: 'Docs', keywords: ['Guide'] }],
@@ -427,12 +421,9 @@ describe('SubCategoryKeywordManager', () => {
     )
     storageLocalGet.mockRejectedValueOnce(new Error('storage failed'))
 
-    fireEvent.change(screen.getByLabelText('Subcategory name'), {
-      target: { value: 'News' },
-    })
-    fireEvent.keyDown(screen.getByLabelText('Subcategory name'), {
-      key: 'Enter',
-    })
+    await user.clear(screen.getByLabelText('Subcategory name'))
+    await user.type(screen.getByLabelText('Subcategory name'), 'News')
+    await user.type(screen.getByLabelText('Subcategory name'), '{Enter}')
 
     await waitFor(() => {
       expect(console.error).toHaveBeenCalledWith(
@@ -443,7 +434,8 @@ describe('SubCategoryKeywordManager', () => {
     expect(storageLocalSet).not.toHaveBeenCalled()
   })
 
-  it('重複したサブカテゴリ作成では toast.error を表示する', () => {
+  it('重複したサブカテゴリ作成では toast.error を表示する', async () => {
+    const user = userEvent.setup()
     renderManager(
       createTabGroup({
         categoryKeywords: [{ categoryName: 'Docs', keywords: ['Guide'] }],
@@ -453,21 +445,19 @@ describe('SubCategoryKeywordManager', () => {
       }),
     )
 
-    fireEvent.change(screen.getByLabelText('Subcategory name'), {
-      target: { value: 'Docs' },
-    })
-    fireEvent.keyDown(screen.getByLabelText('Subcategory name'), {
-      key: 'Enter',
-    })
+    await user.clear(screen.getByLabelText('Subcategory name'))
+    await user.type(screen.getByLabelText('Subcategory name'), 'Docs')
+    await user.type(screen.getByLabelText('Subcategory name'), '{Enter}')
 
     expect(toast.error).toHaveBeenCalledWith('Duplicate subcategory')
     expect(storageLocalSet).not.toHaveBeenCalled()
   })
 
   it('サブカテゴリ削除で savedTabs を更新し toast.success を表示する', async () => {
+    const user = userEvent.setup()
     renderManager(createTabGroup())
 
-    fireEvent.click(screen.getByLabelText('Delete Guides'))
+    await user.click(screen.getByLabelText('Delete Guides'))
 
     await waitFor(() => {
       expect(getLastSavedTab()?.subCategories).toStrictEqual(['Docs'])
@@ -480,12 +470,13 @@ describe('SubCategoryKeywordManager', () => {
   })
 
   it('選択中のサブカテゴリを削除するとキーワード表示をクリアする', async () => {
+    const user = userEvent.setup()
     renderManager(createTabGroup())
 
-    selectCategory('Guides')
+    await selectCategory(user, 'Guides')
     expect(screen.getByText('Article')).not.toBeNull()
 
-    fireEvent.click(screen.getByLabelText('Delete Guides'))
+    await user.click(screen.getByLabelText('Delete Guides'))
 
     await waitFor(() => {
       expect(screen.queryByText('Guides keywords')).toBeNull()
@@ -494,10 +485,11 @@ describe('SubCategoryKeywordManager', () => {
   })
 
   it('削除対象のタブグループが見つからない場合は保存しない', async () => {
+    const user = userEvent.setup()
     const tabGroup = createTabGroup()
     renderManager(tabGroup, [])
 
-    fireEvent.click(screen.getByLabelText('Delete Guides'))
+    await user.click(screen.getByLabelText('Delete Guides'))
 
     await waitFor(() => {
       expect(console.error).toHaveBeenCalledWith('タブグループが見つかりません')
@@ -507,6 +499,7 @@ describe('SubCategoryKeywordManager', () => {
   })
 
   it('サブカテゴリ削除は保存データの不足配列を空配列として扱う', async () => {
+    const user = userEvent.setup()
     const tabGroup = createTabGroup({
       categoryKeywords: undefined,
       subCategories: ['Docs'],
@@ -519,7 +512,7 @@ describe('SubCategoryKeywordManager', () => {
 
     renderManager(tabGroup, [savedTab])
 
-    fireEvent.click(screen.getByLabelText('Delete Docs'))
+    await user.click(screen.getByLabelText('Delete Docs'))
 
     await waitFor(() => {
       expect(getLastSavedTab()).toStrictEqual(
@@ -532,10 +525,11 @@ describe('SubCategoryKeywordManager', () => {
   })
 
   it('サブカテゴリ削除の保存失敗では toast.error を表示する', async () => {
+    const user = userEvent.setup()
     renderManager(createTabGroup())
     storageLocalGet.mockRejectedValueOnce(new Error('storage failed'))
 
-    fireEvent.click(screen.getByLabelText('Delete Guides'))
+    await user.click(screen.getByLabelText('Delete Guides'))
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to delete subcategory')
@@ -543,6 +537,7 @@ describe('SubCategoryKeywordManager', () => {
   })
 
   it('サブカテゴリ名変更で savedTabs の関連フィールドを更新する', async () => {
+    const user = userEvent.setup()
     const tabGroup = createTabGroup({
       urls: [
         {
@@ -578,14 +573,11 @@ describe('SubCategoryKeywordManager', () => {
 
     renderManager(tabGroup, [structuredClone(tabGroup), untouchedTab])
 
-    selectCategory('Docs')
-    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
-    fireEvent.change(screen.getByLabelText('Rename subcategory'), {
-      target: { value: 'Reference' },
-    })
-    fireEvent.keyDown(screen.getByLabelText('Rename subcategory'), {
-      key: 'Enter',
-    })
+    await selectCategory(user, 'Docs')
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+    await user.clear(screen.getByLabelText('Rename subcategory'))
+    await user.type(screen.getByLabelText('Rename subcategory'), 'Reference')
+    await user.type(screen.getByLabelText('Rename subcategory'), '{Enter}')
 
     await waitFor(() => {
       expect(getLastSavedTab()?.subCategories).toStrictEqual([
@@ -624,6 +616,7 @@ describe('SubCategoryKeywordManager', () => {
   })
 
   it('サブカテゴリ名変更は保存データの不足配列を空配列として扱う', async () => {
+    const user = userEvent.setup()
     const tabGroup = createTabGroup({
       categoryKeywords: [{ categoryName: 'Docs', keywords: ['Guide'] }],
       subCategories: ['Docs'],
@@ -638,14 +631,11 @@ describe('SubCategoryKeywordManager', () => {
 
     renderManager(tabGroup, [savedTab])
 
-    selectCategory('Docs')
-    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
-    fireEvent.change(screen.getByLabelText('Rename subcategory'), {
-      target: { value: 'Reference' },
-    })
-    fireEvent.keyDown(screen.getByLabelText('Rename subcategory'), {
-      key: 'Enter',
-    })
+    await selectCategory(user, 'Docs')
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+    await user.clear(screen.getByLabelText('Rename subcategory'))
+    await user.type(screen.getByLabelText('Rename subcategory'), 'Reference')
+    await user.type(screen.getByLabelText('Rename subcategory'), '{Enter}')
 
     await waitFor(() => {
       expect(getLastSavedTab()).toStrictEqual(
@@ -660,90 +650,82 @@ describe('SubCategoryKeywordManager', () => {
     })
   })
 
-  it('サブカテゴリ名変更中に Escape を押すと rename をキャンセルする', () => {
+  it('サブカテゴリ名変更中に Escape を押すと rename をキャンセルする', async () => {
+    const user = userEvent.setup()
     renderManager(createTabGroup())
 
-    selectCategory('Docs')
-    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
-    fireEvent.change(screen.getByLabelText('Rename subcategory'), {
-      target: { value: 'Reference' },
-    })
-    fireEvent.keyDown(screen.getByLabelText('Rename subcategory'), {
-      key: 'Escape',
-    })
+    await selectCategory(user, 'Docs')
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+    await user.clear(screen.getByLabelText('Rename subcategory'))
+    await user.type(screen.getByLabelText('Rename subcategory'), 'Reference')
+    await user.type(screen.getByLabelText('Rename subcategory'), '{Escape}')
 
     expect(screen.queryByLabelText('Rename subcategory')).toBeNull()
     expect(screen.getByText('Docs keywords')).not.toBeNull()
   })
 
-  it('rename 中に別カテゴリを選ぶと rename モードを終了する', () => {
+  it('rename 中に別カテゴリを選ぶと rename モードを終了する', async () => {
+    const user = userEvent.setup()
     renderManager(createTabGroup())
 
-    selectCategory('Docs')
-    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
-    selectCategory('Guides')
+    await selectCategory(user, 'Docs')
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+    await selectCategory(user, 'Guides')
 
     expect(screen.queryByLabelText('Rename subcategory')).toBeNull()
     expect(screen.getByText('Guides keywords')).not.toBeNull()
   })
 
-  it('空のサブカテゴリ名で確定すると rename モードを閉じる', () => {
+  it('空のサブカテゴリ名で確定すると rename モードを閉じる', async () => {
+    const user = userEvent.setup()
     renderManager(createTabGroup())
 
-    selectCategory('Docs')
-    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
-    fireEvent.change(screen.getByLabelText('Rename subcategory'), {
-      target: { value: '   ' },
-    })
-    fireEvent.keyDown(screen.getByLabelText('Rename subcategory'), {
-      key: 'Enter',
-    })
+    await selectCategory(user, 'Docs')
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+    await user.clear(screen.getByLabelText('Rename subcategory'))
+    await user.type(screen.getByLabelText('Rename subcategory'), '   ')
+    await user.type(screen.getByLabelText('Rename subcategory'), '{Enter}')
 
     expect(screen.queryByLabelText('Rename subcategory')).toBeNull()
     expect(storageLocalSet).not.toHaveBeenCalled()
   })
 
-  it('同じサブカテゴリ名で確定すると保存せず rename モードを閉じる', () => {
+  it('同じサブカテゴリ名で確定すると保存せず rename モードを閉じる', async () => {
+    const user = userEvent.setup()
     renderManager(createTabGroup())
 
-    selectCategory('Docs')
-    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
-    fireEvent.keyDown(screen.getByLabelText('Rename subcategory'), {
-      key: 'Enter',
-    })
+    await selectCategory(user, 'Docs')
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+    await user.type(screen.getByLabelText('Rename subcategory'), '{Enter}')
 
     expect(screen.queryByLabelText('Rename subcategory')).toBeNull()
     expect(storageLocalSet).not.toHaveBeenCalled()
   })
 
-  it('重複したサブカテゴリ名変更では toast.error を表示する', () => {
+  it('重複したサブカテゴリ名変更では toast.error を表示する', async () => {
+    const user = userEvent.setup()
     renderManager(createTabGroup())
 
-    selectCategory('Docs')
-    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
-    fireEvent.change(screen.getByLabelText('Rename subcategory'), {
-      target: { value: 'Guides' },
-    })
-    fireEvent.keyDown(screen.getByLabelText('Rename subcategory'), {
-      key: 'Enter',
-    })
+    await selectCategory(user, 'Docs')
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+    await user.clear(screen.getByLabelText('Rename subcategory'))
+    await user.type(screen.getByLabelText('Rename subcategory'), 'Guides')
+    await user.type(screen.getByLabelText('Rename subcategory'), '{Enter}')
 
     expect(toast.error).toHaveBeenCalledWith('Duplicate subcategory')
     expect(storageLocalSet).not.toHaveBeenCalled()
   })
 
   it('サブカテゴリ名変更の保存失敗では toast.error を表示する', async () => {
+    const user = userEvent.setup()
     renderManager(createTabGroup())
     storageLocalSet.mockRejectedValueOnce(new Error('save failed'))
 
-    selectCategory('Docs')
-    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
-    fireEvent.change(screen.getByLabelText('Rename subcategory'), {
-      target: { value: 'Reference' },
-    })
-    fireEvent.keyDown(screen.getByLabelText('Rename subcategory'), {
-      key: 'Enter',
-    })
+    await selectCategory(user, 'Docs')
+    await user.click(screen.getByRole('button', { name: 'Rename' }))
+    await user.clear(screen.getByLabelText('Rename subcategory'))
+    await user.type(screen.getByLabelText('Rename subcategory'), 'Reference')
+    await user.type(screen.getByLabelText('Rename subcategory'), '{Enter}')
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Failed to rename subcategory')

--- a/src/features/options/SubCategoryKeywordManager.test.tsx
+++ b/src/features/options/SubCategoryKeywordManager.test.tsx
@@ -102,7 +102,10 @@ const renderManager = (
   return render(<SubCategoryKeywordManager tabGroup={tabGroup} />)
 }
 
-const selectCategory = async (user: ReturnType<typeof userEvent.setup>, name: string) => {
+const selectCategory = async (
+  user: ReturnType<typeof userEvent.setup>,
+  name: string,
+) => {
   await user.click(screen.getByRole('button', { name }))
 }
 

--- a/src/features/options/routes/OptionsRoute.test.tsx
+++ b/src/features/options/routes/OptionsRoute.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
@@ -191,19 +192,23 @@ describe('OptionsRoute', () => {
   })
 
   it('renders settings sections and commits font size controls', async () => {
+    const user = userEvent.setup()
     render(<OptionsRoute />)
 
     expect(screen.getByText('options.title')).toBeTruthy()
     expect(screen.getByText('import-export-settings')).toBeTruthy()
 
     const slider = screen.getByLabelText('options.fontSize.rangeLabel')
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(slider, { target: { value: '125' } })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyUp(slider, { key: 'Tab' })
     expect(optionsRouteMocks.updateSetting).not.toHaveBeenCalledWith(
       'fontSizePercent',
       125,
     )
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.keyUp(slider, { key: 'ArrowRight' })
     await waitFor(() => {
       expect(optionsRouteMocks.updateSetting).toHaveBeenCalledWith(
@@ -211,8 +216,10 @@ describe('OptionsRoute', () => {
         125,
       )
     })
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(slider, { target: { value: '130' } })
     fireEvent.touchEnd(slider)
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(slider, { target: { value: '135' } })
     fireEvent.blur(slider)
     await waitFor(() => {
@@ -223,29 +230,34 @@ describe('OptionsRoute', () => {
     })
 
     const input = screen.getByLabelText('options.fontSize.inputLabel')
-    fireEvent.change(input, { target: { value: '' } })
+    await user.clear(input)
     fireEvent.blur(input)
     expect((input as HTMLInputElement).value).toBe('100')
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: 'not-number' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.type(input, '{Enter}')
     expect((input as HTMLInputElement).value).toBe('100')
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: 'NaN' } })
     fireEvent.blur(input)
     expect((input as HTMLInputElement).value).toBe('100')
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(input, { target: { value: 'not-number' } })
-    fireEvent.keyDown(input, { key: 'Escape' })
+    await user.type(input, '{Escape}')
     expect((input as HTMLInputElement).value).toBe('')
 
-    fireEvent.keyDown(input, { key: 'Enter' })
+    await user.type(input, '{Enter}')
     expect((input as HTMLInputElement).value).toBe('100')
   })
 
   it('updates behavior, color, reset, exclude removal, and external links', async () => {
+    const user = userEvent.setup()
     render(<OptionsRoute />)
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(screen.getByLabelText('click-behavior'), {
       target: { value: 'saveCurrentTab' },
     })
@@ -254,28 +266,29 @@ describe('OptionsRoute', () => {
       'saveCurrentTab',
     )
 
-    fireEvent.click(screen.getByLabelText('options.autoDelete.openAfter'))
+    await user.click(screen.getByLabelText('options.autoDelete.openAfter'))
     expect(optionsRouteMocks.updateSetting).toHaveBeenCalledWith(
       'removeTabAfterOpen',
       false,
     )
 
+    // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(screen.getAllByDisplayValue(/^#/)[0], {
       target: { value: '#123456' },
     })
     expect(optionsRouteMocks.handleColorChange).toHaveBeenCalled()
 
-    fireEvent.click(screen.getAllByText('common.reset')[0])
+    await user.click(screen.getAllByText('common.reset')[0])
     expect(optionsRouteMocks.updateSetting).toHaveBeenCalledWith(
       'fontSizePercent',
       100,
     )
 
-    fireEvent.click(screen.getAllByText('common.reset')[1])
+    await user.click(screen.getAllByText('common.reset')[1])
     expect(optionsRouteMocks.handleResetColors).toHaveBeenCalled()
 
-    fireEvent.click(screen.getByText('options.contact'))
-    fireEvent.click(screen.getByText('options.releaseNotes'))
+    await user.click(screen.getByText('options.contact'))
+    await user.click(screen.getByText('options.releaseNotes'))
 
     expect(window.open).toHaveBeenCalledWith(
       'https://forms.gle/c9gBiF2TmgXaeU7J6',

--- a/src/features/options/routes/OptionsRoute.test.tsx
+++ b/src/features/options/routes/OptionsRoute.test.tsx
@@ -257,10 +257,10 @@ describe('OptionsRoute', () => {
     const user = userEvent.setup()
     render(<OptionsRoute />)
 
-    // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(screen.getByLabelText('click-behavior'), {
-      target: { value: 'saveCurrentTab' },
-    })
+    await user.selectOptions(
+      screen.getByLabelText('click-behavior'),
+      'saveCurrentTab',
+    )
     expect(optionsRouteMocks.updateSetting).toHaveBeenCalledWith(
       'clickBehavior',
       'saveCurrentTab',

--- a/src/features/periodic-execution/routes/PeriodicExecutionRoute.test.tsx
+++ b/src/features/periodic-execution/routes/PeriodicExecutionRoute.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createElement } from 'react'
 import type { ComponentPropsWithoutRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
@@ -256,7 +257,8 @@ describe('PeriodicExecutionRoute', () => {
     ).toBeTruthy()
   })
 
-  it('自動削除期間が未設定なら never を選択値として扱う', () => {
+  it('自動削除期間が未設定なら never を選択値として扱う', async () => {
+    const user = userEvent.setup()
     mocked.settings = {
       ...mocked.settings,
       autoDeletePeriod: undefined,
@@ -264,7 +266,7 @@ describe('PeriodicExecutionRoute', () => {
 
     render(createElement(PeriodicExecutionRoute))
 
-    fireEvent.click(screen.getAllByTestId('mock-select-change')[0])
+    await user.click(screen.getAllByTestId('mock-select-change')[0])
     expect(mocked.handleSelectAutoDelete).toHaveBeenCalledWith('30days')
   })
 
@@ -277,17 +279,18 @@ describe('PeriodicExecutionRoute', () => {
     expect(screen.queryByText('Loading...')).toBeNull()
   })
 
-  it('自動削除期間の変更と確認操作を処理する', () => {
+  it('自動削除期間の変更と確認操作を処理する', async () => {
+    const user = userEvent.setup()
     render(createElement(PeriodicExecutionRoute))
 
-    fireEvent.click(screen.getAllByTestId('mock-select-change')[0])
+    await user.click(screen.getAllByTestId('mock-select-change')[0])
     expect(mocked.handleSelectAutoDelete).toHaveBeenCalledWith('30days')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Apply' }))
+    await user.click(screen.getByRole('button', { name: 'Apply' }))
     expect(mocked.prepareAutoDeletePeriod).toHaveBeenCalledTimes(1)
 
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
     expect(mocked.hideConfirmation).toHaveBeenCalledTimes(1)
     expect(mocked.confirmationConfirm).toHaveBeenCalledTimes(1)
   })

--- a/src/lib/storybook/deferred-story.test.tsx
+++ b/src/lib/storybook/deferred-story.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { lazy } from 'react'
 import { describe, expect, it } from 'vitest'
 
@@ -11,6 +12,7 @@ const HeavyStory = lazy(async () => ({
 
 describe('DeferredStoryLoader', () => {
   it('does not load the heavy story until requested', async () => {
+    const user = userEvent.setup()
     render(
       <DeferredStoryLoader
         buttonLabel='Load heavy story'
@@ -23,7 +25,7 @@ describe('DeferredStoryLoader', () => {
     expect(screen.getByText('Heavy story')).toBeTruthy()
     expect(screen.queryByText('heavy story content')).toBeNull()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Load heavy story' }))
+    await user.click(screen.getByRole('button', { name: 'Load heavy story' }))
 
     await expect(screen.findByText('heavy story content')).resolves.toBeTruthy()
   })

--- a/tests/profile/saved-tabs-profiler.test.ts
+++ b/tests/profile/saved-tabs-profiler.test.ts
@@ -1,4 +1,5 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 type MockStore = Record<string, unknown>
@@ -173,6 +174,7 @@ describe('SavedTabs プロファイラのベースライン', () => {
   })
 
   it('検索操作中のコミット回数を記録する', async () => {
+    const user = userEvent.setup()
     await import('@/entrypoints/saved-tabs/main.tsx')
 
     document.dispatchEvent(new Event('DOMContentLoaded'))
@@ -196,9 +198,10 @@ describe('SavedTabs プロファイラのベースライン', () => {
         }
       ).savedTabsProfiler?.commits ?? 0
 
-    fireEvent.change(searchInput, { target: { value: 'exa' } })
-    fireEvent.change(searchInput, { target: { value: 'example' } })
-    fireEvent.change(searchInput, { target: { value: '' } })
+    await user.type(searchInput, 'exa')
+    await user.clear(searchInput)
+    await user.type(searchInput, 'example')
+    await user.clear(searchInput)
 
     await waitFor(() => {
       const commits =


### PR DESCRIPTION
## 変更内容

Issue #616 の対応。testing-library/prefer-user-event ルールを error で有効化し、全テストファイルの fireEvent を userEvent に移行した。

### 主な変換パターン

| fireEvent | userEvent | 備考 |
| --- | --- | --- |
| fireEvent.click(el) | await user.click(el) | 全ファイルで変換 |
| fireEvent.change(input, target value) | await user.clear + await user.type | テキスト入力 |
| fireEvent.change(select, target value) | await user.selectOptions | select 要素 |
| fireEvent.keyDown(el, key Enter) | await user.type(el, {Enter}) | キーボードイベント |
| fireEvent.keyDown(el, key Escape) | await user.type(el, {Escape}) | キーボードイベント |

### inline disable で保持した低レベルイベント

userEvent で再現不可能な以下のイベントは fireEvent のまま eslint-disable-next-line で保持:

- fireEvent.pointerDown — dnd-kit ドラッグハンドル
- fireEvent.mouseDown / fireEvent.mouseUp — 長押しスクロール
- fireEvent.keyUp — スライダーのコミット判定
- fireEvent.keyDown — isComposing / stopPropagation モック / window キーボードショートカット
- fireEvent.change — file input (pointer-events none) / color input / range slider

### 追加の調整

- clipboard mock: userEvent.setup() が navigator.clipboard を上書きする問題に対し、setup 後に mock を再定義
- ResizeObserver mock: userEvent + Radix UI ScrollArea の互換性のため mock を追加
- fake timers: userEvent と fake timers の非互換性に対し、real timers + waitFor に切り替え
- 制御された入力: mock が状態を更新しない問題に状態管理ラッパー (useState) で対処
- Radix UI Select/Dialog: pointer-events none で user.click が動作しないため fireEvent.click で保持

## 検証

- [x] bun run lint が通過
- [x] bun run test が全 3132 テストで通過
- [x] testing-library/prefer-user-event が error で有効化済み

Closes #616


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated many UI interaction tests from `fireEvent` to `@testing-library/user-event` with async/await flows.
  * Updated dialog, search, navigation, settings, confirmations, and keyboard interactions to use more realistic user behavior and improved sequencing.

* **Chores**
  * Reformatted lint configuration for consistency and readability.
  * Strengthened test linting by enforcing `prefer-user-event` for test-like files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->