### PR TITLE
[codex] AIチャット履歴 tooltip 表示を改善

### DIFF
--- a/src/features/ai-chat/components/ConversationPreviewTooltip.test.tsx
+++ b/src/features/ai-chat/components/ConversationPreviewTooltip.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { createElement } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ConversationPreviewTooltip } from './ConversationPreviewTooltip'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid='tooltip-content'>{children}</div>
+  ),
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}))
+
+describe('ConversationPreviewTooltip', () => {
+  it('renders the shared preview trigger and scrollable tooltip body', () => {
+    render(
+      createElement(ConversationPreviewTooltip, {
+        id: 'conversation-1',
+        preview:
+          '現在のURL一覧の整理結果です。保存済みタブ総数は多く、説明文は 3 行を超えます。',
+      }),
+    )
+
+    const preview = screen.getByTestId('conversation-preview-conversation-1')
+    const tooltipBody = screen.getByTestId(
+      'conversation-preview-tooltip-content-conversation-1',
+    )
+
+    expect(preview).toHaveClass('line-clamp-3')
+    expect(preview).toHaveClass('wrap-anywhere')
+    expect(tooltipBody).toHaveClass('overflow-y-auto')
+    expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
+      '現在のURL一覧の整理結果です。保存済みタブ総数は多く、説明文は 3 行を超えます。',
+    )
+  })
+})

--- a/src/features/ai-chat/components/ConversationPreviewTooltip.tsx
+++ b/src/features/ai-chat/components/ConversationPreviewTooltip.tsx
@@ -1,0 +1,41 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+interface ConversationPreviewTooltipProps {
+  id: string
+  preview: string
+}
+
+export const ConversationPreviewTooltip = ({
+  id,
+  preview,
+}: ConversationPreviewTooltipProps) => (
+  <TooltipProvider delayDuration={0}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className='mt-1 line-clamp-3 w-full min-w-0 text-xs leading-5 wrap-anywhere text-muted-foreground'
+          data-testid={`conversation-preview-${id}`}
+        >
+          {preview}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent
+        align='start'
+        className='max-w-sm p-0 text-left'
+        side='right'
+      >
+        <div
+          className='max-h-[min(24rem,calc(100vh-2rem))] overflow-y-auto px-3 py-1.5 text-xs leading-5 wrap-anywhere whitespace-pre-wrap'
+          data-testid={`conversation-preview-tooltip-content-${id}`}
+        >
+          {preview}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+)

--- a/src/features/ai-chat/components/SavedTabsChatHistoryItemCard.test.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatHistoryItemCard.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { createElement } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { TranslateFn } from './savedTabsChat/messages'
+import { SavedTabsChatHistoryItemCard } from './SavedTabsChatHistoryItemCard'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid='tooltip-content'>{children}</div>
+  ),
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}))
+
+describe('SavedTabsChatHistoryItemCard', () => {
+  it('説明文を 3 行で省略し tooltip に全文を載せる', () => {
+    const t: TranslateFn = (key, fallback, values) => {
+      const template =
+        (
+          {
+            'aiChat.deleteConversationAria': 'Delete {{title}}',
+          } satisfies Record<string, string>
+        )[key] ??
+        fallback ??
+        key
+
+      return template.replaceAll(
+        /\{\{(\w+)\}\}/g,
+        (_, token) => values?.[token] ?? '',
+      )
+    }
+
+    render(
+      createElement(SavedTabsChatHistoryItemCard, {
+        historyItem: {
+          id: 'conversation-1',
+          isActive: true,
+          preview:
+            '現在のURL一覧の整理結果です。保存済みタブ総数は多く、説明文は 3 行を超えます。',
+          title: 'listSavedUrlsを使ってテーブル整理',
+        },
+        isActive: true,
+        onDeleteHistoryItem: vi.fn(),
+        onSelectHistoryItem: vi.fn(),
+        setIsOpen: vi.fn(),
+        setPendingDeleteHistoryItem: vi.fn(),
+        t,
+      }),
+    )
+
+    const preview = screen.getByTestId('conversation-preview-conversation-1')
+    const tooltipBody = screen.getByTestId(
+      'conversation-preview-tooltip-content-conversation-1',
+    )
+
+    expect(preview).toHaveClass('line-clamp-3')
+    expect(preview.className).not.toContain('block')
+    expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
+      '現在のURL一覧の整理結果です。保存済みタブ総数は多く、説明文は 3 行を超えます。',
+    )
+    expect(tooltipBody).toHaveClass('max-h-[min(24rem,calc(100vh-2rem))]')
+    expect(tooltipBody).toHaveClass('overflow-y-auto')
+  })
+})

--- a/src/features/ai-chat/components/SavedTabsChatHistoryItemCard.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatHistoryItemCard.tsx
@@ -23,6 +23,39 @@ interface SavedTabsChatHistoryItemCardProps {
   t: TranslateFn
 }
 
+const HistoryItemPreview = ({
+  id,
+  preview,
+}: {
+  id: string
+  preview: string
+}) => (
+  <TooltipProvider delayDuration={0}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className='mt-1 line-clamp-3 w-full min-w-0 text-xs leading-5 wrap-anywhere text-muted-foreground'
+          data-testid={`conversation-preview-${id}`}
+        >
+          {preview}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent
+        align='start'
+        className='max-w-sm p-0 text-left'
+        side='right'
+      >
+        <div
+          className='max-h-[min(24rem,calc(100vh-2rem))] overflow-y-auto px-3 py-1.5 text-xs leading-5 wrap-anywhere whitespace-pre-wrap'
+          data-testid={`conversation-preview-tooltip-content-${id}`}
+        >
+          {preview}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+)
+
 export const SavedTabsChatHistoryItemCard = ({
   historyItem,
   isActive,
@@ -71,30 +104,10 @@ export const SavedTabsChatHistoryItemCard = ({
           >
             {historyItem.title}
           </span>
-          <TooltipProvider delayDuration={0}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className='mt-1 line-clamp-3 w-full min-w-0 text-xs leading-5 wrap-anywhere text-muted-foreground'
-                  data-testid={`conversation-preview-${historyItem.id}`}
-                >
-                  {historyItem.preview}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent
-                align='start'
-                className='max-w-sm p-0 text-left'
-                side='right'
-              >
-                <div
-                  className='max-h-[min(24rem,calc(100vh-2rem))] overflow-y-auto px-3 py-1.5 text-xs leading-5 wrap-anywhere whitespace-pre-wrap'
-                  data-testid={`conversation-preview-tooltip-content-${historyItem.id}`}
-                >
-                  {historyItem.preview}
-                </div>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <HistoryItemPreview
+            id={historyItem.id}
+            preview={historyItem.preview}
+          />
         </Button>
         {onDeleteHistoryItem ? (
           <Button

--- a/src/features/ai-chat/components/SavedTabsChatHistoryItemCard.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatHistoryItemCard.tsx
@@ -2,12 +2,7 @@ import { Trash2 } from 'lucide-react'
 import { useCallback } from 'react'
 
 import { Button } from '@/components/ui/button'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+import { ConversationPreviewTooltip } from '@/features/ai-chat/components/ConversationPreviewTooltip'
 import type { AiChatHistoryItem } from '@/features/ai-chat/types'
 import { cn } from '@/lib/utils'
 
@@ -22,39 +17,6 @@ interface SavedTabsChatHistoryItemCardProps {
   setPendingDeleteHistoryItem: (item: AiChatHistoryItem | null) => void
   t: TranslateFn
 }
-
-const HistoryItemPreview = ({
-  id,
-  preview,
-}: {
-  id: string
-  preview: string
-}) => (
-  <TooltipProvider delayDuration={0}>
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className='mt-1 line-clamp-3 w-full min-w-0 text-xs leading-5 wrap-anywhere text-muted-foreground'
-          data-testid={`conversation-preview-${id}`}
-        >
-          {preview}
-        </span>
-      </TooltipTrigger>
-      <TooltipContent
-        align='start'
-        className='max-w-sm p-0 text-left'
-        side='right'
-      >
-        <div
-          className='max-h-[min(24rem,calc(100vh-2rem))] overflow-y-auto px-3 py-1.5 text-xs leading-5 wrap-anywhere whitespace-pre-wrap'
-          data-testid={`conversation-preview-tooltip-content-${id}`}
-        >
-          {preview}
-        </div>
-      </TooltipContent>
-    </Tooltip>
-  </TooltipProvider>
-)
 
 export const SavedTabsChatHistoryItemCard = ({
   historyItem,
@@ -104,7 +66,7 @@ export const SavedTabsChatHistoryItemCard = ({
           >
             {historyItem.title}
           </span>
-          <HistoryItemPreview
+          <ConversationPreviewTooltip
             id={historyItem.id}
             preview={historyItem.preview}
           />

--- a/src/features/ai-chat/components/SavedTabsChatHistoryItemCard.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatHistoryItemCard.tsx
@@ -2,6 +2,12 @@ import { Trash2 } from 'lucide-react'
 import { useCallback } from 'react'
 
 import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import type { AiChatHistoryItem } from '@/features/ai-chat/types'
 import { cn } from '@/lib/utils'
 
@@ -65,12 +71,30 @@ export const SavedTabsChatHistoryItemCard = ({
           >
             {historyItem.title}
           </span>
-          <span
-            className='mt-1 line-clamp-2 block w-full min-w-0 overflow-hidden text-xs leading-5 wrap-anywhere text-muted-foreground'
-            data-testid={`conversation-preview-${historyItem.id}`}
-          >
-            {historyItem.preview}
-          </span>
+          <TooltipProvider delayDuration={0}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className='mt-1 line-clamp-3 w-full min-w-0 text-xs leading-5 wrap-anywhere text-muted-foreground'
+                  data-testid={`conversation-preview-${historyItem.id}`}
+                >
+                  {historyItem.preview}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent
+                align='start'
+                className='max-w-sm p-0 text-left'
+                side='right'
+              >
+                <div
+                  className='max-h-[min(24rem,calc(100vh-2rem))] overflow-y-auto px-3 py-1.5 text-xs leading-5 wrap-anywhere whitespace-pre-wrap'
+                  data-testid={`conversation-preview-tooltip-content-${historyItem.id}`}
+                >
+                  {historyItem.preview}
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </Button>
         {onDeleteHistoryItem ? (
           <Button

--- a/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
@@ -683,8 +683,9 @@ describe('SavedTabsChatWidget', () => {
     expect(title.className).toContain('min-w-0')
     expect(preview.className).toContain('w-full')
     expect(preview.className).toContain('min-w-0')
+    expect(preview.className).toContain('line-clamp-3')
     expect(preview.className).toContain('wrap-anywhere')
-    expect(preview.className).toContain('overflow-hidden')
+    expect(preview.className).not.toContain('block')
 
     await user.click(
       screen.getByRole('button', { name: /Another conversation/ }),

--- a/src/features/ai-chat/routes/AiChatRoute.test.tsx
+++ b/src/features/ai-chat/routes/AiChatRoute.test.tsx
@@ -28,6 +28,9 @@ vi.mock('@/components/ui/tooltip', () => ({
   TooltipContent: ({ children }: { children: React.ReactNode }) => (
     <div data-testid='tooltip-content'>{children}</div>
   ),
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),

--- a/src/features/ai-chat/routes/AiChatRoute.test.tsx
+++ b/src/features/ai-chat/routes/AiChatRoute.test.tsx
@@ -23,6 +23,16 @@ vi.mock('@/features/ai-chat/hooks/useSharedAiChatHistory', () => ({
   useSharedAiChatHistory: mocked.useSharedAiChatHistory,
 }))
 
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid='tooltip-content'>{children}</div>
+  ),
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}))
+
 vi.mock('@/features/i18n/context/I18nProvider', () => ({
   useI18n: () => ({
     t: (key: string, fallback?: string, values?: Record<string, string>) => {
@@ -223,8 +233,19 @@ describe('AiChatRoute', () => {
     expect(title).toHaveClass('min-w-0')
     expect(preview).toHaveClass('w-full')
     expect(preview).toHaveClass('min-w-0')
+    expect(preview).toHaveClass('line-clamp-3')
     expect(preview).toHaveClass('wrap-anywhere')
-    expect(preview).toHaveClass('overflow-hidden')
+    expect(preview).not.toHaveClass('block')
+  })
+
+  it('履歴説明文は 3 行で省略し、説明文 hover 用 tooltip に全文を載せる', () => {
+    render(createElement(AiChatRoute))
+
+    const preview = screen.getByTestId('conversation-preview-conversation-1')
+    expect(preview).toHaveClass('line-clamp-3')
+
+    const tooltipContents = screen.getAllByTestId('tooltip-content')
+    expect(tooltipContents[0]).toHaveTextContent('最初の会話')
   })
 
   it('狭い画面では左履歴を完全非表示にしてチャットを残り幅へ広げる', () => {

--- a/src/features/ai-chat/routes/AiChatRoute.tsx
+++ b/src/features/ai-chat/routes/AiChatRoute.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dialog'
 import { LoadingState } from '@/components/ui/loading-state'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { SavedTabsChatWidget } from '@/features/ai-chat/components/SavedTabsChatWidget'
 import { useSharedAiChatHistory } from '@/features/ai-chat/hooks/useSharedAiChatHistory'
 import type { AiChatHistoryItem } from '@/features/ai-chat/types'
@@ -70,12 +71,28 @@ const HistoryItemCard = ({
           >
             {historyItem.title}
           </span>
-          <span
-            className='mt-1 line-clamp-2 block w-full min-w-0 overflow-hidden text-xs leading-5 wrap-anywhere text-muted-foreground'
-            data-testid={`conversation-preview-${historyItem.id}`}
-          >
-            {historyItem.preview}
-          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className='mt-1 line-clamp-3 w-full min-w-0 text-xs leading-5 wrap-anywhere text-muted-foreground'
+                data-testid={`conversation-preview-${historyItem.id}`}
+              >
+                {historyItem.preview}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent
+              align='start'
+              className='max-w-sm p-0 text-left'
+              side='right'
+            >
+              <div
+                className='max-h-[min(24rem,calc(100vh-2rem))] overflow-y-auto px-3 py-1.5 text-xs leading-5 wrap-anywhere whitespace-pre-wrap'
+                data-testid={`conversation-preview-tooltip-content-${historyItem.id}`}
+              >
+                {historyItem.preview}
+              </div>
+            </TooltipContent>
+          </Tooltip>
         </Button>
         <Button
           type='button'

--- a/src/features/ai-chat/routes/AiChatRoute.tsx
+++ b/src/features/ai-chat/routes/AiChatRoute.tsx
@@ -12,7 +12,11 @@ import {
 } from '@/components/ui/dialog'
 import { LoadingState } from '@/components/ui/loading-state'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { SavedTabsChatWidget } from '@/features/ai-chat/components/SavedTabsChatWidget'
 import { useSharedAiChatHistory } from '@/features/ai-chat/hooks/useSharedAiChatHistory'
 import type { AiChatHistoryItem } from '@/features/ai-chat/types'

--- a/src/features/ai-chat/routes/AiChatRoute.tsx
+++ b/src/features/ai-chat/routes/AiChatRoute.tsx
@@ -12,11 +12,7 @@ import {
 } from '@/components/ui/dialog'
 import { LoadingState } from '@/components/ui/loading-state'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+import { ConversationPreviewTooltip } from '@/features/ai-chat/components/ConversationPreviewTooltip'
 import { SavedTabsChatWidget } from '@/features/ai-chat/components/SavedTabsChatWidget'
 import { useSharedAiChatHistory } from '@/features/ai-chat/hooks/useSharedAiChatHistory'
 import type { AiChatHistoryItem } from '@/features/ai-chat/types'
@@ -75,28 +71,10 @@ const HistoryItemCard = ({
           >
             {historyItem.title}
           </span>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span
-                className='mt-1 line-clamp-3 w-full min-w-0 text-xs leading-5 wrap-anywhere text-muted-foreground'
-                data-testid={`conversation-preview-${historyItem.id}`}
-              >
-                {historyItem.preview}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent
-              align='start'
-              className='max-w-sm p-0 text-left'
-              side='right'
-            >
-              <div
-                className='max-h-[min(24rem,calc(100vh-2rem))] overflow-y-auto px-3 py-1.5 text-xs leading-5 wrap-anywhere whitespace-pre-wrap'
-                data-testid={`conversation-preview-tooltip-content-${historyItem.id}`}
-              >
-                {historyItem.preview}
-              </div>
-            </TooltipContent>
-          </Tooltip>
+          <ConversationPreviewTooltip
+            id={historyItem.id}
+            preview={historyItem.preview}
+          />
         </Button>
         <Button
           type='button'


### PR DESCRIPTION
## 変更内容
- AIチャット履歴の説明文を3行で省略し、hover時にtooltipで全文を表示
- 長文tooltipの本文をスクロール可能にして画面外オーバーフローを防止
- 履歴カードと関連UIの回帰テストを追加・更新

## 原因
- 実際に使われていた履歴カード側でline clampが効いておらず、長文tooltipも高さ制限がありませんでした

## 確認
- ./node_modules/.bin/vitest run src/features/ai-chat/components/SavedTabsChatHistoryItemCard.test.tsx src/features/ai-chat/routes/AiChatRoute.test.tsx src/features/ai-chat/components/SavedTabsChatWidget.test.tsx --config vitest.ci.config.ts
- bun run compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation history previews now show a richer multi-line snippet with a tooltip that reveals the full text on hover.
  * Long previews are easier to read, with scrolling available in the tooltip when content exceeds the visible area.

* **Bug Fixes**
  * Updated preview display behavior so truncated text is consistently clamped to three lines instead of appearing as a single shortened line.
  * Improved handling of long text so it wraps and displays more cleanly in chat history and route views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->