### PR TITLE
background message の payload 検証を強化

### DIFF
--- a/src/lib/background/message-handler.test.ts
+++ b/src/lib/background/message-handler.test.ts
@@ -228,6 +228,10 @@ describe('setupMessageListener', () => {
   it('不正メッセージと未知 action を弾く', () => {
     const { listener } = setupListener()
     const invalidResponse = vi.fn()
+    const invalidRemoveResponse = vi.fn()
+    const invalidBulkRemoveResponse = vi.fn()
+    const invalidAiChatPromptResponse = vi.fn()
+    const invalidAiChatHistoryResponse = vi.fn()
     const unknownResponse = vi.fn()
 
     expect(
@@ -236,6 +240,62 @@ describe('setupMessageListener', () => {
     expect(invalidResponse).toHaveBeenCalledWith({
       status: 'invalid_message',
     })
+
+    expect(
+      listener(
+        { action: 'removeUrlFromStorage', url: 1 },
+        {} as chrome.runtime.MessageSender,
+        invalidRemoveResponse,
+      ),
+    ).toBe(false)
+    expect(invalidRemoveResponse).toHaveBeenCalledWith({
+      status: 'invalid_message',
+    })
+    expect(mocked.removeUrlFromStorage).not.toHaveBeenCalled()
+
+    expect(
+      listener(
+        { action: 'removeUrlRecordsFromStorage', urlIds: 'invalid' },
+        {} as chrome.runtime.MessageSender,
+        invalidBulkRemoveResponse,
+      ),
+    ).toBe(false)
+    expect(invalidBulkRemoveResponse).toHaveBeenCalledWith({
+      status: 'invalid_message',
+    })
+    expect(mocked.removeUrlRecordsFromStorage).not.toHaveBeenCalled()
+
+    expect(
+      listener(
+        {
+          action: 'runAiChat',
+          history: [],
+          prompt: 1,
+        },
+        {} as chrome.runtime.MessageSender,
+        invalidAiChatPromptResponse,
+      ),
+    ).toBe(false)
+    expect(invalidAiChatPromptResponse).toHaveBeenCalledWith({
+      status: 'invalid_message',
+    })
+    expect(mocked.runAiChatRequest).not.toHaveBeenCalled()
+
+    expect(
+      listener(
+        {
+          action: 'runAiChat',
+          history: 'invalid',
+          prompt: 'test',
+        },
+        {} as chrome.runtime.MessageSender,
+        invalidAiChatHistoryResponse,
+      ),
+    ).toBe(false)
+    expect(invalidAiChatHistoryResponse).toHaveBeenCalledWith({
+      status: 'invalid_message',
+    })
+    expect(mocked.runAiChatRequest).not.toHaveBeenCalled()
 
     expect(
       listener(
@@ -352,11 +412,9 @@ describe('setupMessageListener', () => {
     const { listener } = setupListener()
     const bulkRemoveResponse = vi.fn()
     const emptyBulkRemoveResponse = vi.fn()
-    const invalidBulkRemoveResponse = vi.fn()
     const bulkRemoveErrorResponse = vi.fn()
     const errorObjectResponse = vi.fn()
     mocked.removeUrlRecordsFromStorage.mockResolvedValueOnce(2)
-    mocked.removeUrlRecordsFromStorage.mockResolvedValueOnce(0)
     mocked.removeUrlRecordsFromStorage.mockResolvedValueOnce(0)
     mocked.removeUrlRecordsFromStorage.mockRejectedValueOnce('bulk failed')
     mocked.removeUrlRecordsFromStorage.mockRejectedValueOnce(
@@ -396,22 +454,6 @@ describe('setupMessageListener', () => {
         status: 'removed',
       })
     })
-
-    listener(
-      {
-        action: 'removeUrlRecordsFromStorage',
-        urlIds: 'invalid',
-      },
-      {} as chrome.runtime.MessageSender,
-      invalidBulkRemoveResponse,
-    )
-    await vi.waitFor(() => {
-      expect(invalidBulkRemoveResponse).toHaveBeenCalledWith({
-        removedCount: 0,
-        status: 'removed',
-      })
-    })
-    expect(mocked.removeUrlRecordsFromStorage).toHaveBeenCalledWith([])
 
     listener(
       {

--- a/src/lib/background/message-handler.ts
+++ b/src/lib/background/message-handler.ts
@@ -15,7 +15,11 @@ import type {
   StatusResponse,
   TimeRemainingResponse,
 } from '@/types/background'
-import { AI_CHAT_STREAM_PORT_NAME } from '@/types/background'
+import {
+  AI_CHAT_STREAM_PORT_NAME,
+  backgroundMessageSchema,
+  messageActionSchema,
+} from '@/types/background'
 import type { UserSettings } from '@/types/storage'
 
 import { listLocalOllamaModels, runAiChatRequest } from './ai-chat'
@@ -67,6 +71,39 @@ const isRuntimeOnConnect = (value: unknown): value is RuntimeOnConnect =>
   value !== null &&
   typeof Reflect.get(value, 'addListener') === 'function'
 
+const parseBackgroundMessage = (
+  message: unknown,
+):
+  | { status: 'valid'; message: BackgroundMessage }
+  | { action: string; status: 'unknown_action' }
+  | { status: 'invalid_message' } => {
+  if (typeof message !== 'object' || message === null) {
+    return { status: 'invalid_message' }
+  }
+
+  const action: unknown = Reflect.get(message, 'action')
+  if (typeof action !== 'string') {
+    return { status: 'invalid_message' }
+  }
+
+  if (!messageActionSchema.safeParse(action).success) {
+    return {
+      action,
+      status: 'unknown_action',
+    }
+  }
+
+  const result = backgroundMessageSchema.safeParse(message)
+  if (!result.success) {
+    return { status: 'invalid_message' }
+  }
+
+  return {
+    message: result.data,
+    status: 'valid',
+  }
+}
+
 const isAiChatStreamRunMessage = (
   message: unknown,
 ): message is AiChatStreamClientMessage =>
@@ -81,18 +118,24 @@ const setupMessageListener = (): void => {
   // eslint-disable-next-line eslint/complexity
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     console.log('バックグラウンドがメッセージを受信:', message)
-    const isValidMessage = (msg: unknown): msg is BackgroundMessage =>
-      typeof msg === 'object' &&
-      msg !== null &&
-      'action' in msg &&
-      typeof msg.action === 'string'
-    if (!isValidMessage(message)) {
+
+    const parsedMessage = parseBackgroundMessage(message)
+    if (parsedMessage.status === 'invalid_message') {
       sendResponse({
         status: 'invalid_message',
       })
       return false
     }
-    const typedMessage = message
+
+    if (parsedMessage.status === 'unknown_action') {
+      console.warn('未知のメッセージアクション:', parsedMessage.action)
+      sendResponse({
+        status: 'unknown_action',
+      })
+      return false
+    }
+
+    const typedMessage = parsedMessage.message
     switch (typedMessage.action) {
       case 'urlDragStarted': {
         handleUrlDragStartedMessage(typedMessage.url, sendResponse)
@@ -135,11 +178,8 @@ const setupMessageListener = (): void => {
         return true
       }
       default: {
-        // eslint-disable-next-line typescript/no-unsafe-member-access
-        console.warn('未知のメッセージアクション:', message.action)
-        sendResponse({
-          status: 'unknown_action',
-        })
+        const exhaustiveMessage: never = typedMessage
+        void exhaustiveMessage
         return false
       }
     }

--- a/src/types/background.ts
+++ b/src/types/background.ts
@@ -2,6 +2,8 @@
  * Background script用の型定義
  */
 
+import { z } from 'zod'
+
 import type {
   AiChatAttachment,
   AiChartSpec,
@@ -29,17 +31,20 @@ export interface DraggedUrlInfo {
 /**
  * メッセージアクション型定義
  */
-export type MessageAction =
-  | 'urlDragStarted'
-  | 'urlDropped'
-  | 'removeUrlFromStorage'
-  | 'removeUrlRecordsFromStorage'
-  | 'calculateTimeRemaining'
-  | 'checkExpiredTabs'
-  | 'updateTabTimestamps'
-  | 'getAlarmStatus'
-  | 'listOllamaModels'
-  | 'runAiChat'
+export const messageActionSchema = z.enum([
+  'urlDragStarted',
+  'urlDropped',
+  'removeUrlFromStorage',
+  'removeUrlRecordsFromStorage',
+  'calculateTimeRemaining',
+  'checkExpiredTabs',
+  'updateTabTimestamps',
+  'getAlarmStatus',
+  'listOllamaModels',
+  'runAiChat',
+])
+
+export type MessageAction = z.infer<typeof messageActionSchema>
 
 /**
  * メッセージ基底型
@@ -47,6 +52,69 @@ export type MessageAction =
 export interface BaseMessage {
   action: MessageAction
 }
+
+const nonEmptyStringSchema = z.string().min(1)
+
+const aiChatAttachmentSchema = z.object({
+  content: z.string(),
+  filename: z.string(),
+  kind: z.enum(['text', 'image']),
+  mediaType: z.string(),
+})
+
+const aiChatHistoryMessageSchema = z.object({
+  attachments: z.array(aiChatAttachmentSchema).optional(),
+  content: z.string(),
+  role: z.enum(['user', 'assistant']),
+})
+
+export const backgroundMessageSchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('urlDragStarted'),
+    groupId: z.string().optional(),
+    url: nonEmptyStringSchema,
+  }),
+  z.object({
+    action: z.literal('urlDropped'),
+    fromExternal: z.boolean().optional(),
+    groupId: z.string().optional(),
+    url: nonEmptyStringSchema,
+  }),
+  z.object({
+    action: z.literal('removeUrlFromStorage'),
+    url: nonEmptyStringSchema,
+  }),
+  z.object({
+    action: z.literal('removeUrlRecordsFromStorage'),
+    urlIds: z.array(nonEmptyStringSchema),
+  }),
+  z.object({
+    action: z.literal('calculateTimeRemaining'),
+    autoDeletePeriod: z.string(),
+    savedAt: z.number(),
+  }),
+  z.object({
+    action: z.literal('checkExpiredTabs'),
+    period: z.string().optional(),
+    updateTimestamps: z.boolean().optional(),
+  }),
+  z.object({
+    action: z.literal('updateTabTimestamps'),
+    period: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal('getAlarmStatus'),
+  }),
+  z.object({
+    action: z.literal('listOllamaModels'),
+  }),
+  z.object({
+    action: z.literal('runAiChat'),
+    attachments: z.array(aiChatAttachmentSchema).optional(),
+    history: z.array(aiChatHistoryMessageSchema),
+    prompt: nonEmptyStringSchema,
+  }),
+])
 
 /**
  * URLドラッグ開始メッセージ
@@ -59,108 +127,78 @@ export interface BaseMessage {
  * 既存 background handler はそのまま optional 扱いする方針
  * (issue #531)。
  */
-export interface UrlDragStartedMessage extends BaseMessage {
-  action: 'urlDragStarted'
-  url: string
-  /**
-   * ドラッグされた URL が属する savedTabs グループ id。
-   * 旧 presentation 実装 (`ProjectUrlItem` / `SortableUrlItem`) と
-   * 同じ形を維持するため optional とし、background handler 側でも
-   * 未指定でも動作する。
-   */
-  readonly groupId?: string
-}
+export type UrlDragStartedMessage = Extract<
+  BackgroundMessage,
+  { action: 'urlDragStarted' }
+>
 
 /**
  * URLドロップメッセージ
  */
-export interface UrlDroppedMessage extends BaseMessage {
-  action: 'urlDropped'
-  url: string
-  fromExternal?: boolean
-  /**
-   * ドロップされた URL が属する savedTabs グループ id。
-   * 旧 presentation 実装 (`ProjectUrlItem` / `SortableUrlItem`) と
-   * 同じ形を維持するため optional。
-   */
-  readonly groupId?: string
-}
+export type UrlDroppedMessage = Extract<
+  BackgroundMessage,
+  { action: 'urlDropped' }
+>
 
 /**
  * URL削除メッセージ
  */
-export interface RemoveUrlMessage extends BaseMessage {
-  action: 'removeUrlFromStorage'
-  url: string
-}
+export type RemoveUrlMessage = Extract<
+  BackgroundMessage,
+  { action: 'removeUrlFromStorage' }
+>
 
-export interface RemoveUrlRecordsMessage extends BaseMessage {
-  action: 'removeUrlRecordsFromStorage'
-  urlIds: string[]
-}
+export type RemoveUrlRecordsMessage = Extract<
+  BackgroundMessage,
+  { action: 'removeUrlRecordsFromStorage' }
+>
 
 /**
  * 残り時間計算メッセージ
  */
-export interface CalculateTimeRemainingMessage extends BaseMessage {
-  action: 'calculateTimeRemaining'
-  savedAt: number
-  autoDeletePeriod: string
-}
+export type CalculateTimeRemainingMessage = Extract<
+  BackgroundMessage,
+  { action: 'calculateTimeRemaining' }
+>
 
 /**
  * 期限切れチェックメッセージ
  */
-export interface CheckExpiredTabsMessage extends BaseMessage {
-  action: 'checkExpiredTabs'
-  updateTimestamps?: boolean
-  period?: string
-}
+export type CheckExpiredTabsMessage = Extract<
+  BackgroundMessage,
+  { action: 'checkExpiredTabs' }
+>
 
 /**
  * タイムスタンプ更新メッセージ
  */
-export interface UpdateTabTimestampsMessage extends BaseMessage {
-  action: 'updateTabTimestamps'
-  period?: string
-}
+export type UpdateTabTimestampsMessage = Extract<
+  BackgroundMessage,
+  { action: 'updateTabTimestamps' }
+>
 
 /**
  * アラーム状態取得メッセージ
  */
-export interface GetAlarmStatusMessage extends BaseMessage {
-  action: 'getAlarmStatus'
-}
+export type GetAlarmStatusMessage = Extract<
+  BackgroundMessage,
+  { action: 'getAlarmStatus' }
+>
 
-export interface ListOllamaModelsMessage extends BaseMessage {
-  action: 'listOllamaModels'
-}
+export type ListOllamaModelsMessage = Extract<
+  BackgroundMessage,
+  { action: 'listOllamaModels' }
+>
 
-export interface RunAiChatMessage extends BaseMessage {
-  action: 'runAiChat'
-  prompt: string
-  history: {
-    role: 'user' | 'assistant'
-    content: string
-    attachments?: AiChatAttachment[]
-  }[]
-  attachments?: AiChatAttachment[]
-}
+export type RunAiChatMessage = Extract<
+  BackgroundMessage,
+  { action: 'runAiChat' }
+>
 
 /**
  * 全てのメッセージ型のユニオン
  */
-export type BackgroundMessage =
-  | UrlDragStartedMessage
-  | UrlDroppedMessage
-  | RemoveUrlMessage
-  | RemoveUrlRecordsMessage
-  | CalculateTimeRemainingMessage
-  | CheckExpiredTabsMessage
-  | UpdateTabTimestampsMessage
-  | GetAlarmStatusMessage
-  | ListOllamaModelsMessage
-  | RunAiChatMessage
+export type BackgroundMessage = z.infer<typeof backgroundMessageSchema>
 
 /**
  * レスポンス型定義

--- a/src/types/background.ts
+++ b/src/types/background.ts
@@ -28,31 +28,6 @@ export interface DraggedUrlInfo {
   timeoutId?: NodeJS.Timeout
 }
 
-/**
- * メッセージアクション型定義
- */
-export const messageActionSchema = z.enum([
-  'urlDragStarted',
-  'urlDropped',
-  'removeUrlFromStorage',
-  'removeUrlRecordsFromStorage',
-  'calculateTimeRemaining',
-  'checkExpiredTabs',
-  'updateTabTimestamps',
-  'getAlarmStatus',
-  'listOllamaModels',
-  'runAiChat',
-])
-
-export type MessageAction = z.infer<typeof messageActionSchema>
-
-/**
- * メッセージ基底型
- */
-export interface BaseMessage {
-  action: MessageAction
-}
-
 const nonEmptyStringSchema = z.string().min(1)
 
 const aiChatAttachmentSchema = z.object({
@@ -115,6 +90,31 @@ export const backgroundMessageSchema = z.discriminatedUnion('action', [
     prompt: nonEmptyStringSchema,
   }),
 ])
+
+/**
+ * 全てのメッセージ型のユニオン
+ */
+export type BackgroundMessage = z.infer<typeof backgroundMessageSchema>
+
+/**
+ * メッセージアクション型定義
+ */
+export type MessageAction = BackgroundMessage['action']
+
+export const messageActionSchema = z.custom<MessageAction>(
+  (action) =>
+    typeof action === 'string' &&
+    backgroundMessageSchema.options.some(
+      (schema) => schema.shape.action.value === action,
+    ),
+)
+
+/**
+ * メッセージ基底型
+ */
+export interface BaseMessage {
+  action: MessageAction
+}
 
 /**
  * URLドラッグ開始メッセージ
@@ -194,11 +194,6 @@ export type RunAiChatMessage = Extract<
   BackgroundMessage,
   { action: 'runAiChat' }
 >
-
-/**
- * 全てのメッセージ型のユニオン
- */
-export type BackgroundMessage = z.infer<typeof backgroundMessageSchema>
 
 /**
  * レスポンス型定義


### PR DESCRIPTION
## 変更内容
- background message protocol を Zod の discriminatedUnion で定義し、型を z.infer から生成
- chrome.runtime.onMessage 入口で action ごとの payload validation を実施
- removeUrlFromStorage / removeUrlRecordsFromStorage / runAiChat の invalid payload 回帰テストを追加

## 検証
- bun run compile
- bun run quality
- bun run test:coverage

Closes #662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background messages are now validated more strictly, helping ensure only supported actions and well-formed data are processed.

* **Bug Fixes**
  * Invalid or unsupported background requests now fail gracefully with a clear `invalid_message` or `unknown_action` response.
  * Improved handling of malformed inputs helps prevent incorrect message handling in the background process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->