### PR TITLE
Oxlint で静的プロパティアクセスを dot notation に統一する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -321,6 +321,7 @@
       }
     ],
     "typescript/non-nullable-type-assertion-style": "off",
+    "typescript/dot-notation": "error",
     "unicorn/consistent-existence-index-check": "off",
     "unicorn/consistent-function-scoping": "off",
     "unicorn/no-await-expression-member": "off",


### PR DESCRIPTION
## 変更内容

`.oxlintrc.json` に `typescript/dot-notation` ルールを `error` で追加しました。

## 背景

TypeScript / JavaScript では、静的に決まっている property access でも bracket notation が使えますが、dot notation の方が短く、読みやすく、リファクタリングもしやすいため統一します。

## 検証

- `bun run lint` - 0 errors (コードベースに既存の違反はありません)
- `bun run test` - 298 passed, 3218 tests
- `bun run compile` - type check passed
- `bun run format` - format check passed

## 受け入れ条件

- [x] `.oxlintrc.json` に `typescript/dot-notation` が `error` で追加されている
- [x] 静的 property access の bracket notation が検出される
- [x] 動的 key access は維持されている
- [x] dot notation で表現できない property access は維持されている
- [x] `bun run lint` が通る
- [x] `bun run quality` が通る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened linting rules for TypeScript code by enforcing dot-notation usage as an error.
  * This helps maintain more consistent and readable code across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->