### PR TITLE
URL削除の比較を厳密化する

### DIFF
--- a/src/lib/background/url-storage.test.ts
+++ b/src/lib/background/url-storage.test.ts
@@ -20,11 +20,11 @@ import { deleteUrlRecord, invalidateUrlCache } from '@/lib/storage/urls'
 
 import {
   clearDraggedUrlInfo,
+  createComparableUrlKey,
   getDraggedUrlInfo,
   handleTabCreated,
   handleUrlDragStarted,
   handleUrlDropped,
-  normalizeUrl,
   removeUrlFromStorage,
   removeUrlRecordsFromStorage,
   setDraggedUrlInfo,
@@ -285,6 +285,73 @@ describe('url-storage', () => {
     expect(getDraggedUrlInfo()).toBeNull()
   })
 
+  it('新規タブURLの hash だけが違う場合は同じURLとして削除する', async () => {
+    storageState = {
+      savedTabs: [
+        {
+          id: 'group-1',
+          domain: 'example.com',
+          urls: [
+            { url: 'https://example.com/page#saved', title: 'Saved' },
+            { url: 'https://example.org/keep', title: 'Other' },
+          ],
+        },
+      ],
+      parentCategories: [],
+      urls: [],
+    }
+    setupChromeMock()
+    vi.mocked(getUserSettings).mockResolvedValue(
+      createSettings({ removeTabAfterOpen: true }),
+    )
+    handleUrlDragStarted('https://example.com/page#saved')
+
+    await handleTabCreated({
+      url: 'https://example.com/page#opened',
+    } as chrome.tabs.Tab)
+
+    expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      savedTabs: [
+        {
+          id: 'group-1',
+          domain: 'example.com',
+          urls: [{ url: 'https://example.org/keep', title: 'Other' }],
+        },
+      ],
+    })
+    expect(getDraggedUrlInfo()).toBeNull()
+  })
+
+  it('新規タブURLの query が違う場合は削除しない', async () => {
+    vi.mocked(getUserSettings).mockResolvedValue(
+      createSettings({ removeTabAfterOpen: true }),
+    )
+    handleUrlDragStarted('https://example.com/page?mode=edit')
+
+    await handleTabCreated({
+      url: 'https://example.com/page?mode=view',
+    } as chrome.tabs.Tab)
+
+    expect(chrome.storage.local.set).not.toHaveBeenCalled()
+    expect(getUserSettings).not.toHaveBeenCalled()
+    expect(getDraggedUrlInfo()?.url).toBe('https://example.com/page?mode=edit')
+  })
+
+  it('新規タブURLが部分一致しても別URLなら削除しない', async () => {
+    vi.mocked(getUserSettings).mockResolvedValue(
+      createSettings({ removeTabAfterOpen: true }),
+    )
+    handleUrlDragStarted('https://example.com/page')
+
+    await handleTabCreated({
+      url: 'https://example.com/page-2',
+    } as chrome.tabs.Tab)
+
+    expect(chrome.storage.local.set).not.toHaveBeenCalled()
+    expect(getUserSettings).not.toHaveBeenCalled()
+    expect(getDraggedUrlInfo()?.url).toBe('https://example.com/page')
+  })
+
   it('新規タブURLが一致しても removeTabAfterOpen=false なら削除しない', async () => {
     vi.mocked(getUserSettings).mockResolvedValue(
       createSettings({ removeTabAfterOpen: false }),
@@ -292,7 +359,7 @@ describe('url-storage', () => {
     handleUrlDragStarted('https://example.com/path?query=1')
 
     await handleTabCreated({
-      url: 'https://example.com/path',
+      url: 'https://example.com/path?query=1',
     } as chrome.tabs.Tab)
 
     expect(chrome.storage.local.set).not.toHaveBeenCalled()
@@ -341,17 +408,48 @@ describe('url-storage', () => {
     expect(getDraggedUrlInfo()).toBeNull()
   })
 
-  it('normalizeUrl は trim 失敗時にフォールバック値を返す', () => {
-    const malformed = {
-      trim() {
-        throw new Error('trim failed')
-      },
-      toLowerCase() {
-        return 'fallback-url'
-      },
-    } as unknown as string
+  it('createComparableUrlKey は URL API で host を正規化し hash を明示的に無視できる', () => {
+    expect(
+      createComparableUrlKey('https://Example.com/path?x=1#top', {
+        ignoreHash: true,
+      }),
+    ).toBe('https://example.com/path?x=1')
+  })
 
-    expect(normalizeUrl(malformed)).toBe('fallback-url')
+  it('createComparableUrlKey は query を明示的に無視しない限り比較 key に残す', () => {
+    expect(createComparableUrlKey('https://example.com/path?mode=edit')).toBe(
+      'https://example.com/path?mode=edit',
+    )
+    expect(
+      createComparableUrlKey('https://example.com/path?mode=edit', {
+        ignoreSearch: true,
+      }),
+    ).toBe('https://example.com/path')
+  })
+
+  it('createComparableUrlKey は不正URLで null を返す', () => {
+    expect(createComparableUrlKey('not a url')).toBeNull()
+  })
+
+  it('不正URLの削除要求は保存済みデータを変更しない', async () => {
+    storageState = {
+      savedTabs: [
+        {
+          id: 'group-invalid',
+          domain: 'invalid.example.com',
+          urls: [{ url: 'not a url', title: 'Invalid' }],
+        },
+      ],
+      parentCategories: [],
+      urls: [],
+    }
+    setupChromeMock()
+
+    await removeUrlFromStorage('not a url')
+
+    expect(chrome.storage.local.set).not.toHaveBeenCalled()
+    expect(removeUrlFromAllCustomProjects).not.toHaveBeenCalled()
+    expect(deleteUrlRecord).not.toHaveBeenCalled()
   })
 
   it('URL削除でグループが空になったとき parentCategories からIDを外す', async () => {
@@ -818,6 +916,36 @@ describe('url-storage', () => {
 
     expect(removeUrlFromAllCustomProjects).toHaveBeenCalledWith(
       'https://target.example.com/page',
+    )
+    expect(deleteUrlRecord).toHaveBeenCalledWith('url-id-1')
+  })
+
+  it('urlIdsベース削除は URL API の比較 key で対象レコードを特定する', async () => {
+    storageState = {
+      savedTabs: [
+        {
+          id: 'group-target',
+          domain: 'target.example.com',
+          urlIds: ['url-id-1'],
+        },
+      ],
+      parentCategories: [],
+      urls: [
+        {
+          id: 'url-id-1',
+          url: 'https://Target.example.com/page',
+          title: 'Target',
+          savedAt: 1,
+        },
+      ],
+    }
+    setupChromeMock()
+    vi.mocked(deleteUrlRecord).mockResolvedValue(true)
+
+    await removeUrlFromStorage('https://target.example.com/page')
+
+    expect(removeUrlFromAllCustomProjects).toHaveBeenCalledWith(
+      'https://Target.example.com/page',
     )
     expect(deleteUrlRecord).toHaveBeenCalledWith('url-id-1')
   })

--- a/src/lib/background/url-storage.ts
+++ b/src/lib/background/url-storage.ts
@@ -33,17 +33,35 @@ const getDraggedUrlInfo = (): DraggedUrlInfo | null => draggedUrlInfo
 const clearDraggedUrlInfo = (): void => {
   draggedUrlInfo = null
 }
+interface ComparableUrlKeyOptions {
+  readonly ignoreHash?: boolean
+  readonly ignoreSearch?: boolean
+}
+
 /**
- * URLを正規化する関数（比較のため）
+ * URL比較用の安全な key を作成する。
  */
-const normalizeUrl = (url: string): string => {
+const createComparableUrlKey = (
+  rawUrl: string,
+  options: ComparableUrlKeyOptions = {},
+): string | null => {
   try {
-    // 不要なパラメータやフラグメントを取り除く
-    return url.trim().toLowerCase().split('#')[0].split('?')[0]
+    const url = new URL(rawUrl.trim())
+    url.hostname = url.hostname.toLowerCase()
+
+    if (options.ignoreHash) {
+      url.hash = ''
+    }
+    if (options.ignoreSearch) {
+      url.search = ''
+    }
+
+    return url.toString()
   } catch {
-    return url.toLowerCase()
+    return null
   }
 }
+
 const removeUrlIdFromGroup = (
   group: TabGroup,
   matchedUrlId: string,
@@ -78,13 +96,15 @@ const removeUrlIdFromGroup = (
 }
 const removeLegacyUrlFromGroup = (
   group: TabGroup,
-  url: string,
+  targetUrlKey: string,
   removedGroupIds: string[],
 ): TabGroup[] => {
   if (!Array.isArray(group.urls)) {
     return [group]
   }
-  const updatedUrls = group.urls.filter((item) => item.url !== url)
+  const updatedUrls = group.urls.filter(
+    (item) => createComparableUrlKey(item.url) !== targetUrlKey,
+  )
   if (updatedUrls.length === group.urls.length) {
     return [group]
   }
@@ -101,7 +121,7 @@ const removeLegacyUrlFromGroup = (
 }
 const updateGroupAfterUrlRemoval = (
   group: TabGroup,
-  url: string,
+  targetUrlKey: string,
   matchedUrlId: string | undefined,
   removedGroupIds: string[],
 ): TabGroup[] => {
@@ -111,7 +131,7 @@ const updateGroupAfterUrlRemoval = (
     }
     return removeUrlIdFromGroup(group, matchedUrlId, removedGroupIds)
   }
-  return removeLegacyUrlFromGroup(group, url, removedGroupIds)
+  return removeLegacyUrlFromGroup(group, targetUrlKey, removedGroupIds)
 }
 
 interface BulkUrlRemovalStorage {
@@ -309,6 +329,15 @@ const removeUrlRecordsById = (
  */
 const removeUrlFromStorage = async (url: string): Promise<void> => {
   try {
+    const targetUrlKey = createComparableUrlKey(url)
+    if (!targetUrlKey) {
+      console.log(
+        '削除対象URLを比較可能な形式にできないため、削除をスキップしました:',
+        redactUrlForLog(url),
+      )
+      return
+    }
+
     const storageResult = await chrome.storage.local.get<{
       savedTabs?: TabGroup[]
       urls?: UrlRecord[]
@@ -319,12 +348,20 @@ const removeUrlFromStorage = async (url: string): Promise<void> => {
     const urlRecords = Array.isArray(storageResult.urls)
       ? storageResult.urls
       : []
-    const matchedUrlId = urlRecords.find((record) => record.url === url)?.id
+    const matchedUrlRecord = urlRecords.find(
+      (record) => createComparableUrlKey(record.url) === targetUrlKey,
+    )
+    const matchedUrlId = matchedUrlRecord?.id
     const removedGroupIds: string[] = []
 
     // URLを含むグループのみを更新（新形式 urlIds / 旧形式 urls の両方に対応）
     const updatedGroups: TabGroup[] = savedTabs.flatMap((group: TabGroup) =>
-      updateGroupAfterUrlRemoval(group, url, matchedUrlId, removedGroupIds),
+      updateGroupAfterUrlRemoval(
+        group,
+        targetUrlKey,
+        matchedUrlId,
+        removedGroupIds,
+      ),
     )
 
     // 複数グループを単一の read-modify-write で外し、カテゴリ更新の競合を防ぐ。
@@ -335,9 +372,9 @@ const removeUrlFromStorage = async (url: string): Promise<void> => {
       savedTabs: updatedGroups,
     })
 
-    if (matchedUrlId) {
-      await removeUrlFromAllCustomProjects(url)
-      await deleteUrlRecord(matchedUrlId)
+    if (matchedUrlRecord) {
+      await removeUrlFromAllCustomProjects(matchedUrlRecord.url)
+      await deleteUrlRecord(matchedUrlRecord.id)
     }
 
     console.log(`ストレージからURL ${redactUrlForLog(url)} を削除しました`)
@@ -524,29 +561,21 @@ const handleTabCreated = async (tab: chrome.tabs.Tab): Promise<void> => {
     )
     console.log('新しいタブのURL:', redactUrlForLog(tab.url))
 
-    // URLを正規化して比較
-    const normalizedDraggedUrl = normalizeUrl(draggedUrlInfo.url)
-    const normalizedTabUrl = normalizeUrl(tab.url ?? '')
-    console.log(
-      '正規化されたドラッグURL:',
-      redactUrlForLog(normalizedDraggedUrl),
-    )
-    console.log('正規化された新タブURL:', redactUrlForLog(normalizedTabUrl))
+    const draggedUrlKey = createComparableUrlKey(draggedUrlInfo.url, {
+      ignoreHash: true,
+    })
+    const tabUrlKey = createComparableUrlKey(tab.url ?? '', {
+      ignoreHash: true,
+    })
+    console.log('比較用ドラッグURL:', redactUrlForLog(draggedUrlInfo.url))
+    console.log('比較用新タブURL:', redactUrlForLog(tab.url))
 
     // URLが一致しない場合は何もしない
-    if (
-      !normalizedTabUrl ||
-      !normalizedDraggedUrl ||
-      !(
-        normalizedTabUrl === normalizedDraggedUrl ||
-        normalizedTabUrl.includes(normalizedDraggedUrl) ||
-        normalizedDraggedUrl.includes(normalizedTabUrl)
-      )
-    ) {
+    if (!tabUrlKey || !draggedUrlKey || tabUrlKey !== draggedUrlKey) {
       console.log('URLが一致しません。削除をスキップします')
       return
     }
-    console.log('URLが一致または類似しています')
+    console.log('URLが一致しています')
     try {
       // 処理済みとマーク
       draggedUrlInfo.processed = true
@@ -571,11 +600,11 @@ const handleTabCreated = async (tab: chrome.tabs.Tab): Promise<void> => {
 
 export {
   clearDraggedUrlInfo,
+  createComparableUrlKey,
   getDraggedUrlInfo,
   handleTabCreated,
   handleUrlDragStarted,
   handleUrlDropped,
-  normalizeUrl,
   removeUrlFromStorage,
   removeUrlRecordsFromStorage,
   setDraggedUrlInfo,


### PR DESCRIPTION
## 変更内容

- URL 比較用に `URL` API ベースの `createComparableUrlKey` を導入
- `handleTabCreated` の URL 判定から `includes` による部分一致を削除
- tab 作成後の削除判定では hash のみ明示的に無視し、query は区別
- 不正 URL の削除要求は保存済みデータを変更せずにスキップ
- hash 差分、query 差分、`page` / `page-2`、不正 URL、URL record の比較 key 追加テストを追加

## 検証

- `rtk bun run test:node -- src/lib/background/url-storage.test.ts` pass
- `rtk bun run check` pass
- `rtk bun run compile` pass
- `rtk bun run arch:check` pass
- `rtk bun run knip` pass
- `rtk bun run check:duplication` pass
- `rtk bun run secretlint` pass
- `rtk bun run quality` は `src/features/options/SubCategoryKeywordManager.test.tsx` の既存 failure で停止
  - 同じ `rtk bun run test:dom -- src/features/options/SubCategoryKeywordManager.test.tsx` は clean `develop` でも失敗することを確認済み

Closes #655
