### PR TITLE
domain/application層の引数再代入を禁止する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ stats-*.json
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+src/contexts/__oxlint-fixture-*/
 
 # Logs
 logs/

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -644,6 +644,20 @@
       }
     },
     {
+      "files": [
+        "src/contexts/*/domain/**/*.{ts,tsx}",
+        "src/contexts/*/application/**/*.{ts,tsx}"
+      ],
+      "rules": {
+        "eslint/no-param-reassign": [
+          "error",
+          {
+            "props": true
+          }
+        ]
+      }
+    },
+    {
       "files": ["src/contexts/*/domain/**/*.{ts,tsx}"],
       "rules": {
         "eslint/no-restricted-globals": [

--- a/src/contexts/saved-tabs/application/services/SavedTabsCategorizationService.ts
+++ b/src/contexts/saved-tabs/application/services/SavedTabsCategorizationService.ts
@@ -67,48 +67,31 @@ const hasDisplayableUrls = (group: TabGroupDto): boolean => {
   return hasNewUrls || hasOldUrls
 }
 
-const pushGroupToCategory = (
-  categorizedGroups: Record<string, TabGroupDto[]>,
+const assignParentCategory = (
+  group: TabGroupDto,
   categoryId: string,
-  group: TabGroupDto,
-): void => {
-  if (!Object.hasOwn(categorizedGroups, categoryId)) {
-    categorizedGroups[categoryId] = []
-  }
-  const categorizedGroup =
-    group.parentCategoryId === categoryId
-      ? group
-      : {
-          ...group,
-          parentCategoryId: categoryId,
-        }
-  categorizedGroups[categoryId].push(categorizedGroup)
-}
+): TabGroupDto =>
+  group.parentCategoryId === categoryId
+    ? group
+    : {
+        ...group,
+        parentCategoryId: categoryId,
+      }
 
-const tryCategorizeById = (
+const resolveCategoryIdByGroupId = (
   group: TabGroupDto,
   categoryLookup: PresentationCategoryLookup,
-  categorizedGroups: Record<string, TabGroupDto[]>,
-): boolean => {
+): string | undefined => {
   const category = categoryLookup.byGroupId.get(group.id)
-  if (!category) {
-    return false
-  }
-  pushGroupToCategory(categorizedGroups, category.id, group)
-  return true
+  return category?.id
 }
 
-const tryCategorizeByDomainName = (
+const resolveCategoryIdByDomainName = (
   group: TabGroupDto,
   categoryLookup: PresentationCategoryLookup,
-  categorizedGroups: Record<string, TabGroupDto[]>,
-): boolean => {
+): string | undefined => {
   const category = categoryLookup.byDomainName.get(group.domain)
-  if (!category) {
-    return false
-  }
-  pushGroupToCategory(categorizedGroups, category.id, group)
-  return true
+  return category?.id
 }
 
 const matchesParentCategoryQuery = (
@@ -167,30 +150,57 @@ const filterGroupByQuery = (
   }
 }
 
+const sortGroupsByDomainOrder = (
+  groups: readonly TabGroupDto[],
+  domains: readonly string[],
+): TabGroupDto[] => {
+  const domainOrder = new Map(domains.map((domain, index) => [domain, index]))
+  return groups.toSorted((a, b) => {
+    const indexA = domainOrder.get(a.id) ?? -1
+    const indexB = domainOrder.get(b.id) ?? -1
+    if (indexA === -1) {
+      return 1
+    }
+    if (indexB === -1) {
+      return -1
+    }
+    return indexA - indexB
+  })
+}
+
 const sortCategorizedGroups = (
   categorizedGroups: Record<string, TabGroupDto[]>,
   categoryLookup: PresentationCategoryLookup,
-): void => {
-  for (const categoryId of Object.keys(categorizedGroups)) {
-    const category = categoryLookup.byId.get(categoryId)
-    const domains = category?.domains
-    if (!(domains && domains.length > 0)) {
-      continue
-    }
-    const domainOrder = new Map(domains.map((domain, index) => [domain, index]))
-    categorizedGroups[categoryId].sort((a, b) => {
-      const indexA = domainOrder.get(a.id) ?? -1
-      const indexB = domainOrder.get(b.id) ?? -1
-      if (indexA === -1) {
-        return 1
+): Record<string, TabGroupDto[]> =>
+  Object.fromEntries(
+    Object.entries(categorizedGroups).map(([categoryId, groups]) => {
+      const category = categoryLookup.byId.get(categoryId)
+      const domains = category?.domains
+      if (!(domains && domains.length > 0)) {
+        return [categoryId, [...groups]]
       }
-      if (indexB === -1) {
-        return -1
-      }
-      return indexA - indexB
-    })
-  }
-}
+      return [categoryId, sortGroupsByDomainOrder(groups, domains)]
+    }),
+  )
+
+const resolveCategoryId = (
+  group: TabGroupDto,
+  categoryLookup: PresentationCategoryLookup,
+): string | undefined =>
+  resolveCategoryIdByGroupId(group, categoryLookup) ??
+  resolveCategoryIdByDomainName(group, categoryLookup)
+
+const addGroupToCategory = (
+  categorizedGroups: Record<string, TabGroupDto[]>,
+  categoryId: string,
+  group: TabGroupDto,
+): Record<string, TabGroupDto[]> => ({
+  ...categorizedGroups,
+  [categoryId]: [
+    ...(categorizedGroups[categoryId] ?? []),
+    assignParentCategory(group, categoryId),
+  ],
+})
 
 /**
  * `TabGroupDto[]` 配列を `ParentCategoryDto[]` 配列と
@@ -245,43 +255,27 @@ export const organizeTabGroupsWithCategories = ({
       uncategorized: [...tabGroupsWithUrls],
     }
   }
-  const categorizedGroups: Record<string, TabGroupDto[]> = {}
+  let categorizedGroups: Record<string, TabGroupDto[]> = {}
   const uncategorizedGroups: TabGroupDto[] = []
   const normalizedQuery = searchQuery?.trim().toLowerCase() ?? ''
   const hasSearchQuery = normalizedQuery.length > 0
-  const groupsToOrganize = tabGroupsWithUrls.reduce<TabGroupDto[]>(
-    (groups, group) => {
-      const nextGroup = hasSearchQuery
+  const groupsToOrganize = tabGroupsWithUrls
+    .map((group) =>
+      hasSearchQuery
         ? filterGroupByQuery(group, normalizedQuery, categoryLookup)
-        : group
-      if (hasDisplayableUrls(nextGroup)) {
-        groups.push(nextGroup)
-      }
-      return groups
-    },
-    [],
-  )
-  for (const group of groupsToOrganize) {
-    const categorizedById = tryCategorizeById(
-      group,
-      categoryLookup,
-      categorizedGroups,
+        : group,
     )
-    if (categorizedById) {
+    .filter(hasDisplayableUrls)
+  for (const group of groupsToOrganize) {
+    const categoryId = resolveCategoryId(group, categoryLookup)
+    if (!categoryId) {
+      uncategorizedGroups.push(group)
       continue
     }
-    const categorizedByDomainName = tryCategorizeByDomainName(
-      group,
-      categoryLookup,
-      categorizedGroups,
-    )
-    if (!categorizedByDomainName) {
-      uncategorizedGroups.push(group)
-    }
+    categorizedGroups = addGroupToCategory(categorizedGroups, categoryId, group)
   }
-  sortCategorizedGroups(categorizedGroups, categoryLookup)
   return {
-    categorized: categorizedGroups,
+    categorized: sortCategorizedGroups(categorizedGroups, categoryLookup),
     uncategorized: uncategorizedGroups,
   }
 }

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -27,11 +27,14 @@ const loadOxlintConfig = (): OxlintConfig => {
 const findOverride = (
   config: OxlintConfig,
   layer: string,
+  ruleName?: string,
 ): OxlintOverride | undefined => {
   // issue #581: DDD override は saved-tabs 固定ではなく src/contexts/* に一般化されている
   const pattern = `src/contexts/*/${layer}/**`
-  return config.overrides?.find((entry) =>
-    entry.files?.some((file) => file.includes(pattern)),
+  return config.overrides?.find(
+    (entry) =>
+      entry.files?.some((file) => file.includes(pattern)) &&
+      (!ruleName || Object.hasOwn(entry.rules ?? {}, ruleName)),
   )
 }
 
@@ -208,10 +211,20 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
   })
 
   describe('domain 層', () => {
-    const override = findOverride(config, 'domain')
+    const globalsOverride = findOverride(
+      config,
+      'domain',
+      'eslint/no-restricted-globals',
+    )
+    const propertiesOverride = findOverride(
+      config,
+      'domain',
+      'eslint/no-restricted-properties',
+    )
 
     it('override が定義されている', () => {
-      expect(override).toBeDefined()
+      expect(globalsOverride).toBeDefined()
+      expect(propertiesOverride).toBeDefined()
     })
 
     it('UI / routing / notification / animation 系 package の import を禁止している', () => {
@@ -228,7 +241,7 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
     })
 
     it('chrome / localStorage / sessionStorage / document / window の global 参照を禁止している', () => {
-      const names = getRestrictedGlobals(override)
+      const names = getRestrictedGlobals(globalsOverride)
       expect(names).toContain('chrome')
       expect(names).toContain('localStorage')
       expect(names).toContain('sessionStorage')
@@ -237,7 +250,7 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
     })
 
     it('chrome.tabs / chrome.storage / chrome.contextMenus / chrome.alarms / chrome.notifications / chrome.runtime の直叩きを禁止している', () => {
-      const names = getRestrictedProperties(override)
+      const names = getRestrictedProperties(propertiesOverride)
       expect(names).toContain('chrome.tabs')
       expect(names).toContain('chrome.storage')
       expect(names).toContain('chrome.contextMenus')
@@ -247,7 +260,7 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
     })
 
     it('issue #582: Date.now() を no-restricted-properties で禁止している', () => {
-      const names = getRestrictedProperties(override)
+      const names = getRestrictedProperties(propertiesOverride)
       expect(names).toContain('Date.now')
     })
 
@@ -278,10 +291,14 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
   })
 
   describe('application 層', () => {
-    const override = findOverride(config, 'application')
+    const propertiesOverride = findOverride(
+      config,
+      'application',
+      'eslint/no-restricted-properties',
+    )
 
     it('override が定義されている', () => {
-      expect(override).toBeDefined()
+      expect(propertiesOverride).toBeDefined()
     })
 
     it('UI / routing / notification / animation 系 package の import を禁止している', () => {
@@ -298,7 +315,7 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
     })
 
     it('chrome.tabs / chrome.storage / chrome.contextMenus / chrome.alarms / chrome.notifications の直叩きを禁止している', () => {
-      const names = getRestrictedProperties(override)
+      const names = getRestrictedProperties(propertiesOverride)
       expect(names).toContain('chrome.tabs')
       expect(names).toContain('chrome.storage')
       expect(names).toContain('chrome.contextMenus')
@@ -325,14 +342,18 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
   })
 
   describe('presentation 層', () => {
-    const override = findOverride(config, 'presentation')
+    const propertiesOverride = findOverride(
+      config,
+      'presentation',
+      'eslint/no-restricted-properties',
+    )
 
     it('override が定義されている', () => {
-      expect(override).toBeDefined()
+      expect(propertiesOverride).toBeDefined()
     })
 
     it('chrome.storage / chrome.tabs / chrome.contextMenus / chrome.alarms / chrome.runtime の直叩きを禁止している', () => {
-      const names = getRestrictedProperties(override)
+      const names = getRestrictedProperties(propertiesOverride)
       expect(names).toContain('chrome.storage')
       expect(names).toContain('chrome.tabs')
       expect(names).toContain('chrome.contextMenus')

--- a/src/lib/architecture/oxlintConfig.test.ts
+++ b/src/lib/architecture/oxlintConfig.test.ts
@@ -26,11 +26,14 @@ const hasCommandOutput = (
 ): error is { stderr?: unknown; stdout?: unknown; status?: unknown } =>
   typeof error === 'object' && error !== null
 
-const createFixture = (source: string) => {
+const createFixture = (source: string, relativeSourcePath = 'src/index.ts') => {
   const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'tabbin-oxlint-'))
   fixtureDirectories.push(fixtureRoot)
 
-  const sourcePath = path.join(fixtureRoot, 'src/index.ts')
+  const isContextLayerFixture = relativeSourcePath.startsWith('src/contexts/')
+  const sourcePath = isContextLayerFixture
+    ? createContextLayerFixturePath(relativeSourcePath)
+    : path.join(fixtureRoot, relativeSourcePath)
   mkdirSync(path.dirname(sourcePath), { recursive: true })
   writeFileSync(sourcePath, source)
   writeFileSync(
@@ -52,8 +55,23 @@ const createFixture = (source: string) => {
   }
 }
 
-const runOxlint = (source: string): CommandResult => {
-  const fixture = createFixture(source)
+const createContextLayerFixturePath = (relativeSourcePath: string): string => {
+  const contextFixtureRoot = mkdtempSync(
+    path.join(projectRoot, 'src/contexts/__oxlint-fixture-'),
+  )
+  fixtureDirectories.push(contextFixtureRoot)
+
+  return path.join(
+    contextFixtureRoot,
+    relativeSourcePath.replace(/^src\/contexts\/[^/]+\//, ''),
+  )
+}
+
+const runOxlint = (
+  source: string,
+  relativeSourcePath?: string,
+): CommandResult => {
+  const fixture = createFixture(source, relativeSourcePath)
 
   try {
     execFileSync(
@@ -114,6 +132,25 @@ describe('oxlint configuration', () => {
     ])
   })
 
+  it('disallows parameter reassignment in contexts domain and application layers', () => {
+    const config = JSON.parse(readFileSync(oxlintConfigPath, 'utf8'))
+
+    expect(config.overrides).toContainEqual({
+      files: [
+        'src/contexts/*/domain/**/*.{ts,tsx}',
+        'src/contexts/*/application/**/*.{ts,tsx}',
+      ],
+      rules: {
+        'eslint/no-param-reassign': [
+          'error',
+          {
+            props: true,
+          },
+        ],
+      },
+    })
+  })
+
   it('allows const assertions for literal values', () => {
     const result = runOxlint(`
 const statuses = ['saved', 'archived'] as const
@@ -153,5 +190,44 @@ export const options: Options = {}
 
     expect(result.status).not.toBe(0)
     expect(result.output).toContain('typescript/no-empty-object-type')
+  })
+
+  it('reports parameter property mutation in contexts domain files', () => {
+    const result = runOxlint(
+      `
+interface SavedTab {
+  title: string
+}
+
+export const renameTab = (tab: SavedTab): SavedTab => {
+  tab.title = 'new title'
+
+  return tab
+}
+`,
+      'src/contexts/saved-tabs/domain/services/MutatingDomainService.ts',
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(result.output).toContain('eslint/no-param-reassign')
+  })
+
+  it('does not apply parameter reassignment restrictions to presentation files', () => {
+    const result = runOxlint(
+      `
+interface SavedTab {
+  title: string
+}
+
+export const renameTab = (tab: SavedTab): SavedTab => {
+  tab.title = 'new title'
+
+  return tab
+}
+`,
+      'src/contexts/saved-tabs/presentation/services/MutatingPresentationService.ts',
+    )
+
+    expect(result).toEqual({ status: 0, output: '' })
   })
 })


### PR DESCRIPTION
## 変更内容

- `src/contexts/*/{domain,application}/**/*.{ts,tsx}` に限定して `eslint/no-param-reassign` を `props: true` で有効化しました。
- `SavedTabsCategorizationService` のカテゴリ振り分け処理を、引数を書き換えない戻り値ベースの構造に変更しました。
- oxlint 設定の実動テストと DDD layer guard を、複数 override が共存する前提で強化しました。

## 検証

- `bun run test:node src/contexts/saved-tabs/dddLayerGuard.test.ts src/lib/architecture/oxlintConfig.test.ts src/contexts/saved-tabs/application/services/SavedTabsCategorizationService.test.ts`
- `bun run lint`
- `bun run test`
- `bun run quality`

Closes #635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tab grouping behavior and ordering for saved tabs, making category assignment more consistent.
  * Tightened code quality checks for context-layer files to prevent accidental object property mutation in certain layers.
* **Tests**
  * Expanded automated coverage for linting rules and context-layer behavior, including expected pass/fail cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->