### PR TITLE
production src の同期ダイアログ直利用を禁止

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -155,6 +155,7 @@
     "eslint/eqeqeq": ["error", "always"],
     "eslint/guard-for-in": "error",
     "eslint/no-await-in-loop": "error",
+    "eslint/no-alert": "off",
     "eslint/no-debugger": "error",
     "eslint/no-eval": "error",
     "eslint/no-new-func": "error",
@@ -531,6 +532,65 @@
     },
     {
       "files": [
+        "src/contexts/**/*.{ts,tsx}",
+        "src/features/**/*.{ts,tsx}",
+        "src/components/**/*.{ts,tsx}",
+        "src/lib/**/*.{ts,tsx}",
+        "src/entrypoints/**/*.{ts,tsx}"
+      ],
+      "rules": {
+        "eslint/no-restricted-globals": [
+          "error",
+          {
+            "name": "alert",
+            "message": "alert は使わず、toast / dialog component 経由にしてください"
+          },
+          {
+            "name": "confirm",
+            "message": "confirm は使わず、確認 dialog component 経由にしてください"
+          },
+          {
+            "name": "prompt",
+            "message": "prompt は使わず、form / dialog component 経由にしてください"
+          }
+        ],
+        "eslint/no-restricted-properties": [
+          "error",
+          {
+            "object": "window",
+            "property": "alert",
+            "message": "window.alert は使わず、toast / dialog component 経由にしてください"
+          },
+          {
+            "object": "window",
+            "property": "confirm",
+            "message": "window.confirm は使わず、確認 dialog component 経由にしてください"
+          },
+          {
+            "object": "window",
+            "property": "prompt",
+            "message": "window.prompt は使わず、form / dialog component 経由にしてください"
+          },
+          {
+            "object": "globalThis",
+            "property": "alert",
+            "message": "globalThis.alert は使わず、toast / dialog component 経由にしてください"
+          },
+          {
+            "object": "globalThis",
+            "property": "confirm",
+            "message": "globalThis.confirm は使わず、確認 dialog component 経由にしてください"
+          },
+          {
+            "object": "globalThis",
+            "property": "prompt",
+            "message": "globalThis.prompt は使わず、form / dialog component 経由にしてください"
+          }
+        ]
+      }
+    },
+    {
+      "files": [
         "**/*.test.ts",
         "**/*.test.tsx",
         "**/*.spec.ts",
@@ -548,6 +608,8 @@
         "typescript/consistent-type-assertions": "off",
         "typescript/no-unnecessary-condition": "off",
         "eslint/no-magic-numbers": "off",
+        "eslint/no-restricted-globals": "off",
+        "eslint/no-restricted-properties": "off",
         "eslint/max-lines": [
           "error",
           {
@@ -604,6 +666,8 @@
         "import/no-default-export": "off",
         "import/no-anonymous-default-export": "off",
         "eslint/no-magic-numbers": "off",
+        "eslint/no-restricted-globals": "off",
+        "eslint/no-restricted-properties": "off",
         "eslint/max-lines": [
           "error",
           {

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -58,6 +58,34 @@ const getRestrictedGlobals = (
   })
 }
 
+const getRestrictedGlobalMessages = (
+  override: OxlintOverride | undefined,
+): Record<string, string> => {
+  if (!override?.rules) {
+    return {}
+  }
+  const entry = override.rules['eslint/no-restricted-globals']
+  if (!entry || typeof entry === 'string') {
+    return {}
+  }
+  const [, ...rest] = entry
+  return Object.fromEntries(
+    rest.flatMap((value) => {
+      if (!value || typeof value !== 'object') {
+        return []
+      }
+      const record = value as Record<string, unknown>
+      if (
+        typeof record.name === 'string' &&
+        typeof record.message === 'string'
+      ) {
+        return [[record.name, record.message]]
+      }
+      return []
+    }),
+  )
+}
+
 const getRestrictedProperties = (
   override: OxlintOverride | undefined,
 ): string[] => {
@@ -207,6 +235,82 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
           },
         },
       ])
+    })
+  })
+
+  describe('issue #643: production src は同期 browser dialog global を直接使わない', () => {
+    const expectedProductionSrcFiles = [
+      'src/contexts/**/*.{ts,tsx}',
+      'src/features/**/*.{ts,tsx}',
+      'src/components/**/*.{ts,tsx}',
+      'src/lib/**/*.{ts,tsx}',
+      'src/entrypoints/**/*.{ts,tsx}',
+    ]
+
+    const productionDialogOverride = config.overrides?.find((entry) =>
+      expectedProductionSrcFiles.every((file) => entry.files?.includes(file)),
+    )
+
+    it('production src 限定の override が定義されている', () => {
+      expect(productionDialogOverride).toBeDefined()
+      expect(productionDialogOverride?.files).toStrictEqual(
+        expectedProductionSrcFiles,
+      )
+    })
+
+    it('test / story / tools / config / docs / e2e へ過剰適用していない', () => {
+      const files = productionDialogOverride?.files ?? []
+      expect(files).not.toContain('tools/**/*.ts')
+      expect(files).not.toContain('*.config.ts')
+      expect(files).not.toContain('docs/**/*.md')
+      expect(files).not.toContain('e2e/**/*.ts')
+
+      const testOverride = config.overrides?.find((entry) =>
+        entry.files?.includes('**/*.test.ts'),
+      )
+      const storyOverride = config.overrides?.find((entry) =>
+        entry.files?.includes('**/*.stories.tsx'),
+      )
+      expect(testOverride?.rules?.['eslint/no-restricted-globals']).toBe('off')
+      expect(storyOverride?.rules?.['eslint/no-restricted-globals']).toBe('off')
+      expect(testOverride?.rules?.['eslint/no-restricted-properties']).toBe(
+        'off',
+      )
+      expect(storyOverride?.rules?.['eslint/no-restricted-properties']).toBe(
+        'off',
+      )
+    })
+
+    it('alert / confirm / prompt を no-restricted-globals で error にしている', () => {
+      const entry =
+        productionDialogOverride?.rules?.['eslint/no-restricted-globals']
+      expect(entry).toBeDefined()
+      expect(Array.isArray(entry)).toBe(true)
+      expect(entry?.[0]).toBe('error')
+
+      const names = getRestrictedGlobals(productionDialogOverride)
+      expect(names).toContain('alert')
+      expect(names).toContain('confirm')
+      expect(names).toContain('prompt')
+    })
+
+    it('window / globalThis 経由の alert / confirm / prompt も禁止している', () => {
+      const names = getRestrictedProperties(productionDialogOverride)
+      expect(names).toContain('window.alert')
+      expect(names).toContain('window.confirm')
+      expect(names).toContain('window.prompt')
+      expect(names).toContain('globalThis.alert')
+      expect(names).toContain('globalThis.confirm')
+      expect(names).toContain('globalThis.prompt')
+    })
+
+    it('代替 UI への移行方針を message で示している', () => {
+      const messages = getRestrictedGlobalMessages(productionDialogOverride)
+      expect(messages.alert).toContain('toast')
+      expect(messages.alert).toContain('dialog component')
+      expect(messages.confirm).toContain('確認 dialog component')
+      expect(messages.prompt).toContain('form')
+      expect(messages.prompt).toContain('dialog component')
     })
   })
 

--- a/src/features/options/SubCategoryKeywordManager.tsx
+++ b/src/features/options/SubCategoryKeywordManager.tsx
@@ -194,9 +194,6 @@ const useSubCategoryKeywordManagerView = ({
       console.log(`子カテゴリの削除を開始: "${categoryToRemove}"`)
 
       try {
-        // 確認ダイアログを一時的にスキップ (問題特定のため)
-        // If (confirm(`子カテゴリ "${categoryToRemove}" を削除してもよろしいですか？`)) {
-
         // 選択中のカテゴリを削除する場合は選択を解除
         if (activeCategory === categoryToRemove) {
           setActiveCategory(null)

--- a/src/lib/architecture/oxlintConfig.test.ts
+++ b/src/lib/architecture/oxlintConfig.test.ts
@@ -230,4 +230,67 @@ export const renameTab = (tab: SavedTab): SavedTab => {
 
     expect(result).toEqual({ status: 0, output: '' })
   })
+
+  it('reports synchronous browser dialog globals in production src', () => {
+    const result = runOxlint(
+      `
+export const showUnsafeDialogs = (): void => {
+  alert('saved')
+  window.confirm('delete')
+  globalThis.prompt('name')
+}
+`,
+      'src/contexts/saved-tabs/infrastructure/browser/UnsafeDialogAdapter.ts',
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(result.output).toContain('eslint/no-restricted-globals')
+    expect(result.output).toContain('eslint/no-restricted-properties')
+  })
+
+  it('does not apply browser dialog global restrictions to test files', () => {
+    const result = runOxlint(
+      `
+export const showUnsafeDialogsInTest = (): void => {
+  alert('test')
+  window.confirm('test')
+  globalThis.prompt('test')
+}
+`,
+      'src/contexts/saved-tabs/infrastructure/browser/UnsafeDialogAdapter.test.ts',
+    )
+
+    expect(result).toEqual({ status: 0, output: '' })
+  })
+
+  it('does not report browser dialog global restrictions in story files', () => {
+    const result = runOxlint(
+      `
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+  title: 'Fixture/UnsafeDialogAdapter',
+} satisfies Meta
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+export const UnsafeDialogStory = {
+  render: (): null => {
+    alert('story')
+    window.confirm('story')
+    globalThis.prompt('story')
+
+    return null
+  },
+} satisfies Story
+`,
+      'src/contexts/saved-tabs/infrastructure/browser/UnsafeDialogAdapter.stories.ts',
+    )
+
+    expect(result.output).not.toContain('eslint/no-alert')
+    expect(result.output).not.toContain('eslint/no-restricted-globals')
+    expect(result.output).not.toContain('eslint/no-restricted-properties')
+  })
 })


### PR DESCRIPTION
## 変更内容
- production src を対象に `alert` / `confirm` / `prompt` の直接利用を `eslint/no-restricted-globals` で禁止
- `window.*` / `globalThis.*` 経由の同期ダイアログも `eslint/no-restricted-properties` で禁止
- 既存の global `eslint/no-alert` は production 限定ではないため off にし、test / story には過剰適用しない構成へ整理
- 古い `confirm` コメントを production file から削除

## 根本原因
production src に同期 browser dialog を禁止する scoped guard がなく、既存の `eslint/no-alert` は対象を production に限定できていませんでした。

## 検証
- `bun run test:node -- src/contexts/saved-tabs/dddLayerGuard.test.ts src/lib/architecture/oxlintConfig.test.ts -t "issue #643|browser dialog"`
- `bun run lint`
- `bun run test`
- `bun run quality`

Closes #643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened lint rules to prevent browser alert-style dialogs from being used in production app code, while allowing them in tests, stories, and other non-production areas.
  * Improved consistency of confirmation behavior by removing leftover skipped-dialog comments from one deletion flow.
* **Tests**
  * Added coverage to verify the dialog restrictions apply only to the intended source areas and produce the expected guidance messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->