### PR TITLE
ドメイン保存形式をhostnameへ統一し比較のsilentミスマッチを防ぐ

### DIFF
--- a/src/contexts/saved-tabs/application/ports/MigrationPort.ts
+++ b/src/contexts/saved-tabs/application/ports/MigrationPort.ts
@@ -22,4 +22,13 @@ export interface MigrationPort {
    * 緊急マイグレーション用途 (旧 data 形式と新 data 形式の互換維持)。
    */
   migrateParentCategoriesToDomainNames: () => Promise<void>
+
+  /**
+   * スキーム付きドメイン (`https://example.com`) を hostname (`example.com`)
+   * へ正規化し、`savedTabs` / `parentCategories` / `domainCategorySettings` /
+   * `domainCategoryMappings` のドメイン値を hostname 形式へ冪等に統一する
+   * (Finding B の根本治療)。完了フラグ `domainHostnameMigrationCompleted` で
+   * 再実行を抑制する。
+   */
+  migrateDomainStorageToHostname: () => Promise<void>
 }

--- a/src/contexts/saved-tabs/application/testing/SavedTabsPresentationStubs.ts
+++ b/src/contexts/saved-tabs/application/testing/SavedTabsPresentationStubs.ts
@@ -32,6 +32,7 @@ export const createSavedTabsPresentationPortsStub = (
   migrationPort: overrides.migrationPort ?? {
     migrateParentCategoriesToDomainNames: async () => {},
     migrateToUrlsStorage: async () => {},
+    migrateDomainStorageToHostname: async () => {},
   },
   storageChangePort: overrides.storageChangePort ?? {
     subscribe: () => () => {},

--- a/src/contexts/saved-tabs/application/use-cases/SyncCategoryAssignmentsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/SyncCategoryAssignmentsUseCase.ts
@@ -10,7 +10,10 @@ import {
   buildCategoryLookup,
   resolveCategoryForTabGroup,
 } from '@/contexts/saved-tabs/domain/services/CategoryAssignmentPolicy'
-import { createDomainName } from '@/contexts/saved-tabs/domain/value-objects/DomainName'
+import {
+  createDomainName,
+  normalizeDomainString,
+} from '@/contexts/saved-tabs/domain/value-objects/DomainName'
 import { createParentCategoryId } from '@/contexts/saved-tabs/domain/value-objects/ParentCategoryId'
 
 /**
@@ -48,7 +51,9 @@ const syncSingleDomain = async (
   unassignedTabGroupIds: TabGroup['id'][]
   updatedCategoryIds: ParentCategory['id'][]
 }> => {
-  const targetDomainName = createDomainName(moveCommand.domain)
+  const targetDomainName = createDomainName(
+    normalizeDomainString(moveCommand.domain),
+  )
   const targetCategoryId = createParentCategoryId(moveCommand.parentCategoryId)
   const [allTabGroups, allCategories] = await Promise.all([
     deps.tabGroupRepository.findAll(),

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeMigrationAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeMigrationAdapter.ts
@@ -1,5 +1,6 @@
 import type { MigrationPort } from '@/contexts/saved-tabs/application/ports/MigrationPort'
 import {
+  migrateDomainStorageToHostname,
   migrateParentCategoriesToDomainNames,
   migrateToUrlsStorage,
 } from '@/lib/storage/migration'
@@ -20,5 +21,8 @@ export const createChromeMigrationAdapter = (): MigrationPort => ({
   },
   migrateToUrlsStorage: async () => {
     await migrateToUrlsStorage()
+  },
+  migrateDomainStorageToHostname: async () => {
+    await migrateDomainStorageToHostname()
   },
 })

--- a/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
@@ -154,6 +154,7 @@ const createBundle = (initial: StorageState = {}): Bundle => {
         .fn()
         .mockResolvedValue(undefined),
       migrateToUrlsStorage: vi.fn().mockResolvedValue(undefined),
+      migrateDomainStorageToHostname: vi.fn().mockResolvedValue(undefined),
     },
     notificationPort: notification.notificationPort,
     parentCategoryRepository: createChromeParentCategoryRepository(port),
@@ -499,6 +500,7 @@ describe('savedTabs DDD 移行 後 回帰テスト', () => {
             .fn()
             .mockResolvedValue(undefined),
           migrateToUrlsStorage: vi.fn().mockResolvedValue(undefined),
+          migrateDomainStorageToHostname: vi.fn().mockResolvedValue(undefined),
         },
         notificationPort: notification.notificationPort,
         parentCategoryRepository: createChromeParentCategoryRepository(port),

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
@@ -170,6 +170,7 @@ const buildLayoutComposition = () => {
         .fn()
         .mockResolvedValue(undefined),
       migrateToUrlsStorage: vi.fn().mockResolvedValue(undefined),
+      migrateDomainStorageToHostname: vi.fn().mockResolvedValue(undefined),
     },
     categoriesCommandService: {
       updateDomainCategorySettings: vi.fn().mockResolvedValue(undefined),

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
@@ -14,7 +14,7 @@ import type { CategoryAssignmentPort } from '@/contexts/saved-tabs/application/p
 import type { StorageChangePort } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import { normalizeDomainLookupKey } from '@/utils/domain-normalize'
+import { hasNormalizedDomain } from '@/utils/domain-normalize'
 
 /** カテゴリ名のバリデーションスキーマ */
 const MAX_CATEGORY_NAME_LENGTH = 25
@@ -71,13 +71,10 @@ const resolveSelectedParentCategoryId = (
   if (group.parentCategoryId) {
     return group.parentCategoryId
   }
-  const groupDomainKey = normalizeDomainLookupKey(group.domain)
   const matchedCategory = storedCategories.find(
     (category) =>
       category.domains.includes(group.id) ||
-      category.domainNames.some(
-        (name) => normalizeDomainLookupKey(name) === groupDomainKey,
-      ),
+      hasNormalizedDomain(category.domainNames, group.domain),
   )
   return matchedCategory ? matchedCategory.id : 'none'
 }

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
@@ -14,7 +14,7 @@ import type { CategoryAssignmentPort } from '@/contexts/saved-tabs/application/p
 import type { StorageChangePort } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
-import { hasNormalizedDomain } from '@/utils/domain-normalize'
+import { tabGroupMatchesCategory } from '@/utils/domain-normalize'
 
 /** カテゴリ名のバリデーションスキーマ */
 const MAX_CATEGORY_NAME_LENGTH = 25
@@ -71,10 +71,13 @@ const resolveSelectedParentCategoryId = (
   if (group.parentCategoryId) {
     return group.parentCategoryId
   }
-  const matchedCategory = storedCategories.find(
-    (category) =>
-      category.domains.includes(group.id) ||
-      hasNormalizedDomain(category.domainNames, group.domain),
+  const matchedCategory = storedCategories.find((category) =>
+    tabGroupMatchesCategory(
+      category.domains,
+      category.domainNames,
+      group.id,
+      group.domain,
+    ),
   )
   return matchedCategory ? matchedCategory.id : 'none'
 }

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
@@ -14,6 +14,7 @@ import type { CategoryAssignmentPort } from '@/contexts/saved-tabs/application/p
 import type { StorageChangePort } from '@/contexts/saved-tabs/application/ports/StorageChangePort'
 import type { GetSavedTabsPageDataQuery } from '@/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
+import { normalizeDomainLookupKey } from '@/utils/domain-normalize'
 
 /** カテゴリ名のバリデーションスキーマ */
 const MAX_CATEGORY_NAME_LENGTH = 25
@@ -70,10 +71,13 @@ const resolveSelectedParentCategoryId = (
   if (group.parentCategoryId) {
     return group.parentCategoryId
   }
+  const groupDomainKey = normalizeDomainLookupKey(group.domain)
   const matchedCategory = storedCategories.find(
     (category) =>
       category.domains.includes(group.id) ||
-      category.domainNames.includes(group.domain),
+      category.domainNames.some(
+        (name) => normalizeDomainLookupKey(name) === groupDomainKey,
+      ),
   )
   return matchedCategory ? matchedCategory.id : 'none'
 }

--- a/src/contexts/saved-tabs/presentation/hooks/useTabData.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useTabData.test.tsx
@@ -31,6 +31,7 @@ const createMigrationPortMock = () => ({
   migrateParentCategoriesToDomainNames:
     migrateParentCategoriesToDomainNamesMock,
   migrateToUrlsStorage: migrateToUrlsStorageMock,
+  migrateDomainStorageToHostname: vi.fn(async () => {}),
 })
 
 let migrationPort: ReturnType<typeof createMigrationPortMock>

--- a/src/contexts/saved-tabs/presentation/hooks/useTabData.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useTabData.ts
@@ -94,6 +94,16 @@ const runInitialMigrations = async (
   } catch (error) {
     console.error('URL管理マイグレーションエラー:', error)
   }
+  // 既有のスキーム付きドメインを hostname へ正規化してストレージ形式を一本化する。
+  // 他のマイグレーション (domainNames 再構築含む) の後に実行し、最終的に
+  // hostname 形式で揃える (Finding B の根本治療)。
+  try {
+    console.log('ドメイン hostname 化マイグレーションを開始...')
+    await migrationPort.migrateDomainStorageToHostname()
+    console.log('ドメイン hostname 化マイグレーションが完了しました')
+  } catch (error) {
+    console.error('ドメイン hostname 化マイグレーションエラー:', error)
+  }
 }
 const logSavedTabsSummary = (savedTabs: TabGroup[]): void => {
   console.log('タブグループ数:', savedTabs.length)

--- a/src/features/ai-chat/lib/buildAiContext.test.ts
+++ b/src/features/ai-chat/lib/buildAiContext.test.ts
@@ -204,7 +204,7 @@ describe('buildAiSavedUrlRecords', () => {
 
     expect(records[0]).toStrictEqual(
       expect.objectContaining({
-        domain: 'not-a-url',
+        domain: '',
         parentCategories: [],
         projectCategories: [],
         savedInProjects: ['Project without metadata'],
@@ -312,7 +312,7 @@ describe('searchSavedUrls', () => {
     expect(searchSavedUrls(records, 'reading')).toStrictEqual([records[1]])
   })
 
-  it('空クエリなら全件を返し、不正URLは domain に元文字列を使う', () => {
+  it('空クエリなら全件を返し、不正URLは domain を空にする', () => {
     const records = buildAiSavedUrlRecords({
       urlRecords: [
         {
@@ -327,7 +327,7 @@ describe('searchSavedUrls', () => {
       parentCategories: [],
     })
 
-    expect(records[0]?.domain).toBe('not a url')
+    expect(records[0]?.domain).toBe('')
     expect(searchSavedUrls(records, '   ')).toStrictEqual(records)
   })
 })

--- a/src/features/ai-chat/lib/buildAiContext.test.ts
+++ b/src/features/ai-chat/lib/buildAiContext.test.ts
@@ -132,6 +132,39 @@ describe('buildAiSavedUrlRecords', () => {
     expect(records[0]?.parentCategories).toStrictEqual(['Domain Match'])
   })
 
+  // 回帰 (Finding B): ストレージ形 (スキーム付き domainNames) と
+  // hostname 形 (group.domain) が混在しても normalizeDomainLookupKey で一致する。
+  it('domainNames (スキーム付き) と group.domain (hostname) の形式差を吸収して一致する', () => {
+    const records = buildAiSavedUrlRecords({
+      urlRecords: [
+        {
+          id: 'url-1',
+          url: 'https://react.dev/learn',
+          title: 'React Learn',
+          savedAt: 1,
+        },
+      ],
+      savedTabs: [
+        {
+          id: 'group-1',
+          domain: 'react.dev',
+          urlIds: ['url-1'],
+        },
+      ],
+      customProjects: [],
+      parentCategories: [
+        {
+          id: 'cat-1',
+          name: 'Mixed Form Match',
+          domains: [],
+          domainNames: ['https://react.dev'],
+        },
+      ],
+    })
+
+    expect(records[0]?.parentCategories).toStrictEqual(['Mixed Form Match'])
+  })
+
   it('project metadata と parent category が一致しない場合はカテゴリ配列を空にする', () => {
     const records = buildAiSavedUrlRecords({
       urlRecords: [

--- a/src/features/ai-chat/lib/buildAiContext.ts
+++ b/src/features/ai-chat/lib/buildAiContext.ts
@@ -5,7 +5,7 @@ import type {
   TabGroup,
   UrlRecord,
 } from '@/types/storage'
-import { hasNormalizedDomain, toHostname } from '@/utils/domain-normalize'
+import { tabGroupMatchesCategory, toHostname } from '@/utils/domain-normalize'
 import { isTimestampInLocalMonth } from '@/utils/localDateTime'
 
 const unique = (values: string[]): string[] => [...new Set(values)]
@@ -16,13 +16,6 @@ interface BuildAiSavedUrlRecordsInput {
   customProjects: CustomProject[]
   parentCategories: ParentCategory[]
 }
-
-const categoryMatchesGroup = (
-  category: ParentCategory,
-  group: TabGroup,
-): boolean =>
-  category.domains.includes(group.id) ||
-  hasNormalizedDomain(category.domainNames, group.domain)
 
 export const buildAiSavedUrlRecords = ({
   urlRecords,
@@ -53,7 +46,14 @@ export const buildAiSavedUrlRecords = ({
       const parentCategoryNames = unique(
         matchingGroups.flatMap((group) =>
           parentCategories.flatMap((category) =>
-            categoryMatchesGroup(category, group) ? [category.name] : [],
+            tabGroupMatchesCategory(
+              category.domains,
+              category.domainNames,
+              group.id,
+              group.domain,
+            )
+              ? [category.name]
+              : [],
           ),
         ),
       )

--- a/src/features/ai-chat/lib/buildAiContext.ts
+++ b/src/features/ai-chat/lib/buildAiContext.ts
@@ -5,6 +5,7 @@ import type {
   TabGroup,
   UrlRecord,
 } from '@/types/storage'
+import { normalizeDomainLookupKey } from '@/utils/domain-normalize'
 import { isTimestampInLocalMonth } from '@/utils/localDateTime'
 
 const getDomainFromUrl = (value: string): string => {
@@ -23,6 +24,16 @@ interface BuildAiSavedUrlRecordsInput {
   customProjects: CustomProject[]
   parentCategories: ParentCategory[]
 }
+
+const categoryMatchesGroup = (
+  category: ParentCategory,
+  group: TabGroup,
+): boolean =>
+  category.domains.includes(group.id) ||
+  category.domainNames.some(
+    (name) =>
+      normalizeDomainLookupKey(name) === normalizeDomainLookupKey(group.domain),
+  )
 
 export const buildAiSavedUrlRecords = ({
   urlRecords,
@@ -53,10 +64,7 @@ export const buildAiSavedUrlRecords = ({
       const parentCategoryNames = unique(
         matchingGroups.flatMap((group) =>
           parentCategories.flatMap((category) =>
-            category.domains.includes(group.id) ||
-            category.domainNames.includes(group.domain)
-              ? [category.name]
-              : [],
+            categoryMatchesGroup(category, group) ? [category.name] : [],
           ),
         ),
       )

--- a/src/features/ai-chat/lib/buildAiContext.ts
+++ b/src/features/ai-chat/lib/buildAiContext.ts
@@ -5,16 +5,8 @@ import type {
   TabGroup,
   UrlRecord,
 } from '@/types/storage'
-import { normalizeDomainLookupKey } from '@/utils/domain-normalize'
+import { hasNormalizedDomain, toHostname } from '@/utils/domain-normalize'
 import { isTimestampInLocalMonth } from '@/utils/localDateTime'
-
-const getDomainFromUrl = (value: string): string => {
-  try {
-    return new URL(value).hostname
-  } catch {
-    return value
-  }
-}
 
 const unique = (values: string[]): string[] => [...new Set(values)]
 
@@ -30,10 +22,7 @@ const categoryMatchesGroup = (
   group: TabGroup,
 ): boolean =>
   category.domains.includes(group.id) ||
-  category.domainNames.some(
-    (name) =>
-      normalizeDomainLookupKey(name) === normalizeDomainLookupKey(group.domain),
-  )
+  hasNormalizedDomain(category.domainNames, group.domain)
 
 export const buildAiSavedUrlRecords = ({
   urlRecords,
@@ -70,7 +59,7 @@ export const buildAiSavedUrlRecords = ({
       )
 
       return {
-        domain: getDomainFromUrl(record.url),
+        domain: toHostname(record.url),
         id: record.id,
         parentCategories: parentCategoryNames,
         projectCategories,

--- a/src/lib/storage/categories.test.ts
+++ b/src/lib/storage/categories.test.ts
@@ -271,3 +271,34 @@ describe('categories storage', () => {
     expect(state.domainCategoryMappings).toStrictEqual([])
   })
 })
+
+// 回帰 (CodeRabbit PR #626): updateDomainCategoryMapping は触った mapping の
+// domain を現在の (hostname) 値で上書きし、legacy スキーム付き形式を漸進移行する
+it('updateDomainCategoryMapping は既存マッピングの domain を渡した値へ書き換える', async () => {
+  const state: StorageState = {
+    domainCategoryMappings: [
+      {
+        categoryId: 'cat-old',
+        domain: 'https://legacy.example.com',
+      },
+    ],
+  }
+  globalThis.chrome = {
+    storage: {
+      local: createChromeStorageLocal(state),
+    },
+  } as unknown as typeof chrome
+
+  const { updateDomainCategoryMapping, getDomainCategoryMappings } =
+    await loadModule()
+
+  // 既存の schemeful マッピングを hostname で更新すると domain も hostname へ書き換わる
+  await updateDomainCategoryMapping('legacy.example.com', 'cat-new')
+
+  await expect(getDomainCategoryMappings()).resolves.toStrictEqual([
+    {
+      categoryId: 'cat-new',
+      domain: 'legacy.example.com',
+    },
+  ])
+})

--- a/src/lib/storage/categories.ts
+++ b/src/lib/storage/categories.ts
@@ -6,6 +6,7 @@ import type {
   ParentCategory,
   SubCategoryKeyword,
 } from '@/types/storage'
+import { normalizeDomainLookupKey } from '@/utils/domain-normalize'
 
 // 親カテゴリを取得する関数
 export const getParentCategories = async (): Promise<ParentCategory[]> => {
@@ -46,9 +47,13 @@ export const findCategoryByDomainName = async (
   domainName: string,
 ): Promise<ParentCategory | null> => {
   const categories = await getParentCategories()
+  const lookupKey = normalizeDomainLookupKey(domainName)
   return (
-    categories.find((category) => category.domainNames.includes(domainName)) ??
-    null
+    categories.find((category) =>
+      category.domainNames.some(
+        (name) => normalizeDomainLookupKey(name) === lookupKey,
+      ),
+    ) ?? null
   )
 } // ドメインのカテゴリ設定を取得する関数
 export const getDomainCategorySettings = async (): Promise<
@@ -73,8 +78,11 @@ export const updateDomainCategorySettings = async (
 ): Promise<void> => {
   const settings = await getDomainCategorySettings()
 
-  // 既存の設定を探す
-  const existingIndex = settings.findIndex((s) => s.domain === domain)
+  // 既存の設定を探す (ストレージ形式のスキーム付き/hostname 混在を吸収)
+  const domainKey = normalizeDomainLookupKey(domain)
+  const existingIndex = settings.findIndex(
+    (s) => normalizeDomainLookupKey(s.domain) === domainKey,
+  )
   if (existingIndex !== -1) {
     // 既存の設定を更新
     settings[existingIndex] = {
@@ -113,8 +121,11 @@ export const updateDomainCategoryMapping = async (
 ): Promise<void> => {
   const mappings = await getDomainCategoryMappings()
 
-  // 既存のマッピングを探す
-  const existingIndex = mappings.findIndex((m) => m.domain === domain)
+  // 既存のマッピングを探す (ストレージ形式のスキーム付き/hostname 混在を吸収)
+  const mappingDomainKey = normalizeDomainLookupKey(domain)
+  const existingIndex = mappings.findIndex(
+    (m) => normalizeDomainLookupKey(m.domain) === mappingDomainKey,
+  )
   if (categoryId === null) {
     // カテゴリIDがnullの場合は、マッピングを削除
     if (existingIndex !== -1) {

--- a/src/lib/storage/categories.ts
+++ b/src/lib/storage/categories.ts
@@ -130,8 +130,10 @@ export const updateDomainCategoryMapping = async (
     return
   }
   if (existingIndex !== -1) {
-    // 既存のマッピングを更新
-    mappings[existingIndex].categoryId = categoryId
+    // 既存のマッピングを更新。触ったレコードの domain を現在の (hostname) 値で
+    // 上書きし、legacy スキーム付き形式を漸進的に解消する
+    // (updateDomainCategorySettings と同じ挙動) (CodeRabbit PR #626 review)。
+    mappings[existingIndex] = { categoryId, domain }
   } else {
     // 新しいマッピングを追加
     mappings.push({

--- a/src/lib/storage/categories.ts
+++ b/src/lib/storage/categories.ts
@@ -6,7 +6,7 @@ import type {
   ParentCategory,
   SubCategoryKeyword,
 } from '@/types/storage'
-import { normalizeDomainLookupKey } from '@/utils/domain-normalize'
+import { domainMatches, hasNormalizedDomain } from '@/utils/domain-normalize'
 
 // 親カテゴリを取得する関数
 export const getParentCategories = async (): Promise<ParentCategory[]> => {
@@ -47,12 +47,9 @@ export const findCategoryByDomainName = async (
   domainName: string,
 ): Promise<ParentCategory | null> => {
   const categories = await getParentCategories()
-  const lookupKey = normalizeDomainLookupKey(domainName)
   return (
     categories.find((category) =>
-      category.domainNames.some(
-        (name) => normalizeDomainLookupKey(name) === lookupKey,
-      ),
+      hasNormalizedDomain(category.domainNames, domainName),
     ) ?? null
   )
 } // ドメインのカテゴリ設定を取得する関数
@@ -79,9 +76,8 @@ export const updateDomainCategorySettings = async (
   const settings = await getDomainCategorySettings()
 
   // 既存の設定を探す (ストレージ形式のスキーム付き/hostname 混在を吸収)
-  const domainKey = normalizeDomainLookupKey(domain)
-  const existingIndex = settings.findIndex(
-    (s) => normalizeDomainLookupKey(s.domain) === domainKey,
+  const existingIndex = settings.findIndex((s) =>
+    domainMatches(s.domain, domain),
   )
   if (existingIndex !== -1) {
     // 既存の設定を更新
@@ -122,9 +118,8 @@ export const updateDomainCategoryMapping = async (
   const mappings = await getDomainCategoryMappings()
 
   // 既存のマッピングを探す (ストレージ形式のスキーム付き/hostname 混在を吸収)
-  const mappingDomainKey = normalizeDomainLookupKey(domain)
-  const existingIndex = mappings.findIndex(
-    (m) => normalizeDomainLookupKey(m.domain) === mappingDomainKey,
+  const existingIndex = mappings.findIndex((m) =>
+    domainMatches(m.domain, domain),
   )
   if (categoryId === null) {
     // カテゴリIDがnullの場合は、マッピングを削除

--- a/src/lib/storage/migration.test.ts
+++ b/src/lib/storage/migration.test.ts
@@ -107,6 +107,15 @@ const loadModule = async () => {
   return import('./migration')
 }
 
+const setupChrome = (state: StorageState) => {
+  globalThis.chrome = {
+    storage: {
+      local: createChromeStorageLocal(state),
+    },
+  } as unknown as typeof chrome
+  return state
+}
+
 describe('migration storage facade', () => {
   beforeEach(() => {
     mocks.reset()
@@ -1266,15 +1275,6 @@ describe('migration storage facade', () => {
 })
 
 describe('migrateDomainStorageToHostname', () => {
-  const setupChrome = (state: StorageState) => {
-    globalThis.chrome = {
-      storage: {
-        local: createChromeStorageLocal(state),
-      },
-    } as unknown as typeof chrome
-    return state
-  }
-
   it('スキーム付き savedTabs.domain / parentCategories.domainNames を hostname へ正規化する', async () => {
     const state = setupChrome({
       domainCategoryMappings: [
@@ -1569,4 +1569,92 @@ it('書き込み直前に再読み込みし、並行保存で追加されたエ�
       }),
     ]),
   )
+})
+
+it('parentCategories.domainNames は正規化後に同ドメインの重複を除去する', async () => {
+  const state = setupChrome({
+    parentCategories: [
+      createCategory({
+        domainNames: [
+          'https://x.example.com',
+          'x.example.com',
+          'y.example.com',
+        ],
+        id: 'c-1',
+      }),
+    ],
+  })
+  const { migrateDomainStorageToHostname } = await loadModule()
+  await migrateDomainStorageToHostname()
+  expect(state.parentCategories?.[0]?.domainNames).toStrictEqual([
+    'x.example.com',
+    'y.example.com',
+  ])
+})
+
+it('domainCategorySettings の同一ドメイン重複エントリをマージし dead data を残さない', async () => {
+  const state = setupChrome({
+    domainCategorySettings: [
+      {
+        categoryKeywords: [{ categoryName: 'docs', keywords: ['Guide'] }],
+        domain: 'https://x.example.com',
+        subCategories: ['docs'],
+      },
+      {
+        categoryKeywords: [{ categoryName: 'news', keywords: ['Top'] }],
+        domain: 'x.example.com',
+        subCategories: ['news'],
+      },
+    ],
+  })
+  const { migrateDomainStorageToHostname } = await loadModule()
+  await migrateDomainStorageToHostname()
+  // 1 件にマージされ、subCategories / categoryKeywords が union される
+  expect(state.domainCategorySettings).toHaveLength(1)
+  expect(state.domainCategorySettings?.[0]?.domain).toBe('x.example.com')
+  expect(state.domainCategorySettings?.[0]?.subCategories).toStrictEqual([
+    'docs',
+    'news',
+  ])
+  expect(state.domainCategorySettings?.[0]?.categoryKeywords).toStrictEqual([
+    { categoryName: 'docs', keywords: ['Guide'] },
+    { categoryName: 'news', keywords: ['Top'] },
+  ])
+})
+
+it('domainCategoryMappings の同ドメイン競合は最初のエントリを保持し破棄を warn する', async () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  const state = setupChrome({
+    domainCategoryMappings: [
+      { categoryId: 'keep', domain: 'https://x.example.com' },
+      { categoryId: 'drop', domain: 'x.example.com' },
+    ],
+  })
+  const { migrateDomainStorageToHostname } = await loadModule()
+  await migrateDomainStorageToHostname()
+  expect(state.domainCategoryMappings).toStrictEqual([
+    { categoryId: 'keep', domain: 'x.example.com' },
+  ])
+  expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('drop'))
+  warnSpy.mockRestore()
+})
+
+it('savedTabs の同一正規化ドメイン重複はマージせず warn する (domains 参照を壊さない)', async () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  const state = setupChrome({
+    savedTabs: [
+      { domain: 'https://x.example.com', id: 'group-1', urlIds: ['u1'] },
+      { domain: 'x.example.com', id: 'group-2', urlIds: ['u2'] },
+    ],
+  })
+  const { migrateDomainStorageToHostname } = await loadModule()
+  await migrateDomainStorageToHostname()
+  // 両グループとも domain は hostname 化されるが、マージはせず件数を保持
+  expect(state.savedTabs).toHaveLength(2)
+  expect(state.savedTabs?.[0]?.domain).toBe('x.example.com')
+  expect(state.savedTabs?.[1]?.domain).toBe('x.example.com')
+  expect(warnSpy).toHaveBeenCalledWith(
+    expect.stringContaining('重複するドメイングループ'),
+  )
+  warnSpy.mockRestore()
 })

--- a/src/lib/storage/migration.test.ts
+++ b/src/lib/storage/migration.test.ts
@@ -1465,3 +1465,108 @@ describe('migrateDomainStorageToHostname', () => {
     expect(state.domainHostnameMigrationCompleted).toBe(true)
   })
 })
+
+it('完了フラグはデータ書き込みとは別の set 呼び出しで書く (部分失敗でフラグだけ立つのを防ぐ)', async () => {
+  const state: StorageState = {
+    savedTabs: [{ domain: 'https://docs.example.com', id: 'group-1' }],
+  }
+  const setCalls: Record<string, unknown>[] = []
+  globalThis.chrome = {
+    storage: {
+      local: {
+        get: vi.fn(async (keys?: string | string[]) => {
+          if (keys === 'domainHostnameMigrationCompleted') {
+            return { domainHostnameMigrationCompleted: false }
+          }
+          if (keys === 'savedTabs') {
+            return { savedTabs: state.savedTabs }
+          }
+          return {}
+        }),
+        set: vi.fn(async (value: Record<string, unknown>) => {
+          setCalls.push(value)
+          Object.assign(state, value)
+        }),
+      },
+    },
+  } as unknown as typeof chrome
+
+  const { migrateDomainStorageToHostname } = await loadModule()
+  await migrateDomainStorageToHostname()
+
+  // データ (savedTabs) と完了フラグは別の set 呼び出し
+  const dataSets = setCalls.filter((c) => 'savedTabs' in c)
+  const flagSets = setCalls.filter(
+    (c) => 'domainHostnameMigrationCompleted' in c,
+  )
+  expect(dataSets).toHaveLength(1)
+  expect(flagSets).toHaveLength(1)
+  // フラグの set はデータを含まない (分離)
+  const flagSet = flagSets[0]
+  if (!flagSet) {
+    throw new Error('完了フラグの set が記録されていません')
+  }
+  expect(Object.keys(flagSet)).toStrictEqual([
+    'domainHostnameMigrationCompleted',
+  ])
+})
+
+it('書き込み直前に再読み込みし、並行保存で追加されたエントリを巻き戻さない', async () => {
+  // savedTabs の書き込みと同時に並行保存が parentCategories を更新したと想定し、
+  // savedTabs の set 副作用で parentCategories へ新規カテゴリを追加する。
+  // migration は parentCategories を savedTabs 書き込み「後」に再読み込みするため、
+  // 並行追加を取り込んで巻き戻さない。
+  const state: StorageState = {
+    parentCategories: [
+      createCategory({
+        domainNames: ['https://legacy.example.com'],
+        id: 'category-1',
+        name: 'Legacy',
+      }),
+    ],
+    savedTabs: [{ domain: 'https://docs.example.com', id: 'group-1' }],
+  }
+  globalThis.chrome = {
+    storage: {
+      local: {
+        get: vi.fn(async (keys?: string | string[]) => {
+          if (keys === 'domainHostnameMigrationCompleted') {
+            return { domainHostnameMigrationCompleted: false }
+          }
+          return { [keys as string]: state[keys as keyof StorageState] }
+        }),
+        set: vi.fn(async (value: Record<string, unknown>) => {
+          Object.assign(state, value)
+          // savedTabs 書き込みと同時に並行保存が parentCategories へ新規カテゴリを追加
+          if ('savedTabs' in value) {
+            state.parentCategories = [
+              ...(state.parentCategories ?? []),
+              createCategory({
+                domainNames: ['concurrent.example.com'],
+                id: 'category-concurrent',
+                name: 'Concurrent',
+              }),
+            ]
+          }
+        }),
+      },
+    },
+  } as unknown as typeof chrome
+
+  const { migrateDomainStorageToHostname } = await loadModule()
+  await migrateDomainStorageToHostname()
+
+  // 並行保存で追加されたカテゴリも hostname 化されて保持される (巻き戻らない)
+  expect(state.parentCategories).toStrictEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        domainNames: ['legacy.example.com'],
+        id: 'category-1',
+      }),
+      expect.objectContaining({
+        domainNames: ['concurrent.example.com'],
+        id: 'category-concurrent',
+      }),
+    ]),
+  )
+})

--- a/src/lib/storage/migration.test.ts
+++ b/src/lib/storage/migration.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import type {
+  DomainCategorySettings,
   DomainParentCategoryMapping,
   ParentCategory,
   TabGroup,
@@ -66,6 +67,8 @@ vi.mock('./urls', () => ({
 
 interface StorageState {
   domainCategoryMappings?: DomainParentCategoryMapping[]
+  domainCategorySettings?: DomainCategorySettings[]
+  domainHostnameMigrationCompleted?: boolean
   parentCategories?: ParentCategory[]
   savedTabs?: TabGroup[]
 }
@@ -145,7 +148,7 @@ describe('migration storage facade', () => {
 
     expect(getTabDomain('not a url')).toBeNull()
     expect(getTabDomain('https://docs.example.com/path')).toBe(
-      'https://docs.example.com',
+      'docs.example.com',
     )
     expect(
       getTabsWithDomains([
@@ -163,7 +166,7 @@ describe('migration storage facade', () => {
       ] as chrome.tabs.Tab[]),
     ).toStrictEqual([
       {
-        domain: 'https://docs.example.com',
+        domain: 'docs.example.com',
         tab: {
           title: 'Docs',
           url: 'https://docs.example.com/path',
@@ -185,7 +188,7 @@ describe('migration storage facade', () => {
           url: 'https://docs.example.com/path',
         },
       ] as chrome.tabs.Tab[]),
-    ]).toStrictEqual(['https://docs.example.com'])
+    ]).toStrictEqual(['docs.example.com'])
     expect(errorSpy).toHaveBeenCalledTimes(2)
   })
 
@@ -368,7 +371,7 @@ describe('migration storage facade', () => {
       // eslint-disable-line
       ...group,
       categoryKeywords:
-        group.domain === 'https://mapped.example.com'
+        group.domain === 'mapped.example.com'
           ? [
               {
                 categoryName: 'docs',
@@ -420,20 +423,20 @@ describe('migration storage facade', () => {
             keywords: ['Guide'],
           },
         ],
-        domain: 'https://mapped.example.com',
+        domain: 'mapped.example.com',
         id: 'uuid-1',
         parentCategoryId: 'category-1',
         urlIds: ['id:https://mapped.example.com/guide'],
       }),
       expect.objectContaining({
-        domain: 'https://named.example.com',
+        domain: 'named.example.com',
         id: 'uuid-2',
         parentCategoryId: 'category-1',
         urlIds: ['id:https://named.example.com/page'],
       }),
     ])
     expect(mocks.updateDomainCategoryMapping).toHaveBeenCalledWith(
-      'https://mapped.example.com',
+      'mapped.example.com',
       'category-1',
     )
     expect(mocks.autoCategorizeTabs).toHaveBeenCalledWith('uuid-1')
@@ -580,7 +583,7 @@ describe('migration storage facade', () => {
     expect(state.savedTabs).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          domain: 'https://new.example.com',
+          domain: 'new.example.com',
           id: 'uuid-1',
         }),
       ]),
@@ -903,7 +906,7 @@ describe('migration storage facade', () => {
           urlIds: ['id:https://existing-no-ids.example.com/path'],
         }),
         expect.objectContaining({
-          domain: 'https://new-unmatched.example.com',
+          domain: 'new-unmatched.example.com',
           id: 'uuid-1',
         }),
       ]),
@@ -938,7 +941,7 @@ describe('migration storage facade', () => {
     ])
     expect(state.savedTabs).toStrictEqual([
       expect.objectContaining({
-        domain: 'https://untitled.example.com',
+        domain: 'untitled.example.com',
         urlIds: ['id:https://untitled.example.com/path'],
       }),
     ])
@@ -982,14 +985,14 @@ describe('migration storage facade', () => {
     expect(state.savedTabs).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          domain: 'https://same.example.com',
+          domain: 'same.example.com',
           urlIds: [
             'id:https://same.example.com/a',
             'id:https://same.example.com/b',
           ],
         }),
         expect.objectContaining({
-          domain: 'https://other.example.com',
+          domain: 'other.example.com',
           urlIds: ['id:https://other.example.com/c'],
         }),
       ]),
@@ -1048,8 +1051,8 @@ describe('migration storage facade', () => {
       expect.objectContaining({
         domainNames: [
           'https://seed.example.com',
-          'https://docs.example.com',
-          'https://issues.example.com',
+          'docs.example.com',
+          'issues.example.com',
         ],
         domains: ['uuid-1', 'uuid-2'],
         id: 'category-1',
@@ -1057,11 +1060,11 @@ describe('migration storage facade', () => {
     ])
     expect(state.savedTabs).toStrictEqual([
       expect.objectContaining({
-        domain: 'https://docs.example.com',
+        domain: 'docs.example.com',
         parentCategoryId: 'category-1',
       }),
       expect.objectContaining({
-        domain: 'https://issues.example.com',
+        domain: 'issues.example.com',
         parentCategoryId: 'category-1',
       }),
     ])
@@ -1207,13 +1210,13 @@ describe('migration storage facade', () => {
 
     expect(state.savedTabs).toStrictEqual([
       expect.objectContaining({
-        domain: 'https://mapped-invalid.example.com',
+        domain: 'mapped-invalid.example.com',
         parentCategoryId: 'category-invalid',
       }),
     ])
     expect(mocks.saveParentCategories).toHaveBeenCalledWith([
       expect.objectContaining({
-        domainNames: ['https://mapped-invalid.example.com'],
+        domainNames: ['mapped-invalid.example.com'],
         domains: ['uuid-1'],
         id: 'category-invalid',
       }),
@@ -1259,5 +1262,206 @@ describe('migration storage facade', () => {
       }),
     ])
     expect(mocks.autoCategorizeTabs).toHaveBeenCalledWith('docs-group')
+  })
+})
+
+describe('migrateDomainStorageToHostname', () => {
+  const setupChrome = (state: StorageState) => {
+    globalThis.chrome = {
+      storage: {
+        local: createChromeStorageLocal(state),
+      },
+    } as unknown as typeof chrome
+    return state
+  }
+
+  it('スキーム付き savedTabs.domain / parentCategories.domainNames を hostname へ正規化する', async () => {
+    const state = setupChrome({
+      domainCategoryMappings: [
+        { categoryId: 'category-1', domain: 'https://mapped.example.com' },
+      ],
+      domainCategorySettings: [
+        {
+          categoryKeywords: [],
+          domain: 'https://settings.example.com',
+          subCategories: ['docs'],
+        },
+      ],
+      parentCategories: [
+        createCategory({
+          domainNames: ['https://existing.example.com', 'plain.org'],
+          id: 'category-1',
+          name: 'Docs',
+        }),
+      ],
+      savedTabs: [
+        {
+          domain: 'https://docs.example.com',
+          id: 'group-1',
+          urlIds: ['url-1'],
+        },
+      ],
+    })
+
+    const { migrateDomainStorageToHostname } = await loadModule()
+    await migrateDomainStorageToHostname()
+
+    expect(state.savedTabs).toStrictEqual([
+      {
+        domain: 'docs.example.com',
+        id: 'group-1',
+        urlIds: ['url-1'],
+      },
+    ])
+    expect(state.parentCategories).toStrictEqual([
+      expect.objectContaining({
+        domainNames: ['existing.example.com', 'plain.org'],
+        id: 'category-1',
+      }),
+    ])
+    expect(state.domainCategorySettings).toStrictEqual([
+      {
+        categoryKeywords: [],
+        domain: 'settings.example.com',
+        subCategories: ['docs'],
+      },
+    ])
+    expect(state.domainCategoryMappings).toStrictEqual([
+      { categoryId: 'category-1', domain: 'mapped.example.com' },
+    ])
+    expect(state.domainHostnameMigrationCompleted).toBe(true)
+  })
+
+  it('大文字混在のスキーム付きドメインも小文字 hostname へ正規化する', async () => {
+    const state = setupChrome({
+      savedTabs: [{ domain: 'https://Example.COM', id: 'group-1' }],
+    })
+    const { migrateDomainStorageToHostname } = await loadModule()
+    await migrateDomainStorageToHostname()
+    expect(state.savedTabs?.[0]?.domain).toBe('example.com')
+  })
+
+  it('既に hostname のデータは変化せず (冪等)', async () => {
+    const state = setupChrome({
+      parentCategories: [
+        createCategory({ domainNames: ['example.com'], id: 'c-1' }),
+      ],
+      savedTabs: [{ domain: 'example.com', id: 'group-1' }],
+    })
+    const { migrateDomainStorageToHostname } = await loadModule()
+    await migrateDomainStorageToHostname()
+    expect(state.savedTabs?.[0]?.domain).toBe('example.com')
+    expect(state.parentCategories?.[0]?.domainNames).toStrictEqual([
+      'example.com',
+    ])
+    expect(state.domainHostnameMigrationCompleted).toBe(true)
+  })
+
+  it('完了フラグ済みのときはストレージへ書き込まない (再実行抑制)', async () => {
+    const setSpy = vi.fn(async () => {})
+    globalThis.chrome = {
+      storage: {
+        local: {
+          get: vi.fn(async (keys?: string | string[]) => {
+            if (keys === 'domainHostnameMigrationCompleted') {
+              return { domainHostnameMigrationCompleted: true }
+            }
+            return {}
+          }),
+          set: setSpy,
+        },
+      },
+    } as unknown as typeof chrome
+
+    const { migrateDomainStorageToHostname } = await loadModule()
+    await migrateDomainStorageToHostname()
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+
+  it('同一セッション内の2回目はメモリフラグで書き込まない', async () => {
+    const state = setupChrome({
+      savedTabs: [{ domain: 'https://docs.example.com', id: 'group-1' }],
+    })
+    const { migrateDomainStorageToHostname } = await loadModule()
+    await migrateDomainStorageToHostname()
+    expect(state.savedTabs?.[0]?.domain).toBe('docs.example.com')
+    // 2回目はモジュールスコープのメモリフラグで早期リターンし set が呼ばれない
+    let secondSetCalled = false
+    globalThis.chrome.storage.local.set = vi.fn(async () => {
+      secondSetCalled = true
+    })
+    await migrateDomainStorageToHostname()
+    expect(secondSetCalled).toBe(false)
+  })
+
+  it('正規化結果が無効な値 (host-less / パース失敗) は元の値を保持してデータを悪化させない', async () => {
+    const state = setupChrome({
+      parentCategories: [
+        createCategory({
+          domainNames: ['https://', '://invalid', 'good.example.com'],
+          id: 'c-1',
+        }),
+      ],
+      savedTabs: [{ domain: 'https://', id: 'group-1' }],
+    })
+    const { migrateDomainStorageToHostname } = await loadModule()
+    await migrateDomainStorageToHostname()
+    // host-less / パース失敗は元の値を保持 (データを悪化させない)
+    expect(state.savedTabs?.[0]?.domain).toBe('https://')
+    expect(state.parentCategories?.[0]?.domainNames).toStrictEqual([
+      'https://',
+      '://invalid',
+      'good.example.com',
+    ])
+  })
+
+  it('ドメイン以外のフィールド (urlIds / subCategories / categoryKeywords) を保持する', async () => {
+    const state = setupChrome({
+      domainCategorySettings: [
+        {
+          categoryKeywords: [{ categoryName: 'docs', keywords: ['Guide'] }],
+          domain: 'https://docs.example.com',
+          subCategories: ['docs', 'guide'],
+        },
+      ],
+      savedTabs: [
+        {
+          domain: 'https://docs.example.com',
+          id: 'group-1',
+          parentCategoryId: 'category-1',
+          subCategories: ['docs'],
+          urlIds: ['url-1', 'url-2'],
+          urlSubCategories: { 'url-1': 'docs' },
+        },
+      ],
+    })
+    const { migrateDomainStorageToHostname } = await loadModule()
+    await migrateDomainStorageToHostname()
+    expect(state.savedTabs).toStrictEqual([
+      {
+        domain: 'docs.example.com',
+        id: 'group-1',
+        parentCategoryId: 'category-1',
+        subCategories: ['docs'],
+        urlIds: ['url-1', 'url-2'],
+        urlSubCategories: { 'url-1': 'docs' },
+      },
+    ])
+    expect(state.domainCategorySettings).toStrictEqual([
+      {
+        categoryKeywords: [{ categoryName: 'docs', keywords: ['Guide'] }],
+        domain: 'docs.example.com',
+        subCategories: ['docs', 'guide'],
+      },
+    ])
+  })
+
+  it('存在しないキーは書き換えず、完了フラグだけ書き込む', async () => {
+    const state = setupChrome({})
+    const { migrateDomainStorageToHostname } = await loadModule()
+    await migrateDomainStorageToHostname()
+    expect(state.savedTabs).toBeUndefined()
+    expect(state.parentCategories).toBeUndefined()
+    expect(state.domainHostnameMigrationCompleted).toBe(true)
   })
 })

--- a/src/lib/storage/migration.test.ts
+++ b/src/lib/storage/migration.test.ts
@@ -1658,3 +1658,45 @@ it('savedTabs の同一正規化ドメイン重複はマージせず warn する
   )
   warnSpy.mockRestore()
 })
+
+// 回帰 (CodeRabbit PR #626): 正規化後に hostname が取れない (空 key) エントリ同士は
+// 空文字列キーでマージ・消失せず、別々に保持される。
+it('空に正規化されるエントリ同士はマージ/破棄せず別々に保持する', async () => {
+  const state = setupChrome({
+    domainCategoryMappings: [
+      { categoryId: 'cat-a', domain: '' },
+      { categoryId: 'cat-b', domain: '   ' },
+    ],
+    domainCategorySettings: [
+      {
+        categoryKeywords: [],
+        domain: '',
+        subCategories: ['a'],
+      },
+      {
+        categoryKeywords: [],
+        domain: '   ',
+        subCategories: ['b'],
+      },
+    ],
+  })
+  const { migrateDomainStorageToHostname } = await loadModule()
+  await migrateDomainStorageToHostname()
+  // 両エントリとも空 key なので別々に保持 (マージ/破棄されない)
+  expect(state.domainCategorySettings).toStrictEqual([
+    {
+      categoryKeywords: [],
+      domain: '',
+      subCategories: ['a'],
+    },
+    {
+      categoryKeywords: [],
+      domain: '   ',
+      subCategories: ['b'],
+    },
+  ])
+  expect(state.domainCategoryMappings).toStrictEqual([
+    { categoryId: 'cat-a', domain: '' },
+    { categoryId: 'cat-b', domain: '   ' },
+  ])
+})

--- a/src/lib/storage/migration.ts
+++ b/src/lib/storage/migration.ts
@@ -6,6 +6,7 @@ import type {
   DomainCategorySettings,
   DomainParentCategoryMapping,
   ParentCategory,
+  SubCategoryKeyword,
   TabGroup,
 } from '@/types/storage'
 import {
@@ -585,6 +586,126 @@ const toHostnameOrKeep = (value: string): string => {
   return key.length > 0 && !key.includes('://') ? key : value
 }
 
+const mergeCategoryKeywords = (
+  a: readonly SubCategoryKeyword[] | undefined,
+  b: readonly SubCategoryKeyword[] | undefined,
+): SubCategoryKeyword[] => {
+  const byName = new Map<string, Set<string>>()
+  for (const ck of [...(a ?? []), ...(b ?? [])]) {
+    let set = byName.get(ck.categoryName)
+    if (!set) {
+      set = new Set()
+      byName.set(ck.categoryName, set)
+    }
+    for (const keyword of ck.keywords) {
+      set.add(keyword)
+    }
+  }
+  return [...byName.entries()].map(([categoryName, keywords]) => ({
+    categoryName,
+    keywords: [...keywords],
+  }))
+}
+
+/**
+ * `domainCategorySettings` を正規化ドメインキーでマージする。
+ * 同一ドメインの重複エントリ (legacy スキーム付き + hostname 等) は
+ * subCategories / categoryKeywords を union して 1 件に統合し、
+ * `.find()` で 2 件目が到達不能の dead data になるのを防ぐ
+ * (CodeRabbit PR #626 review)。
+ */
+const mergeDomainCategorySettings = (
+  settings: DomainCategorySettings[],
+): DomainCategorySettings[] => {
+  const byKey = new Map<string, DomainCategorySettings>()
+  let merged = 0
+  for (const entry of settings) {
+    const normalized = { ...entry, domain: toHostnameOrKeep(entry.domain) }
+    const key = normalizeDomainLookupKey(normalized.domain)
+    const existing = byKey.get(key)
+    if (!existing) {
+      byKey.set(key, normalized)
+      continue
+    }
+    merged += 1
+    existing.subCategories = Array.from(
+      new Set([...existing.subCategories, ...normalized.subCategories]),
+    )
+    existing.categoryKeywords = mergeCategoryKeywords(
+      existing.categoryKeywords,
+      normalized.categoryKeywords,
+    )
+  }
+  if (merged > 0) {
+    console.log(
+      `domainCategorySettings の hostname 正規化で ${merged} 件の重複エントリをマージしました`,
+    )
+  }
+  return [...byKey.values()]
+}
+
+/**
+ * `domainCategoryMappings` を正規化ドメインキーで dedup する。
+ * 同一ドメインの競合 (異なる categoryId) は最初のエントリを保持し、
+ * 競合を warn して silent に破棄しない (CodeRabbit PR #626 review)。
+ */
+const dedupDomainCategoryMappings = (
+  mappings: DomainParentCategoryMapping[],
+): DomainParentCategoryMapping[] => {
+  const byKey = new Map<string, DomainParentCategoryMapping>()
+  let conflicts = 0
+  for (const mapping of mappings) {
+    const normalized = { ...mapping, domain: toHostnameOrKeep(mapping.domain) }
+    const key = normalizeDomainLookupKey(normalized.domain)
+    const existing = byKey.get(key)
+    if (!existing) {
+      byKey.set(key, normalized)
+      continue
+    }
+    if (existing.categoryId !== normalized.categoryId) {
+      conflicts += 1
+      console.warn(
+        `domainCategoryMappings でドメイン ${key} の競合を検出: categoryId ${normalized.categoryId} を破棄し ${existing.categoryId} を保持します`,
+      )
+    }
+  }
+  if (conflicts > 0) {
+    console.log(
+      `domainCategoryMappings の hostname 正規化で ${conflicts} 件の競合を解決しました`,
+    )
+  }
+  return [...byKey.values()]
+}
+
+/**
+ * `savedTabs` を正規化し、同一正規化ドメインの重複グループを検出して warn する。
+ * マージは parentCategories[].domains (TabGroupId 参照) との整合を壊さないよう
+ * 行わず、重複を検出した場合のみ警告してユーザー判断に委ねる
+ * (CodeRabbit PR #626 review)。
+ */
+const normalizeSavedTabsAndWarnDuplicates = (
+  groups: TabGroup[],
+): TabGroup[] => {
+  const seen = new Set<string>()
+  let duplicates = 0
+  const normalized = groups.map((group) => {
+    const domain = toHostnameOrKeep(group.domain)
+    const key = normalizeDomainLookupKey(domain)
+    if (key !== '' && seen.has(key)) {
+      duplicates += 1
+    } else {
+      seen.add(key)
+    }
+    return { ...group, domain }
+  })
+  if (duplicates > 0) {
+    console.warn(
+      `savedTabs に hostname 正規化後も重複するドメイングループが ${duplicates} 件検出されました。手動で統合してください`,
+    )
+  }
+  return normalized
+}
+
 const runDomainHostnameMigration = async (): Promise<void> => {
   if (domainHostnameMigrationDone) {
     return
@@ -602,10 +723,7 @@ const runDomainHostnameMigration = async (): Promise<void> => {
     }>('savedTabs')
     if (Array.isArray(savedTabsRes.savedTabs)) {
       await chrome.storage.local.set({
-        savedTabs: savedTabsRes.savedTabs.map((group) => ({
-          ...group,
-          domain: toHostnameOrKeep(group.domain),
-        })),
+        savedTabs: normalizeSavedTabsAndWarnDuplicates(savedTabsRes.savedTabs),
       })
     }
     const parentCategoriesRes = await chrome.storage.local.get<{
@@ -617,7 +735,10 @@ const runDomainHostnameMigration = async (): Promise<void> => {
           Array.isArray(category.domainNames)
             ? {
                 ...category,
-                domainNames: category.domainNames.map(toHostnameOrKeep),
+                // 正規化後に同ドメインになる重複を除去 (CodeRabbit PR #626 review)
+                domainNames: Array.from(
+                  new Set(category.domainNames.map(toHostnameOrKeep)),
+                ),
               }
             : category,
         ),
@@ -628,8 +749,8 @@ const runDomainHostnameMigration = async (): Promise<void> => {
     }>('domainCategorySettings')
     if (Array.isArray(settingsRes.domainCategorySettings)) {
       await chrome.storage.local.set({
-        domainCategorySettings: settingsRes.domainCategorySettings.map(
-          (entry) => ({ ...entry, domain: toHostnameOrKeep(entry.domain) }),
+        domainCategorySettings: mergeDomainCategorySettings(
+          settingsRes.domainCategorySettings,
         ),
       })
     }
@@ -638,11 +759,8 @@ const runDomainHostnameMigration = async (): Promise<void> => {
     }>('domainCategoryMappings')
     if (Array.isArray(mappingsRes.domainCategoryMappings)) {
       await chrome.storage.local.set({
-        domainCategoryMappings: mappingsRes.domainCategoryMappings.map(
-          (mapping) => ({
-            ...mapping,
-            domain: toHostnameOrKeep(mapping.domain),
-          }),
+        domainCategoryMappings: dedupDomainCategoryMappings(
+          mappingsRes.domainCategoryMappings,
         ),
       })
     }

--- a/src/lib/storage/migration.ts
+++ b/src/lib/storage/migration.ts
@@ -8,7 +8,11 @@ import type {
   ParentCategory,
   TabGroup,
 } from '@/types/storage'
-import { normalizeDomainLookupKey } from '@/utils/domain-normalize'
+import {
+  domainMatches,
+  hasNormalizedDomain,
+  normalizeDomainLookupKey,
+} from '@/utils/domain-normalize'
 
 import {
   getDomainCategoryMappings,
@@ -46,29 +50,23 @@ const assignDomainToCategory = async (
       if (!tabGroup || category.domains.includes(domainId)) {
         return category
       }
-      const tabGroupDomainKey = normalizeDomainLookupKey(tabGroup.domain)
       return {
         ...category,
         domains: [...category.domains, domainId],
-        domainNames: domainNames.some(
-          (name) => normalizeDomainLookupKey(name) === tabGroupDomainKey,
-        )
+        domainNames: hasNormalizedDomain(domainNames, tabGroup.domain)
           ? domainNames
           : [...domainNames, tabGroup.domain],
       }
     }
     // 他のカテゴリからは削除（重複を避けるため）
-    const otherTabGroupDomainKey = tabGroup
-      ? normalizeDomainLookupKey(tabGroup.domain)
-      : null
     return {
       ...category,
       domains: category.domains.filter((id) => id !== domainId),
-      domainNames: domainNames.filter((domain) =>
-        otherTabGroupDomainKey !== null
-          ? normalizeDomainLookupKey(domain) !== otherTabGroupDomainKey
-          : true,
-      ),
+      domainNames: tabGroup
+        ? domainNames.filter(
+            (domain) => !domainMatches(domain, tabGroup.domain),
+          )
+        : domainNames,
     }
   })
   await saveParentCategories(updatedCategories)
@@ -237,9 +235,8 @@ const findCategoryByDomainMapping = (
   domainCategoryMappings: DomainParentCategoryMapping[],
   parentCategories: ParentCategory[],
 ): DomainCategoryMatch | null => {
-  const domainKey = normalizeDomainLookupKey(domain)
-  const domainMapping = domainCategoryMappings.find(
-    (m) => normalizeDomainLookupKey(m.domain) === domainKey,
+  const domainMapping = domainCategoryMappings.find((m) =>
+    domainMatches(m.domain, domain),
   )
   if (!domainMapping) {
     return null
@@ -262,7 +259,6 @@ const findCategoryByDomainNames = (
   domain: string,
   parentCategories: ParentCategory[],
 ): DomainCategoryMatch | null => {
-  const domainKey = normalizeDomainLookupKey(domain)
   for (const category of parentCategories) {
     if (!Array.isArray(category.domainNames)) {
       console.log(`カテゴリ「${category.name}」のdomainNamesが不正です`)
@@ -272,11 +268,7 @@ const findCategoryByDomainNames = (
       domainCount: category.domainNames.length,
       searchDomain: redactUrlForLog(domain),
     })
-    if (
-      category.domainNames.some(
-        (d) => normalizeDomainLookupKey(d) === domainKey,
-      )
-    ) {
+    if (hasNormalizedDomain(category.domainNames, domain)) {
       console.log(
         `ドメイン ${redactUrlForLog(domain)} は親カテゴリ「${category.name}」のdomainNamesに見つかりました`,
       )
@@ -310,12 +302,9 @@ const assignGroupToCategory = async (
   const domainNames = Array.isArray(match.category.domainNames)
     ? match.category.domainNames
     : []
-  const assignDomainKey = normalizeDomainLookupKey(domain)
   const updatedCategory: ParentCategory = {
     ...match.category,
-    domainNames: domainNames.some(
-      (name) => normalizeDomainLookupKey(name) === assignDomainKey,
-    )
+    domainNames: hasNormalizedDomain(domainNames, domain)
       ? domainNames
       : [...domainNames, domain],
     domains: [...match.category.domains, group.id],
@@ -596,7 +585,7 @@ const toHostnameOrKeep = (value: string): string => {
   return key.length > 0 && !key.includes('://') ? key : value
 }
 
-const migrateDomainStorageToHostname = async (): Promise<void> => {
+const runDomainHostnameMigration = async (): Promise<void> => {
   if (domainHostnameMigrationDone) {
     return
   }
@@ -605,56 +594,61 @@ const migrateDomainStorageToHostname = async (): Promise<void> => {
     return
   }
   try {
-    const [savedTabsRes, parentCategoriesRes, settingsRes, mappingsRes] =
-      await Promise.all([
-        chrome.storage.local.get<{ savedTabs?: TabGroup[] }>('savedTabs'),
-        chrome.storage.local.get<{ parentCategories?: ParentCategory[] }>(
-          'parentCategories',
+    // 各キーを「直前再読み込み → 正規化 → 書き込み」で順次処理し、並行保存
+    // (context-menu save 等) との競合で新しいデータを巻き戻さない。
+    // 正規化は冪等なので並行書き込み混入でも安全。
+    const savedTabsRes = await chrome.storage.local.get<{
+      savedTabs?: TabGroup[]
+    }>('savedTabs')
+    if (Array.isArray(savedTabsRes.savedTabs)) {
+      await chrome.storage.local.set({
+        savedTabs: savedTabsRes.savedTabs.map((group) => ({
+          ...group,
+          domain: toHostnameOrKeep(group.domain),
+        })),
+      })
+    }
+    const parentCategoriesRes = await chrome.storage.local.get<{
+      parentCategories?: ParentCategory[]
+    }>('parentCategories')
+    if (Array.isArray(parentCategoriesRes.parentCategories)) {
+      await chrome.storage.local.set({
+        parentCategories: parentCategoriesRes.parentCategories.map((category) =>
+          Array.isArray(category.domainNames)
+            ? {
+                ...category,
+                domainNames: category.domainNames.map(toHostnameOrKeep),
+              }
+            : category,
         ),
-        chrome.storage.local.get<{
-          domainCategorySettings?: DomainCategorySettings[]
-        }>('domainCategorySettings'),
-        chrome.storage.local.get<{
-          domainCategoryMappings?: DomainParentCategoryMapping[]
-        }>('domainCategoryMappings'),
-      ])
-
-    const patch: Record<string, unknown> = {
-      domainHostnameMigrationCompleted: true,
+      })
     }
-    const savedTabs = savedTabsRes.savedTabs
-    if (Array.isArray(savedTabs)) {
-      patch.savedTabs = savedTabs.map((group) => ({
-        ...group,
-        domain: toHostnameOrKeep(group.domain),
-      }))
+    const settingsRes = await chrome.storage.local.get<{
+      domainCategorySettings?: DomainCategorySettings[]
+    }>('domainCategorySettings')
+    if (Array.isArray(settingsRes.domainCategorySettings)) {
+      await chrome.storage.local.set({
+        domainCategorySettings: settingsRes.domainCategorySettings.map(
+          (entry) => ({ ...entry, domain: toHostnameOrKeep(entry.domain) }),
+        ),
+      })
     }
-    const parentCategories = parentCategoriesRes.parentCategories
-    if (Array.isArray(parentCategories)) {
-      patch.parentCategories = parentCategories.map((category) =>
-        Array.isArray(category.domainNames)
-          ? {
-              ...category,
-              domainNames: category.domainNames.map(toHostnameOrKeep),
-            }
-          : category,
-      )
+    const mappingsRes = await chrome.storage.local.get<{
+      domainCategoryMappings?: DomainParentCategoryMapping[]
+    }>('domainCategoryMappings')
+    if (Array.isArray(mappingsRes.domainCategoryMappings)) {
+      await chrome.storage.local.set({
+        domainCategoryMappings: mappingsRes.domainCategoryMappings.map(
+          (mapping) => ({
+            ...mapping,
+            domain: toHostnameOrKeep(mapping.domain),
+          }),
+        ),
+      })
     }
-    const settings = settingsRes.domainCategorySettings
-    if (Array.isArray(settings)) {
-      patch.domainCategorySettings = settings.map((entry) => ({
-        ...entry,
-        domain: toHostnameOrKeep(entry.domain),
-      }))
-    }
-    const mappings = mappingsRes.domainCategoryMappings
-    if (Array.isArray(mappings)) {
-      patch.domainCategoryMappings = mappings.map((mapping) => ({
-        ...mapping,
-        domain: toHostnameOrKeep(mapping.domain),
-      }))
-    }
-    await chrome.storage.local.set(patch)
+    // データ正規化後に完了フラグを分離して書く。フラグ書き込み前に並行保存が
+    // 入ってもデータは既に hostname 化済みなので安全。
+    await chrome.storage.local.set({ domainHostnameMigrationCompleted: true })
     domainHostnameMigrationDone = true
     console.log(
       'ドメインストレージの hostname 化マイグレーションが完了しました',
@@ -662,6 +656,29 @@ const migrateDomainStorageToHostname = async (): Promise<void> => {
   } catch (error) {
     console.error('ドメイン hostname 化マイグレーションエラー:', error)
     throw error
+  }
+}
+
+const migrateDomainStorageToHostname = async (): Promise<void> => {
+  // 複数コンテキスト (saved-tabs page 複数起動等) で同時実行されないよう
+  // Web Locks で直列化する。ロック取得不可環境 (古いブラウザ) はそのまま実行。
+  // 複数コンテキスト (saved-tabs page 複数起動等) での同時実行を Web Locks で直列化する。
+  // Locks API は型上は常に存在する扱いだが実行環境によっては未実装なので、
+  // 部分型へ安全にキャストして feature-detect する。
+  const locksApi = (
+    navigator as {
+      locks?: {
+        request?: (name: string, callback: () => Promise<void>) => Promise<void>
+      }
+    }
+  ).locks
+  if (locksApi?.request) {
+    await locksApi.request(
+      'domainHostnameMigration',
+      runDomainHostnameMigration,
+    )
+  } else {
+    await runDomainHostnameMigration()
   }
 }
 

--- a/src/lib/storage/migration.ts
+++ b/src/lib/storage/migration.ts
@@ -617,11 +617,15 @@ const mergeCategoryKeywords = (
 const mergeDomainCategorySettings = (
   settings: DomainCategorySettings[],
 ): DomainCategorySettings[] => {
-  const byKey = new Map<string, DomainCategorySettings>()
+  const byKey = new Map<string | symbol, DomainCategorySettings>()
   let merged = 0
   for (const entry of settings) {
     const normalized = { ...entry, domain: toHostnameOrKeep(entry.domain) }
     const key = normalizeDomainLookupKey(normalized.domain)
+    if (key === '') {
+      byKey.set(Symbol('unkeyed-domain-category-setting'), normalized)
+      continue
+    }
     const existing = byKey.get(key)
     if (!existing) {
       byKey.set(key, normalized)
@@ -652,11 +656,15 @@ const mergeDomainCategorySettings = (
 const dedupDomainCategoryMappings = (
   mappings: DomainParentCategoryMapping[],
 ): DomainParentCategoryMapping[] => {
-  const byKey = new Map<string, DomainParentCategoryMapping>()
+  const byKey = new Map<string | symbol, DomainParentCategoryMapping>()
   let conflicts = 0
   for (const mapping of mappings) {
     const normalized = { ...mapping, domain: toHostnameOrKeep(mapping.domain) }
     const key = normalizeDomainLookupKey(normalized.domain)
+    if (key === '') {
+      byKey.set(Symbol('unkeyed-domain-category-mapping'), normalized)
+      continue
+    }
     const existing = byKey.get(key)
     if (!existing) {
       byKey.set(key, normalized)

--- a/src/lib/storage/migration.ts
+++ b/src/lib/storage/migration.ts
@@ -3,10 +3,12 @@ import { v4 as uuidv4 } from 'uuid'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
 import { filterItemsBySavableUrl } from '@/lib/url-filter'
 import type {
+  DomainCategorySettings,
   DomainParentCategoryMapping,
   ParentCategory,
   TabGroup,
 } from '@/types/storage'
+import { normalizeDomainLookupKey } from '@/utils/domain-normalize'
 
 import {
   getDomainCategoryMappings,
@@ -44,20 +46,28 @@ const assignDomainToCategory = async (
       if (!tabGroup || category.domains.includes(domainId)) {
         return category
       }
+      const tabGroupDomainKey = normalizeDomainLookupKey(tabGroup.domain)
       return {
         ...category,
         domains: [...category.domains, domainId],
-        domainNames: domainNames.includes(tabGroup.domain)
+        domainNames: domainNames.some(
+          (name) => normalizeDomainLookupKey(name) === tabGroupDomainKey,
+        )
           ? domainNames
           : [...domainNames, tabGroup.domain],
       }
     }
     // 他のカテゴリからは削除（重複を避けるため）
+    const otherTabGroupDomainKey = tabGroup
+      ? normalizeDomainLookupKey(tabGroup.domain)
+      : null
     return {
       ...category,
       domains: category.domains.filter((id) => id !== domainId),
       domainNames: domainNames.filter((domain) =>
-        tabGroup ? domain !== tabGroup.domain : true,
+        otherTabGroupDomainKey !== null
+          ? normalizeDomainLookupKey(domain) !== otherTabGroupDomainKey
+          : true,
       ),
     }
   })
@@ -175,17 +185,6 @@ const buildGroupedTabsByDomain = (
     groupedTabs.set(group.domain, group)
   }
   return groupedTabs
-}
-const normalizeDomainLookupKey = (domain: string): string => {
-  const trimmedDomain = domain.trim().toLowerCase()
-  if (!trimmedDomain.includes('://')) {
-    return trimmedDomain
-  }
-  try {
-    return new URL(trimmedDomain).hostname
-  } catch {
-    return trimmedDomain
-  }
 }
 const buildGroupedTabsLookup = (
   savedTabs: TabGroup[],
@@ -311,9 +310,12 @@ const assignGroupToCategory = async (
   const domainNames = Array.isArray(match.category.domainNames)
     ? match.category.domainNames
     : []
+  const assignDomainKey = normalizeDomainLookupKey(domain)
   const updatedCategory: ParentCategory = {
     ...match.category,
-    domainNames: domainNames.includes(domain)
+    domainNames: domainNames.some(
+      (name) => normalizeDomainLookupKey(name) === assignDomainKey,
+    )
       ? domainNames
       : [...domainNames, domain],
     domains: [...match.category.domains, group.id],
@@ -364,10 +366,14 @@ const dedupeGroupsById = (groupArray: TabGroup[]): TabGroup[] => {
     return true
   })
 }
+// hostname 形 (`example.com`) を返す。host が取れない URL は保存対象外として null を返す。
+// 既有のスキーム付きデータとの混在は normalizeDomainLookupKey 経由の比較で吸収し、
+// 保存データは別途 migrateDomainStorageToHostname で hostname へ統一する。
 const getTabDomain = (tabUrl: string): string | null => {
   try {
     const parsedUrl = new URL(tabUrl)
-    return `${parsedUrl.protocol}//${parsedUrl.hostname}`
+    const hostname = parsedUrl.hostname
+    return hostname.length > 0 ? hostname : null
   } catch (error) {
     console.error(`Invalid URL: ${redactUrlForLog(tabUrl)}`, error)
     return null
@@ -397,7 +403,8 @@ const getUniqueDomainsFromTabs = (tabs: chrome.tabs.Tab[]): Set<string> =>
     tabs.flatMap((tab) => {
       try {
         const url = new URL(tab.url ?? '')
-        return [`${url.protocol}//${url.hostname}`]
+        const hostname = url.hostname
+        return hostname.length > 0 ? [hostname] : []
       } catch {
         return []
       }
@@ -557,12 +564,114 @@ const getTabGroupById = async (groupId: string): Promise<TabGroup | null> => {
   return savedTabs.find((group: TabGroup) => group.id === groupId) ?? null
 }
 
+/** モジュールスコープのメモ化フラグ (ページセッション中の重複ストレージアクセスを防ぐ) */
+let domainHostnameMigrationDone = false
+
+const isDomainHostnameMigrationCompleted = async (): Promise<boolean> => {
+  const { domainHostnameMigrationCompleted } = await chrome.storage.local.get(
+    'domainHostnameMigrationCompleted',
+  )
+  return Boolean(domainHostnameMigrationCompleted)
+}
+
+/**
+ * スキーム付きドメイン (`https://example.com`) を hostname (`example.com`) へ
+ * 正規化し、既存ユーザーのストレージを hostname 形式へ冪等に統一する。
+ *
+ * 対象: `savedTabs[].domain` / `parentCategories[].domainNames` /
+ * `domainCategorySettings[].domain` / `domainCategoryMappings[].domain`。
+ * 書き込み経路 (getTabDomain / getDomainFromUrl) は hostname を返すよう
+ * 修正済みのため、本 migration で既有のスキーム付きデータを hostname 化して
+ * 形式を一本化する (Finding B の根本治療)。
+ *
+ * 安全性:
+ * - 冪等: `normalizeDomainLookupKey` は hostname→hostname で変化なし。完了
+ *   フラグ `domainHostnameMigrationCompleted` で再実行を抑制する。
+ * - 保守: 正規化結果が有効な hostname (空でなく `://` を含まない) なら採用、
+ *   不正値なら元の値を保持してデータを悪化させない。
+ * - 対象キーが配列でない場合は書き換えを行わない (存在しないキーは触らない)。
+ */
+const toHostnameOrKeep = (value: string): string => {
+  const key = normalizeDomainLookupKey(value)
+  return key.length > 0 && !key.includes('://') ? key : value
+}
+
+const migrateDomainStorageToHostname = async (): Promise<void> => {
+  if (domainHostnameMigrationDone) {
+    return
+  }
+  if (await isDomainHostnameMigrationCompleted()) {
+    domainHostnameMigrationDone = true
+    return
+  }
+  try {
+    const [savedTabsRes, parentCategoriesRes, settingsRes, mappingsRes] =
+      await Promise.all([
+        chrome.storage.local.get<{ savedTabs?: TabGroup[] }>('savedTabs'),
+        chrome.storage.local.get<{ parentCategories?: ParentCategory[] }>(
+          'parentCategories',
+        ),
+        chrome.storage.local.get<{
+          domainCategorySettings?: DomainCategorySettings[]
+        }>('domainCategorySettings'),
+        chrome.storage.local.get<{
+          domainCategoryMappings?: DomainParentCategoryMapping[]
+        }>('domainCategoryMappings'),
+      ])
+
+    const patch: Record<string, unknown> = {
+      domainHostnameMigrationCompleted: true,
+    }
+    const savedTabs = savedTabsRes.savedTabs
+    if (Array.isArray(savedTabs)) {
+      patch.savedTabs = savedTabs.map((group) => ({
+        ...group,
+        domain: toHostnameOrKeep(group.domain),
+      }))
+    }
+    const parentCategories = parentCategoriesRes.parentCategories
+    if (Array.isArray(parentCategories)) {
+      patch.parentCategories = parentCategories.map((category) =>
+        Array.isArray(category.domainNames)
+          ? {
+              ...category,
+              domainNames: category.domainNames.map(toHostnameOrKeep),
+            }
+          : category,
+      )
+    }
+    const settings = settingsRes.domainCategorySettings
+    if (Array.isArray(settings)) {
+      patch.domainCategorySettings = settings.map((entry) => ({
+        ...entry,
+        domain: toHostnameOrKeep(entry.domain),
+      }))
+    }
+    const mappings = mappingsRes.domainCategoryMappings
+    if (Array.isArray(mappings)) {
+      patch.domainCategoryMappings = mappings.map((mapping) => ({
+        ...mapping,
+        domain: toHostnameOrKeep(mapping.domain),
+      }))
+    }
+    await chrome.storage.local.set(patch)
+    domainHostnameMigrationDone = true
+    console.log(
+      'ドメインストレージの hostname 化マイグレーションが完了しました',
+    )
+  } catch (error) {
+    console.error('ドメイン hostname 化マイグレーションエラー:', error)
+    throw error
+  }
+}
+
 export { migrateToUrlsStorage } from './url-migration'
 export {
   assignDomainToCategory,
   getTabDomain,
   getTabsWithDomains,
   getUniqueDomainsFromTabs,
+  migrateDomainStorageToHostname,
   migrateParentCategoriesToDomainNames,
   saveTabs,
   saveTabsWithAutoCategory,

--- a/src/lib/storage/project-keywords.ts
+++ b/src/lib/storage/project-keywords.ts
@@ -1,4 +1,5 @@
 import type { CustomProject, ProjectKeywordSettings } from '@/types/storage'
+import { toHostname } from '@/utils/domain-normalize'
 
 interface SavedTabKeywordMatchTarget {
   title: string
@@ -38,14 +39,6 @@ const normalizeKeywordArray = (keywords: string[] | undefined): string[] => {
   return normalizedKeywords
 }
 
-const getDomainFromUrl = (url: string): string => {
-  try {
-    return new URL(url).hostname
-  } catch {
-    return ''
-  }
-}
-
 const includesKeyword = (target: string, keywords: string[]): boolean => {
   const normalizedTarget = target.toLowerCase()
   return keywords.some((keyword) =>
@@ -69,10 +62,7 @@ const projectMatchesSavedTab = (
   return (
     includesKeyword(savedTab.title, projectKeywords.titleKeywords) ||
     includesKeyword(savedTab.url, projectKeywords.urlKeywords) ||
-    includesKeyword(
-      getDomainFromUrl(savedTab.url),
-      projectKeywords.domainKeywords,
-    )
+    includesKeyword(toHostname(savedTab.url), projectKeywords.domainKeywords)
   )
 }
 

--- a/src/lib/storage/projects.test.ts
+++ b/src/lib/storage/projects.test.ts
@@ -1397,6 +1397,30 @@ describe('projects storage', () => {
     ])
   })
 
+  // 回帰 (CodeRabbit PR #626): host が取れない URL はドメインモードの
+  // savedTabs へ空ドメイングループを作らず、他の不正 URL を誤マージしない。
+  it('addUrlToCustomProject は host が取れない URL をドメインモードへ追加しない', async () => {
+    const state: StorageState = {
+      customProjects: [createProject({ id: 'target' })],
+      savedTabs: [],
+      urls: [],
+    }
+    globalThis.chrome = {
+      storage: {
+        local: createChromeStorageLocal(state),
+      },
+    } as unknown as typeof chrome
+
+    const { addUrlToCustomProject } = await loadModule()
+
+    await addUrlToCustomProject('target', 'not a url', 'Broken')
+
+    // カスタムプロジェクトには URL が保持されるが、ドメインモードの
+    // savedTabs には空ドメイングループが作られない
+    expect(state.customProjects?.[0]?.urlIds).toEqual(['uuid-1'])
+    expect(state.savedTabs).toEqual([])
+  })
+
   it('addUrlToCustomProject は既存ドメイングループの URL IDs を補完する', async () => {
     const target = createProject({ id: 'target' })
     delete target.urlIds

--- a/src/lib/storage/projects.test.ts
+++ b/src/lib/storage/projects.test.ts
@@ -522,7 +522,7 @@ describe('projects storage', () => {
 
     expect(state.savedTabs).toEqual([
       expect.objectContaining({
-        domain: 'https://docs.example.com',
+        domain: 'docs.example.com',
         urlIds: expect.arrayContaining([
           state.urls?.[0]?.id,
           state.urls?.[1]?.id,
@@ -578,7 +578,7 @@ describe('projects storage', () => {
 
     expect(state.savedTabs).toEqual([
       expect.objectContaining({
-        domain: 'https://docs.example.com',
+        domain: 'docs.example.com',
         urlIds: expect.arrayContaining([
           state.urls?.find(
             (record) => record.url === 'https://docs.example.com/a',
@@ -589,7 +589,7 @@ describe('projects storage', () => {
         ]),
       }),
       expect.objectContaining({
-        domain: 'https://news.example.com',
+        domain: 'news.example.com',
         urlIds: [
           state.urls?.find(
             (record) => record.url === 'https://news.example.com/x',
@@ -656,11 +656,11 @@ describe('projects storage', () => {
     )
     expect(state.savedTabs).toStrictEqual([
       expect.objectContaining({
-        domain: 'https://docs.example.com',
+        domain: 'docs.example.com',
         urlIds: [state.urls?.[0]?.id],
       }),
       expect.objectContaining({
-        domain: 'https://issues.example.com',
+        domain: 'issues.example.com',
         urlIds: [state.urls?.[1]?.id],
       }),
     ])
@@ -1389,7 +1389,7 @@ describe('projects storage', () => {
 
     expect(state.savedTabs).toEqual([
       {
-        domain: 'https://docs.example.com',
+        domain: 'docs.example.com',
         id: 'uuid-2',
         savedAt: 1000,
         urlIds: ['uuid-1'],

--- a/src/lib/storage/projects.ts
+++ b/src/lib/storage/projects.ts
@@ -7,6 +7,7 @@ import type {
   TabGroup,
   UrlRecord,
 } from '@/types/storage'
+import { normalizeDomainLookupKey } from '@/utils/domain-normalize'
 
 import {
   findMatchingProjectIdForSavedTab,
@@ -383,9 +384,12 @@ const setProjectUrlMetadata = (
     notes,
   }
 }
+// hostname 形 (`example.com`) を返す。既有のスキーム付きデータとの混在は
+// normalizeDomainLookupKey 経由の比較で吸収し、保存データは別途
+// migrateDomainStorageToHostname で hostname へ統一する。
 const getDomainFromUrl = (url: string): string => {
   const urlObj = new URL(url)
-  return `${urlObj.protocol}//${urlObj.hostname}`
+  return urlObj.hostname
 }
 const ensureUrlIdInGroup = (group: TabGroup, urlId: string): TabGroup => {
   group.urlIds ??= []
@@ -410,8 +414,9 @@ const addUrlIdToDomainMode = async (
       savedTabs?: TabGroup[]
     }>('savedTabs')
     const domain = getDomainFromUrl(url)
+    const domainKey = normalizeDomainLookupKey(domain)
     const domainGroup = savedTabs.find(
-      (group: TabGroup) => group.domain === domain,
+      (group: TabGroup) => normalizeDomainLookupKey(group.domain) === domainKey,
     )
     if (domainGroup) {
       ensureUrlIdInGroup(domainGroup, urlId)

--- a/src/lib/storage/projects.ts
+++ b/src/lib/storage/projects.ts
@@ -407,6 +407,11 @@ const addUrlIdToDomainMode = async (
       savedTabs?: TabGroup[]
     }>('savedTabs')
     const domain = toHostname(url)
+    // host が取れない URL はドメイングループを作らず、空ドメイン bucket に
+    // 他の不正 URL を誤マージしない (CodeRabbit PR #626 review)。
+    if (domain === '') {
+      return
+    }
     const domainGroup = savedTabs.find((group: TabGroup) =>
       domainMatches(group.domain, domain),
     )

--- a/src/lib/storage/projects.ts
+++ b/src/lib/storage/projects.ts
@@ -7,7 +7,7 @@ import type {
   TabGroup,
   UrlRecord,
 } from '@/types/storage'
-import { normalizeDomainLookupKey } from '@/utils/domain-normalize'
+import { domainMatches, toHostname } from '@/utils/domain-normalize'
 
 import {
   findMatchingProjectIdForSavedTab,
@@ -384,13 +384,6 @@ const setProjectUrlMetadata = (
     notes,
   }
 }
-// hostname 形 (`example.com`) を返す。既有のスキーム付きデータとの混在は
-// normalizeDomainLookupKey 経由の比較で吸収し、保存データは別途
-// migrateDomainStorageToHostname で hostname へ統一する。
-const getDomainFromUrl = (url: string): string => {
-  const urlObj = new URL(url)
-  return urlObj.hostname
-}
 const ensureUrlIdInGroup = (group: TabGroup, urlId: string): TabGroup => {
   group.urlIds ??= []
   if (!group.urlIds.includes(urlId)) {
@@ -413,10 +406,9 @@ const addUrlIdToDomainMode = async (
     const { savedTabs = [] } = await chrome.storage.local.get<{
       savedTabs?: TabGroup[]
     }>('savedTabs')
-    const domain = getDomainFromUrl(url)
-    const domainKey = normalizeDomainLookupKey(domain)
-    const domainGroup = savedTabs.find(
-      (group: TabGroup) => normalizeDomainLookupKey(group.domain) === domainKey,
+    const domain = toHostname(url)
+    const domainGroup = savedTabs.find((group: TabGroup) =>
+      domainMatches(group.domain, domain),
     )
     if (domainGroup) {
       ensureUrlIdInGroup(domainGroup, urlId)

--- a/src/lib/storage/tabs.test.ts
+++ b/src/lib/storage/tabs.test.ts
@@ -530,6 +530,67 @@ describe('tabs storage', () => {
     ])
   })
 
+  // 回帰 (Finding B): 既存ドメイン設定がスキーム付き (legacy) でグループが
+  // hostname 形のとき、normalizeDomainLookupKey 比較で既存設定を見つけて更新し、
+  // 重複設定を作らない。
+  it('スキーム付き既存ドメイン設定と hostname グループを形式差で吸収して重複設定を作らない', async () => {
+    const state = {
+      savedTabs: [
+        {
+          categoryKeywords: [
+            {
+              categoryName: 'docs',
+              keywords: ['old'],
+            },
+          ],
+          domain: 'example.com',
+          id: 'group-1',
+          subCategories: ['docs'],
+        } as TabGroup,
+      ],
+    }
+    globalThis.chrome = {
+      storage: {
+        local: {
+          get: vi.fn(async () => state),
+
+          set: vi.fn(async (value: typeof state) => {
+            Object.assign(state, value)
+          }),
+        },
+      },
+    } as unknown as typeof chrome
+    // 既存設定は legacy のスキーム付き形式
+    const settings = [
+      {
+        categoryKeywords: [
+          {
+            categoryName: 'docs',
+            keywords: ['old'],
+          },
+        ],
+        domain: 'https://example.com',
+        subCategories: ['docs'],
+      },
+    ]
+    mocks.getDomainCategorySettingsMock.mockResolvedValue(settings)
+
+    const { setCategoryKeywords } = await loadTabsModule()
+
+    await setCategoryKeywords('group-1', 'docs', ['new'])
+
+    // 既存設定 (schemeful domain) が hostname グループと一致して更新され、
+    // 重複エントリが追加されない
+    expect(settings).toHaveLength(1)
+    expect(settings[0].domain).toBe('https://example.com')
+    expect(settings[0].categoryKeywords).toStrictEqual([
+      {
+        categoryName: 'docs',
+        keywords: ['new'],
+      },
+    ])
+  })
+
   it('setUrlSubCategory は既存 urlSubCategories に上書き保存する', async () => {
     const state = {
       savedTabs: [

--- a/src/lib/storage/tabs.test.ts
+++ b/src/lib/storage/tabs.test.ts
@@ -580,9 +580,9 @@ describe('tabs storage', () => {
     await setCategoryKeywords('group-1', 'docs', ['new'])
 
     // 既存設定 (schemeful domain) が hostname グループと一致して更新され、
-    // 重複エントリが追加されない
+    // 触ったレコードの domain は hostname へ漸進移行される (CodeRabbit PR #626 review)
     expect(settings).toHaveLength(1)
-    expect(settings[0].domain).toBe('https://example.com')
+    expect(settings[0].domain).toBe('example.com')
     expect(settings[0].categoryKeywords).toStrictEqual([
       {
         categoryName: 'docs',

--- a/src/lib/storage/tabs.ts
+++ b/src/lib/storage/tabs.ts
@@ -1,6 +1,6 @@
 import { redactUrlForLog } from '@/lib/logging/redact-url'
 import type { SubCategoryKeyword, TabGroup, UrlRecord } from '@/types/storage'
-import { normalizeDomainLookupKey } from '@/utils/domain-normalize'
+import { domainMatches } from '@/utils/domain-normalize'
 
 import {
   getDomainCategorySettings,
@@ -188,9 +188,8 @@ const addSubCategoryToGroup = async (
 
   // ドメイン別設定にも保存して永続化
   const settings = await getDomainCategorySettings()
-  const groupDomainKey = normalizeDomainLookupKey(group.domain)
-  const existingSetting = settings.find(
-    (s) => normalizeDomainLookupKey(s.domain) === groupDomainKey,
+  const existingSetting = settings.find((s) =>
+    domainMatches(s.domain, group.domain),
   )
   if (existingSetting) {
     // 既存の設定がある場合は更新
@@ -305,9 +304,8 @@ const setCategoryKeywords = async (
 
   // ドメイン別設定にも保存して永続化
   const settings = await getDomainCategorySettings()
-  const groupDomainKey = normalizeDomainLookupKey(group.domain)
-  const existingSetting = settings.find(
-    (s) => normalizeDomainLookupKey(s.domain) === groupDomainKey,
+  const existingSetting = settings.find((s) =>
+    domainMatches(s.domain, group.domain),
   )
   if (existingSetting) {
     // 既存の設定がある場合は更新
@@ -502,9 +500,8 @@ const restoreCategorySettings = async (
   tabGroup: TabGroup,
 ): Promise<TabGroup> => {
   const settings = await getDomainCategorySettings()
-  const tabGroupDomainKey = normalizeDomainLookupKey(tabGroup.domain)
-  const domainSettings = settings.find(
-    (s) => normalizeDomainLookupKey(s.domain) === tabGroupDomainKey,
+  const domainSettings = settings.find((s) =>
+    domainMatches(s.domain, tabGroup.domain),
   )
   if (domainSettings) {
     return {

--- a/src/lib/storage/tabs.ts
+++ b/src/lib/storage/tabs.ts
@@ -192,9 +192,16 @@ const addSubCategoryToGroup = async (
     domainMatches(s.domain, group.domain),
   )
   if (existingSetting) {
-    // 既存の設定がある場合は更新
-    if (!existingSetting.subCategories.includes(subCategoryName)) {
+    // 既存の設定がある場合は更新。触ったレコードの domain を現在の
+    // group.domain (hostname) へ書き換えて legacy スキーム付き形式を漸進的に
+    // 解消する (CodeRabbit PR #626 review)。
+    const domainChanged = existingSetting.domain !== group.domain
+    existingSetting.domain = group.domain
+    const subAdded = !existingSetting.subCategories.includes(subCategoryName)
+    if (subAdded) {
       existingSetting.subCategories.push(subCategoryName)
+    }
+    if (domainChanged || subAdded) {
       await saveDomainCategorySettings(settings)
     }
   } else {
@@ -308,7 +315,8 @@ const setCategoryKeywords = async (
     domainMatches(s.domain, group.domain),
   )
   if (existingSetting) {
-    // 既存の設定がある場合は更新
+    // 既存の設定がある場合は更新。触ったレコードの domain を hostname へ書き換え
+    existingSetting.domain = group.domain
     const keywordIndex = existingSetting.categoryKeywords.findIndex(
       (ck) => ck.categoryName === categoryName,
     )

--- a/src/lib/storage/tabs.ts
+++ b/src/lib/storage/tabs.ts
@@ -1,5 +1,6 @@
 import { redactUrlForLog } from '@/lib/logging/redact-url'
 import type { SubCategoryKeyword, TabGroup, UrlRecord } from '@/types/storage'
+import { normalizeDomainLookupKey } from '@/utils/domain-normalize'
 
 import {
   getDomainCategorySettings,
@@ -187,7 +188,10 @@ const addSubCategoryToGroup = async (
 
   // ドメイン別設定にも保存して永続化
   const settings = await getDomainCategorySettings()
-  const existingSetting = settings.find((s) => s.domain === group.domain)
+  const groupDomainKey = normalizeDomainLookupKey(group.domain)
+  const existingSetting = settings.find(
+    (s) => normalizeDomainLookupKey(s.domain) === groupDomainKey,
+  )
   if (existingSetting) {
     // 既存の設定がある場合は更新
     if (!existingSetting.subCategories.includes(subCategoryName)) {
@@ -301,7 +305,10 @@ const setCategoryKeywords = async (
 
   // ドメイン別設定にも保存して永続化
   const settings = await getDomainCategorySettings()
-  const existingSetting = settings.find((s) => s.domain === group.domain)
+  const groupDomainKey = normalizeDomainLookupKey(group.domain)
+  const existingSetting = settings.find(
+    (s) => normalizeDomainLookupKey(s.domain) === groupDomainKey,
+  )
   if (existingSetting) {
     // 既存の設定がある場合は更新
     const keywordIndex = existingSetting.categoryKeywords.findIndex(
@@ -495,7 +502,10 @@ const restoreCategorySettings = async (
   tabGroup: TabGroup,
 ): Promise<TabGroup> => {
   const settings = await getDomainCategorySettings()
-  const domainSettings = settings.find((s) => s.domain === tabGroup.domain)
+  const tabGroupDomainKey = normalizeDomainLookupKey(tabGroup.domain)
+  const domainSettings = settings.find(
+    (s) => normalizeDomainLookupKey(s.domain) === tabGroupDomainKey,
+  )
   if (domainSettings) {
     return {
       ...tabGroup,

--- a/src/utils/domain-normalize.test.ts
+++ b/src/utils/domain-normalize.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizeDomainLookupKey } from './domain-normalize'
+import {
+  domainMatches,
+  hasNormalizedDomain,
+  normalizeDomainLookupKey,
+  toHostname,
+} from './domain-normalize'
 
 describe('normalizeDomainLookupKey', () => {
   it('スキームなし hostname は trim + 小文字化して返す', () => {
@@ -29,5 +34,53 @@ describe('normalizeDomainLookupKey', () => {
 
   it('空文字列は空文字列を返す', () => {
     expect(normalizeDomainLookupKey('')).toBe('')
+  })
+})
+
+describe('toHostname', () => {
+  it('URL から hostname を取り出す', () => {
+    expect(toHostname('https://Example.com/path')).toBe('example.com')
+  })
+
+  it('http スキームも hostname を取り出す', () => {
+    expect(toHostname('http://other.example.com')).toBe('other.example.com')
+  })
+
+  it('不正 URL は空文字列を返し例外を投げない', () => {
+    expect(toHostname('not a url')).toBe('')
+  })
+
+  it('空文字列は空文字列を返す', () => {
+    expect(toHostname('')).toBe('')
+  })
+})
+
+describe('domainMatches', () => {
+  it('スキーム付きと hostname は等価とみなす', () => {
+    expect(domainMatches('https://example.com', 'example.com')).toBe(true)
+  })
+
+  it('大文字小文字差を吸収する', () => {
+    expect(domainMatches('Example.COM', 'example.com')).toBe(true)
+  })
+
+  it('異なるドメインは false', () => {
+    expect(domainMatches('a.example.com', 'b.example.com')).toBe(false)
+  })
+})
+
+describe('hasNormalizedDomain', () => {
+  it('配列中に等価なドメインがあれば true', () => {
+    expect(
+      hasNormalizedDomain(['https://example.com', 'other.com'], 'example.com'),
+    ).toBe(true)
+  })
+
+  it('一致がなければ false', () => {
+    expect(hasNormalizedDomain(['other.com'], 'example.com')).toBe(false)
+  })
+
+  it('空配列は false', () => {
+    expect(hasNormalizedDomain([], 'example.com')).toBe(false)
   })
 })

--- a/src/utils/domain-normalize.test.ts
+++ b/src/utils/domain-normalize.test.ts
@@ -4,6 +4,7 @@ import {
   domainMatches,
   hasNormalizedDomain,
   normalizeDomainLookupKey,
+  tabGroupMatchesCategory,
   toHostname,
 } from './domain-normalize'
 
@@ -82,5 +83,51 @@ describe('hasNormalizedDomain', () => {
 
   it('空配列は false', () => {
     expect(hasNormalizedDomain([], 'example.com')).toBe(false)
+  })
+})
+
+describe('domainMatches 空衝突ガード (CodeRabbit PR #626)', () => {
+  it('両辺空文字列は一致とみなさない (空ドメイン同士の誤マージを防ぐ)', () => {
+    expect(domainMatches('', '')).toBe(false)
+  })
+
+  it('片方が空の場合は一致しない', () => {
+    expect(domainMatches('example.com', '')).toBe(false)
+    expect(domainMatches('', 'example.com')).toBe(false)
+  })
+
+  it('異なる不正 URL は一致しない (異なる lookup key)', () => {
+    expect(domainMatches('not a url', 'also not a url')).toBe(false)
+  })
+
+  it('同一の不正 URL (非空 key) は従来どおり一致する', () => {
+    // normalizeDomainLookupKey は scheme 無し文字列をそのまま返すため、
+    // 同一の不正文字列は非空 key で一致する (空ガードの対象外)。
+    expect(domainMatches('not-a-url', 'not-a-url')).toBe(true)
+  })
+})
+
+describe('tabGroupMatchesCategory', () => {
+  it('domains に tabGroupId が含まれれば true', () => {
+    expect(
+      tabGroupMatchesCategory(['group-1'], ['other.com'], 'group-1', 'x.com'),
+    ).toBe(true)
+  })
+
+  it('domainNames に等価なドメインがあれば true', () => {
+    expect(
+      tabGroupMatchesCategory(
+        [],
+        ['https://example.com'],
+        'group-1',
+        'example.com',
+      ),
+    ).toBe(true)
+  })
+
+  it('どちらにも一致しなければ false', () => {
+    expect(
+      tabGroupMatchesCategory(['group-2'], ['other.com'], 'group-1', 'x.com'),
+    ).toBe(false)
   })
 })

--- a/src/utils/domain-normalize.test.ts
+++ b/src/utils/domain-normalize.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeDomainLookupKey } from './domain-normalize'
+
+describe('normalizeDomainLookupKey', () => {
+  it('スキームなし hostname は trim + 小文字化して返す', () => {
+    expect(normalizeDomainLookupKey('  Example.COM  ')).toBe('example.com')
+  })
+
+  it('https スキーム付きは hostname を取り出す', () => {
+    expect(normalizeDomainLookupKey('https://Example.com/path')).toBe(
+      'example.com',
+    )
+  })
+
+  it('http スキーム付きは hostname を取り出す', () => {
+    expect(normalizeDomainLookupKey('http://other.com')).toBe('other.com')
+  })
+
+  it('スキーム付きと hostname は同じ key になる (形式差を吸収)', () => {
+    expect(normalizeDomainLookupKey('https://example.com')).toBe(
+      normalizeDomainLookupKey('example.com'),
+    )
+  })
+
+  it('パース失敗形 (://invalid) は trim+小文字化をそのまま返す', () => {
+    expect(normalizeDomainLookupKey('://Invalid')).toBe('://invalid')
+  })
+
+  it('空文字列は空文字列を返す', () => {
+    expect(normalizeDomainLookupKey('')).toBe('')
+  })
+})

--- a/src/utils/domain-normalize.ts
+++ b/src/utils/domain-normalize.ts
@@ -1,0 +1,33 @@
+/**
+ * ドメイン文字列の正規化と等価比較のための共通ヘルパー。
+ *
+ * このリポジトリのストレージ層では、`TabGroup.domain` や
+ * `ParentCategory.domainNames` が `https://example.com` のように
+ * スキーム付きで書き込まれる既有データと、hostname 形 (`example.com`)
+ * の新規データが混在し得る。直接 `===` / `.includes()` で比較すると
+ * 形式差で silent にミスマッチし、分類やマッチングが壊れる。
+ *
+ * そのためドメイン値の比較は本ヘルパー経由で lookup key 化して行う
+ * (Finding B の防御)。`lib/storage/migration` の旧 private 版を
+ * 共通化したもの (Finding C の重複解消)。
+ */
+
+/**
+ * ドメイン値を比較用の lookup key へ正規化する。
+ * trim + 小文字化し、スキーム付きなら hostname を取り出す。
+ * パース失敗時は入力の trim+小文字化をそのまま返す。
+ *
+ * `https://example.com` / `example.com` / `Example.COM` は
+ * すべて `example.com` になるため、形式差を吸収して同ドメインを一致させる。
+ */
+export const normalizeDomainLookupKey = (domain: string): string => {
+  const trimmed = domain.trim().toLowerCase()
+  if (!trimmed.includes('://')) {
+    return trimmed
+  }
+  try {
+    return new URL(trimmed).hostname
+  } catch {
+    return trimmed
+  }
+}

--- a/src/utils/domain-normalize.ts
+++ b/src/utils/domain-normalize.ts
@@ -31,3 +31,39 @@ export const normalizeDomainLookupKey = (domain: string): string => {
     return trimmed
   }
 }
+
+/**
+ * URL 文字列から hostname を取り出す。不正 URL は例外を投げず空文字列を返す。
+ *
+ * `src/lib/storage/projects.ts` / `src/lib/storage/project-keywords.ts` /
+ * `src/features/ai-chat/lib/buildAiContext.ts` に分散していた
+ * `getDomainFromUrl` を一本化したもの (CodeRabbit PR #626 review)。
+ * 呼び出し側は savable URL で呼ぶ前提だが、不正値でも投げず `''` を返すことで
+ * 保存/マッチングの silent 失敗を防ぐ。
+ */
+export const toHostname = (url: string): string => {
+  try {
+    return new URL(url).hostname
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * 2 つのドメイン値が正規化後に等価かを判定する。
+ * `normalizeDomainLookupKey` 経由でスキーム付き/hostname の形式差を吸収する。
+ */
+export const domainMatches = (a: string, b: string): boolean =>
+  normalizeDomainLookupKey(a) === normalizeDomainLookupKey(b)
+
+/**
+ * `domainNames` 配列の中に `domain` と等価なエントリが存在するかを判定する。
+ * `normalizeDomainLookupKey` 比較を 1 箇所に集約し、`assignDomainToCategory` /
+ * `assignGroupToCategory` / `findCategoryByDomainName` 等での
+ * `domainNames.some((name) => normalizeDomainLookupKey(name) === key)`
+ * の重複を解消する (CodeRabbit PR #626 review)。
+ */
+export const hasNormalizedDomain = (
+  domainNames: readonly string[],
+  domain: string,
+): boolean => domainNames.some((name) => domainMatches(name, domain))

--- a/src/utils/domain-normalize.ts
+++ b/src/utils/domain-normalize.ts
@@ -52,9 +52,16 @@ export const toHostname = (url: string): string => {
 /**
  * 2 つのドメイン値が正規化後に等価かを判定する。
  * `normalizeDomainLookupKey` 経由でスキーム付き/hostname の形式差を吸収する。
+ *
+ * ただし両辺のいずれかが空文字列に正規化される (host が取れない等) 場合は
+ * 一致とみなさない。これにより不正 URL 同士や空ドメイン同士が同じ bucket に
+ * マージされる空衝突を防ぐ (CodeRabbit PR #626 review)。
  */
-export const domainMatches = (a: string, b: string): boolean =>
-  normalizeDomainLookupKey(a) === normalizeDomainLookupKey(b)
+export const domainMatches = (a: string, b: string): boolean => {
+  const keyA = normalizeDomainLookupKey(a)
+  const keyB = normalizeDomainLookupKey(b)
+  return keyA !== '' && keyB !== '' && keyA === keyB
+}
 
 /**
  * `domainNames` 配列の中に `domain` と等価なエントリが存在するかを判定する。
@@ -67,3 +74,21 @@ export const hasNormalizedDomain = (
   domainNames: readonly string[],
   domain: string,
 ): boolean => domainNames.some((name) => domainMatches(name, domain))
+
+/**
+ * TabGroup が ParentCategory に所属するかを判定する共有 predicate。
+ * `category.domains` (TabGroupId リスト) に group id が含まれるか、
+ * `category.domainNames` に group の domain と等価なエントリがあるか。
+ *
+ * `useCategoryKeywordModal` と `buildAiContext` で重複していた
+ * 「`domains.includes(id)` || `hasNormalizedDomain(domainNames, domain)`」を集約し、
+ * ドリフトを防ぐ (CodeRabbit PR #626 review)。
+ */
+export const tabGroupMatchesCategory = (
+  categoryDomainIds: readonly string[],
+  categoryDomainNames: readonly string[],
+  tabGroupId: string,
+  tabGroupDomain: string,
+): boolean =>
+  categoryDomainIds.includes(tabGroupId) ||
+  hasNormalizedDomain(categoryDomainNames, tabGroupDomain)


### PR DESCRIPTION
## 変更内容

<!-- 変更の詳細を記述してください -->

## チェックリスト

- [ ] ローカル環境でエラーになっていない


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an idempotent migration that automatically converts previously saved scheme-based domains (e.g., `https://example.com`) into hostname-only values (e.g., `example.com`) and updates related saved-tab and category data.
* **Bug Fixes**
  * Improved domain matching to consistently normalize and compare domains, preventing incorrect syncing and reducing duplicates across saving/restoring, category synchronization, mappings, and keyword persistence.
  * Ensured parent-category selection and AI URL grouping use the same hostname-aware matching.
* **Tests**
  * Expanded regression coverage for the migration, hostname normalization behavior, and related domain-matching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->