### PR TITLE
no-container/no-node-access ルールを有効化し直接 DOM アクセスを意味的 query へ移行する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -761,7 +761,9 @@
         "testing-library/no-dom-import": "error",
         "testing-library/prefer-user-event-setup": "error",
         "testing-library/no-debugging-utils": "error",
-        "testing-library/prefer-user-event": "error"
+        "testing-library/prefer-user-event": "error",
+        "testing-library/no-container": "error",
+        "testing-library/no-node-access": "error"
       }
     }
   ]

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
@@ -1063,7 +1063,11 @@ describe('SavedTabsApp custom search', () => {
   it('AI サイドバーが開いている場合は全幅レイアウトを使う', () => {
     render(<SavedTabsApp isAiSidebarOpen />)
 
-    expect(document.querySelector('.min-h-screen.w-full.py-2')).toBeTruthy()
+    expect(screen.getByTestId('saved-tabs-layout')).toHaveClass(
+      'min-h-screen',
+      'w-full',
+      'py-2',
+    )
   })
 
   it('カテゴリ並び替えモードでは一時順序とフッター表示条件を使う', async () => {

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -511,6 +511,7 @@ const useSavedTabsAppView = ({
     <>
       <Toaster />
       <div
+        data-testid='saved-tabs-layout'
         className={
           isAiSidebarOpen
             ? 'min-h-screen w-full py-2'

--- a/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.test.tsx
@@ -1028,12 +1028,7 @@ describe('CategoryManagementModal', () => {
       )
 
       await screen.findByTestId('select-item-g2')
-      const plusButton = screen.getByText('選択したドメインを親カテゴリに追加')
-        .previousElementSibling as HTMLButtonElement | null
-      expect(plusButton).toBeTruthy()
-      if (!plusButton) {
-        throw new Error('plusButton not found')
-      }
+      const plusButton = screen.getByTestId('add-domain-button')
       await user.click(plusButton)
 
       await waitFor(() => {
@@ -1085,13 +1080,7 @@ describe('CategoryManagementModal', () => {
       )
 
       await screen.findByTestId('select-item-g2')
-      const secondPlusButton = screen.getByText(
-        '選択したドメインを親カテゴリに追加',
-      ).previousElementSibling as HTMLButtonElement | null
-      expect(secondPlusButton).toBeTruthy()
-      if (!secondPlusButton) {
-        throw new Error('secondPlusButton not found')
-      }
+      const secondPlusButton = screen.getByTestId('add-domain-button')
       await user.click(secondPlusButton)
 
       await waitFor(() => {
@@ -1171,12 +1160,7 @@ describe('CategoryManagementModal', () => {
 
     await screen.findByTestId('select-item-g2')
     expect(screen.getByTestId('select-item-g3')).toBeTruthy()
-    const plusButton = screen.getByText('選択したドメインを親カテゴリに追加')
-      .previousElementSibling as HTMLButtonElement | null
-    expect(plusButton).toBeTruthy()
-    if (!plusButton) {
-      throw new Error('plusButton not found')
-    }
+    const plusButton = screen.getByTestId('add-domain-button')
 
     await user.click(plusButton)
     await waitFor(() => {
@@ -1272,12 +1256,7 @@ describe('CategoryManagementModal', () => {
       )
 
       await screen.findByTestId('select-item-g1')
-      const plusButton = screen.getByText('選択したドメインを親カテゴリに追加')
-        .previousElementSibling as HTMLButtonElement | null
-      expect(plusButton).toBeTruthy()
-      if (!plusButton) {
-        throw new Error('plusButton not found')
-      }
+      const plusButton = screen.getByTestId('add-domain-button')
       await user.click(plusButton)
       await waitFor(() => {
         expect(toastErrorSpy).toHaveBeenCalledWith(
@@ -1304,12 +1283,7 @@ describe('CategoryManagementModal', () => {
         />,
       )
       await screen.findByTestId('select-item-g2')
-      const plusButton = screen.getByText('選択したドメインを親カテゴリに追加')
-        .previousElementSibling as HTMLButtonElement | null
-      expect(plusButton).toBeTruthy()
-      if (!plusButton) {
-        throw new Error('plusButton not found')
-      }
+      const plusButton = screen.getByTestId('add-domain-button')
 
       const originalFind = Array.prototype.find
       using findSpy = vi.spyOn(Array.prototype, 'find')

--- a/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.tsx
@@ -400,6 +400,7 @@ const AddDomainSection = ({
                 size='icon'
                 onClick={onAddDomain}
                 className='cursor-pointer'
+                data-testid='add-domain-button'
                 disabled={!activeSelectedDomain || isProcessing}
               >
                 <Plus size={18} />

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.test.tsx
@@ -650,12 +650,8 @@ describe('CustomProjectCategory', () => {
       />,
     )
 
-    expect(screen.getByTestId('card').className.includes('border-2')).toBe(true)
-    expect(
-      screen
-        .getByTestId('category-url-list')
-        .className.includes('bg-primary/5'),
-    ).toBe(true)
+    expect(screen.getByTestId('card')).toHaveClass('border-2')
+    expect(screen.getByTestId('category-url-list')).toHaveClass('bg-primary/5')
 
     rerender(
       <CustomProjectCategory

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.test.tsx
@@ -477,7 +477,7 @@ describe('CustomProjectCategory', () => {
       />,
     )
 
-    const emptyState = screen.getByTestId('card-content').querySelector('div')
+    const emptyState = screen.getByTestId('empty-state')
     expect(emptyState).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'カテゴリ管理' })).toBeNull()
     expect(screen.queryByRole('button', { name: 'すべて開く' })).toBeNull()
@@ -550,7 +550,7 @@ describe('CustomProjectCategory', () => {
       />,
     )
 
-    const emptyState = screen.getByTestId('card-content').querySelector('div')
+    const emptyState = screen.getByTestId('empty-state')
     expect(emptyState).toBeTruthy()
     expect(
       // eslint-disable-next-line typescript/non-nullable-type-assertion-style
@@ -652,7 +652,9 @@ describe('CustomProjectCategory', () => {
 
     expect(screen.getByTestId('card').className.includes('border-2')).toBe(true)
     expect(
-      document.querySelector('ul')?.className.includes('bg-primary/5'),
+      screen
+        .getByTestId('category-url-list')
+        .className.includes('bg-primary/5'),
     ).toBe(true)
 
     rerender(

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.tsx
@@ -158,6 +158,7 @@ const CategoryContent = (props: CategoryContentProps) => {
         >
           <ul
             className={`gap-y-1 ${props.isOver ? 'rounded bg-primary/5 p-1' : ''}`}
+            data-testid='category-url-list'
           >
             {props.urls.map((item) => (
               <ProjectUrlItem
@@ -176,6 +177,7 @@ const CategoryContent = (props: CategoryContentProps) => {
           className={`rounded border-2 border-dashed p-4 py-2 text-center text-muted-foreground ${
             props.isOver ? 'border-primary bg-primary/10' : ''
           }`}
+          data-testid='empty-state'
         />
       )}
     </CardContent>

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectSection.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectSection.test.tsx
@@ -250,13 +250,11 @@ describe('CustomProjectSection', () => {
     render(<CustomProjectSection {...createProps({ projects: [] })} />)
 
     expect(screen.getByText('No projects')).toBeTruthy()
-    const description = document.querySelector(
-      '.text-center.text-muted-foreground',
-    )
-    expect(description?.textContent).toContain(
+    const description = screen.getByTestId('empty-state-description')
+    expect(description).toHaveTextContent(
       'No projects are available to display',
     )
-    expect(description?.textContent).toContain(
+    expect(description).toHaveTextContent(
       'Create a parent category to show it as a project',
     )
   })

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectSection.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectSection.tsx
@@ -819,7 +819,10 @@ const useCustomProjectSectionView = ({
           <div className='text-2xl text-foreground'>
             {t('savedTabs.customProjects.emptyTitle')}
           </div>
-          <div className='text-center text-muted-foreground'>
+          <div
+            className='text-center text-muted-foreground'
+            data-testid='empty-state-description'
+          >
             {t('savedTabs.customProjects.emptyDescription')}
             <br />
             {t('savedTabs.customProjects.emptyHint')}

--- a/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.test.tsx
@@ -191,7 +191,7 @@ describe('ProjectUrlItem', () => {
       />,
     )
 
-    const listItem = document.querySelector('li')
+    const listItem = screen.getByTestId('project-url-item')
     expect(listItem).toBeTruthy()
     expect(listItem?.getAttribute('data-url')).toBe(item.url)
     expect(listItem?.getAttribute('data-project-id')).toBe('project-1')
@@ -202,16 +202,14 @@ describe('ProjectUrlItem', () => {
     expect(listItem?.getAttribute('data-in-uncategorized')).toBe('false')
     expect(listItem?.className).not.toContain('pl-2')
     expect(listItem?.className).not.toContain('border-l-2')
-    const dragHandle = listItem?.querySelector('svg')?.parentElement
+    const dragHandle = screen.getByTestId('project-url-drag-handle')
     expect(dragHandle?.className).not.toContain('opacity-')
-    const actionBar = screen.getByRole('button', {
-      name: 'タブを削除',
-    }).parentElement
+    const actionBar = screen.getByTestId('project-url-action-bar')
     expect(actionBar?.className).toContain('group-focus-within:opacity-100')
 
     const link = screen.getByRole('button', { name: item.url })
     expect(link.className).toContain('min-w-0')
-    const titleLabel = link.querySelector('span')
+    const titleLabel = screen.getByTestId('project-url-title')
     expect(titleLabel?.className).toContain('min-w-0')
     expect(titleLabel?.className).toContain('truncate')
     await user.click(link)
@@ -272,7 +270,7 @@ describe('ProjectUrlItem', () => {
       />,
     )
 
-    const listItem = document.querySelector('li')
+    const listItem = screen.getByTestId('project-url-item')
     expect(listItem?.className).toContain('bg-secondary/50')
     expect(listItem?.className).toContain('opacity-50')
     expect(listItem?.className).toContain('pl-2')

--- a/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx
@@ -209,6 +209,7 @@ const ProjectUrlItemComponent = ({
         ref={setNodeRef}
         style={style}
         className={`group relative flex min-w-0 items-center overflow-hidden border-b border-border pb-1 last:border-0 ${isDragging ? 'bg-secondary/50 opacity-50' : ''} ${isInSubcategory ? 'pl-2' : ''} ${item.category ? 'border-l-2 border-l-primary/30' : ''} `}
+        data-testid='project-url-item'
         data-url={originalUrl}
         data-project-id={projectId}
         data-category={item.category}
@@ -221,6 +222,7 @@ const ProjectUrlItemComponent = ({
           {...attributes}
           {...listeners}
           className='cursor-grab p-1 active:cursor-grabbing'
+          data-testid='project-url-drag-handle'
         >
           <GripVertical size={16} className='text-muted-foreground' />
         </div>
@@ -243,7 +245,10 @@ const ProjectUrlItemComponent = ({
                 className='mr-1 inline-block text-primary'
               />
             )}
-            <span className='min-w-0 flex-1 truncate'>
+            <span
+              className='min-w-0 flex-1 truncate'
+              data-testid='project-url-title'
+            >
               {item.title || item.url}
             </span>
             {/* カテゴリ階層の視覚的な表示をシンプル化 */}
@@ -255,7 +260,10 @@ const ProjectUrlItemComponent = ({
           </Button>
         </div>
         {/* ボタン群 */}
-        <div className='flex shrink-0 items-center gap-1 opacity-0 transition-opacity duration-200 group-focus-within:opacity-100 group-hover:opacity-100'>
+        <div
+          className='flex shrink-0 items-center gap-1 opacity-0 transition-opacity duration-200 group-focus-within:opacity-100 group-hover:opacity-100'
+          data-testid='project-url-action-bar'
+        >
           <Button
             variant='ghost'
             size='sm'

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsContent.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsContent.test.tsx
@@ -271,7 +271,7 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
       isDragging: true,
     })
     const handleOpenAllTabs = vi.fn()
-    const { container } = render(
+    render(
       <SavedTabsContentComponent
         {...createProps({
           urls: undefined as unknown as { url: string; title: string }[],
@@ -282,8 +282,12 @@ describe('SavedTabsContent.tsx (legacy SortableCategorySection)', () => {
     )
 
     expect(screen.getByRole('heading', { name: /0/ })).toBeTruthy()
-    expect(container.innerHTML.includes('shadow-lg')).toBe(true)
-    expect(container.innerHTML.includes('cursor-grabbing')).toBe(true)
+    expect(screen.getByTestId('draggable-category-section')).toHaveClass(
+      'shadow-lg',
+    )
+    expect(screen.getByTestId('draggable-category-handle')).toHaveClass(
+      'cursor-grabbing',
+    )
 
     await user.click(
       screen.getByRole('button', { name: getOpenAllButtonName('news') }),

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsContent.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsContent.tsx
@@ -118,6 +118,7 @@ export const SortableCategorySection = ({
       <div
         ref={setNodeRef}
         style={style}
+        data-testid='draggable-category-section'
         className={
           isDragging
             ? 'category-section mb-1 rounded-md bg-muted shadow-lg'
@@ -128,6 +129,7 @@ export const SortableCategorySection = ({
           {/* ドラッグハンドル部分 */}
           <div
             className={`flex grow items-center ${isDragging ? 'cursor-grabbing' : 'cursor-grab hover:cursor-grab active:cursor-grabbing'}`}
+            data-testid='draggable-category-handle'
             {...attributes}
             {...listeners}
           >

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { useRef } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -328,7 +329,8 @@ describe('SavedTabsPresentationLayout', () => {
     expect(presentationMock.onAiSidebarOpenChange).toBe(onAiSidebarOpenChange)
   })
 
-  it('onViewModeNavigate を SavedTabsApp へ伝える', () => {
+  it('onViewModeNavigate を SavedTabsApp へ伝える', async () => {
+    const user = userEvent.setup()
     const onViewModeNavigate = vi.fn()
     const Probe = () => {
       const leftPaneRef = useRef<HTMLDivElement>(null)
@@ -353,7 +355,7 @@ describe('SavedTabsPresentationLayout', () => {
       )
     }
     render(<Probe />)
-    screen.getByText('navigate-custom').click()
+    await user.click(screen.getByRole('button', { name: 'navigate-custom' }))
     expect(onViewModeNavigate).toHaveBeenCalledWith('custom')
   })
 })

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsScrollControls.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsScrollControls.test.tsx
@@ -149,11 +149,10 @@ describe('contexts/SavedTabsScrollControls', () => {
 
   it('scroll ボタンを hover なしでも opacity-100 で表示する', () => {
     renderWithContainer('domain')
-    const scrollButtonGroup =
-      screen.getByLabelText('Scroll to top').parentElement
-    expect(scrollButtonGroup?.className.includes('opacity-100')).toBe(true)
-    expect(scrollButtonGroup?.className.includes('opacity-35')).toBe(false)
-    expect(scrollButtonGroup?.className.includes('opacity-70')).toBe(false)
+    const scrollButtonGroup = screen.getByTestId('scroll-button-group')
+    expect(scrollButtonGroup).toHaveClass('opacity-100')
+    expect(scrollButtonGroup).not.toHaveClass('opacity-35')
+    expect(scrollButtonGroup).not.toHaveClass('opacity-70')
   })
 
   it('初期状態で全ボタンが active なら disabled にならない', () => {

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsScrollControls.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsScrollControls.tsx
@@ -386,7 +386,10 @@ const useSavedTabsScrollControlsView = ({
   return (
     <TooltipProvider delayDuration={0}>
       <div className='flex h-full w-12 shrink-0 items-center justify-center border-l border-border bg-background/80'>
-        <div className='flex flex-col gap-2 opacity-100'>
+        <div
+          className='flex flex-col gap-2 opacity-100'
+          data-testid='scroll-button-group'
+        >
           <SavedTabsScrollControlButton
             ariaLabel={scrollToTopLabel}
             disabled={!availability.top}

--- a/src/contexts/saved-tabs/presentation/components/SortableCategorySection.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableCategorySection.test.tsx
@@ -490,7 +490,7 @@ describe('SortableCategorySection', () => {
       isDragging: true,
     })
 
-    const { rerender, container } = render(
+    const { rerender } = render(
       <SortableCategorySection
         {...createProps({
           isReorderMode: true,
@@ -504,8 +504,10 @@ describe('SortableCategorySection', () => {
     })
     expect(collapseButton.hasAttribute('disabled')).toBe(true)
     expect(screen.queryByTestId('category-section')).toBeNull()
-    expect(container.querySelector('.top-20')).toBeTruthy()
-    expect(container.innerHTML.includes('shadow-lg')).toBe(true)
+    expect(screen.getByTestId('sortable-category-header')).toHaveClass('top-20')
+    expect(screen.getByTestId('sortable-category-section')).toHaveClass(
+      'shadow-lg',
+    )
 
     await user.click(
       screen.getByRole('button', { name: '「未分類」の並び順: デフォルト' }),

--- a/src/contexts/saved-tabs/presentation/components/SortableCategorySection.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableCategorySection.tsx
@@ -307,9 +307,11 @@ const useSortableCategorySectionView = ({
         style={style}
         className={sectionClassName}
         data-saved-tabs-scroll-target='child'
+        data-testid='sortable-category-section'
       >
         <div
           className={`category-header sticky ${stickyTop} z-30 mb-0.5 flex items-center justify-between gap-2 bg-background pb-0.5`}
+          data-testid='sortable-category-header'
         >
           {/* 折りたたみ切り替えボタン */}
           <TooltipIconButton

--- a/src/contexts/saved-tabs/presentation/components/SortableUrlItem.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableUrlItem.test.tsx
@@ -110,21 +110,21 @@ describe('SortableUrlItem', () => {
       />,
     )
 
-    const listItem = document.querySelector('li')
-    expect(listItem?.className).toContain('min-w-0')
+    const listItem = screen.getByTestId('sortable-url-item')
+    expect(listItem).toHaveClass('min-w-0')
 
     const openButton = screen.getByRole('button', {
       name: /Very long saved tab title/,
     })
-    expect(openButton.className).toContain('w-full')
-    expect(openButton.className).toContain('min-w-0')
+    expect(openButton).toHaveClass('w-full')
+    expect(openButton).toHaveClass('min-w-0')
 
-    const textColumn = openButton.querySelector(':scope > span')
-    expect(textColumn?.className).toContain('min-w-0')
-    expect(textColumn?.className).toContain('overflow-hidden')
+    const textColumn = screen.getByTestId('url-text-column')
+    expect(textColumn).toHaveClass('min-w-0')
+    expect(textColumn).toHaveClass('overflow-hidden')
 
-    const titleLabel = openButton.querySelector(':scope > span > span')
-    expect(titleLabel?.className).toContain('truncate')
+    const titleLabel = screen.getByTestId('url-title-label')
+    expect(titleLabel).toHaveClass('truncate')
     expect(screen.getByText('2026/06/02 12:34')).toBeTruthy()
     expect(screen.getByTestId('time-remaining')).toBeTruthy()
 

--- a/src/contexts/saved-tabs/presentation/components/SortableUrlItem.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableUrlItem.tsx
@@ -23,8 +23,13 @@ const ButtonContent = ({
   autoDeletePeriod?: string | undefined
   settings: { showSavedTime: boolean }
 }) => (
-  <span className='flex w-full min-w-0 flex-col overflow-hidden'>
-    <span className='block truncate text-left'>{title}</span>
+  <span
+    className='flex w-full min-w-0 flex-col overflow-hidden'
+    data-testid='url-text-column'
+  >
+    <span className='block truncate text-left' data-testid='url-title-label'>
+      {title}
+    </span>
     {savedAt && (
       <span className='flex min-w-0 items-center gap-2 overflow-hidden text-xs'>
         {settings.showSavedTime && (
@@ -205,6 +210,7 @@ export const SortableUrlItem = ({
         style={style}
         className='group relative flex min-w-0 items-center overflow-hidden pb-1 last:border-0 last:pb-0'
         data-category-context={categoryContext}
+        data-testid='sortable-url-item'
       >
         <div
           className='z-10 shrink-0 cursor-grab px-2.5 text-muted-foreground hover:cursor-grab active:cursor-grabbing'

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardRoot.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardRoot.test.tsx
@@ -152,9 +152,7 @@ describe('DomainCardRoot', () => {
       </DomainCardRoot>,
     )
 
-    const root = document.querySelector<HTMLElement>(
-      '[data-saved-tabs-scroll-target="domain"]',
-    )
+    const root = screen.getByTestId('domain-scroll-target') as HTMLElement
     expect(root?.style.contentVisibility).toBe('auto')
     expect(root?.style.containIntrinsicSize).toBe('360px')
     expect(screen.getByText('2')).toBeTruthy()

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardRoot.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardRoot.test.tsx
@@ -152,7 +152,7 @@ describe('DomainCardRoot', () => {
       </DomainCardRoot>,
     )
 
-    const root = screen.getByTestId('domain-scroll-target') as HTMLElement
+    const root = screen.getByTestId('domain-scroll-target')
     expect(root?.style.contentVisibility).toBe('auto')
     expect(root?.style.containIntrinsicSize).toBe('360px')
     expect(screen.getByText('2')).toBeTruthy()

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardRoot.tsx
@@ -125,6 +125,7 @@ export const DomainCardRoot = ({
         className='shadow-md'
         data-category-id={categoryId}
         data-saved-tabs-scroll-target='domain'
+        data-testid='domain-scroll-target'
         data-urls-count={group.urls?.length ?? 0}
       >
         {children}

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardTitle.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardTitle.test.tsx
@@ -58,11 +58,11 @@ describe('DomainCardTitle', () => {
       },
     })
 
-    const { container } = render(<DomainCardTitle />)
+    render(<DomainCardTitle />)
 
     expect(screen.getByText('example.com')).toBeTruthy()
-    const dragHandle = container.querySelector('svg')?.parentElement
-    expect(dragHandle?.className).not.toContain('/80')
+    const dragHandle = screen.getByTestId('drag-handle')
+    expect(dragHandle).not.toHaveClass('text-muted-foreground/80')
     expect(screen.getByText('1')).toBeTruthy()
     expect(screen.getByText('タブ数')).toBeTruthy()
     expect(screen.getByText('2')).toBeTruthy()

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardTitle.tsx
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardTitle.tsx
@@ -20,7 +20,7 @@ export const DomainCardTitle = () => {
       {...sortable.attributes}
       {...sortable.listeners}
     >
-      <div className='shrink-0 text-muted-foreground'>
+      <div className='shrink-0 text-muted-foreground' data-testid='drag-handle'>
         <GripVertical size={16} aria-hidden='true' />
       </div>
       <h2 className='truncate text-lg font-semibold text-foreground'>

--- a/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordEditor.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordEditor.test.tsx
@@ -98,7 +98,7 @@ describe('KeywordEditor', () => {
 
     const { container } = render(<KeywordEditor />)
 
-    expect(container.childElementCount).toBe(0)
+    expect(container).toBeEmptyDOMElement()
   })
 
   it('入力変更を state setter へ渡す', async () => {

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardRoot.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardRoot.test.tsx
@@ -250,16 +250,10 @@ describe('ProjectCardRoot', () => {
     expect(screen.getByTestId('card').style.contentVisibility).toBe('auto')
     expect(screen.getByTestId('card').style.containIntrinsicSize).toBe('360px')
 
-    // 以前はbutton要素でしたが、CardGroupTitle内でdiv要素に変更され、
-    // aria-labelなどは付与されていないため、親の attributes から取得した属性で検証します
-    const dragHandle = screen
-      .getByText('Project A')
-      .closest('div[data-sortable-attr="project"]')
-    expect(dragHandle).toBeTruthy()
-    if (dragHandle) {
-      // eslint-disable-next-line testing-library/prefer-user-event
-      fireEvent.pointerDown(dragHandle)
-    }
+    // CardGroupTitle のルート div がドラッグハンドル（sortable listeners を受ける要素）
+    const dragHandle = screen.getByTestId('card-group-title')
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.pointerDown(dragHandle)
     expect(projectDragListenerMock).toHaveBeenCalled()
 
     expect(registerHandlersMock).toHaveBeenCalledWith(
@@ -373,11 +367,9 @@ describe('ProjectCardRoot', () => {
       </ProjectCardRoot>,
     )
 
-    const description = screen
-      .getByTestId('card-content')
-      .querySelector('.py-4.text-center.text-muted-foreground')
-    expect(description?.textContent).toContain('This project has no tabs.')
-    expect(description?.textContent).toContain(
+    const description = screen.getByTestId('project-empty-state')
+    expect(description).toHaveTextContent('This project has no tabs.')
+    expect(description).toHaveTextContent(
       'Save tabs from the extension icon or add them from the context menu.',
     )
   })

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardRoot.tsx
@@ -350,7 +350,10 @@ export const ProjectCardRoot = ({
               {urls.projectUrls.length === 0 &&
                 !isExternalItemOver &&
                 !urls.isLoadingUrls && (
-                  <div className='py-4 text-center text-muted-foreground'>
+                  <div
+                    className='py-4 text-center text-muted-foreground'
+                    data-testid='project-empty-state'
+                  >
                     {t('savedTabs.project.emptyTitle')}
                     <br />
                     {t('savedTabs.project.emptyDescription')}

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardUncategorizedArea.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardUncategorizedArea.test.tsx
@@ -241,6 +241,6 @@ describe('ProjectCardUncategorizedArea', () => {
 
     const { container } = render(<ProjectCardUncategorizedArea />)
 
-    expect(container.firstChild).toBeNull()
+    expect(container).toBeEmptyDOMElement()
   })
 })

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.test.tsx
@@ -11,6 +11,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
@@ -435,19 +436,13 @@ describe('ProjectManagementModal', () => {
     fireEvent.change(domainInput, { target: { value: 'github.com' } })
     fireEvent.blur(domainInput)
 
-    const urlDeleteButton = screen
-      .getByText('docs')
-      .parentElement?.querySelector('button')
-    if (!urlDeleteButton) {
-      throw new Error('URL keyword delete button not found')
-    }
+    const urlDeleteButton = within(
+      screen.getByTestId('keyword-badge-docs'),
+    ).getByRole('button')
     await user.click(urlDeleteButton)
-    const domainDeleteButton = screen
-      .getByText('example.com')
-      .parentElement?.querySelector('button')
-    if (!domainDeleteButton) {
-      throw new Error('domain keyword delete button not found')
-    }
+    const domainDeleteButton = within(
+      screen.getByTestId('keyword-badge-example.com'),
+    ).getByRole('button')
     await user.click(domainDeleteButton)
 
     await waitFor(() => {

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.tsx
@@ -71,6 +71,7 @@ const KeywordBadge = ({
     <Badge
       variant='outline'
       className='flex items-center gap-1 rounded px-2 py-1'
+      data-testid={`keyword-badge-${keyword}`}
     >
       {keyword}
       <Button

--- a/src/contexts/saved-tabs/presentation/components/shared/CardControls.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/CardControls.test.tsx
@@ -137,11 +137,10 @@ describe('CardCollapseControl', () => {
 
 describe('CardGroupTitle', () => {
   it('ドラッグハンドルを muted foreground 色で描画する', () => {
-    const { container } = render(<CardGroupTitle title='動画' />)
+    render(<CardGroupTitle title='動画' />)
 
-    const dragHandle = container.querySelector('svg')
-    // eslint-disable-next-line typescript/no-deprecated
-    expect(dragHandle?.className.baseVal).toContain('text-muted-foreground')
+    const dragHandle = screen.getByTestId('drag-handle')
+    expect(dragHandle).toHaveClass('text-muted-foreground')
   })
 })
 

--- a/src/contexts/saved-tabs/presentation/components/shared/CardGroupTitle.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/CardGroupTitle.tsx
@@ -24,6 +24,7 @@ export const CardGroupTitle = ({
   className = '',
 }: CardGroupTitleProps) => (
   <div
+    data-testid='card-group-title'
     className={`flex w-full cursor-grab items-center gap-2 text-foreground hover:cursor-grab active:cursor-grabbing ${className}`}
     {...sortableAttributes}
     {...sortableListeners}
@@ -31,6 +32,7 @@ export const CardGroupTitle = ({
     <GripVertical
       size={16}
       aria-hidden='true'
+      data-testid='drag-handle'
       className='shrink-0 text-muted-foreground'
     />
     <div className='flex min-w-0 items-center gap-2'>

--- a/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.test.tsx
+++ b/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.test.tsx
@@ -439,10 +439,8 @@ describe('DomainModeContainer', () => {
       />,
     )
 
-    const header = screen
-      .getByText('未分類のドメイン')
-      .closest('[data-saved-tabs-scroll-target="parent"]')
-    expect(header?.className).toContain('mt-6')
+    const header = screen.getByTestId('uncategorized-section-header')
+    expect(header).toHaveClass('mt-6')
 
     expect(
       screen.queryByRole('button', {

--- a/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.tsx
+++ b/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.tsx
@@ -271,6 +271,7 @@ const UncategorizedDomainSection = ({
         <div
           className={`sticky top-0 z-50 flex items-center justify-between bg-card ${hasVisibleCategoryGroups ? 'mt-6' : 'mt-2'}`}
           data-saved-tabs-scroll-target='parent'
+          data-testid='uncategorized-section-header'
         >
           <div className='flex min-w-0 items-center gap-3'>
             <h2 className='text-xl font-semibold text-foreground'>

--- a/src/entrypoints/app/main.test.tsx
+++ b/src/entrypoints/app/main.test.tsx
@@ -91,7 +91,7 @@ describe('app bootstrap', () => {
     domReadyHandler?.(new Event('DOMContentLoaded'))
 
     expect(mocked.createRoot).toHaveBeenCalledWith(
-      document.querySelector('#app'),
+      document.querySelector('#app'), // eslint-disable-line testing-library/no-node-access -- createRoot のマウント先要素の検証には DOM ノード参照が必須
     )
     expect(mocked.renderRoot).toHaveBeenCalledTimes(1)
   })

--- a/src/entrypoints/changelog/main.test.tsx
+++ b/src/entrypoints/changelog/main.test.tsx
@@ -75,7 +75,7 @@ describe('changelog bootstrap', () => {
     domReadyHandler?.(new Event('DOMContentLoaded'))
 
     expect(mocked.createRoot).toHaveBeenCalledWith(
-      document.querySelector('#app'),
+      document.querySelector('#app'), // eslint-disable-line testing-library/no-node-access -- createRoot のマウント先要素の検証には DOM ノード参照が必須
     )
     expect(mocked.renderRoot).toHaveBeenCalledTimes(1)
   })

--- a/src/entrypoints/options/main.behavior.test.tsx
+++ b/src/entrypoints/options/main.behavior.test.tsx
@@ -519,7 +519,7 @@ describe('options route behavior', () => {
     await user.click(resetButtons[1])
     expect(mocked.handleResetColors).toHaveBeenCalledTimes(1)
 
-    const colorInput = screen.getAllByTestId('color-picker')[0]
+    const colorInput = screen.getByTestId('color-picker-background')
     const hexInput = screen.getAllByPlaceholderText('e.g. #FF5733, #3366CC')[0]
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(colorInput, { target: { value: '#ffffff' } })

--- a/src/entrypoints/options/main.behavior.test.tsx
+++ b/src/entrypoints/options/main.behavior.test.tsx
@@ -519,11 +519,8 @@ describe('options route behavior', () => {
     await user.click(resetButtons[1])
     expect(mocked.handleResetColors).toHaveBeenCalledTimes(1)
 
-    const colorInput = document.querySelector('input[type="color"]')
+    const colorInput = screen.getAllByTestId('color-picker')[0]
     const hexInput = screen.getAllByPlaceholderText('e.g. #FF5733, #3366CC')[0]
-    if (!colorInput) {
-      throw new Error('color input not found')
-    }
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.change(colorInput, { target: { value: '#ffffff' } })
     // eslint-disable-next-line testing-library/prefer-user-event

--- a/src/features/ai-chat/components/OllamaErrorNotice.test.tsx
+++ b/src/features/ai-chat/components/OllamaErrorNotice.test.tsx
@@ -125,15 +125,13 @@ describe('OllamaErrorNotice', () => {
       />,
     )
 
-    const root = screen.getByText(
-      'Ollama denied access from the extension (403 Forbidden).',
-    ).parentElement
+    const root = screen.getByTestId('ollama-error-notice')
 
-    expect(root?.className).toContain('max-h-')
-    expect(root?.className).toContain('overflow-y-auto')
-    expect(root?.className).toContain('overflow-x-hidden')
-    expect(root?.className).toContain('[&_a]:break-all')
-    expect(root?.className).toContain('[&_code]:break-all')
+    expect(root).toHaveClass('max-h-40')
+    expect(root).toHaveClass('overflow-y-auto')
+    expect(root).toHaveClass('overflow-x-hidden')
+    expect(root).toHaveClass('[&_a]:break-all')
+    expect(root).toHaveClass('[&_code]:break-all')
   })
 
   it('can copy the macOS command row', async () => {

--- a/src/features/ai-chat/components/OllamaErrorNotice.tsx
+++ b/src/features/ai-chat/components/OllamaErrorNotice.tsx
@@ -201,6 +201,7 @@ const OllamaErrorNotice = ({
   return (
     <TooltipProvider delayDuration={0}>
       <div
+        data-testid='ollama-error-notice'
         className={cn(
           'max-h-40 space-y-2 overflow-x-hidden overflow-y-auto pr-1 wrap-break-word',
           '[&_a]:break-all',

--- a/src/features/ai-chat/components/SavedTabsChatHistoryItemCard.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatHistoryItemCard.tsx
@@ -49,17 +49,26 @@ export const SavedTabsChatHistoryItemCard = ({
           : 'border-transparent hover:bg-muted/40',
       )}
     >
-      <div className='grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2'>
+      <div
+        className='grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2'
+        data-testid={`conversation-row-${historyItem.id}`}
+      >
         <Button
           className='h-auto w-full min-w-0 flex-col items-start justify-start overflow-hidden px-0 text-left whitespace-normal hover:bg-transparent'
           onClick={handleSelect}
           type='button'
           variant='ghost'
         >
-          <span className='block w-full min-w-0 truncate text-sm font-medium'>
+          <span
+            className='block w-full min-w-0 truncate text-sm font-medium'
+            data-testid={`conversation-title-${historyItem.id}`}
+          >
             {historyItem.title}
           </span>
-          <span className='mt-1 line-clamp-2 block w-full min-w-0 overflow-hidden text-xs leading-5 wrap-anywhere text-muted-foreground'>
+          <span
+            className='mt-1 line-clamp-2 block w-full min-w-0 overflow-hidden text-xs leading-5 wrap-anywhere text-muted-foreground'
+            data-testid={`conversation-preview-${historyItem.id}`}
+          >
             {historyItem.preview}
           </span>
         </Button>

--- a/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
@@ -1731,22 +1731,18 @@ describe('SavedTabsChatWidget', () => {
         name: 'Most-saved categories',
       }),
     ])
-    const messageContent = screen
-      .getAllByTestId('message-content')
-      .find((el) =>
-        within(el).queryByRole('heading', {
-          level: 3,
-          name: 'Most-saved categories',
-        }),
-      )
-    const assistantMessage = screen
-      .getAllByTestId('chat-message')
-      .find((el) =>
-        within(el).queryByRole('heading', {
-          level: 3,
-          name: 'Most-saved categories',
-        }),
-      )
+    const messageContent = screen.getAllByTestId('message-content').find((el) =>
+      within(el).queryByRole('heading', {
+        level: 3,
+        name: 'Most-saved categories',
+      }),
+    )
+    const assistantMessage = screen.getAllByTestId('chat-message').find((el) =>
+      within(el).queryByRole('heading', {
+        level: 3,
+        name: 'Most-saved categories',
+      }),
+    )
 
     expect(screen.getByText('Recent saved category mix')).toBeTruthy()
     expect(messageContent?.className).toContain('overflow-visible')

--- a/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
@@ -511,6 +511,8 @@ describe('SavedTabsChatWidget', () => {
     )
 
     const log = screen.getByRole('log')
+    // 内部スクロール viewport は意味的 query で参照できないため log の直接子要素を検証する
+    // eslint-disable-next-line testing-library/no-node-access
     const scrollContainer = log.firstElementChild
 
     expect(scrollContainer?.className.includes('overscroll-contain')).toBe(true)
@@ -529,12 +531,11 @@ describe('SavedTabsChatWidget', () => {
       }),
     )
 
-    const sidebar = screen.getByLabelText('AI chat sidebar')
-    const shell = sidebar.parentElement
+    const shell = screen.getByTestId('chat-shell')
 
-    expect(shell?.className.includes('h-screen')).toBe(true)
-    expect(shell?.className.includes('overflow-hidden')).toBe(true)
-    expect(shell?.className.includes('overscroll-none')).toBe(true)
+    expect(shell).toHaveClass('h-screen')
+    expect(shell).toHaveClass('overflow-hidden')
+    expect(shell).toHaveClass('overscroll-none')
   })
 
   it('does not show a model-name badge in the header', async () => {
@@ -566,11 +567,11 @@ describe('SavedTabsChatWidget', () => {
       }),
     )
 
-    const title = screen.getByText('Chat').parentElement
+    const title = screen.getByTestId('chat-header-title')
 
-    expect(title?.className.includes('absolute')).toBe(true)
-    expect(title?.className.includes('inset-x-0')).toBe(true)
-    expect(title?.className.includes('justify-center')).toBe(true)
+    expect(title).toHaveClass('absolute')
+    expect(title).toHaveClass('inset-x-0')
+    expect(title).toHaveClass('justify-center')
   })
 
   it('shows the system prompt settings icon and selector on the left of the header', async () => {
@@ -661,10 +662,11 @@ describe('SavedTabsChatWidget', () => {
     const conversationButton = screen.getByRole('button', {
       name: /Another conversation/,
     })
-    const conversationRow = conversationButton.parentElement
-    const textRows = conversationButton.querySelectorAll(':scope > span')
-    const title = textRows[0]
-    const preview = textRows[1]
+    const conversationRow = screen.getByTestId(
+      'conversation-row-conversation-2',
+    )
+    const title = screen.getByTestId('conversation-title-conversation-2')
+    const preview = screen.getByTestId('conversation-preview-conversation-2')
 
     expect(conversationButton.className).toContain('flex-col')
     expect(conversationButton.className).toContain('items-start')
@@ -672,17 +674,17 @@ describe('SavedTabsChatWidget', () => {
     expect(conversationButton.className).toContain('overflow-hidden')
     expect(conversationButton.className).toContain('whitespace-normal')
     expect(conversationButton.className).not.toContain('flex-1')
-    expect(conversationRow?.className).toContain('min-w-0')
-    expect(conversationRow?.className).toContain('grid')
-    expect(conversationRow?.className).toContain(
+    expect(conversationRow.className).toContain('min-w-0')
+    expect(conversationRow.className).toContain('grid')
+    expect(conversationRow.className).toContain(
       'grid-cols-[minmax(0,1fr)_auto]',
     )
-    expect(title?.className).toContain('w-full')
-    expect(title?.className).toContain('min-w-0')
-    expect(preview?.className).toContain('w-full')
-    expect(preview?.className).toContain('min-w-0')
-    expect(preview?.className).toContain('wrap-anywhere')
-    expect(preview?.className).toContain('overflow-hidden')
+    expect(title.className).toContain('w-full')
+    expect(title.className).toContain('min-w-0')
+    expect(preview.className).toContain('w-full')
+    expect(preview.className).toContain('min-w-0')
+    expect(preview.className).toContain('wrap-anywhere')
+    expect(preview.className).toContain('overflow-hidden')
 
     await user.click(
       screen.getByRole('button', { name: /Another conversation/ }),
@@ -1264,12 +1266,16 @@ describe('SavedTabsChatWidget', () => {
     const listItemButton = await screen.findByRole('button', {
       name: normalizedLongName,
     })
-    const listItemName = within(listItemButton).getByText(normalizedLongName)
-    const listItemRow = listItemName.parentElement
+    const listItemName = screen.getByTestId(
+      'system-prompt-name-long-system-prompt',
+    )
+    const listItemRow = screen.getByTestId(
+      'system-prompt-row-long-system-prompt',
+    )
 
     expect(listItemButton.className.includes('overflow-hidden')).toBe(true)
     expect(listItemName.className.includes('truncate')).toBe(true)
-    expect(listItemRow?.className.includes('min-w-0')).toBe(true)
+    expect(listItemRow.className.includes('min-w-0')).toBe(true)
   })
 
   it('shows new conversation as an icon button with a tooltip label', async () => {
@@ -1725,8 +1731,22 @@ describe('SavedTabsChatWidget', () => {
         name: 'Most-saved categories',
       }),
     ])
-    const messageContent = chartHeading.closest('[class*="overflow"]')
-    const assistantMessage = chartHeading.closest('[class*="max-w"]')
+    const messageContent = screen
+      .getAllByTestId('message-content')
+      .find((el) =>
+        within(el).queryByRole('heading', {
+          level: 3,
+          name: 'Most-saved categories',
+        }),
+      )
+    const assistantMessage = screen
+      .getAllByTestId('chat-message')
+      .find((el) =>
+        within(el).queryByRole('heading', {
+          level: 3,
+          name: 'Most-saved categories',
+        }),
+      )
 
     expect(screen.getByText('Recent saved category mix')).toBeTruthy()
     expect(messageContent?.className).toContain('overflow-visible')
@@ -1840,10 +1860,7 @@ describe('SavedTabsChatWidget', () => {
     })
     await user.click(sourcesTrigger)
 
-    const sourcesGroup =
-      // eslint-disable-next-line typescript/no-unnecessary-type-assertion
-      (sourcesTrigger.closest('[data-slot="sources"]') as HTMLElement | null) ??
-      document.body
+    const sourcesGroup = screen.getByTestId('message-sources')
 
     expect(
       within(sourcesGroup).getAllByRole('link', {
@@ -2165,14 +2182,11 @@ describe('SavedTabsChatWidget', () => {
       }),
     )
 
-    const emptyStateMessage = screen.getByRole('heading', {
-      name: 'Select a model',
-    })
-    const emptyStateRoot = emptyStateMessage.closest('div')?.parentElement
+    expect(screen.getByRole('heading', { name: 'Select a model' })).toBeTruthy()
+    const emptyStateRoot = screen.getByTestId('empty-state-root')
 
-    expect(emptyStateMessage).toBeTruthy()
     expect(screen.queryByTestId('ai-chat-intro')).toBeNull()
-    expect(emptyStateRoot?.className.includes('justify-center')).toBe(true)
+    expect(emptyStateRoot.className.includes('justify-center')).toBe(true)
   })
 
   it('does not send when the input is empty', async () => {
@@ -2188,10 +2202,7 @@ describe('SavedTabsChatWidget', () => {
       }),
     )
 
-    const form = screen.getByLabelText('Ask AI').closest('form')
-    if (!form) {
-      throw new Error('form not found')
-    }
+    const form = screen.getByTestId('chat-form')
 
     fireEvent.submit(form)
     expect(mocked.sendRuntimeMessage).not.toHaveBeenCalled()

--- a/src/features/ai-chat/components/SavedTabsChatWidget.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.tsx
@@ -651,7 +651,10 @@ const useChatSidebarHeaderView = ({
           {systemPromptSelector}
         </div>
 
-        <CardTitle className='pointer-events-none absolute inset-x-0 flex items-center justify-center px-20 text-base'>
+        <CardTitle
+          className='pointer-events-none absolute inset-x-0 flex items-center justify-center px-20 text-base'
+          data-testid='chat-header-title'
+        >
           <span className='truncate'>{title}</span>
         </CardTitle>
 
@@ -759,11 +762,16 @@ const renderChatConversationMessage = ({
     Boolean(message.charts && message.charts.length > 0)
 
   return (
-    <Message className={cn(hasCharts && 'max-w-full')} from={message.role}>
+    <Message
+      className={cn(hasCharts && 'max-w-full')}
+      data-testid='chat-message'
+      from={message.role}
+    >
       {messageSources.length > 0 ? (
         <Sources
           className='mb-0 rounded-md border border-border/70 bg-background/70 px-3 py-2 text-foreground'
           data-slot='sources'
+          data-testid='message-sources'
         >
           <SourcesTrigger
             className='w-full justify-between text-muted-foreground'
@@ -798,6 +806,7 @@ const renderChatConversationMessage = ({
           hasCharts && 'w-full overflow-visible',
           'wrap-break-word whitespace-pre-wrap',
         )}
+        data-testid='message-content'
       >
         {message.attachments && message.attachments.length > 0
           ? renderChatMessageAttachments({
@@ -923,6 +932,7 @@ const useChatPromptComposerView = ({
     <PromptInput
       accept={getAiChatAttachmentInputAccept()}
       className='shrink-0'
+      data-testid='chat-form'
       maxFiles={AI_CHAT_MAX_ATTACHMENTS}
       maxFileSize={AI_CHAT_MAX_ATTACHMENT_SIZE_BYTES}
       multiple
@@ -1137,6 +1147,7 @@ const useSavedTabsChatPanelView = ({
         <Conversation className='min-h-0 flex-1'>
           {messages.length === 0 && !isConfigured ? (
             <ConversationEmptyState
+              data-testid='empty-state-root'
               description=''
               title={t('aiChat.emptySelectModel')}
             />
@@ -1179,7 +1190,10 @@ const useSavedTabsChatPanelView = ({
   }
 
   return (
-    <div className='sticky top-0 z-50 flex h-screen max-w-[calc(100vw-24px)] shrink-0 self-start overflow-hidden overscroll-none'>
+    <div
+      className='sticky top-0 z-50 flex h-screen max-w-[calc(100vw-24px)] shrink-0 self-start overflow-hidden overscroll-none'
+      data-testid='chat-shell'
+    >
       <Button
         aria-label={t('aiChat.resizeAria')}
         className={`relative min-h-0 w-4 shrink-0 cursor-col-resize touch-none self-stretch rounded-none border-0 bg-transparent ${

--- a/src/features/ai-chat/components/SystemPromptManagerDialog.tsx
+++ b/src/features/ai-chat/components/SystemPromptManagerDialog.tsx
@@ -72,8 +72,14 @@ const PresetButton = ({
       type='button'
       variant='ghost'
     >
-      <span className='flex min-w-0 items-center justify-between gap-2'>
-        <span className='min-w-0 flex-1 truncate text-sm font-medium'>
+      <span
+        className='flex min-w-0 items-center justify-between gap-2'
+        data-testid={`system-prompt-row-${prompt.id}`}
+      >
+        <span
+          className='min-w-0 flex-1 truncate text-sm font-medium'
+          data-testid={`system-prompt-name-${prompt.id}`}
+        >
           {prompt.name}
         </span>
         {prompt.id === activePromptId ? (

--- a/src/features/ai-chat/routes/AiChatRoute.test.tsx
+++ b/src/features/ai-chat/routes/AiChatRoute.test.tsx
@@ -199,10 +199,14 @@ describe('AiChatRoute', () => {
   it('履歴項目の本文ボタンは縦積みレイアウトで削除ボタンを押し出さない', () => {
     render(createElement(AiChatRoute))
 
-    const conversationButton = screen.getAllByTestId('conversation-button')[0]
-    const conversationRow = screen.getAllByTestId('conversation-row')[0]
-    const title = screen.getAllByTestId('conversation-title')[0]
-    const preview = screen.getAllByTestId('conversation-preview')[0]
+    const conversationButton = screen.getByTestId(
+      'conversation-button-conversation-1',
+    )
+    const conversationRow = screen.getByTestId(
+      'conversation-row-conversation-1',
+    )
+    const title = screen.getByTestId('conversation-title-conversation-1')
+    const preview = screen.getByTestId('conversation-preview-conversation-1')
 
     expect(conversationButton).toHaveTextContent('最初の会話')
 

--- a/src/features/ai-chat/routes/AiChatRoute.test.tsx
+++ b/src/features/ai-chat/routes/AiChatRoute.test.tsx
@@ -199,33 +199,28 @@ describe('AiChatRoute', () => {
   it('履歴項目の本文ボタンは縦積みレイアウトで削除ボタンを押し出さない', () => {
     render(createElement(AiChatRoute))
 
-    const conversationButton = screen
-      .getAllByRole('button', { name: /最初の会話/ })
-      .find((button) => button.className.includes('flex-col'))
-    const conversationRow = conversationButton?.parentElement
-    const textRows = conversationButton?.querySelectorAll(':scope > span')
-    const title = textRows?.[0]
-    const preview = textRows?.[1]
+    const conversationButton = screen.getAllByTestId('conversation-button')[0]
+    const conversationRow = screen.getAllByTestId('conversation-row')[0]
+    const title = screen.getAllByTestId('conversation-title')[0]
+    const preview = screen.getAllByTestId('conversation-preview')[0]
 
-    expect(conversationButton).toBeTruthy()
+    expect(conversationButton).toHaveTextContent('最初の会話')
 
-    expect(conversationButton?.className).toContain('flex-col')
-    expect(conversationButton?.className).toContain('items-start')
-    expect(conversationButton?.className).toContain('whitespace-normal')
-    expect(conversationButton?.className).toContain('w-full')
-    expect(conversationButton?.className).toContain('overflow-hidden')
-    expect(conversationButton?.className).not.toContain('flex-1')
-    expect(conversationRow?.className).toContain('min-w-0')
-    expect(conversationRow?.className).toContain('grid')
-    expect(conversationRow?.className).toContain(
-      'grid-cols-[minmax(0,1fr)_auto]',
-    )
-    expect(title?.className).toContain('w-full')
-    expect(title?.className).toContain('min-w-0')
-    expect(preview?.className).toContain('w-full')
-    expect(preview?.className).toContain('min-w-0')
-    expect(preview?.className).toContain('wrap-anywhere')
-    expect(preview?.className).toContain('overflow-hidden')
+    expect(conversationButton).toHaveClass('flex-col')
+    expect(conversationButton).toHaveClass('items-start')
+    expect(conversationButton).toHaveClass('whitespace-normal')
+    expect(conversationButton).toHaveClass('w-full')
+    expect(conversationButton).toHaveClass('overflow-hidden')
+    expect(conversationButton).not.toHaveClass('flex-1')
+    expect(conversationRow).toHaveClass('min-w-0')
+    expect(conversationRow).toHaveClass('grid')
+    expect(conversationRow).toHaveClass('grid-cols-[minmax(0,1fr)_auto]')
+    expect(title).toHaveClass('w-full')
+    expect(title).toHaveClass('min-w-0')
+    expect(preview).toHaveClass('w-full')
+    expect(preview).toHaveClass('min-w-0')
+    expect(preview).toHaveClass('wrap-anywhere')
+    expect(preview).toHaveClass('overflow-hidden')
   })
 
   it('狭い画面では左履歴を完全非表示にしてチャットを残り幅へ広げる', () => {
@@ -235,12 +230,10 @@ describe('AiChatRoute', () => {
 
     expect(screen.queryByText('Recent conversations')).toBeNull()
 
-    const widgetShell = screen.getByTestId(
-      'saved-tabs-chat-widget',
-    ).parentElement
-    expect(widgetShell?.className.includes('min-h-0')).toBe(true)
-    expect(widgetShell?.className.includes('flex-1')).toBe(true)
-    expect(widgetShell?.className.includes('overflow-hidden')).toBe(true)
+    const widgetShell = screen.getByTestId('chat-widget-shell')
+    expect(widgetShell).toHaveClass('min-h-0')
+    expect(widgetShell).toHaveClass('flex-1')
+    expect(widgetShell).toHaveClass('overflow-hidden')
   })
 
   it('狭い画面でも履歴ボタンで左履歴を再表示できる', async () => {

--- a/src/features/ai-chat/routes/AiChatRoute.tsx
+++ b/src/features/ai-chat/routes/AiChatRoute.tsx
@@ -55,24 +55,24 @@ const HistoryItemCard = ({
     >
       <div
         className='grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2'
-        data-testid='conversation-row'
+        data-testid={`conversation-row-${historyItem.id}`}
       >
         <Button
           className='h-auto w-full min-w-0 flex-col items-start justify-start overflow-hidden px-0 text-left whitespace-normal hover:bg-transparent'
-          data-testid='conversation-button'
+          data-testid={`conversation-button-${historyItem.id}`}
           onClick={handleClick}
           type='button'
           variant='ghost'
         >
           <span
             className='block w-full min-w-0 truncate text-sm font-medium text-foreground'
-            data-testid='conversation-title'
+            data-testid={`conversation-title-${historyItem.id}`}
           >
             {historyItem.title}
           </span>
           <span
             className='mt-1 line-clamp-2 block w-full min-w-0 overflow-hidden text-xs leading-5 wrap-anywhere text-muted-foreground'
-            data-testid='conversation-preview'
+            data-testid={`conversation-preview-${historyItem.id}`}
           >
             {historyItem.preview}
           </span>

--- a/src/features/ai-chat/routes/AiChatRoute.tsx
+++ b/src/features/ai-chat/routes/AiChatRoute.tsx
@@ -53,17 +53,27 @@ const HistoryItemCard = ({
           : 'border-transparent bg-transparent hover:bg-background/80'
       }`}
     >
-      <div className='grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2'>
+      <div
+        className='grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2'
+        data-testid='conversation-row'
+      >
         <Button
           className='h-auto w-full min-w-0 flex-col items-start justify-start overflow-hidden px-0 text-left whitespace-normal hover:bg-transparent'
+          data-testid='conversation-button'
           onClick={handleClick}
           type='button'
           variant='ghost'
         >
-          <span className='block w-full min-w-0 truncate text-sm font-medium text-foreground'>
+          <span
+            className='block w-full min-w-0 truncate text-sm font-medium text-foreground'
+            data-testid='conversation-title'
+          >
             {historyItem.title}
           </span>
-          <span className='mt-1 line-clamp-2 block w-full min-w-0 overflow-hidden text-xs leading-5 wrap-anywhere text-muted-foreground'>
+          <span
+            className='mt-1 line-clamp-2 block w-full min-w-0 overflow-hidden text-xs leading-5 wrap-anywhere text-muted-foreground'
+            data-testid='conversation-preview'
+          >
             {historyItem.preview}
           </span>
         </Button>
@@ -195,7 +205,10 @@ export const AiChatRoute = () => {
       <div className='flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden'>
         <main className='min-h-0 flex-1 overflow-hidden bg-muted/10 px-3 py-3 sm:px-4 sm:py-4 lg:px-6 lg:py-5'>
           <div className='mx-auto flex h-full min-h-0 max-w-7xl overflow-hidden'>
-            <div className='flex min-h-0 flex-1 overflow-hidden'>
+            <div
+              className='flex min-h-0 flex-1 overflow-hidden'
+              data-testid='chat-widget-shell'
+            >
               <SavedTabsChatWidget
                 conversationId={activeConversation.id}
                 defaultOpen

--- a/src/features/analytics/routes/AnalyticsDrilldownPanel.tsx
+++ b/src/features/analytics/routes/AnalyticsDrilldownPanel.tsx
@@ -86,7 +86,10 @@ const DrilldownRecordCard = ({
       className='rounded-2xl border-border bg-card p-3 shadow-none'
       style={deferredDrilldownCardStyle}
     >
-      <div className='grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start'>
+      <div
+        className='grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start'
+        data-testid='analytics-card-layout'
+      >
         <div className='min-w-0 flex-1'>
           <p className='truncate text-sm font-medium'>{record.title}</p>
           <div className='mt-2 flex flex-wrap gap-2 text-xs'>
@@ -113,7 +116,10 @@ const DrilldownRecordCard = ({
             ))}
           </div>
         </div>
-        <div className='flex shrink-0 flex-col gap-2 sm:items-end'>
+        <div
+          className='flex shrink-0 flex-col gap-2 sm:items-end'
+          data-testid='analytics-action-column'
+        >
           <time className='text-xs text-muted-foreground'>
             {formatLocaleDateTime(
               record.savedAt,

--- a/src/features/analytics/routes/AnalyticsDrilldownPanel.tsx
+++ b/src/features/analytics/routes/AnalyticsDrilldownPanel.tsx
@@ -88,7 +88,7 @@ const DrilldownRecordCard = ({
     >
       <div
         className='grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start'
-        data-testid='analytics-card-layout'
+        data-testid={`analytics-card-layout-${record.id}`}
       >
         <div className='min-w-0 flex-1'>
           <p className='truncate text-sm font-medium'>{record.title}</p>
@@ -118,7 +118,7 @@ const DrilldownRecordCard = ({
         </div>
         <div
           className='flex shrink-0 flex-col gap-2 sm:items-end'
-          data-testid='analytics-action-column'
+          data-testid={`analytics-action-column-${record.id}`}
         >
           <time className='text-xs text-muted-foreground'>
             {formatLocaleDateTime(

--- a/src/features/analytics/routes/AnalyticsRecordActionButtons.tsx
+++ b/src/features/analytics/routes/AnalyticsRecordActionButtons.tsx
@@ -92,7 +92,7 @@ export const AnalyticsRecordActionButtons = ({
     <TooltipProvider delayDuration={0}>
       <div
         className='flex items-center justify-end gap-1'
-        data-testid='analytics-action-row'
+        data-testid={`analytics-action-row-${record.id}`}
       >
         <OpenLinkButton
           ariaLabel={t('analytics.openAria', undefined, {

--- a/src/features/analytics/routes/AnalyticsRecordActionButtons.tsx
+++ b/src/features/analytics/routes/AnalyticsRecordActionButtons.tsx
@@ -90,7 +90,10 @@ export const AnalyticsRecordActionButtons = ({
 
   return (
     <TooltipProvider delayDuration={0}>
-      <div className='flex items-center justify-end gap-1'>
+      <div
+        className='flex items-center justify-end gap-1'
+        data-testid='analytics-action-row'
+      >
         <OpenLinkButton
           ariaLabel={t('analytics.openAria', undefined, {
             title: record.title,

--- a/src/features/analytics/routes/AnalyticsRoute.test.tsx
+++ b/src/features/analytics/routes/AnalyticsRoute.test.tsx
@@ -12,6 +12,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Children, isValidElement } from 'react'
@@ -144,10 +145,19 @@ vi.mock('@/components/ui/select', () => {
     const triggerProps = isValidElement(triggerNode)
       ? (triggerNode.props as Record<string, unknown>)
       : {}
+    const extractChildren = (
+      props: { children?: ReactNode } | undefined,
+    ): ReactNode | undefined => {
+      if (!props) {
+        return undefined
+      }
+      const { children } = props
+      return children
+    }
     const contentChildren = isValidElement<{ children?: ReactNode }>(
       contentNode,
     )
-      ? contentNode.props.children
+      ? extractChildren(contentNode.props as { children?: ReactNode })
       : undefined
     const items = contentChildren
       ? Children.toArray(contentChildren).reduce<
@@ -157,15 +167,12 @@ vi.mock('@/components/ui/select', () => {
           if (!isValidElement(item)) {
             return values
           }
-          const props = item.props as {
+          const { children, value } = item.props as {
             children?: ReactNode
             value: string
           }
 
-          values.push({
-            children: props.children,
-            value: props.value,
-          })
+          values.push({ children, value })
           return values
         }, [])
       : []
@@ -178,9 +185,9 @@ vi.mock('@/components/ui/select', () => {
         onChange={(event) => onValueChange?.(event.target.value)}
         value={value}
       >
-        {items.map((item) => (
-          <option key={item.value} value={item.value}>
-            {item.children}
+        {items.map(({ children, value }) => (
+          <option key={value} value={value}>
+            {children}
           </option>
         ))}
       </select>
@@ -1335,10 +1342,10 @@ describe('AnalyticsRoute', () => {
 
     const saveButton = screen.getByRole('button', { name: 'Save' })
     const resetButton = screen.getByRole('button', { name: 'Reset' })
-    const buttonRow = saveButton.parentElement
+    const buttonRow = screen.getByTestId('analytics-action-button-row')
 
-    expect(buttonRow?.className.includes('grid')).toBe(true)
-    expect(buttonRow?.className.includes('grid-cols-2')).toBe(true)
+    expect(buttonRow.className.includes('grid')).toBe(true)
+    expect(buttonRow.className.includes('grid-cols-2')).toBe(true)
     expect(saveButton.className.includes('w-full')).toBe(true)
     expect(resetButton.className.includes('w-full')).toBe(true)
   })
@@ -1791,7 +1798,9 @@ describe('AnalyticsRoute', () => {
     expect(actionButtonsSource).toContain("t('common.delete')")
     expect(drilldownSource).toContain('<AnalyticsRecordActionButtons')
     expect(
-      openLink.closest('div')?.parentElement?.className.includes('shrink-0'),
+      screen
+        .getByTestId('analytics-action-column')
+        .className.includes('shrink-0'),
     ).toBe(true)
   })
 
@@ -2004,23 +2013,25 @@ describe('AnalyticsRoute', () => {
     expect((await screen.findAllByText('Saved count by domain')).length).toBe(1)
     await user.click(screen.getByRole('button', { name: 'emit-chart-click' }))
 
-    const openLink = await screen.findByRole('link', {
+    await screen.findByRole('link', {
       name: 'Open Extremely long analytics drilldown title that should never push the action area out of view even when the canvas is narrow',
     })
     const deleteButton = screen.getByRole('button', { name: 'Delete tab' })
 
-    const buttonRow = openLink.closest('div')
-    const actionColumn = buttonRow?.parentElement
-    const cardLayout = actionColumn?.parentElement
+    const buttonRow = screen.getByTestId('analytics-action-row')
+    const actionColumn = screen.getByTestId('analytics-action-column')
+    const cardLayout = screen.getByTestId('analytics-card-layout')
 
-    expect(cardLayout?.className.includes('grid')).toBe(true)
+    expect(cardLayout.className.includes('grid')).toBe(true)
     expect(
-      cardLayout?.className.includes('sm:grid-cols-[minmax(0,1fr)_auto]'),
+      cardLayout.className.includes('sm:grid-cols-[minmax(0,1fr)_auto]'),
     ).toBe(true)
-    expect(buttonRow?.className.includes('items-center')).toBe(true)
-    expect(buttonRow?.className.includes('justify-end')).toBe(true)
-    expect(deleteButton.parentElement).toBe(buttonRow)
-    expect(actionColumn?.className.includes('sm:items-end')).toBe(true)
+    expect(buttonRow.className.includes('items-center')).toBe(true)
+    expect(buttonRow.className.includes('justify-end')).toBe(true)
+    expect(within(buttonRow).getByRole('button', { name: 'Delete tab' })).toBe(
+      deleteButton,
+    )
+    expect(actionColumn.className.includes('sm:items-end')).toBe(true)
   })
 
   it('ドリルダウン各行に削除ボタンを表示する', async () => {

--- a/src/features/analytics/routes/AnalyticsRoute.test.tsx
+++ b/src/features/analytics/routes/AnalyticsRoute.test.tsx
@@ -1797,11 +1797,9 @@ describe('AnalyticsRoute', () => {
     expect(actionButtonsSource).toContain("t('analytics.open')")
     expect(actionButtonsSource).toContain("t('common.delete')")
     expect(drilldownSource).toContain('<AnalyticsRecordActionButtons')
-    expect(
-      screen
-        .getByTestId('analytics-action-column')
-        .className.includes('shrink-0'),
-    ).toBe(true)
+    expect(screen.getByTestId('analytics-action-column-1')).toHaveClass(
+      'shrink-0',
+    )
   })
 
   it('ドリルダウンは現在の分析条件で絞り込まれた保存タブだけを表示する', async () => {
@@ -2018,20 +2016,18 @@ describe('AnalyticsRoute', () => {
     })
     const deleteButton = screen.getByRole('button', { name: 'Delete tab' })
 
-    const buttonRow = screen.getByTestId('analytics-action-row')
-    const actionColumn = screen.getByTestId('analytics-action-column')
-    const cardLayout = screen.getByTestId('analytics-card-layout')
+    const buttonRow = screen.getByTestId('analytics-action-row-1')
+    const actionColumn = screen.getByTestId('analytics-action-column-1')
+    const cardLayout = screen.getByTestId('analytics-card-layout-1')
 
-    expect(cardLayout.className.includes('grid')).toBe(true)
-    expect(
-      cardLayout.className.includes('sm:grid-cols-[minmax(0,1fr)_auto]'),
-    ).toBe(true)
-    expect(buttonRow.className.includes('items-center')).toBe(true)
-    expect(buttonRow.className.includes('justify-end')).toBe(true)
+    expect(cardLayout).toHaveClass('grid')
+    expect(cardLayout).toHaveClass('sm:grid-cols-[minmax(0,1fr)_auto]')
+    expect(buttonRow).toHaveClass('items-center')
+    expect(buttonRow).toHaveClass('justify-end')
     expect(within(buttonRow).getByRole('button', { name: 'Delete tab' })).toBe(
       deleteButton,
     )
-    expect(actionColumn.className.includes('sm:items-end')).toBe(true)
+    expect(actionColumn).toHaveClass('sm:items-end')
   })
 
   it('ドリルダウン各行に削除ボタンを表示する', async () => {

--- a/src/features/analytics/routes/AnalyticsSidebar.tsx
+++ b/src/features/analytics/routes/AnalyticsSidebar.tsx
@@ -368,7 +368,10 @@ export const AnalyticsSidebar = ({
               />
               <LimitInput onApplyQuery={onApplyQuery} query={query} t={t} />
             </CardContent>
-            <div className='mt-4 grid grid-cols-2 gap-2'>
+            <div
+              className='mt-4 grid grid-cols-2 gap-2'
+              data-testid='analytics-action-button-row'
+            >
               <Button
                 className='w-full cursor-pointer rounded-xl'
                 // eslint-disable-next-line typescript/no-misused-promises

--- a/src/features/i18n/context/I18nProvider.test.tsx
+++ b/src/features/i18n/context/I18nProvider.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import { useI18nText } from '@/features/i18n/lib/useI18nText'
@@ -92,6 +93,7 @@ describe('I18nProvider', () => {
   })
 
   it('設定を読み込み system 言語をUIロケールから解決し保存変更できる', async () => {
+    const user = userEvent.setup()
     render(
       <I18nProvider>
         <Consumer />
@@ -105,9 +107,7 @@ describe('I18nProvider', () => {
     expect(screen.getByTestId('message').textContent).toContain('キャンセル')
     expect(screen.getByTestId('message').textContent).toContain('Hello Taro')
 
-    await act(async () => {
-      screen.getByText('set-en').click()
-    })
+    await user.click(screen.getByText('set-en'))
 
     expect(mocks.saveUserSettings).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/features/navigation/components/ExtensionSidebar.test.tsx
+++ b/src/features/navigation/components/ExtensionSidebar.test.tsx
@@ -30,7 +30,7 @@ vi.mock('@/components/ui/sidebar', () => ({
     <footer data-testid='sidebar-footer'>{children}</footer>
   ),
   SidebarGroup: ({ children }: { children: React.ReactNode }) => (
-    <section>{children}</section>
+    <section data-testid='sidebar-group'>{children}</section>
   ),
   SidebarGroupContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -134,8 +134,8 @@ describe('ExtensionSidebar', () => {
     const content = screen.getByTestId('sidebar-content')
     const footer = screen.getByTestId('sidebar-footer')
 
-    expect(content.querySelectorAll('section')).toHaveLength(1)
-    expect(content.firstChild?.textContent).toContain('タブ一覧')
+    expect(screen.getAllByTestId('sidebar-group')).toHaveLength(1)
+    expect(screen.getByTestId('sidebar-group')).toHaveTextContent('タブ一覧')
     expect(content.textContent).toContain('チャット')
     expect(content.textContent).toContain('分析')
     expect(content.textContent).toContain('定期実行')
@@ -166,7 +166,7 @@ describe('ExtensionSidebar', () => {
   })
 
   it('タブ一覧の親アイコンは共通入口へ飛ぶ', () => {
-    const { container } = render(
+    render(
       <ExtensionSidebar
         state={{
           expandedGroup: 'tab-list',
@@ -175,9 +175,10 @@ describe('ExtensionSidebar', () => {
       />,
     )
 
-    const tabListLinks = container.querySelectorAll('a[href^="app.html#"]')
-
-    expect(tabListLinks[0]?.getAttribute('href')).toBe('app.html#/saved-tabs')
+    expect(screen.getByRole('link', { name: 'タブ一覧' })).toHaveAttribute(
+      'href',
+      'app.html#/saved-tabs',
+    )
   })
 
   it('saved tabs submenu labels also come from i18n keys', () => {
@@ -275,7 +276,7 @@ describe('ExtensionSidebar', () => {
   it('通常幅ではヘッダーに開くボタンを表示しない', () => {
     sidebarContextValue.sidebarWidth = 256
 
-    const { container } = render(
+    render(
       <ExtensionSidebar
         state={{
           expandedGroup: 'tab-list',
@@ -290,7 +291,7 @@ describe('ExtensionSidebar', () => {
     expect(
       screen.getByRole('button', { name: 'サイドバーを小さくする' }),
     ).not.toBeNull()
-    expect(container.querySelector('header > div')?.className).toContain(
+    expect(screen.getByTestId('sidebar-header-row')).toHaveClass(
       'justify-between',
     )
   })

--- a/src/features/navigation/components/ExtensionSidebar.tsx
+++ b/src/features/navigation/components/ExtensionSidebar.tsx
@@ -271,7 +271,10 @@ const HeaderSection = ({
   const { t } = useI18n()
 
   return (
-    <div className='flex items-center justify-between gap-2 rounded-lg py-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0'>
+    <div
+      className='flex items-center justify-between gap-2 rounded-lg py-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0'
+      data-testid='sidebar-header-row'
+    >
       {isIconCollapsed ? (
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/features/options/ImportExportSettings.test.tsx
+++ b/src/features/options/ImportExportSettings.test.tsx
@@ -5,6 +5,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
@@ -158,30 +159,11 @@ class MockFileReader {
   }
 }
 
-const getHiddenFileInput = (container: HTMLElement): HTMLInputElement => {
-  // eslint-disable-next-line typescript/no-unnecessary-type-assertion
-  const fileInput = container.querySelector(
-    'input[type="file"].hidden',
-  ) as HTMLInputElement | null
-  if (!fileInput) {
-    throw new Error('hidden file input not found')
-  }
-  return fileInput
-}
+const getHiddenFileInput = (container: HTMLElement): HTMLInputElement =>
+  within(container).getByTestId('hidden-file-input') as HTMLInputElement
 
-const getDropzoneFileInput = (container: HTMLElement): HTMLInputElement => {
-  // eslint-disable-next-line typescript/no-unnecessary-type-assertion
-  const fileInputs = Array.from(
-    document.querySelectorAll('input[type="file"]'),
-  ) as HTMLInputElement[]
-  const dropzoneInput =
-    fileInputs.find((input) => !input.classList.contains('hidden')) ??
-    fileInputs.find((input) => input !== getHiddenFileInput(container))
-  if (!dropzoneInput) {
-    throw new Error('dropzone file input not found')
-  }
-  return dropzoneInput
-}
+const getDropzoneFileInput = (): HTMLInputElement =>
+  screen.getByTestId('dropzone-file-input') as HTMLInputElement
 
 describe('ImportExportSettingsコンポーネント', () => {
   beforeEach(() => {
@@ -367,7 +349,7 @@ describe('ImportExportSettingsコンポーネント', () => {
       message: 'ok',
     })
 
-    const { container } = render(<ImportExportSettings />)
+    render(<ImportExportSettings />)
 
     await user.click(
       screen.getByRole('button', { name: 'Import settings and tab data' }),
@@ -375,7 +357,7 @@ describe('ImportExportSettingsコンポーネント', () => {
 
     // user.upload internally calls user.click which fails on hidden inputs (pointer-events: none)
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.change(getDropzoneFileInput(container), {
+    fireEvent.change(getDropzoneFileInput(), {
       target: {
         files: [
           new File(['dummy'], 'dropzone.json', { type: 'application/json' }),
@@ -402,16 +384,13 @@ describe('ImportExportSettingsコンポーネント', () => {
 
   it('dropzone 上でドラッグ中にドラッグアクティブラベルを表示する', async () => {
     const user = userEvent.setup()
-    const { container } = render(<ImportExportSettings />)
+    render(<ImportExportSettings />)
 
     await user.click(
       screen.getByRole('button', { name: 'Import settings and tab data' }),
     )
 
-    const dropzone = getDropzoneFileInput(container).parentElement
-    if (!dropzone) {
-      throw new Error('dropzone container not found')
-    }
+    const dropzone = screen.getByTestId('import-dropzone')
 
     fireEvent.dragEnter(dropzone, {
       dataTransfer: {
@@ -428,16 +407,13 @@ describe('ImportExportSettingsコンポーネント', () => {
 
   it('受け入れファイルがない drop イベントは処理しない', async () => {
     const user = userEvent.setup()
-    const { container } = render(<ImportExportSettings />)
+    render(<ImportExportSettings />)
 
     await user.click(
       screen.getByRole('button', { name: 'Import settings and tab data' }),
     )
 
-    const dropzone = getDropzoneFileInput(container).parentElement
-    if (!dropzone) {
-      throw new Error('dropzone container not found')
-    }
+    const dropzone = screen.getByTestId('import-dropzone')
 
     fireEvent.drop(dropzone, {
       dataTransfer: {

--- a/src/features/options/ImportFileDialog.tsx
+++ b/src/features/options/ImportFileDialog.tsx
@@ -77,13 +77,14 @@ const ImportSelectStep: React.FC<ImportSelectStepProps> = ({
 
       <div
         {...getRootProps()}
+        data-testid='import-dropzone'
         className={`cursor-pointer rounded-lg border-2 border-dashed p-6 text-center transition-colors ${
           isDragActive
             ? 'border-primary bg-primary/5'
             : 'border-muted-foreground/20'
         }`}
       >
-        <input {...getInputProps()} />
+        <input {...getInputProps()} data-testid='dropzone-file-input' />
         <Upload className='mx-auto mb-2 size-12 text-muted-foreground' />
         <p className='mb-1 text-sm font-medium'>
           {isDragActive
@@ -374,6 +375,7 @@ export const ImportFileDialog: React.FC<ImportFileDialogProps> = ({
 
       <input
         aria-label={t('options.importExport.import')}
+        data-testid='hidden-file-input'
         type='file'
         ref={fileInputRef}
         accept='.json'

--- a/src/features/options/OptionsColorPickerRow.tsx
+++ b/src/features/options/OptionsColorPickerRow.tsx
@@ -29,6 +29,7 @@ export const OptionsColorPickerRow = ({
       <div className='flex items-center gap-x-4'>
         <input
           aria-label={label}
+          data-testid='color-picker'
           id={`${colorKey}-picker`}
           type='color'
           value={color}

--- a/src/features/options/OptionsColorPickerRow.tsx
+++ b/src/features/options/OptionsColorPickerRow.tsx
@@ -29,7 +29,7 @@ export const OptionsColorPickerRow = ({
       <div className='flex items-center gap-x-4'>
         <input
           aria-label={label}
-          data-testid='color-picker'
+          data-testid={`color-picker-${colorKey}`}
           id={`${colorKey}-picker`}
           type='color'
           value={color}

--- a/src/features/periodic-execution/routes/PeriodicExecutionRoute.test.tsx
+++ b/src/features/periodic-execution/routes/PeriodicExecutionRoute.test.tsx
@@ -300,19 +300,9 @@ describe('PeriodicExecutionRoute', () => {
 
     const dialog = screen.getByRole('alertdialog')
     const cancelButton = screen.getByRole('button', { name: 'Cancel' })
-    const labelledBy = dialog.getAttribute('aria-labelledby')
-    const describedBy = dialog.getAttribute('aria-describedby')
 
-    expect(labelledBy).toBeTruthy()
-    expect(describedBy).toBeTruthy()
-    // eslint-disable-next-line unicorn/prefer-query-selector
-    expect(document.getElementById(labelledBy ?? '')?.textContent).toBe(
-      'Auto delete',
-    )
-    // eslint-disable-next-line unicorn/prefer-query-selector
-    expect(document.getElementById(describedBy ?? '')?.textContent).toBe(
-      '確認メッセージ',
-    )
-    expect(document.activeElement).toBe(cancelButton)
+    expect(dialog).toHaveAccessibleName('Auto delete')
+    expect(dialog).toHaveAccessibleDescription('確認メッセージ')
+    expect(cancelButton).toHaveFocus()
   })
 })

--- a/src/test/setup-console.ts
+++ b/src/test/setup-console.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach } from 'vitest'
 
+import '@testing-library/jest-dom/vitest'
+
 const allowedConsoleMessagePrefixes = [
   'The width(-1) and height(-1) of chart should be greater than 0,',
   '[カテゴリ同期] ストレージ同期エラー:',


### PR DESCRIPTION
Closes #617

## 変更内容

`testing-library/no-container` と `testing-library/no-node-access` を `error` で有効化し、テスト内の直接 DOM アクセス（合計 132 件）を Testing Library の意味的 query + jest-dom matcher へ移行した。

### 移行方針

- 意味的 query で取得した要素のクラス・属性は jest-dom matcher（`toHaveClass` / `toHaveAttribute` / `toHaveTextContent` / `toHaveFocus` / `toBeEmptyDOMElement` 等）で検証
- 親・祖先・兄弟へのトラバーサル（`.parentElement` / `.closest` / `.previousElementSibling` / `.firstElementChild`）は、対象要素へ `data-testid` を付与して `getByTestId` で取得
- "X は Y の子" などの構造確認は `within(...).getByRole(...)` で検証
- ドラッグハンドル等のアイコン要素にも `data-testid` を付与
- 視覚・レイアウト状態（shadow-lg / cursor-grabbing / grid-cols 等）の検証は対象要素へ `data-testid` を付与して対応
- `screen.getByText(...).click()` は `userEvent.click` へ移行
- モック内の React 要素 `.children` アクセスは分割代入で回避
- createRoot のマウント先検証など本質的に DOM ノード参照が必要な箇所のみ、理由を明記して `eslint-disable`
- jest-dom matcher を利用するため `src/test/setup-console.ts` へ `@testing-library/jest-dom/vitest` を追加

コンポーネント側は `data-testid` / `aria-*` の追加のみで、既存のロジック・スタイル・振る舞いは変更していない。

### 受け入れ条件

- [x] 132 件の直接 DOM アクセスが解消されている
- [x] `testing-library/no-container` / `no-node-access` が `error` で有効化されている
- [x] `bun run test` が通る（3132 tests / 294 files）
- [x] `bun run lint` が通る

## ローカル検証

- [x] ローカル環境でエラーになっていない（`bun run lint` / `bun run compile` / `bun run test` / `bun run knip` / `bun run validate:html` / `bun run arch:check` / `bun run format:check` 全て通過）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved selector stability across saved tabs, AI chat, analytics, navigation, options, and import/export component tests by favoring dedicated `data-testid` hooks and more direct element targeting.
  * Updated several interaction assertions to reflect realistic user behavior (including `user-event`) and strengthened empty-state/drag-and-drop/styling checks.
  * Enhanced accessibility-related assertions in the periodic execution flow.
* **Chores**
  * Tightened Testing Library lint rules and added jest-dom matchers to the test setup to support the updated assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->