### PR TITLE
eslint-plugin-storybook を Oxlint jsPlugins 経由で導入し Storybook 品質を強化する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -29,6 +29,10 @@
     {
       "name": "playwright",
       "specifier": "eslint-plugin-playwright"
+    },
+    {
+      "name": "storybook",
+      "specifier": "eslint-plugin-storybook"
     }
   ],
   "categories": {
@@ -809,6 +813,35 @@
         "playwright/valid-expect-in-promise": "error",
         "playwright/valid-test-tags": "error",
         "playwright/valid-title": "error"
+      }
+    },
+    {
+      "files": [
+        "src/**/*.stories.ts",
+        "src/**/*.stories.tsx",
+        "src/**/*.story.ts",
+        "src/**/*.story.tsx"
+      ],
+      "rules": {
+        "storybook/default-exports": "error",
+        "storybook/story-exports": "error",
+        "storybook/no-redundant-story-name": "error",
+        "storybook/prefer-pascal-case": "error",
+        "storybook/context-in-play-function": "error",
+        "storybook/use-storybook-expect": "error",
+        "storybook/use-storybook-testing-library": "error",
+        "storybook/meta-satisfies-type": "error"
+      }
+    },
+    {
+      "files": [
+        ".storybook/main.ts",
+        ".storybook/main.js",
+        ".storybook/main.mjs",
+        ".storybook/main.cjs"
+      ],
+      "rules": {
+        "storybook/no-uninstalled-addons": "error"
       }
     }
   ]

--- a/bun.lock
+++ b/bun.lock
@@ -95,6 +95,7 @@
         "dependency-cruiser": "^17.4.3",
         "eslint-plugin-playwright": "^2.10.4",
         "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-storybook": "^10.4.6",
         "eslint-plugin-testing-library": "^7.16.2",
         "happy-dom": "^20.10.2",
         "html-validate": "^11.5.3",
@@ -1518,6 +1519,8 @@
     "eslint-plugin-react-web-api": ["eslint-plugin-react-web-api@5.9.5", "", { "dependencies": { "@eslint-react/ast": "5.9.5", "@eslint-react/core": "5.9.5", "@eslint-react/eslint": "5.9.5", "@eslint-react/shared": "5.9.5", "@eslint-react/var": "5.9.5", "@typescript-eslint/types": "^8.62.0", "@typescript-eslint/utils": "^8.62.0", "birecord": "^0.1.1", "ts-pattern": "^5.9.0" }, "peerDependencies": { "eslint": "*", "typescript": "*" } }, "sha512-QySgjUrlEifAZp0phtA+VzuJZdRYcIxTjFXPMaSY+QPKAsHZo3cJ3rjFcbtR9DS/kdGGf6p/Oa02Rqgk9cw2FQ=="],
 
     "eslint-plugin-react-x": ["eslint-plugin-react-x@5.9.5", "", { "dependencies": { "@eslint-react/ast": "5.9.5", "@eslint-react/core": "5.9.5", "@eslint-react/eslint": "5.9.5", "@eslint-react/jsx": "5.9.5", "@eslint-react/shared": "5.9.5", "@eslint-react/var": "5.9.5", "@typescript-eslint/scope-manager": "^8.62.0", "@typescript-eslint/type-utils": "^8.62.0", "@typescript-eslint/types": "^8.62.0", "@typescript-eslint/typescript-estree": "^8.62.0", "@typescript-eslint/utils": "^8.62.0", "compare-versions": "^6.1.1", "string-ts": "^2.3.1", "ts-api-utils": "^2.5.0", "ts-pattern": "^5.9.0" }, "peerDependencies": { "eslint": "*", "typescript": "*" } }, "sha512-GToujy4Aj5xs5h/yMG7gUWYlb52oyMTvk1KXqcXefMhYY31AY0xEN1385W/dGVGOMyobNrHDVzoZ2lBDF2cquw=="],
+
+    "eslint-plugin-storybook": ["eslint-plugin-storybook@10.4.6", "", { "dependencies": { "@typescript-eslint/utils": "^8.48.0" }, "peerDependencies": { "eslint": ">=8", "storybook": "^10.4.6" } }, "sha512-CfGSXn6zFspeYTU8R7v797MOmJFj8xc6MWf/oGuRwbKeMoSwnliR+OlXSjMZYM1D6gfmwiuH1VX58LSHdn+ZPg=="],
 
     "eslint-plugin-testing-library": ["eslint-plugin-testing-library@7.16.2", "", { "dependencies": { "@typescript-eslint/scope-manager": "^8.56.0", "@typescript-eslint/utils": "^8.56.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0" } }, "sha512-8gleGnQXK2ZA3hHwjCwpYTZvM+9VsrJ+/9kDI8CjqAQGAdMQOdn/rJNu7ZySENuiWlGKQWyZJ4ZjEg2zamaRHw=="],
 

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "dependency-cruiser": "^17.4.3",
     "eslint-plugin-playwright": "^2.10.4",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-storybook": "^10.4.6",
     "eslint-plugin-testing-library": "^7.16.2",
     "happy-dom": "^20.10.2",
     "html-validate": "^11.5.3",


### PR DESCRIPTION
## 概要

issue #611。`eslint-plugin-storybook@10.4.6` を Oxlint の `jsPlugins` に追加し、story ファイルと `.storybook/main.ts` に限定して Storybook 向けルールを `error` で有効化します。既存の `jsPlugins` 運用（`eslint-react` / `react-hooks` / `testing-library` / `playwright`）と同じ経路を使うため、`bun run lint` / `bun run quality` に自動で組み込まれ、専用の lint script は不要です。

## 検証結果

- **Storybook 10 系での利用可否**: Storybook 10.4.4 + Oxlint 1.69.0 の `jsPlugins` で `eslint-plugin-storybook@10.4.6` が読み込まれ、ルールが実際に発火することをプローブファイルで確認しました（default-exports / prefer-pascal-case / await-interactions / context-in-play-function / use-storybook-expect / use-storybook-testing-library / meta-satisfies-type / no-uninstalled-addons すべて発火）。
- **peer 互換性**: `eslint-plugin-storybook@10.4.6` は `storybook: ^10.4.6` を要求しますが、本リポジトリは `10.4.4` です。ルールは静的解析のみを行い Storybook ランタイムに依存しないため、10.4.4 でも問題なく動作することを確認済みです。ランタイム升级は本 issue のスコープ外のため見送っています（bun は peer 警告のみ出します）。
- **対象ファイル限定**: CSF 系ルールは `src/**/*.stories.{ts,tsx}` / `src/**/*.story.{ts,tsx}` のみ、`no-uninstalled-addons` は `.storybook/main.{ts,js,mjs,cjs}` のみに適用。実運用コードにはかかりません。既存の `ignorePatterns`（`src/components/ui/**` / `src/components/ai-elements/**`）はベンダー配置ディレクトリのまま維持し、その配下の story は他のベンダーコードと一貫して lint 対象外としています。

## 採用ルール（すべて `error`）

story ファイル:
- `storybook/default-exports` — story ファイルの default export 漏れを検出
- `storybook/story-exports` — story export 漏れを検出
- `storybook/no-redundant-story-name` — 冗長な `name` 注釈を検出
- `storybook/prefer-pascal-case` — story 名の PascalCase を強制
- `storybook/context-in-play-function` — 別 story の play 呼び出し時の context 未渡しを検出
- `storybook/use-storybook-expect` — `expect` の storybook からの import を強制
- `storybook/use-storybook-testing-library` — `@testing-library/*` 直接 import を禁止し `storybook/test` を推奨
- `storybook/meta-satisfies-type` — `meta` の `satisfies Meta` 型付けを強制

`.storybook/main.ts`:
- `storybook/no-uninstalled-addons` — 未導入 addon 指定を検出

## 見送りルールと理由

- `storybook/await-interactions` — Storybook 10 の正規 import 先 `storybook/test` をルールが認識せず（`@storybook/test` / `@storybook/testing-library` のみを参照）、かつ import 検出が最後の `ImportDeclaration` のみを上書き参照するため、oxfmt の import 整列後に実質的に発火しなくなります。誤検知・検出漏れが前提となるため見送り。
- `storybook/csf-component` — 複数コンポーネントを遅延描画する showcase 系 story（`display` / `inputs` / `workspace` / `showcase`）が `render` で構成され `component` を持たない正当な書き方を誤報告するため見送り。
- `storybook/no-title-property-in-meta` — 全 story が sidebar 分類のために `title` を意図的に設定しており、CSF3 のスタイル推奨を `error` で強制すると分類構造が破壊されるため見送り（`warn` 運用も本 issue の方針により不可）。
- `hierarchy-separator` / `no-renderer-packages` / `no-stories-of` / `meta-inline-properties` — issue の候補外、かつ現状で問題がないため見送り。

## 変更ファイル

- `.oxlintrc.json`: `jsPlugins` に `storybook` を追加、story / `.storybook/main.* 向け overrides を追加
- `package.json` / `bun.lock`: `eslint-plugin-storybook@^10.4.6` (devDependencies) を追加

## ローカル検証

- [x] `bun run lint`（oxlint .）が通る
- [x] `bun run build-storybook` が通る
- [x] `bun run test:node`（173 files / 2286 tests）が通る
- [x] `bun run test:dom`（121 files / 846 tests）が通る
- [x] storybook smoke test が通る
- [x] `bun run knip` が通る（未使用依存として検出されない）
- [x] `bun run format:check` が通る

Closes #611


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting setup to include Storybook-specific checks.
  * Added stricter Storybook rules for story files and Storybook configuration files.
  * Added the required Storybook ESLint plugin to the project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->