### PR TITLE
eslint-plugin-playwright を Oxlint jsPlugins 経由で導入し e2e テスト品質を強化する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -25,6 +25,10 @@
     {
       "name": "testing-library",
       "specifier": "eslint-plugin-testing-library"
+    },
+    {
+      "name": "playwright",
+      "specifier": "eslint-plugin-playwright"
     }
   ],
   "categories": {
@@ -764,6 +768,47 @@
         "testing-library/prefer-user-event": "error",
         "testing-library/no-container": "error",
         "testing-library/no-node-access": "error"
+      }
+    },
+    {
+      "files": ["e2e/**/*.ts", "e2e/**/*.tsx"],
+      "rules": {
+        "eslint/no-empty-pattern": "off",
+        "playwright/consistent-spacing-between-blocks": "error",
+        "playwright/expect-expect": "error",
+        "playwright/max-nested-describe": "error",
+        "playwright/missing-playwright-await": "error",
+        "playwright/no-conditional-expect": "error",
+        "playwright/no-conditional-in-test": "error",
+        "playwright/no-duplicate-hooks": "error",
+        "playwright/no-duplicate-slow": "error",
+        "playwright/no-element-handle": "error",
+        "playwright/no-eval": "error",
+        "playwright/no-focused-test": "error",
+        "playwright/no-force-option": "error",
+        "playwright/no-nested-step": "error",
+        "playwright/no-networkidle": "error",
+        "playwright/no-page-pause": "error",
+        "playwright/no-skipped-test": "error",
+        "playwright/no-standalone-expect": "error",
+        "playwright/no-unsafe-references": "error",
+        "playwright/no-unused-locators": "error",
+        "playwright/no-useless-await": "error",
+        "playwright/no-useless-not": "error",
+        "playwright/no-wait-for-navigation": "error",
+        "playwright/no-wait-for-selector": "error",
+        "playwright/no-wait-for-timeout": "error",
+        "playwright/prefer-hooks-in-order": "error",
+        "playwright/prefer-hooks-on-top": "error",
+        "playwright/prefer-locator": "error",
+        "playwright/prefer-to-have-count": "error",
+        "playwright/prefer-to-have-length": "error",
+        "playwright/prefer-web-first-assertions": "error",
+        "playwright/valid-describe-callback": "error",
+        "playwright/valid-expect": "error",
+        "playwright/valid-expect-in-promise": "error",
+        "playwright/valid-test-tags": "error",
+        "playwright/valid-title": "error"
       }
     }
   ]

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
         "@wxt-dev/module-react": "^1.2.2",
         "autoprefixer": "^10.5.0",
         "dependency-cruiser": "^17.4.3",
+        "eslint-plugin-playwright": "^2.10.4",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-testing-library": "^7.16.2",
         "happy-dom": "^20.10.2",
@@ -1502,6 +1503,8 @@
 
     "eslint": ["eslint@10.4.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ=="],
 
+    "eslint-plugin-playwright": ["eslint-plugin-playwright@2.10.4", "", { "dependencies": { "globals": "^17.3.0" }, "peerDependencies": { "eslint": ">=8.40.0" } }, "sha512-l0V/VxyqfFbtqCTxj5AdRn3Q6S/hIW4nKBnKZVleVbZ24N2My6Usj//ytX3dKKqAoSbvKck9YtSytfdZ5qjLuA=="],
+
     "eslint-plugin-react-dom": ["eslint-plugin-react-dom@5.9.5", "", { "dependencies": { "@eslint-react/ast": "5.9.5", "@eslint-react/eslint": "5.9.5", "@eslint-react/jsx": "5.9.5", "@eslint-react/shared": "5.9.5", "@typescript-eslint/types": "^8.62.0", "@typescript-eslint/utils": "^8.62.0", "compare-versions": "^6.1.1" }, "peerDependencies": { "eslint": "*", "typescript": "*" } }, "sha512-49tHxOSa2kSGXMpCsHDCONTx7dU0GQGJTE5ZYj+QA6TCf9ryiJgtU9N6vvEohjr0zSxaYFBGBy18rO+gQ3/JVA=="],
 
     "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
@@ -1627,6 +1630,8 @@
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
 
     "global-directory": ["global-directory@4.0.1", "", { "dependencies": { "ini": "4.1.1" } }, "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q=="],
+
+    "globals": ["globals@17.7.0", "", {}, "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "@wxt-dev/module-react": "^1.2.2",
     "autoprefixer": "^10.5.0",
     "dependency-cruiser": "^17.4.3",
+    "eslint-plugin-playwright": "^2.10.4",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-testing-library": "^7.16.2",
     "happy-dom": "^20.10.2",


### PR DESCRIPTION
## 変更内容

[issue #610](https://github.com/haruto-yamada1/TABBIN/issues/610) 対応。`eslint-plugin-playwright` を導入し、Playwright e2e テストの flaky 化を防ぐ。

### 導入方法

`eslint-plugin-playwright` を Oxlint の **jsPlugins** 機能経由で利用する。専用 ESLint script は不要。

- `.oxlintrc.json` の `jsPlugins` に `eslint-plugin-playwright` を追加
- `overrides` で `e2e/**/*.ts` / `e2e/**/*.tsx` 限定のルールブロックを追加
- 既存の `bun run lint` で e2e ファイルも含めて一括検査されるため、`quality` への追加組み込み不要（`lint` は既に `quality` に含まれる）

### 採用ルール（recommended config 相当、すべて `error`）

#### issue 優先ルール（推奨 warn のものは `error` に格上げ）

| ルール | recommended | 採用 |
|---|---|---|
| `missing-playwright-await` | error | ✅ error |
| `no-focused-test` | error | ✅ error |
| `no-skipped-test` | warn | ✅ error |
| `no-wait-for-timeout` | warn | ✅ error |
| `no-networkidle` | error | ✅ error |
| `no-wait-for-selector` | warn | ✅ error |
| `no-force-option` | warn | ✅ error |
| `no-element-handle` | warn | ✅ error |
| `no-eval` | warn | ✅ error |
| `prefer-locator` | warn | ✅ error |
| `prefer-web-first-assertions` | error | ✅ error |
| `no-conditional-expect` | warn | ✅ error |
| `no-conditional-in-test` | warn | ✅ error |
| `no-standalone-expect` | error | ✅ error |

#### その他 recommended ルール

| ルール | recommended | 採用 |
|---|---|---|
| `consistent-spacing-between-blocks` | warn | ✅ error |
| `expect-expect` | warn | ✅ error |
| `max-nested-describe` | warn | ✅ error |
| `no-duplicate-hooks` | warn | ✅ error |
| `no-duplicate-slow` | warn | ✅ error |
| `no-nested-step` | warn | ✅ error |
| `no-page-pause` | warn | ✅ error |
| `no-unsafe-references` | error | ✅ error |
| `no-unused-locators` | error | ✅ error |
| `no-useless-await` | warn | ✅ error |
| `no-useless-not` | warn | ✅ error |
| `no-wait-for-navigation` | error | ✅ error |
| `prefer-hooks-in-order` | warn | ✅ error |
| `prefer-hooks-on-top` | warn | ✅ error |
| `prefer-to-have-count` | warn | ✅ error |
| `prefer-to-have-length` | warn | ✅ error |
| `valid-describe-callback` | error | ✅ error |
| `valid-expect` | error | ✅ error |
| `valid-expect-in-promise` | error | ✅ error |
| `valid-test-tags` | error | ✅ error |
| `valid-title` | error | ✅ error |

### 見送りルール

| ルール | 理由 |
|---|---|
| `no-raw-locators` | 設計方針に強く関わるため初回導入では必須にしない（issue 指定） |
| `prefer-native-locators` | 同上 |
| recommended 外ルール全般 | 今回は recommended config 相当を対象とする |

### 検証

- jsPlugins 経由で全 recommended ルールが正しく発火することを確認済み（各ルールに対して違反コードで検証）
- 既存 e2e ファイルに対する違反は 0 件
- `e2e/` 配外のファイルにはルールが適用されないことを確認

## チェックリスト

- [x] ローカル環境でエラーになっていない

Closes #610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Playwright linting support for end-to-end test files.
  * Enabled stricter checks for browser test code to help catch issues earlier.
  * Updated development tooling with the required linting plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->