### PR TITLE
保存タブ開封時のドメイン名スキーム例外を修正する

### DIFF
--- a/src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.test.ts
+++ b/src/contexts/saved-tabs/application/mappers/SavedTabsSnapshotMapper.test.ts
@@ -218,6 +218,31 @@ describe('SavedTabsSnapshotMapper.toDomainParentCategories', () => {
       name: 'Reading',
     })
   })
+
+  // 回帰: 保存フロー (lib/storage/migration getTabDomain) が
+  // `https://example.com` のようにスキーム付き文字列を domainNames に書き込む
+  // 既存データを開くとき、toDomainParentCategories 経由で
+  // createDomainName が「ドメイン名にスキームを含めることはできません」を投げて
+  // useTabOpeningHandlers.handleOpenTab がタブを開けなくする不具合の回帰。
+  it('domainNames にスキーム付き文字列が含まれても hostname へ正規化して例外を投げない', () => {
+    const result = toDomainParentCategories([
+      {
+        domains: ['group-1'],
+        domainNames: [
+          'https://example.com',
+          'http://other.com/path',
+          'plain.org',
+        ],
+        id: 'cat-1',
+        name: 'Reading',
+      },
+    ])
+    expect(result?.[0].domainNames).toStrictEqual([
+      'example.com',
+      'other.com',
+      'plain.org',
+    ])
+  })
 })
 
 describe('SavedTabsSnapshotMapper.toDomainTabGroupsForReorder', () => {

--- a/src/contexts/saved-tabs/domain/entities/ParentCategory.test.ts
+++ b/src/contexts/saved-tabs/domain/entities/ParentCategory.test.ts
@@ -112,4 +112,32 @@ describe('ParentCategory entity', () => {
       ),
     ).toBe(true)
   })
+
+  // 回帰 (CodeRabbit PR #625): normalizeDomainString で有効な hostname が取れない
+  // 不正エントリ (host-less スキーム / パース失敗形 / 空白のみ) が混入していても、
+  // 1 件の不正値でカテゴリ全体の生成 (toDomainParentCategories) が落ちず、
+  // 不正エントリだけ除外して有効なドメインだけ残る。
+  it('host-less / パース失敗 / 空白のみの domainNames は除外されカテゴリ生成は成功する', () => {
+    const category = createParentCategory({
+      ...baseInput,
+      domainNames: [
+        'https://example.com',
+        'https://',
+        '://invalid',
+        '   ',
+        '',
+        'other.com',
+      ],
+    })
+    expect(category.domainNames).toStrictEqual(['example.com', 'other.com'])
+  })
+
+  it('domainNames が全て不正でもカテゴリ生成は例外を投げず空配列になる', () => {
+    const category = createParentCategory({
+      ...baseInput,
+      domains: [],
+      domainNames: ['https://', '://invalid', '   '],
+    })
+    expect(category.domainNames).toStrictEqual([])
+  })
 })

--- a/src/contexts/saved-tabs/domain/entities/ParentCategory.test.ts
+++ b/src/contexts/saved-tabs/domain/entities/ParentCategory.test.ts
@@ -71,4 +71,45 @@ describe('ParentCategory entity', () => {
     const b = createParentCategory({ ...baseInput, name: 'Renamed' })
     expect(isSameParentCategory(a, b)).toBe(true)
   })
+
+  // 回帰: 保存フロー (getTabDomain) が `https://example.com` のように
+  // スキーム付き文字列を domainNames に書き込む既存データを開くとき、
+  // createDomainName が「ドメイン名にスキームを含めることはできません」で
+  // 例外を投げてタブを開けなくする不具合 (issue: タブ消失・保存タブ開封失敗) の回帰。
+  it('domainNames にスキーム付き文字列が含まれても hostname へ正規化して保持する', () => {
+    const category = createParentCategory({
+      ...baseInput,
+      domainNames: [
+        'https://example.com',
+        'http://other.com/path',
+        'plain.org',
+      ],
+    })
+    expect(category.domainNames).toStrictEqual([
+      'example.com',
+      'other.com',
+      'plain.org',
+    ])
+  })
+
+  it('domainNames のスキーム付き値は小文字へ正規化される', () => {
+    const category = createParentCategory({
+      ...baseInput,
+      domainNames: ['https://Example.COM'],
+    })
+    expect(category.domainNames).toStrictEqual(['example.com'])
+  })
+
+  it('parentCategoryContainsDomainName は正規化済みの domainNames と一致する', () => {
+    const category = createParentCategory({
+      ...baseInput,
+      domainNames: ['https://example.com'],
+    })
+    expect(
+      parentCategoryContainsDomainName(
+        category,
+        createDomainName('example.com'),
+      ),
+    ).toBe(true)
+  })
 })

--- a/src/contexts/saved-tabs/domain/entities/ParentCategory.ts
+++ b/src/contexts/saved-tabs/domain/entities/ParentCategory.ts
@@ -1,10 +1,7 @@
 import { SavedTabsDomainError } from '@/contexts/saved-tabs/domain/errors/SavedTabsDomainError'
 import { createCategoryName } from '@/contexts/saved-tabs/domain/value-objects/CategoryName'
 import type { CategoryName } from '@/contexts/saved-tabs/domain/value-objects/CategoryName'
-import {
-  createDomainName,
-  normalizeDomainString,
-} from '@/contexts/saved-tabs/domain/value-objects/DomainName'
+import { tryCreateDomainName } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 import type { DomainName } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 import { createParentCategoryId } from '@/contexts/saved-tabs/domain/value-objects/ParentCategoryId'
 import type { ParentCategoryId } from '@/contexts/saved-tabs/domain/value-objects/ParentCategoryId'
@@ -76,11 +73,14 @@ export const createParentCategory = (
     // 保存フロー (getTabDomain) が `https://example.com` のようにスキーム付き
     // 文字列を domainNames に書き込む既存データと互換するため、TabGroup.domain
     // と同じく normalizeDomainString で hostname へ正規化してから DomainName 化する。
-    // これにより toDomainParentCategories 経由の読み込みで
-    // 「ドメイン名にスキームを含めることはできません」エラーを防ぐ。
-    domainNames: input.domainNames.map((name) =>
-      createDomainName(normalizeDomainString(name)),
-    ),
+    // さらに `https://` (host-less) や `://invalid` (パース失敗) のように
+    // 正規化後に有効な hostname が取れない不正エントリは tryCreateDomainName で
+    // null 化して除外し、1 件の不正値でカテゴリ全体の読み込み
+    // (toDomainParentCategories) が落ちないようにする
+    // (CodeRabbit PR #625 review 指摘)。
+    domainNames: input.domainNames
+      .map(tryCreateDomainName)
+      .filter((name): name is DomainName => name !== null),
   }
 }
 

--- a/src/contexts/saved-tabs/domain/entities/ParentCategory.ts
+++ b/src/contexts/saved-tabs/domain/entities/ParentCategory.ts
@@ -1,7 +1,10 @@
 import { SavedTabsDomainError } from '@/contexts/saved-tabs/domain/errors/SavedTabsDomainError'
 import { createCategoryName } from '@/contexts/saved-tabs/domain/value-objects/CategoryName'
 import type { CategoryName } from '@/contexts/saved-tabs/domain/value-objects/CategoryName'
-import { createDomainName } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
+import {
+  createDomainName,
+  normalizeDomainString,
+} from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 import type { DomainName } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 import { createParentCategoryId } from '@/contexts/saved-tabs/domain/value-objects/ParentCategoryId'
 import type { ParentCategoryId } from '@/contexts/saved-tabs/domain/value-objects/ParentCategoryId'
@@ -70,7 +73,14 @@ export const createParentCategory = (
     id: createParentCategoryId(input.id),
     name: createCategoryName(input.name),
     domains: input.domains.map((domain) => createTabGroupId(domain)),
-    domainNames: input.domainNames.map((name) => createDomainName(name)),
+    // 保存フロー (getTabDomain) が `https://example.com` のようにスキーム付き
+    // 文字列を domainNames に書き込む既存データと互換するため、TabGroup.domain
+    // と同じく normalizeDomainString で hostname へ正規化してから DomainName 化する。
+    // これにより toDomainParentCategories 経由の読み込みで
+    // 「ドメイン名にスキームを含めることはできません」エラーを防ぐ。
+    domainNames: input.domainNames.map((name) =>
+      createDomainName(normalizeDomainString(name)),
+    ),
   }
 }
 

--- a/src/contexts/saved-tabs/domain/value-objects/DomainName.test.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/DomainName.test.ts
@@ -7,6 +7,7 @@ import {
   domainNameToString,
   equalsDomainName,
   normalizeDomainString,
+  tryCreateDomainName,
 } from './DomainName'
 
 describe('DomainName 値オブジェクト', () => {
@@ -58,5 +59,49 @@ describe('normalizeDomainString', () => {
     expect(() =>
       createDomainName(normalizeDomainString('https://example.com')),
     ).not.toThrow()
+  })
+})
+
+describe('tryCreateDomainName', () => {
+  it('有効な hostname は DomainName を返す', () => {
+    const domain = tryCreateDomainName('example.com')
+    if (domain === null) {
+      throw new Error('expected DomainName, got null')
+    }
+    expect(domainNameToString(domain)).toBe('example.com')
+  })
+
+  it('スキーム付き文字列は正規化して DomainName を返す', () => {
+    const domain = tryCreateDomainName('https://Example.COM')
+    if (domain === null) {
+      throw new Error('expected DomainName, got null')
+    }
+    expect(domainNameToString(domain)).toBe('example.com')
+  })
+
+  it('host-less スキーム (https://) は null を返す (カテゴリ全体の読み込み失敗を防ぐ)', () => {
+    expect(tryCreateDomainName('https://')).toBeNull()
+  })
+
+  it('パース失敗形 (://invalid) は null を返す', () => {
+    expect(tryCreateDomainName('://invalid')).toBeNull()
+  })
+
+  it('空白のみは null を返す', () => {
+    expect(tryCreateDomainName('   ')).toBeNull()
+  })
+
+  it('空文字列は null を返す', () => {
+    expect(tryCreateDomainName('')).toBeNull()
+  })
+
+  it('https:///path は hostname (path) を取り出して DomainName を返す', () => {
+    // Node の URL は `https:///path` を host=path と解釈するため、
+    // 有効な hostname が取れれば DomainName 化する (空でなければ許容)。
+    const domain = tryCreateDomainName('https:///path')
+    if (domain === null) {
+      throw new Error('expected DomainName, got null')
+    }
+    expect(domainNameToString(domain)).toBe('path')
   })
 })

--- a/src/contexts/saved-tabs/domain/value-objects/DomainName.ts
+++ b/src/contexts/saved-tabs/domain/value-objects/DomainName.ts
@@ -71,6 +71,24 @@ export const createDomainName = (value: string): DomainName => {
 }
 
 /**
+ * `createDomainName` の安全版。`normalizeDomainString` で正規化した結果が
+ * 不正（空文字列・スキーム残留・パース失敗で hostname が取れない等）の場合は
+ * 例外を投げず `null` を返す。
+ *
+ * 旧ストレージの `parentCategories[].domainNames` に混入した不正エントリ
+ * （`https://` の host-less スキーム、`://invalid` のパース失敗形など）を、
+ * カテゴリ全体の読み込み失敗にせず個別にスキップするために使う
+ * (CodeRabbit PR #625 review 指摘)。
+ */
+export const tryCreateDomainName = (value: string): DomainName | null => {
+  try {
+    return createDomainName(normalizeDomainString(value))
+  } catch {
+    return null
+  }
+}
+
+/**
  * `DomainName` を生文字列へ戻す。永続化や UI へ渡すための変換口。
  */
 export const domainNameToString = (domain: DomainName): string => domain

--- a/src/contexts/saved-tabs/infrastructure/composition/LibCategoryAssignmentPort.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/LibCategoryAssignmentPort.test.ts
@@ -65,4 +65,38 @@ describe('createLibCategoryAssignmentPort', () => {
       expect.objectContaining({ id: 'group-2', urlIds: ['url-1'] }),
     ])
   })
+
+  // 回帰: 保存フロー (getTabDomain) が `https://example.com` のように
+  // スキーム付き domain を書き込む既存データが saveTabGroups に流れた場合、
+  // createTabGroup → createDomainName が「ドメイン名にスキームを含めることは
+  // できません」で例外を投げないよう、入口で hostname へ正規化する。
+  it('スキーム付き domain は hostname へ正規化して entity 化する', async () => {
+    const saveAll = vi.fn()
+    const port = createLibCategoryAssignmentPort({
+      parentCategoryRepository: {
+        findAll: vi.fn(),
+        findById: vi.fn(),
+        removeByIds: vi.fn(),
+        saveAll: vi.fn(),
+      },
+      tabGroupRepository: {
+        findAll: vi.fn(),
+        findById: vi.fn(),
+        findRawDomainById: vi.fn(),
+        findRawTabGroupById: vi.fn(),
+        removeByIds: vi.fn(),
+        saveAll,
+      },
+    })
+
+    await port.saveTabGroups([
+      { domain: 'https://example.com', id: 'group-1', urlIds: [] },
+      { domain: 'http://docs.example.com/path', id: 'group-2', urlIds: [] },
+    ])
+
+    expect(saveAll).toHaveBeenCalledTimes(1)
+    const saved = saveAll.mock.calls[0]?.[0] as { domain: string }[]
+    expect(saved[0].domain).toBe('example.com')
+    expect(saved[1].domain).toBe('docs.example.com')
+  })
 })

--- a/src/contexts/saved-tabs/infrastructure/composition/LibCategoryAssignmentPort.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/LibCategoryAssignmentPort.ts
@@ -3,6 +3,7 @@ import { createParentCategory } from '@/contexts/saved-tabs/domain/entities/Pare
 import { createTabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
 import type { ParentCategoryRepository } from '@/contexts/saved-tabs/domain/repositories/ParentCategoryRepository'
 import type { TabGroupRepository } from '@/contexts/saved-tabs/domain/repositories/TabGroupRepository'
+import { normalizeDomainString } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 
 /**
  * `CategoryAssignmentPort` の `parentCategoryRepository` /
@@ -29,7 +30,15 @@ export const createLibCategoryAssignmentPort = (deps: {
   saveTabGroups: async (tabGroups) => {
     await deps.tabGroupRepository.saveAll(
       tabGroups.map((group) =>
-        createTabGroup({ ...group, urlIds: group.urlIds ?? [] }),
+        // 保存フローが `https://example.com` のようにスキーム付き domain を
+        // 書き込む既存データと互換するため、toDomainTabGroupFromStorage /
+        // toTabGroupFromRaw / RepairTabGroupParentCategoryIdsUseCase と同じく
+        // createTabGroup 入口で hostname へ正規化する。
+        createTabGroup({
+          ...group,
+          domain: normalizeDomainString(group.domain),
+          urlIds: group.urlIds ?? [],
+        }),
       ),
     )
   },


### PR DESCRIPTION
## 変更内容

<!-- 変更の詳細を記述してください -->

## チェックリスト

- [ ] ローカル環境でエラーになっていない


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where saved tabs could fail to load when stored domain values included URL schemes (for example, `https://` / `http://`).
  * Domain values are now normalized consistently to hostname-only form (case-insensitive), including cases with extra path content.
  * Invalid or unparsable domain entries are skipped instead of breaking category creation, and domain matching now works reliably after normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->