### PR TITLE
空 object 型を禁止する Oxlint 設定を明示

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -158,6 +158,13 @@
     "eslint/no-debugger": "error",
     "eslint/no-eval": "error",
     "eslint/no-new-func": "error",
+    "typescript/no-empty-object-type": [
+      "error",
+      {
+        "allowInterfaces": "never",
+        "allowObjectTypes": "never"
+      }
+    ],
     "eslint/sort-imports": "off",
     "eslint/sort-keys": "off",
     "eslint/prefer-named-capture-group": "off",

--- a/src/components/ai-elements/model-selector.tsx
+++ b/src/components/ai-elements/model-selector.tsx
@@ -163,7 +163,7 @@ export type ModelSelectorLogoProps = Omit<
     | 'scaleway'
     | 'amazon-bedrock'
     | 'cerebras'
-    | (string & {})
+    | (string & Record<never, never>)
 }
 
 export const ModelSelectorLogo = ({

--- a/src/lib/architecture/oxlintConfig.test.ts
+++ b/src/lib/architecture/oxlintConfig.test.ts
@@ -102,6 +102,18 @@ describe('oxlint configuration', () => {
     ])
   })
 
+  it('disallows empty object types and empty interfaces', () => {
+    const config = JSON.parse(readFileSync(oxlintConfigPath, 'utf8'))
+
+    expect(config.rules['typescript/no-empty-object-type']).toEqual([
+      'error',
+      {
+        allowInterfaces: 'never',
+        allowObjectTypes: 'never',
+      },
+    ])
+  })
+
   it('allows const assertions for literal values', () => {
     const result = runOxlint(`
 const statuses = ['saved', 'archived'] as const
@@ -127,5 +139,19 @@ export const user = rawUser as User
 
     expect(result.status).not.toBe(0)
     expect(result.output).toContain('typescript/consistent-type-assertions')
+  })
+
+  it('reports empty type literals and empty interfaces as errors', () => {
+    const result = runOxlint(`
+type Props = {}
+
+interface Options {}
+
+export const props: Props = {}
+export const options: Options = {}
+`)
+
+    expect(result.status).not.toBe(0)
+    expect(result.output).toContain('typescript/no-empty-object-type')
   })
 })


### PR DESCRIPTION
## 変更内容

- .oxlintrc.json に typescript/no-empty-object-type を error として明示設定
- allowInterfaces / allowObjectTypes を never に固定
- 既存の string & {} を string & Record<never, never> に置き換え
- Oxlint 設定テストで設定値と空 type/interface の検出を検証

Closes #637

## チェックリスト

- [x] ローカル環境でエラーになっていない

## 検証

- bun run test:node src/lib/architecture/oxlintConfig.test.ts
- rtk bun run lint
- rtk bun run compile
- rtk bun run quality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened TypeScript linting to catch empty interfaces and empty object types, helping prevent unsafe type patterns.
  * Updated a public type fallback for better compatibility with stricter type checking.

* **Tests**
  * Expanded lint coverage to verify the new TypeScript rule is enforced and reports failures as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->