### PR TITLE
ci: permissions を contents: read に固定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]


### PR DESCRIPTION
## 変更内容

`ci.yml` に workflow-level で `permissions: contents: read` を追加し、最小権限に固定しました。

## 権限分析

| Job | 必要な権限 | 備考 |
|---|---|---|
| `lint-typecheck` | `contents: read` | checkout + lint/typecheck のみ |
| `verify-build` | `contents: read` | upload-artifact は runtime token を使用 |
| `run-tests-shard-*` | `contents: read` | checkout + テスト実行のみ |

他の workflow（`react-doctor.yml`, `update-pr-branches.yml`）は既に適切に設定済みのため変更していません。

## 確認項目

- [x] workflow-level で `permissions` を明示
- [x] `actions/upload-artifact` は `contents: read` のみで動作（runner の `ACTIONS_RUNTIME_TOKEN` を使用）
- [x] 追加権限は不要

Closes #682