### PR TITLE
Firefox 向け data_collection_permissions 対応を追加する

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -10,7 +10,7 @@ const vitePlugins = tailwindcss() as unknown as NonNullable< // eslint-disable-l
 export default defineConfig({
   srcDir: 'src',
   publicDir: 'src/public',
-  manifest: {
+  manifest: (env) => ({
     default_locale: 'ja',
     name: '__MSG_extensionName__',
     description: '__MSG_extensionDescription__',
@@ -24,7 +24,21 @@ export default defineConfig({
       page: 'options.html',
       open_in_tab: true,
     },
-  },
+    // Firefox requires data_collection_permissions from Nov 3, 2025.
+    // TABBIN does not collect personal data - all data stays local
+    // and the only external call is to the user's local Ollama server.
+    ...(env.browser === 'firefox'
+      ? {
+          browser_specific_settings: {
+            gecko: {
+              data_collection_permissions: {
+                required: ['none'],
+              },
+            },
+          },
+        }
+      : {}),
+  }),
   modules: ['@wxt-dev/module-react', '@wxt-dev/i18n/module'],
   vite: () => ({
     plugins: vitePlugins,


### PR DESCRIPTION
## 変更内容

Issue #374 の対応です。

Firefox build 時に出ていた `data_collection_permissions` に関する WXT warning を解消しました。

### 背景
Firefox Add-ons の新規拡張要件 (2025-11-03 以降) により `data_collection_permissions` の宣言が必要です。

### 変更点
`wxt.config.ts` の manifest を関数に変更し、Firefox build 時のみ `browser_specific_settings.gecko.data_collection_permissions` に `required: ['none']` を追加しました。TABBIN は個人データを収集しないため `none` を宣言しています (PRIVACY.md 参照)。

### 確認
- [x] `bun run build:firefox` で warning が出ない
- [x] `bun run build` (Chrome) で browser_specific_settings が含まれない
- [x] `bun run compile` / `bun run lint` / `bun run format` が通る
- [x] `bun run test:node` が全件通る (173 files / 2286 tests)

Closes #374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-specific manifest settings, with Firefox now receiving the required data collection permissions automatically.
  * Improved configuration flexibility so the extension can adapt its manifest based on the detected browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->