### PR TITLE
feat: DOM HTML injection API の直接利用を禁止する (#647)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -553,10 +553,31 @@
           {
             "name": "prompt",
             "message": "prompt は使わず、form / dialog component 経由にしてください"
+          },
+          {
+            "name": "DOMParser",
+            "message": "DOMParser は HTML parsing / injection リスクがあるため、用途を限定した sanitizer / adapter 経由にしてください"
           }
         ],
         "eslint/no-restricted-properties": [
           "error",
+          {
+            "property": "innerHTML",
+            "message": "innerHTML は HTML injection / XSS リスクがあるため禁止です。React render / textContent / sanitizer 経由にしてください"
+          },
+          {
+            "property": "outerHTML",
+            "message": "outerHTML は HTML injection / XSS リスクがあるため禁止です"
+          },
+          {
+            "property": "insertAdjacentHTML",
+            "message": "insertAdjacentHTML は HTML injection / XSS リスクがあるため禁止です"
+          },
+          {
+            "object": "document",
+            "property": "write",
+            "message": "document.write は禁止です。React render / safe renderer に置き換えてください"
+          },
           {
             "object": "window",
             "property": "alert",


### PR DESCRIPTION
## 概要

production src での DOM HTML injection API（`innerHTML` / `outerHTML` / `insertAdjacentHTML` / `document.write` / `DOMParser`）の直接利用を禁止する lint ルールを追加する。

## 変更内容

`.oxlintrc.json` の production src override に以下を追加:

- `eslint/no-restricted-properties`:
  - `{property: "innerHTML"}` — 任意オブジェクトの innerHTML を禁止
  - `{property: "outerHTML"}` — 任意オブジェクトの outerHTML を禁止
  - `{property: "insertAdjacentHTML"}` — 任意オブジェクトの insertAdjacentHTML を禁止
  - `{object: "document", property: "write"}` — document.write を禁止
- `eslint/no-restricted-globals`:
  - `{name: "DOMParser"}` — DOMParser を禁止（`no-restricted-syntax` が Oxlint 非対応のため代替）

## React 側の既存制約との役割分担

- `react/no-danger`: JSX の `dangerouslySetInnerHTML` を禁止（既存）
- 本 PR: DOM API による HTML injection を禁止

両方を入れることで、React 経由・DOM API 経由の両方をカバーする。

## 検証

- production src に該当 API の既存利用はなく、linter は 0 error を確認
- test / story / e2e の各 override では本ルールを off にしており、過剰適用なし
- `bun run quality` 通過（lint / test / knip / jscpd / secretlint / depcruise）

## 補足

- `no-restricted-syntax`（`NewExpression[callee.name='DOMParser']`）は Oxlint が未サポートのため、`no-restricted-globals` で代替。DOMParser を adapter に閉じ込める必要が生じた場合は、適宜 override で例外を追加する。
- warn 運用ではなく error 運用。

Closes #647