### PR TITLE
URLレコード更新をmutation queueに統一

### DIFF
--- a/src/lib/background/url-storage.test.ts
+++ b/src/lib/background/url-storage.test.ts
@@ -12,6 +12,7 @@ vi.mock('@/lib/storage/projects', () => ({
 vi.mock('@/lib/storage/urls', () => ({
   deleteUrlRecord: vi.fn(),
   invalidateUrlCache: vi.fn(),
+  withUrlRecordMutation: vi.fn(async (mutation) => mutation()),
 }))
 
 import { removeUrlFromAllCustomProjects } from '@/lib/storage/projects'

--- a/src/lib/background/url-storage.ts
+++ b/src/lib/background/url-storage.ts
@@ -4,7 +4,7 @@
 
 import { redactUrlForLog } from '@/lib/logging/redact-url'
 import { getUserSettings } from '@/lib/storage/settings'
-import { invalidateUrlCache } from '@/lib/storage/urls'
+import { invalidateUrlCache, withUrlRecordMutation } from '@/lib/storage/urls'
 import type { DraggedUrlInfo } from '@/types/background'
 import type {
   CustomProject,
@@ -403,6 +403,141 @@ const removeUrlRecordsById = (
   }
 }
 
+const getBulkUrlRemovalStorage = async (): Promise<{
+  customProjects: CustomProject[]
+  parentCategories: ParentCategory[]
+  savedTabs: TabGroup[]
+  urls: UrlRecord[]
+}> => {
+  const storageResult = await chrome.storage.local.get<BulkUrlRemovalStorage>([
+    'savedTabs',
+    'urls',
+    'customProjects',
+    'parentCategories',
+  ])
+
+  return {
+    customProjects: Array.isArray(storageResult.customProjects)
+      ? storageResult.customProjects
+      : [],
+    parentCategories: Array.isArray(storageResult.parentCategories)
+      ? storageResult.parentCategories
+      : [],
+    savedTabs: Array.isArray(storageResult.savedTabs)
+      ? storageResult.savedTabs
+      : [],
+    urls: Array.isArray(storageResult.urls) ? storageResult.urls : [],
+  }
+}
+
+const writeBulkUrlRemovalPayload = async (
+  payload: BulkUrlRemovalStorage,
+  hasUrlChanges: boolean,
+): Promise<void> => {
+  if (Object.keys(payload).length === 0) {
+    return
+  }
+
+  await chrome.storage.local.set(payload)
+  if (hasUrlChanges) {
+    invalidateUrlCache()
+  }
+}
+
+const removeUrlFromStorageUnsafe = async (
+  targetUrlKey: string,
+): Promise<void> => {
+  const { customProjects, parentCategories, savedTabs, urls } =
+    await getBulkUrlRemovalStorage()
+  const matchedUrlRecord = urls.find(
+    (record) => createComparableUrlKey(record.url) === targetUrlKey,
+  )
+  const matchedUrlId = matchedUrlRecord?.id
+  const removedGroupIds: string[] = []
+
+  // URLを含むグループのみを更新（新形式 urlIds / 旧形式 urls の両方に対応）
+  const updatedGroups: TabGroup[] = savedTabs.flatMap((group: TabGroup) =>
+    updateGroupAfterUrlRemoval(
+      group,
+      targetUrlKey,
+      matchedUrlId,
+      removedGroupIds,
+    ),
+  )
+  const removedGroupIdsWithDomain = removedGroupIds.filter((groupId) => {
+    const group = savedTabs.find((item) => item.id === groupId)
+    return Boolean(group?.domain)
+  })
+  const parentCategoriesResult = removeGroupsFromParentCategories(
+    parentCategories,
+    removedGroupIdsWithDomain,
+  )
+  const targetUrlIds = matchedUrlId
+    ? createUrlIdSet([matchedUrlId])
+    : new Set<string>()
+  const customProjectsResult = removeUrlIdsFromCustomProjects(
+    customProjects,
+    targetUrlIds,
+  )
+  const urlsResult = removeUrlRecordsById(urls, targetUrlIds)
+  const payload: BulkUrlRemovalStorage = {}
+
+  if (haveTabGroupsChanged(savedTabs, updatedGroups)) {
+    payload.savedTabs = updatedGroups
+  }
+  if (parentCategoriesResult.hasChanges) {
+    payload.parentCategories = parentCategoriesResult.parentCategories
+  }
+  if (customProjectsResult.hasChanges) {
+    payload.customProjects = customProjectsResult.customProjects
+  }
+  if (urlsResult.hasChanges) {
+    payload.urls = urlsResult.urls
+  }
+
+  await writeBulkUrlRemovalPayload(payload, urlsResult.hasChanges)
+}
+
+const removeUrlRecordsFromStorageUnsafe = async (
+  targetUrlIds: Set<string>,
+): Promise<number> => {
+  const { customProjects, parentCategories, savedTabs, urls } =
+    await getBulkUrlRemovalStorage()
+  const targetUrlKeys = createComparableUrlKeySet(urls, targetUrlIds)
+  const savedTabsResult = removeUrlIdsFromSavedTabs(
+    savedTabs,
+    targetUrlIds,
+    targetUrlKeys,
+  )
+  const customProjectsResult = removeUrlIdsFromCustomProjects(
+    customProjects,
+    targetUrlIds,
+  )
+  const parentCategoriesResult = removeGroupsFromParentCategories(
+    parentCategories,
+    savedTabsResult.removedGroupIds,
+  )
+  const urlsResult = removeUrlRecordsById(urls, targetUrlIds)
+  const payload: BulkUrlRemovalStorage = {}
+
+  if (savedTabsResult.hasChanges) {
+    payload.savedTabs = savedTabsResult.savedTabs
+  }
+  if (customProjectsResult.hasChanges) {
+    payload.customProjects = customProjectsResult.customProjects
+  }
+  if (parentCategoriesResult.hasChanges) {
+    payload.parentCategories = parentCategoriesResult.parentCategories
+  }
+  if (urlsResult.hasChanges) {
+    payload.urls = urlsResult.urls
+  }
+
+  await writeBulkUrlRemovalPayload(payload, urlsResult.hasChanges)
+  console.log(`${urlsResult.removedCount}件のURLレコードを一括削除しました`)
+  return urlsResult.removedCount
+}
+
 /**
  * URLをストレージから削除する関数（カテゴリ設定とマッピングを保持）
  */
@@ -418,77 +553,9 @@ const removeUrlFromStorage = async (url: string): Promise<void> => {
 
   try {
     await enqueueStorageMutation(async () => {
-      const storageResult =
-        await chrome.storage.local.get<BulkUrlRemovalStorage>([
-          'savedTabs',
-          'urls',
-          'customProjects',
-          'parentCategories',
-        ])
-      const savedTabs: TabGroup[] = Array.isArray(storageResult.savedTabs)
-        ? storageResult.savedTabs
-        : []
-      const urlRecords = Array.isArray(storageResult.urls)
-        ? storageResult.urls
-        : []
-      const customProjects = Array.isArray(storageResult.customProjects)
-        ? storageResult.customProjects
-        : []
-      const parentCategories = Array.isArray(storageResult.parentCategories)
-        ? storageResult.parentCategories
-        : []
-      const matchedUrlRecord = urlRecords.find(
-        (record) => createComparableUrlKey(record.url) === targetUrlKey,
+      await withUrlRecordMutation(async () =>
+        removeUrlFromStorageUnsafe(targetUrlKey),
       )
-      const matchedUrlId = matchedUrlRecord?.id
-      const removedGroupIds: string[] = []
-
-      // URLを含むグループのみを更新（新形式 urlIds / 旧形式 urls の両方に対応）
-      const updatedGroups: TabGroup[] = savedTabs.flatMap((group: TabGroup) =>
-        updateGroupAfterUrlRemoval(
-          group,
-          targetUrlKey,
-          matchedUrlId,
-          removedGroupIds,
-        ),
-      )
-      const removedGroupIdsWithDomain = removedGroupIds.filter((groupId) => {
-        const group = savedTabs.find((item) => item.id === groupId)
-        return Boolean(group?.domain)
-      })
-      const parentCategoriesResult = removeGroupsFromParentCategories(
-        parentCategories,
-        removedGroupIdsWithDomain,
-      )
-      const targetUrlIds = matchedUrlId
-        ? createUrlIdSet([matchedUrlId])
-        : new Set<string>()
-      const customProjectsResult = removeUrlIdsFromCustomProjects(
-        customProjects,
-        targetUrlIds,
-      )
-      const urlsResult = removeUrlRecordsById(urlRecords, targetUrlIds)
-      const payload: BulkUrlRemovalStorage = {}
-
-      if (haveTabGroupsChanged(savedTabs, updatedGroups)) {
-        payload.savedTabs = updatedGroups
-      }
-      if (parentCategoriesResult.hasChanges) {
-        payload.parentCategories = parentCategoriesResult.parentCategories
-      }
-      if (customProjectsResult.hasChanges) {
-        payload.customProjects = customProjectsResult.customProjects
-      }
-      if (urlsResult.hasChanges) {
-        payload.urls = urlsResult.urls
-      }
-
-      if (Object.keys(payload).length > 0) {
-        await chrome.storage.local.set(payload)
-        if (urlsResult.hasChanges) {
-          invalidateUrlCache()
-        }
-      }
     })
 
     console.log(`ストレージからURL ${redactUrlForLog(url)} を削除しました`)
@@ -508,64 +575,12 @@ const removeUrlRecordsFromStorage = async (
   }
 
   try {
-    return await enqueueStorageMutation(async () => {
-      const storageResult =
-        await chrome.storage.local.get<BulkUrlRemovalStorage>([
-          'savedTabs',
-          'urls',
-          'customProjects',
-          'parentCategories',
-        ])
-      const savedTabs = Array.isArray(storageResult.savedTabs)
-        ? storageResult.savedTabs
-        : []
-      const urls = Array.isArray(storageResult.urls) ? storageResult.urls : []
-      const customProjects = Array.isArray(storageResult.customProjects)
-        ? storageResult.customProjects
-        : []
-      const parentCategories = Array.isArray(storageResult.parentCategories)
-        ? storageResult.parentCategories
-        : []
-      const targetUrlKeys = createComparableUrlKeySet(urls, targetUrlIds)
-      const savedTabsResult = removeUrlIdsFromSavedTabs(
-        savedTabs,
-        targetUrlIds,
-        targetUrlKeys,
-      )
-      const customProjectsResult = removeUrlIdsFromCustomProjects(
-        customProjects,
-        targetUrlIds,
-      )
-      const parentCategoriesResult = removeGroupsFromParentCategories(
-        parentCategories,
-        savedTabsResult.removedGroupIds,
-      )
-      const urlsResult = removeUrlRecordsById(urls, targetUrlIds)
-      const payload: BulkUrlRemovalStorage = {}
-
-      if (savedTabsResult.hasChanges) {
-        payload.savedTabs = savedTabsResult.savedTabs
-      }
-      if (customProjectsResult.hasChanges) {
-        payload.customProjects = customProjectsResult.customProjects
-      }
-      if (parentCategoriesResult.hasChanges) {
-        payload.parentCategories = parentCategoriesResult.parentCategories
-      }
-      if (urlsResult.hasChanges) {
-        payload.urls = urlsResult.urls
-      }
-
-      if (Object.keys(payload).length > 0) {
-        await chrome.storage.local.set(payload)
-        if (urlsResult.hasChanges) {
-          invalidateUrlCache()
-        }
-      }
-
-      console.log(`${urlsResult.removedCount}件のURLレコードを一括削除しました`)
-      return urlsResult.removedCount
-    })
+    const removedCount = await enqueueStorageMutation(async () =>
+      withUrlRecordMutation(async () =>
+        removeUrlRecordsFromStorageUnsafe(targetUrlIds),
+      ),
+    )
+    return removedCount
   } catch (error) {
     console.error('URLレコードの一括削除中にエラーが発生しました:', error)
     throw error

--- a/src/lib/storage/urls.test.ts
+++ b/src/lib/storage/urls.test.ts
@@ -27,27 +27,44 @@ interface StorageState {
   urls?: UrlRecord[] | unknown
 }
 
-const createChromeStorageLocal = (state: StorageState) => ({
-  get: vi.fn(async (keys?: string | string[]) => {
-    if (!keys) {
-      return state
-    }
+interface ChromeStorageLocalOptions {
+  cloneReads?: boolean
+  getSetDelayMs?: (value: Record<string, unknown>) => number
+}
 
-    if (Array.isArray(keys)) {
-      return Object.fromEntries(
-        keys.map((key) => [key, state[key as keyof StorageState]]),
-      )
-    }
+const createChromeStorageLocal = (
+  state: StorageState,
+  options: ChromeStorageLocalOptions = {},
+) => {
+  const readValue = <T>(value: T): T =>
+    options.cloneReads ? structuredClone(value) : value
 
-    return {
-      [keys]: state[keys as keyof StorageState],
-    }
-  }),
+  return {
+    get: vi.fn(async (keys?: string | string[]) => {
+      if (!keys) {
+        return readValue(state)
+      }
 
-  set: vi.fn(async (value: Record<string, unknown>) => {
-    Object.assign(state, value)
-  }),
-})
+      if (Array.isArray(keys)) {
+        return Object.fromEntries(
+          keys.map((key) => [key, readValue(state[key as keyof StorageState])]),
+        )
+      }
+
+      return {
+        [keys]: readValue(state[keys as keyof StorageState]),
+      }
+    }),
+
+    set: vi.fn(async (value: Record<string, unknown>) => {
+      const delayMs = options.getSetDelayMs?.(value) ?? 0
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs))
+      }
+      Object.assign(state, value)
+    }),
+  }
+}
 
 const loadUrlsModule = async () => {
   vi.resetModules()
@@ -134,6 +151,48 @@ describe('urls storage', () => {
     ])
 
     expect(state.urls).toStrictEqual([first, second, third])
+  })
+
+  it('同時 create と delete が URL レコードの更新を失わない', async () => {
+    const state: StorageState = {
+      customProjects: [],
+      savedTabs: [],
+      urls: [
+        {
+          id: 'delete-target',
+          savedAt: 1,
+          title: 'Delete target',
+          url: 'https://example.com/delete-target',
+        },
+      ],
+    }
+    globalThis.chrome = {
+      storage: {
+        local: createChromeStorageLocal(state, {
+          cloneReads: true,
+          getSetDelayMs: (value) =>
+            Array.isArray(value.urls) && value.urls.length === 0 ? 10 : 0,
+        }),
+      },
+    } as unknown as typeof chrome
+
+    const { createOrUpdateUrlRecord, deleteUrlRecord, getUrlRecords } =
+      await loadUrlsModule()
+
+    await Promise.all([
+      createOrUpdateUrlRecord('https://example.com/new', 'New'),
+      deleteUrlRecord('delete-target'),
+    ])
+
+    await expect(getUrlRecords()).resolves.toStrictEqual([
+      {
+        id: 'uuid-1',
+        savedAt: expect.any(Number),
+        title: 'New',
+        url: 'https://example.com/new',
+        favIconUrl: undefined,
+      },
+    ])
   })
 
   it('一括 upsert で空URLを除外しながら新規作成と更新を行う', async () => {

--- a/src/lib/storage/urls.ts
+++ b/src/lib/storage/urls.ts
@@ -49,7 +49,7 @@ const getUrlRecords = async (): Promise<UrlRecord[]> => {
 /**
  * URLレコードを保存する
  */
-const saveUrlRecords = async (urlRecords: UrlRecord[]): Promise<void> => {
+const saveUrlRecordsUnsafe = async (urlRecords: UrlRecord[]): Promise<void> => {
   try {
     await chrome.storage.local.set({
       urls: urlRecords,
@@ -114,7 +114,7 @@ const createOrUpdateUrlRecordUnsafe = async (
     const updatedRecords = urlRecords.map((record) =>
       record.id === existingRecord.id ? updatedRecord : record,
     )
-    await saveUrlRecords(updatedRecords)
+    await saveUrlRecordsUnsafe(updatedRecords)
     return updatedRecord
   }
   // 新しいレコードを作成
@@ -125,7 +125,7 @@ const createOrUpdateUrlRecordUnsafe = async (
     title,
     url,
   }
-  await saveUrlRecords([...urlRecords, newRecord])
+  await saveUrlRecordsUnsafe([...urlRecords, newRecord])
   return newRecord
 }
 
@@ -194,20 +194,27 @@ const createOrUpdateUrlRecordsBatchUnsafe = async (
     resolvedRecordByUrl.set(input.url, updatedRecord)
   }
 
-  await saveUrlRecords(records)
+  await saveUrlRecordsUnsafe(records)
   return resolvedRecordByUrl
 }
 
 const enqueueUrlRecordMutation = async <T>(
   operation: () => Promise<T>,
 ): Promise<T> => {
-  const result = urlRecordMutationQueue.then(operation)
+  const result = urlRecordMutationQueue.then(operation, operation)
   urlRecordMutationQueue = result.then(
     () => undefined,
     () => undefined,
   )
   return result
 }
+
+const withUrlRecordMutation = async <T>(
+  operation: () => Promise<T>,
+): Promise<T> => enqueueUrlRecordMutation(operation)
+
+const saveUrlRecords = async (urlRecords: UrlRecord[]): Promise<void> =>
+  enqueueUrlRecordMutation(async () => saveUrlRecordsUnsafe(urlRecords))
 
 const createOrUpdateUrlRecord = async (
   url: string,
@@ -229,7 +236,7 @@ const createOrUpdateUrlRecordsBatch = async (
 /**
  * URLレコードを削除する（参照されていない場合のみ）
  */
-const deleteUrlRecord = async (id: string): Promise<boolean> => {
+const deleteUrlRecordUnsafe = async (id: string): Promise<boolean> => {
   // 参照チェック（SavedTabsとCustomProjectsで使用されていないか確認）
   const isReferenced = await isUrlRecordReferenced(id)
   if (isReferenced) {
@@ -239,12 +246,15 @@ const deleteUrlRecord = async (id: string): Promise<boolean> => {
   const urlRecords = await getUrlRecords()
   const filteredRecords = urlRecords.filter((record) => record.id !== id)
   if (filteredRecords.length < urlRecords.length) {
-    await saveUrlRecords(filteredRecords)
+    await saveUrlRecordsUnsafe(filteredRecords)
     console.log(`URLレコード ${id} を削除しました`)
     return true
   }
   return false
 }
+
+const deleteUrlRecord = async (id: string): Promise<boolean> =>
+  enqueueUrlRecordMutation(async () => deleteUrlRecordUnsafe(id))
 /**
  * URLレコードが他の場所で参照されているかチェックする
  */
@@ -275,7 +285,7 @@ const isUrlRecordReferenced = async (urlId: string): Promise<boolean> => {
 /**
  * 使用されていないURLレコードをクリーンアップする
  */
-const cleanupUnreferencedUrls = async (): Promise<number> => {
+const cleanupUnreferencedUrlsUnsafe = async (): Promise<number> => {
   try {
     const [urlRecords, savedTabsResult, customProjectsResult] =
       await Promise.all([
@@ -317,7 +327,7 @@ const cleanupUnreferencedUrls = async (): Promise<number> => {
     )
     const deletedCount = urlRecords.length - referencedRecords.length
     if (deletedCount > 0) {
-      await saveUrlRecords(referencedRecords)
+      await saveUrlRecordsUnsafe(referencedRecords)
       console.log(
         `${deletedCount}個の未参照URLレコードをクリーンアップしました`,
       )
@@ -328,10 +338,14 @@ const cleanupUnreferencedUrls = async (): Promise<number> => {
     return 0
   }
 }
+
+const cleanupUnreferencedUrls = async (): Promise<number> =>
+  enqueueUrlRecordMutation(cleanupUnreferencedUrlsUnsafe)
+
 /**
  * 重複するURLレコードを統合する
  */
-const deduplicateUrlRecords = async (): Promise<number> => {
+const deduplicateUrlRecordsUnsafe = async (): Promise<number> => {
   try {
     const urlRecords = await getUrlRecords()
     const urlMap = new Map<string, UrlRecord>()
@@ -357,11 +371,11 @@ const deduplicateUrlRecords = async (): Promise<number> => {
     }
     if (duplicateIds.length > 0) {
       // 重複IDの参照を更新
-      await updateUrlReferences(duplicateIds, replacementIdMap)
+      await updateUrlReferencesUnsafe(duplicateIds, replacementIdMap)
 
       // 重複レコードを削除
       const deduplicatedRecords = [...urlMap.values()]
-      await saveUrlRecords(deduplicatedRecords)
+      await saveUrlRecordsUnsafe(deduplicatedRecords)
       console.log(`${duplicateIds.length}個の重複URLレコードを統合しました`)
     }
     return duplicateIds.length
@@ -370,6 +384,9 @@ const deduplicateUrlRecords = async (): Promise<number> => {
     return 0
   }
 }
+
+const deduplicateUrlRecords = async (): Promise<number> =>
+  enqueueUrlRecordMutation(deduplicateUrlRecordsUnsafe)
 
 const remapReferenceKeys = <T>(
   values: Record<string, T> | undefined,
@@ -405,7 +422,7 @@ const remapReferenceKeys = <T>(
  */
 // TODO(#557): SavedTabs/CustomProjects の重複ロジックを共通化して複雑度を削減する。
 // eslint-disable-next-line eslint/complexity
-const updateUrlReferences = async (
+const updateUrlReferencesUnsafe = async (
   duplicateIds: string[],
   replacementIdMap: Map<string, string>,
 ): Promise<void> => {
@@ -487,6 +504,14 @@ const updateUrlReferences = async (
   }
 }
 
+const updateUrlReferences = async (
+  duplicateIds: string[],
+  replacementIdMap: Map<string, string>,
+): Promise<void> =>
+  enqueueUrlRecordMutation(async () =>
+    updateUrlReferencesUnsafe(duplicateIds, replacementIdMap),
+  )
+
 export {
   cleanupUnreferencedUrls,
   createOrUpdateUrlRecord,
@@ -501,4 +526,5 @@ export {
   isUrlRecordReferenced,
   saveUrlRecords,
   updateUrlReferences,
+  withUrlRecordMutation,
 }


### PR DESCRIPTION
## 変更内容

- URL record の保存処理を `saveUrlRecordsUnsafe` と公開 `saveUrlRecords` に分け、公開 mutation を queue 経由に統一
- `deleteUrlRecord` / `cleanupUnreferencedUrls` / `deduplicateUrlRecords` / `updateUrlReferences` を URL record mutation queue 内で実行
- `background/url-storage.ts` の URL record を含む bulk removal を同じ URL record mutation queue 内へ移動
- 同時 create/delete で後勝ちの古い snapshot が新規 URL record を消す競合テストを追加

## 検証

- `rtk bun run test:node -- src/lib/storage/urls.test.ts src/lib/background/url-storage.test.ts`
- `rtk bun run check`
- `rtk bun run quality`
- `rtk bun run test:coverage` は `src/features/options/SubCategoryKeywordManager.test.tsx` の既存失敗で停止。clean `develop` でも同じ `rtk bun run test:dom -- src/features/options/SubCategoryKeywordManager.test.tsx` が失敗することを確認済み。

Closes #666


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving or deleting URL records, reducing the chance of data being overwritten during overlapping changes.
  * Bulk URL removal now updates related saved tabs, categories, and project links more consistently.
  * URL cache updates are now applied more safely after storage changes, helping keep the app in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->