### PR TITLE
savedTabs更新をmutation queueに統一

### DIFF
--- a/src/lib/background/url-storage.test.ts
+++ b/src/lib/background/url-storage.test.ts
@@ -477,9 +477,8 @@ describe('url-storage', () => {
     await Promise.resolve()
     await Promise.resolve()
 
-    expect(chrome.storage.local.set).toHaveBeenCalledWith({ savedTabs: [] })
-
     expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      savedTabs: [],
       parentCategories: [
         {
           id: 'cat-1',
@@ -557,7 +556,7 @@ describe('url-storage', () => {
     })
   })
 
-  it('parentCategories 更新時に例外が起きても削除処理は継続する', async () => {
+  it('一括取得で失敗した場合は removeUrlFromStorage がエラーを再スローする', async () => {
     storageState = {
       savedTabs: [
         {
@@ -571,25 +570,9 @@ describe('url-storage', () => {
     setupChromeMock()
 
     vi.mocked(chrome.storage.local.get).mockImplementation(
-      // eslint-disable-line
-      // eslint-disable-line
-      // eslint-disable-line
       async (key: unknown) => {
-        // eslint-disable-line
-        // eslint-disable-line
-        // eslint-disable-line
-        // eslint-disable-line
         if (Array.isArray(key)) {
-          return {
-            savedTabs: storageState.savedTabs,
-            urls: storageState.urls,
-          }
-        }
-        if (key === 'savedTabs') {
-          return { savedTabs: storageState.savedTabs }
-        }
-        if (key === 'parentCategories') {
-          throw new Error('parent category read failed')
+          throw new TypeError('storage read failed')
         }
         return {}
       },
@@ -597,13 +580,11 @@ describe('url-storage', () => {
 
     await expect(
       removeUrlFromStorage('https://single.example.com'),
-    ).resolves.toBeUndefined()
-    await Promise.resolve()
+    ).rejects.toThrow('storage read failed')
 
-    expect(chrome.storage.local.set).toHaveBeenCalledWith({ savedTabs: [] })
     expect(console.error).toHaveBeenCalledWith(
-      '親カテゴリからの削除中にエラーが発生しました:',
-      'parent category read failed',
+      'URLの削除中にエラーが発生しました:',
+      expect.any(Error),
     )
   })
 
@@ -695,6 +676,7 @@ describe('url-storage', () => {
     await Promise.resolve()
 
     expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      savedTabs: [],
       parentCategories: [
         {
           id: 'cat-1',
@@ -743,7 +725,7 @@ describe('url-storage', () => {
     ).resolves.toBeUndefined()
   })
 
-  it('removeFromParentCategories で非Error例外が発生しても処理を継続する', async () => {
+  it('一括取得で非Error例外が発生しても再スローする', async () => {
     storageState = {
       savedTabs: [
         {
@@ -757,24 +739,8 @@ describe('url-storage', () => {
     setupChromeMock()
 
     vi.mocked(chrome.storage.local.get).mockImplementation(
-      // eslint-disable-line
-      // eslint-disable-line
-      // eslint-disable-line
       async (key: unknown) => {
-        // eslint-disable-line
-        // eslint-disable-line
-        // eslint-disable-line
-        // eslint-disable-line
         if (Array.isArray(key)) {
-          return {
-            savedTabs: storageState.savedTabs,
-            urls: storageState.urls,
-          }
-        }
-        if (key === 'savedTabs') {
-          return { savedTabs: storageState.savedTabs }
-        }
-        if (key === 'parentCategories') {
           // eslint-disable-next-line eslint/no-throw-literal
           throw 'non-error-thrown' // eslint-disable-line
         }
@@ -782,11 +748,12 @@ describe('url-storage', () => {
       },
     )
 
-    await removeUrlFromStorage('https://non-error.example.com')
-    await Promise.resolve()
+    await expect(
+      removeUrlFromStorage('https://non-error.example.com'),
+    ).rejects.toBe('non-error-thrown')
 
     expect(console.error).toHaveBeenCalledWith(
-      '親カテゴリからの削除中にエラーが発生しました:',
+      'URLの削除中にエラーが発生しました:',
       'non-error-thrown',
     )
   })
@@ -887,10 +854,18 @@ describe('url-storage', () => {
           urlSubCategories: { 'url-id-2': 'catB' },
         },
       ],
+      urls: [
+        {
+          id: 'url-id-2',
+          url: 'https://other.example.com/page',
+          title: 'Other',
+          savedAt: 2,
+        },
+      ],
     })
   })
 
-  it('urlIdsベース削除ではカスタムプロジェクト同期後に未参照URLレコードも削除する', async () => {
+  it('urlIdsベース削除では同一mutation内で未参照URLレコードも削除する', async () => {
     storageState = {
       savedTabs: [
         {
@@ -910,14 +885,129 @@ describe('url-storage', () => {
       ],
     }
     setupChromeMock()
-    vi.mocked(deleteUrlRecord).mockResolvedValue(true)
 
     await removeUrlFromStorage('https://target.example.com/page')
 
-    expect(removeUrlFromAllCustomProjects).toHaveBeenCalledWith(
-      'https://target.example.com/page',
-    )
-    expect(deleteUrlRecord).toHaveBeenCalledWith('url-id-1')
+    expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      savedTabs: [],
+      urls: [],
+    })
+    expect(removeUrlFromAllCustomProjects).not.toHaveBeenCalled()
+    expect(deleteUrlRecord).not.toHaveBeenCalled()
+  })
+
+  it('同時URL削除でもsavedTabs関連ストレージを古いsnapshotで上書きしない', async () => {
+    storageState = {
+      customProjects: [
+        {
+          id: 'project-1',
+          name: 'Project 1',
+          urlIds: ['url-a', 'url-b', 'url-keep'],
+          urlMetadata: {
+            'url-a': { category: 'Remove A' },
+            'url-b': { category: 'Remove B' },
+            'url-keep': { category: 'Keep' },
+          },
+          categories: [],
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+      savedTabs: [
+        {
+          id: 'group-a',
+          domain: 'a.example.com',
+          urlIds: ['url-a'],
+          urlSubCategories: { 'url-a': 'Remove A' },
+        },
+        {
+          id: 'group-b',
+          domain: 'b.example.com',
+          urlIds: ['url-b'],
+          urlSubCategories: { 'url-b': 'Remove B' },
+        },
+        {
+          id: 'group-keep',
+          domain: 'keep.example.com',
+          urlIds: ['url-keep'],
+          urlSubCategories: { 'url-keep': 'Keep' },
+        },
+      ],
+      parentCategories: [
+        {
+          id: 'cat-1',
+          name: 'Category 1',
+          domains: ['group-a', 'group-b', 'group-keep'],
+          domainNames: ['a.example.com', 'b.example.com', 'keep.example.com'],
+        },
+      ],
+      urls: [
+        {
+          id: 'url-a',
+          url: 'https://a.example.com/page',
+          title: 'A',
+          savedAt: 1,
+        },
+        {
+          id: 'url-b',
+          url: 'https://b.example.com/page',
+          title: 'B',
+          savedAt: 2,
+        },
+        {
+          id: 'url-keep',
+          url: 'https://keep.example.com/page',
+          title: 'Keep',
+          savedAt: 3,
+        },
+      ],
+    }
+    setupChromeMock({ cloneReads: true })
+
+    await Promise.all([
+      removeUrlFromStorage('https://a.example.com/page'),
+      removeUrlFromStorage('https://b.example.com/page'),
+    ])
+
+    expect(storageState.savedTabs).toStrictEqual([
+      {
+        id: 'group-keep',
+        domain: 'keep.example.com',
+        urlIds: ['url-keep'],
+        urlSubCategories: { 'url-keep': 'Keep' },
+      },
+    ])
+    expect(storageState.parentCategories).toStrictEqual([
+      {
+        id: 'cat-1',
+        name: 'Category 1',
+        domains: ['group-keep'],
+        domainNames: ['a.example.com', 'b.example.com', 'keep.example.com'],
+      },
+    ])
+    expect(storageState.customProjects).toStrictEqual([
+      {
+        id: 'project-1',
+        name: 'Project 1',
+        urlIds: ['url-keep'],
+        urlMetadata: {
+          'url-keep': { category: 'Keep' },
+        },
+        categories: [],
+        createdAt: 1,
+        updatedAt: expect.any(Number),
+      },
+    ])
+    expect(storageState.urls).toStrictEqual([
+      {
+        id: 'url-keep',
+        url: 'https://keep.example.com/page',
+        title: 'Keep',
+        savedAt: 3,
+      },
+    ])
+    expect(removeUrlFromAllCustomProjects).not.toHaveBeenCalled()
+    expect(deleteUrlRecord).not.toHaveBeenCalled()
   })
 
   it('urlIdsベース削除は URL API の比較 key で対象レコードを特定する', async () => {
@@ -940,14 +1030,15 @@ describe('url-storage', () => {
       ],
     }
     setupChromeMock()
-    vi.mocked(deleteUrlRecord).mockResolvedValue(true)
 
     await removeUrlFromStorage('https://target.example.com/page')
 
-    expect(removeUrlFromAllCustomProjects).toHaveBeenCalledWith(
-      'https://Target.example.com/page',
-    )
-    expect(deleteUrlRecord).toHaveBeenCalledWith('url-id-1')
+    expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      savedTabs: [],
+      urls: [],
+    })
+    expect(removeUrlFromAllCustomProjects).not.toHaveBeenCalled()
+    expect(deleteUrlRecord).not.toHaveBeenCalled()
   })
 
   it('urlIdsベースで対象URLを削除しても他URLが残る場合はグループを維持する', async () => {
@@ -994,6 +1085,14 @@ describe('url-storage', () => {
           },
         },
       ],
+      urls: [
+        {
+          id: 'url-id-3',
+          url: 'https://target.example.com/keep',
+          title: 'Keep',
+          savedAt: 3,
+        },
+      ],
     })
   })
 
@@ -1038,6 +1137,14 @@ describe('url-storage', () => {
           urlSubCategories: undefined,
         },
       ],
+      urls: [
+        {
+          id: 'url-id-2',
+          url: 'https://target.example.com/keep',
+          title: 'Keep',
+          savedAt: 2,
+        },
+      ],
     })
   })
 
@@ -1077,6 +1184,14 @@ describe('url-storage', () => {
           domain: 'target.example.com',
           urlIds: ['url-id-2'],
           urlSubCategories: undefined,
+        },
+      ],
+      urls: [
+        {
+          id: 'url-id-2',
+          url: 'https://target.example.com/keep',
+          title: 'Keep',
+          savedAt: 2,
         },
       ],
     })
@@ -1188,6 +1303,7 @@ describe('url-storage', () => {
     await removeUrlFromStorage('https://domainnames.example.com')
 
     expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      savedTabs: [],
       parentCategories: [
         {
           id: 'cat-1',

--- a/src/lib/background/url-storage.test.ts
+++ b/src/lib/background/url-storage.test.ts
@@ -62,7 +62,7 @@ interface StorageState {
     id: string
     domain: string
     parentCategoryId?: string
-    urls?: { url: string; title: string }[]
+    urls?: { id?: string; url: string; title: string; savedAt?: number }[]
     urlIds?: string[]
     urlSubCategories?: Record<string, string>
   }[]
@@ -382,11 +382,11 @@ describe('url-storage', () => {
     vi.mocked(getUserSettings).mockResolvedValue(
       createSettings({ removeTabAfterOpen: true }),
     )
-    handleUrlDragStarted('https://example.com/path')
+    handleUrlDragStarted('https://example.com')
 
     await expect(
       handleTabCreated({
-        url: 'https://example.com/path',
+        url: 'https://example.com',
       } as chrome.tabs.Tab),
     ).resolves.toBeUndefined()
 
@@ -606,7 +606,7 @@ describe('url-storage', () => {
     )
   })
 
-  it('savedTabs が未定義でも空配列として保存する', async () => {
+  it('savedTabs が未定義で削除対象がない場合は保存しない', async () => {
     storageState = {
       parentCategories: [],
     }
@@ -614,7 +614,7 @@ describe('url-storage', () => {
 
     await removeUrlFromStorage('https://example.com')
 
-    expect(chrome.storage.local.set).toHaveBeenCalledWith({ savedTabs: [] })
+    expect(chrome.storage.local.set).not.toHaveBeenCalled()
   })
 
   it('urls/urlIds 未定義グループは保持し、カテゴリ更新を行わない', async () => {
@@ -638,18 +638,7 @@ describe('url-storage', () => {
     await removeUrlFromStorage('https://does-not-exist.example.com')
     await Promise.resolve()
 
-    expect(chrome.storage.local.set).toHaveBeenCalledWith({
-      savedTabs: [
-        {
-          id: 'group-no-urls',
-          domain: 'no-urls.example.com',
-        },
-      ],
-    })
-
-    expect(chrome.storage.local.set).not.toHaveBeenCalledWith({
-      parentCategories: expect.anything(),
-    })
+    expect(chrome.storage.local.set).not.toHaveBeenCalled()
   })
 
   it('domainNames に対象ドメインがない場合の分岐を通る', async () => {
@@ -1221,16 +1210,80 @@ describe('url-storage', () => {
 
     await removeUrlFromStorage('https://target.example.com/page')
 
-    expect(chrome.storage.local.set).toHaveBeenCalledWith({
+    expect(chrome.storage.local.set).not.toHaveBeenCalled()
+  })
+
+  it('単一URL削除でsavedTabsが変わらない場合はsavedTabsを書き戻さない', async () => {
+    storageState = {
+      customProjects: [
+        {
+          id: 'project-1',
+          name: 'Project 1',
+          urlIds: ['url-id-1', 'url-id-keep'],
+          urlMetadata: {
+            'url-id-1': { category: 'Remove' },
+            'url-id-keep': { category: 'Keep' },
+          },
+          categories: [],
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+      parentCategories: [],
       savedTabs: [
         {
-          id: 'group-target',
-          domain: 'target.example.com',
-          urlIds: ['url-id-1'],
-          urlSubCategories: { 'url-id-1': 'catA' },
+          id: 'group-keep',
+          domain: 'keep.example.com',
+          urlIds: ['url-id-keep'],
+        },
+      ],
+      urls: [
+        {
+          id: 'url-id-1',
+          url: 'https://project.example.com/remove',
+          title: 'Remove',
+          savedAt: 1,
+        },
+        {
+          id: 'url-id-keep',
+          url: 'https://keep.example.com/page',
+          title: 'Keep',
+          savedAt: 2,
+        },
+      ],
+    }
+    setupChromeMock({ cloneReads: true })
+
+    await removeUrlFromStorage('https://project.example.com/remove')
+
+    expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      customProjects: [
+        {
+          id: 'project-1',
+          name: 'Project 1',
+          urlIds: ['url-id-keep'],
+          urlMetadata: {
+            'url-id-keep': { category: 'Keep' },
+          },
+          categories: [],
+          createdAt: 1,
+          updatedAt: expect.any(Number),
+        },
+      ],
+      urls: [
+        {
+          id: 'url-id-keep',
+          url: 'https://keep.example.com/page',
+          title: 'Keep',
+          savedAt: 2,
         },
       ],
     })
+    expect(chrome.storage.local.set).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        savedTabs: expect.anything(),
+      }),
+    )
   })
 
   it('カテゴリ削除処理で parentCategories/savedTabs 未定義でもフォールバックする', async () => {
@@ -1619,6 +1672,93 @@ describe('url-storage', () => {
           savedAt: 2,
           title: 'Keep',
           url: 'https://project.example.com/2',
+        },
+      ],
+    })
+  })
+
+  it('一括削除は旧形式urlsだけのグループと親カテゴリ参照も更新する', async () => {
+    storageState = {
+      customProjects: [],
+      parentCategories: [
+        {
+          id: 'cat-1',
+          name: 'Category 1',
+          domains: ['legacy-empty', 'group-keep'],
+          domainNames: ['legacy.example.com', 'keep.example.com'],
+        },
+      ],
+      savedTabs: [
+        {
+          id: 'legacy-empty',
+          domain: 'legacy.example.com',
+          urls: [
+            {
+              url: 'https://legacy.example.com/remove',
+              title: 'Remove',
+            },
+          ],
+        },
+        {
+          id: 'group-keep',
+          domain: 'keep.example.com',
+          urls: [
+            {
+              id: 'keep-url',
+              url: 'https://keep.example.com/page',
+              title: 'Keep',
+            },
+          ],
+        },
+      ],
+      urls: [
+        {
+          id: 'legacy-url',
+          savedAt: 1,
+          title: 'Remove',
+          url: 'https://legacy.example.com/remove',
+        },
+        {
+          id: 'keep-url',
+          savedAt: 2,
+          title: 'Keep',
+          url: 'https://keep.example.com/page',
+        },
+      ],
+    }
+    setupChromeMock({ cloneReads: true })
+
+    const removedCount = await removeUrlRecordsFromStorage(['legacy-url'])
+
+    expect(removedCount).toBe(1)
+    expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      parentCategories: [
+        {
+          id: 'cat-1',
+          name: 'Category 1',
+          domains: ['group-keep'],
+          domainNames: ['legacy.example.com', 'keep.example.com'],
+        },
+      ],
+      savedTabs: [
+        {
+          id: 'group-keep',
+          domain: 'keep.example.com',
+          urls: [
+            {
+              id: 'keep-url',
+              url: 'https://keep.example.com/page',
+              title: 'Keep',
+            },
+          ],
+        },
+      ],
+      urls: [
+        {
+          id: 'keep-url',
+          savedAt: 2,
+          title: 'Keep',
+          url: 'https://keep.example.com/page',
         },
       ],
     })

--- a/src/lib/background/url-storage.ts
+++ b/src/lib/background/url-storage.ts
@@ -132,6 +132,40 @@ const removeLegacyUrlFromGroup = (
     },
   ]
 }
+
+const removeLegacyUrlIdsFromGroup = (
+  group: TabGroup,
+  targetUrlIds: Set<string>,
+  targetUrlKeys: Set<string>,
+  removedGroupIds: string[],
+): TabGroup[] => {
+  if (!Array.isArray(group.urls)) {
+    return [group]
+  }
+
+  const updatedUrls = group.urls.filter((item) => {
+    if (item.id && targetUrlIds.has(item.id)) {
+      return false
+    }
+
+    const itemUrlKey = createComparableUrlKey(item.url)
+    return !(itemUrlKey && targetUrlKeys.has(itemUrlKey))
+  })
+  if (updatedUrls.length === group.urls.length) {
+    return [group]
+  }
+  if (updatedUrls.length === 0) {
+    removedGroupIds.push(group.id)
+    return []
+  }
+  return [
+    {
+      ...group,
+      urls: updatedUrls,
+    },
+  ]
+}
+
 const updateGroupAfterUrlRemoval = (
   group: TabGroup,
   targetUrlKey: string,
@@ -173,6 +207,28 @@ interface BulkParentCategoriesRemovalResult {
 const createUrlIdSet = (urlIds: string[]): Set<string> =>
   new Set(urlIds.filter((id) => typeof id === 'string' && id.length > 0))
 
+const createComparableUrlKeySet = (
+  urls: UrlRecord[],
+  urlIds: Set<string>,
+): Set<string> =>
+  new Set(
+    urls.flatMap((record) => {
+      if (!urlIds.has(record.id)) {
+        return []
+      }
+
+      const urlKey = createComparableUrlKey(record.url)
+      return urlKey ? [urlKey] : []
+    }),
+  )
+
+const haveTabGroupsChanged = (
+  currentGroups: TabGroup[],
+  nextGroups: TabGroup[],
+): boolean =>
+  currentGroups.length !== nextGroups.length ||
+  nextGroups.some((group, index) => group !== currentGroups[index])
+
 const removeUrlIdsFromRecord = <T>(
   record: Record<string, T> | undefined,
   urlIds: Set<string>,
@@ -199,6 +255,7 @@ const removeUrlIdsFromRecord = <T>(
 const removeUrlIdsFromSavedTabs = (
   savedTabs: TabGroup[],
   urlIds: Set<string>,
+  targetUrlKeys = new Set<string>(),
 ): BulkSavedTabsRemovalResult => {
   let hasChanges = false
   const removedGroupIds: string[] = []
@@ -206,7 +263,16 @@ const removeUrlIdsFromSavedTabs = (
 
   for (const group of savedTabs) {
     if (!Array.isArray(group.urlIds)) {
-      updatedTabs.push(group)
+      const nextGroups = removeLegacyUrlIdsFromGroup(
+        group,
+        urlIds,
+        targetUrlKeys,
+        removedGroupIds,
+      )
+      if (nextGroups[0] !== group || nextGroups.length === 0) {
+        hasChanges = true
+      }
+      updatedTabs.push(...nextGroups)
       continue
     }
 
@@ -402,10 +468,11 @@ const removeUrlFromStorage = async (url: string): Promise<void> => {
         targetUrlIds,
       )
       const urlsResult = removeUrlRecordsById(urlRecords, targetUrlIds)
-      const payload: BulkUrlRemovalStorage = {
-        savedTabs: updatedGroups,
-      }
+      const payload: BulkUrlRemovalStorage = {}
 
+      if (haveTabGroupsChanged(savedTabs, updatedGroups)) {
+        payload.savedTabs = updatedGroups
+      }
       if (parentCategoriesResult.hasChanges) {
         payload.parentCategories = parentCategoriesResult.parentCategories
       }
@@ -416,9 +483,11 @@ const removeUrlFromStorage = async (url: string): Promise<void> => {
         payload.urls = urlsResult.urls
       }
 
-      await chrome.storage.local.set(payload)
-      if (urlsResult.hasChanges) {
-        invalidateUrlCache()
+      if (Object.keys(payload).length > 0) {
+        await chrome.storage.local.set(payload)
+        if (urlsResult.hasChanges) {
+          invalidateUrlCache()
+        }
       }
     })
 
@@ -457,7 +526,12 @@ const removeUrlRecordsFromStorage = async (
       const parentCategories = Array.isArray(storageResult.parentCategories)
         ? storageResult.parentCategories
         : []
-      const savedTabsResult = removeUrlIdsFromSavedTabs(savedTabs, targetUrlIds)
+      const targetUrlKeys = createComparableUrlKeySet(urls, targetUrlIds)
+      const savedTabsResult = removeUrlIdsFromSavedTabs(
+        savedTabs,
+        targetUrlIds,
+        targetUrlKeys,
+      )
       const customProjectsResult = removeUrlIdsFromCustomProjects(
         customProjects,
         targetUrlIds,

--- a/src/lib/background/url-storage.ts
+++ b/src/lib/background/url-storage.ts
@@ -3,9 +3,8 @@
  */
 
 import { redactUrlForLog } from '@/lib/logging/redact-url'
-import { removeUrlFromAllCustomProjects } from '@/lib/storage/projects'
 import { getUserSettings } from '@/lib/storage/settings'
-import { deleteUrlRecord, invalidateUrlCache } from '@/lib/storage/urls'
+import { invalidateUrlCache } from '@/lib/storage/urls'
 import type { DraggedUrlInfo } from '@/types/background'
 import type {
   CustomProject,
@@ -16,6 +15,20 @@ import type {
 
 // ドラッグされたURL情報を一時保存するためのストア
 let draggedUrlInfo: DraggedUrlInfo | null = null
+let savedTabsStorageMutationQueue: Promise<void> = Promise.resolve()
+
+const enqueueStorageMutation = async <T>(
+  mutation: () => Promise<T>,
+): Promise<T> => {
+  const nextTask = savedTabsStorageMutationQueue.then(mutation, mutation)
+
+  savedTabsStorageMutationQueue = nextTask.then(
+    () => undefined,
+    () => undefined,
+  )
+
+  return nextTask
+}
 
 /**
  * ドラッグ情報を設定
@@ -328,54 +341,86 @@ const removeUrlRecordsById = (
  * URLをストレージから削除する関数（カテゴリ設定とマッピングを保持）
  */
 const removeUrlFromStorage = async (url: string): Promise<void> => {
+  const targetUrlKey = createComparableUrlKey(url)
+  if (!targetUrlKey) {
+    console.log(
+      '削除対象URLを比較可能な形式にできないため、削除をスキップしました:',
+      redactUrlForLog(url),
+    )
+    return
+  }
+
   try {
-    const targetUrlKey = createComparableUrlKey(url)
-    if (!targetUrlKey) {
-      console.log(
-        '削除対象URLを比較可能な形式にできないため、削除をスキップしました:',
-        redactUrlForLog(url),
+    await enqueueStorageMutation(async () => {
+      const storageResult =
+        await chrome.storage.local.get<BulkUrlRemovalStorage>([
+          'savedTabs',
+          'urls',
+          'customProjects',
+          'parentCategories',
+        ])
+      const savedTabs: TabGroup[] = Array.isArray(storageResult.savedTabs)
+        ? storageResult.savedTabs
+        : []
+      const urlRecords = Array.isArray(storageResult.urls)
+        ? storageResult.urls
+        : []
+      const customProjects = Array.isArray(storageResult.customProjects)
+        ? storageResult.customProjects
+        : []
+      const parentCategories = Array.isArray(storageResult.parentCategories)
+        ? storageResult.parentCategories
+        : []
+      const matchedUrlRecord = urlRecords.find(
+        (record) => createComparableUrlKey(record.url) === targetUrlKey,
       )
-      return
-    }
+      const matchedUrlId = matchedUrlRecord?.id
+      const removedGroupIds: string[] = []
 
-    const storageResult = await chrome.storage.local.get<{
-      savedTabs?: TabGroup[]
-      urls?: UrlRecord[]
-    }>(['savedTabs', 'urls'])
-    const savedTabs: TabGroup[] = Array.isArray(storageResult.savedTabs)
-      ? storageResult.savedTabs
-      : []
-    const urlRecords = Array.isArray(storageResult.urls)
-      ? storageResult.urls
-      : []
-    const matchedUrlRecord = urlRecords.find(
-      (record) => createComparableUrlKey(record.url) === targetUrlKey,
-    )
-    const matchedUrlId = matchedUrlRecord?.id
-    const removedGroupIds: string[] = []
+      // URLを含むグループのみを更新（新形式 urlIds / 旧形式 urls の両方に対応）
+      const updatedGroups: TabGroup[] = savedTabs.flatMap((group: TabGroup) =>
+        updateGroupAfterUrlRemoval(
+          group,
+          targetUrlKey,
+          matchedUrlId,
+          removedGroupIds,
+        ),
+      )
+      const removedGroupIdsWithDomain = removedGroupIds.filter((groupId) => {
+        const group = savedTabs.find((item) => item.id === groupId)
+        return Boolean(group?.domain)
+      })
+      const parentCategoriesResult = removeGroupsFromParentCategories(
+        parentCategories,
+        removedGroupIdsWithDomain,
+      )
+      const targetUrlIds = matchedUrlId
+        ? createUrlIdSet([matchedUrlId])
+        : new Set<string>()
+      const customProjectsResult = removeUrlIdsFromCustomProjects(
+        customProjects,
+        targetUrlIds,
+      )
+      const urlsResult = removeUrlRecordsById(urlRecords, targetUrlIds)
+      const payload: BulkUrlRemovalStorage = {
+        savedTabs: updatedGroups,
+      }
 
-    // URLを含むグループのみを更新（新形式 urlIds / 旧形式 urls の両方に対応）
-    const updatedGroups: TabGroup[] = savedTabs.flatMap((group: TabGroup) =>
-      updateGroupAfterUrlRemoval(
-        group,
-        targetUrlKey,
-        matchedUrlId,
-        removedGroupIds,
-      ),
-    )
+      if (parentCategoriesResult.hasChanges) {
+        payload.parentCategories = parentCategoriesResult.parentCategories
+      }
+      if (customProjectsResult.hasChanges) {
+        payload.customProjects = customProjectsResult.customProjects
+      }
+      if (urlsResult.hasChanges) {
+        payload.urls = urlsResult.urls
+      }
 
-    // 複数グループを単一の read-modify-write で外し、カテゴリ更新の競合を防ぐ。
-    await removeFromParentCategories(removedGroupIds, savedTabs)
-
-    // 更新したグループをストレージに保存
-    await chrome.storage.local.set({
-      savedTabs: updatedGroups,
+      await chrome.storage.local.set(payload)
+      if (urlsResult.hasChanges) {
+        invalidateUrlCache()
+      }
     })
-
-    if (matchedUrlRecord) {
-      await removeUrlFromAllCustomProjects(matchedUrlRecord.url)
-      await deleteUrlRecord(matchedUrlRecord.id)
-    }
 
     console.log(`ストレージからURL ${redactUrlForLog(url)} を削除しました`)
   } catch (error) {
@@ -394,102 +439,62 @@ const removeUrlRecordsFromStorage = async (
   }
 
   try {
-    const storageResult = await chrome.storage.local.get<BulkUrlRemovalStorage>(
-      ['savedTabs', 'urls', 'customProjects', 'parentCategories'],
-    )
-    const savedTabs = Array.isArray(storageResult.savedTabs)
-      ? storageResult.savedTabs
-      : []
-    const urls = Array.isArray(storageResult.urls) ? storageResult.urls : []
-    const customProjects = Array.isArray(storageResult.customProjects)
-      ? storageResult.customProjects
-      : []
-    const parentCategories = Array.isArray(storageResult.parentCategories)
-      ? storageResult.parentCategories
-      : []
-    const savedTabsResult = removeUrlIdsFromSavedTabs(savedTabs, targetUrlIds)
-    const customProjectsResult = removeUrlIdsFromCustomProjects(
-      customProjects,
-      targetUrlIds,
-    )
-    const parentCategoriesResult = removeGroupsFromParentCategories(
-      parentCategories,
-      savedTabsResult.removedGroupIds,
-    )
-    const urlsResult = removeUrlRecordsById(urls, targetUrlIds)
-    const payload: BulkUrlRemovalStorage = {}
+    return await enqueueStorageMutation(async () => {
+      const storageResult =
+        await chrome.storage.local.get<BulkUrlRemovalStorage>([
+          'savedTabs',
+          'urls',
+          'customProjects',
+          'parentCategories',
+        ])
+      const savedTabs = Array.isArray(storageResult.savedTabs)
+        ? storageResult.savedTabs
+        : []
+      const urls = Array.isArray(storageResult.urls) ? storageResult.urls : []
+      const customProjects = Array.isArray(storageResult.customProjects)
+        ? storageResult.customProjects
+        : []
+      const parentCategories = Array.isArray(storageResult.parentCategories)
+        ? storageResult.parentCategories
+        : []
+      const savedTabsResult = removeUrlIdsFromSavedTabs(savedTabs, targetUrlIds)
+      const customProjectsResult = removeUrlIdsFromCustomProjects(
+        customProjects,
+        targetUrlIds,
+      )
+      const parentCategoriesResult = removeGroupsFromParentCategories(
+        parentCategories,
+        savedTabsResult.removedGroupIds,
+      )
+      const urlsResult = removeUrlRecordsById(urls, targetUrlIds)
+      const payload: BulkUrlRemovalStorage = {}
 
-    if (savedTabsResult.hasChanges) {
-      payload.savedTabs = savedTabsResult.savedTabs
-    }
-    if (customProjectsResult.hasChanges) {
-      payload.customProjects = customProjectsResult.customProjects
-    }
-    if (parentCategoriesResult.hasChanges) {
-      payload.parentCategories = parentCategoriesResult.parentCategories
-    }
-    if (urlsResult.hasChanges) {
-      payload.urls = urlsResult.urls
-    }
-
-    if (Object.keys(payload).length > 0) {
-      await chrome.storage.local.set(payload)
-      if (urlsResult.hasChanges) {
-        invalidateUrlCache()
+      if (savedTabsResult.hasChanges) {
+        payload.savedTabs = savedTabsResult.savedTabs
       }
-    }
+      if (customProjectsResult.hasChanges) {
+        payload.customProjects = customProjectsResult.customProjects
+      }
+      if (parentCategoriesResult.hasChanges) {
+        payload.parentCategories = parentCategoriesResult.parentCategories
+      }
+      if (urlsResult.hasChanges) {
+        payload.urls = urlsResult.urls
+      }
 
-    console.log(`${urlsResult.removedCount}件のURLレコードを一括削除しました`)
-    return urlsResult.removedCount
+      if (Object.keys(payload).length > 0) {
+        await chrome.storage.local.set(payload)
+        if (urlsResult.hasChanges) {
+          invalidateUrlCache()
+        }
+      }
+
+      console.log(`${urlsResult.removedCount}件のURLレコードを一括削除しました`)
+      return urlsResult.removedCount
+    })
   } catch (error) {
     console.error('URLレコードの一括削除中にエラーが発生しました:', error)
     throw error
-  }
-}
-/**
- * 空になったグループを親カテゴリから一括削除する。
- */
-const removeFromParentCategories = async (
-  groupIds: string[],
-  savedTabs: TabGroup[],
-): Promise<void> => {
-  if (groupIds.length === 0) {
-    return
-  }
-
-  try {
-    const groupIdsToRemove = new Set(groupIds)
-    const groupsToRemove = savedTabs.filter(
-      (group) => groupIdsToRemove.has(group.id) && Boolean(group.domain),
-    )
-    if (groupsToRemove.length === 0) {
-      console.log('削除対象のグループが見つからないか、ドメイン名がありません')
-      return
-    }
-
-    const categoriesStorage = await chrome.storage.local.get<{
-      parentCategories?: ParentCategory[]
-    }>('parentCategories')
-    const parentCategories: ParentCategory[] =
-      categoriesStorage.parentCategories ?? []
-    const removalResult = removeGroupsFromParentCategories(
-      parentCategories,
-      groupsToRemove.map((group) => group.id),
-    )
-    if (!removalResult.hasChanges) {
-      return
-    }
-    await chrome.storage.local.set({
-      parentCategories: removalResult.parentCategories,
-    })
-    console.log(
-      `${groupsToRemove.length}個のグループIDをカテゴリから削除しました（ドメイン名を保持）`,
-    )
-  } catch (error: unknown) {
-    console.error(
-      '親カテゴリからの削除中にエラーが発生しました:',
-      error instanceof Error ? error.message : error,
-    )
   }
 }
 /**


### PR DESCRIPTION
## 変更内容
- savedTabs 関連の単一 URL 削除と bulk URL 削除を in-memory mutation queue 経由で直列化
- 単一 URL 削除で savedTabs / urls / customProjects / parentCategories を同一 read-modify-write payload に集約
- 同時 URL 削除で古い snapshot が保存済みタブ関連データを上書きしない regression test を追加

Closes #656

## 検証
- [x] ローカル環境でエラーになっていない
- rtk bun run compile
- rtk bun run test:node -- src/lib/background/url-storage.test.ts
- rtk bun run check
- rtk bun run test
- rtk bun run quality
- rtk bun run test:coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL removal handling so saved tabs, project links, and related metadata update more reliably.
  * Fixed edge cases where deletions could leave outdated or mismatched records behind.
  * Enhanced error handling to consistently surface failures during URL removal.
  * Corrected behavior when saved tab data or domain information is missing or in legacy formats.
* **Tests**
  * Updated and expanded coverage for URL deletion scenarios, including bulk and legacy entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->