### PR TITLE
release: 配布前チェック用の release script を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ TABBIN(タビン)はブラウザのタブを整理・分類する拡張機能で
 
 ### [🌐 DeepWiki](https://deepwiki.com/TarouTanakaYokohama/TABBIN/1-overview)
 
+### 📦 リリース手順
+
+配布前に以下のコマンドで品質とビルドを確認します。
+
+```bash
+bun run release:check   # quality → Chrome build → Firefox build
+bun run release:zip     # release:check → Chrome zip → Firefox zip
+```
+
+詳細は [docs/release.md](docs/release.md) を参照してください。
+
 ## 📞 サポート
 
 問題が発生した場合や質問がある場合は、[Issues](https://github.com/yourusername/tabbin/issues) か、[お問い合わせフォーム](https://forms.gle/c9gBiF2TmgXaeU7J6)をご利用ください。

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,50 @@
+# リリース手順
+
+## 事前チェック
+
+配布前に以下のコマンドで品質とビルドを確認します。
+
+```bash
+bun run release:check
+```
+
+このコマンドは以下の流れで実行されます：
+
+1. `bun run quality` — フォーマット、lint、テスト、重複チェックなど
+2. `bun run build` — Chrome 拡張機能のビルド
+3. `bun run build:firefox` — Firefox 拡張機能のビルド
+
+## ZIP 生成
+
+品質確認とビルドが通ったら、ZIP を作成します。
+
+```bash
+bun run release:zip
+```
+
+このコマンドは以下の流れで実行されます：
+
+1. `bun run release:check` — 上記の事前チェック
+2. `bun run zip` — Chrome 用 ZIP 生成
+3. `bun run zip:firefox` — Firefox 用 ZIP 生成
+
+## Chrome ウェブストアへの公開
+
+1. `bun run release:zip` で生成された `.output/*.zip` を用意します
+2. [Chrome ウェブストア デベロッパーダッシュボード](https://chrome.google.com/webstore/devconsole) にアクセスします
+3. 該当の拡張機能を選択し、「新しいパッケージをアップロード」から ZIP をアップロードします
+4. ストアの掲載情報を確認し、必要に応じて更新します
+5. 審査を送信します
+
+## Firefox アドオンへの公開
+
+1. `bun run release:zip` で生成された `.output/*.zip` を用意します
+2. [Firefox Add-on Developer Hub](https://addons.mozilla.org/ja/developers/) にアクセスします
+3. 該当のアドオンを選択し、新しいバージョンをアップロードします
+4. 必要に応じてソースコードをアップロードします
+5. 審査を送信します
+
+## 注意事項
+
+- `release:check` は通常の開発サイクルでは使用せず、配布前の最終確認に使います
+- `bun run release:check` をパスしない ZIP は配布しないでください

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "build:firefox": "wxt build -b firefox",
     "zip": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",
+    "release:check": "bun run quality && bun run build && bun run build:firefox",
+    "release:zip": "bun run release:check && bun run zip && bun run zip:firefox",
     "compile": "tsgo --noEmit",
     "secretlint": "secretlint \"**/*\"",
     "postinstall": "wxt prepare",


### PR DESCRIPTION
## 変更内容

配布前に品質確認と両ブラウザビルドをまとめて実行できる script を追加しました。

- `release:check`: quality → Chrome build → Firefox build を順次実行
- `release:zip`: release:check → Chrome zip → Firefox zip を順次実行
- `docs/release.md`: リリース手順書を追加
- README にリリース手順へのリンクを追加

## チェックリスト

- [x] ローカル環境でエラーになっていない

Closes #680