### PR TITLE
[codex] React Doctor の shallow checkout を解消

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - uses: millionco/react-doctor@v2
         # Strict gate: any new error-severity finding fails the check and


### PR DESCRIPTION
## 変更内容
- `.github/workflows/react-doctor.yml` の `actions/checkout@v5` に `fetch-depth: 0` を追加

## 原因
- React Doctor が PR 差分を `develop` との merge base 比較で判定する前提なのに、workflow が shallow checkout のままで履歴不足になっていました
- そのため baseline 比較に失敗し、PR で変更していない既存 issue まで changed files 全件として報告されていました

## 影響
- React Doctor が PR で新規に持ち込んだ問題だけを正しく報告できるようになります
- `github-actions[bot]` の warning comment (`#issuecomment-4881040573`) の原因を解消します

## 確認
- `bun run check`
