### PR TITLE
Knip の vitest plugin を有効化する

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -10,9 +10,7 @@
     "src/utils/**/*.{test,stories}.{ts,tsx}",
     "e2e/**/*.{ts,tsx}",
     "tools/**/*.{ts,tsx}",
-    ".storybook/**/*.{ts,tsx}",
-    "vitest.config.ts",
-    "vitest.workspace.ts"
+    ".storybook/**/*.{ts,tsx}"
   ],
   "project": [
     "src/app/**/*.{ts,tsx}",
@@ -44,7 +42,6 @@
   "ignoreFiles": ["src/stories/**", "tests/**"],
   "ignoreDependencies": [
     "@storybook/addon-onboarding",
-    "@testing-library/jest-dom",
     "autoprefixer",
     "path",
     "postcss",
@@ -53,5 +50,5 @@
   "lefthook": true,
   "playwright": true,
   "storybook": true,
-  "vitest": false
+  "vitest": true
 }


### PR DESCRIPTION
## 概要

Knip の `vitest` plugin を `true` に変更し、Storybook / Playwright と同様に有効化します。

## 背景

`knip.json` で `vitest: false` になっていたため、Vitest config や test utility 由来の参照検出が弱くなっている可能性がありました。git 履歴を調査したところ、初期導入時から `false` のまま特段の理由やコメントがない状態でした。

## 変更内容

1. `vitest: false` → `vitest: true` に変更
2. 自動検出されるようになった `vitest.config.ts` / `vitest.workspace.ts` を `entry` から削除
3. Vitest plugin が setup file 経由で正しく検出できるようになった `@testing-library/jest-dom` を `ignoreDependencies` から削除

## 確認観点

- ✅ `vitest: true` で `bun run knip` を実行しても false positive は発生しない（既存の 2 件の Configuration hints のみ）
- ✅ `bun run quality` が成功（298 test files / 3218 tests passed）
- ✅ test setup file（`src/test/setup-console.ts`）が正しく entry として認識される
- ✅ `@testing-library/jest-dom` が未使用扱いされず、正しく依存関係として検出される

## 補足

- 広すぎる ignore は一切追加していません
- 有効化により新たな unused / unlisted の検出は発生していません

Closes #670