### PR TITLE
feat: Playwright / Context7 の MCP サーバーを追加 (opencode対応)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp"
+      ]
+    },
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,10 +3,7 @@
     "playwright": {
       "type": "stdio",
       "command": "npx",
-      "args": [
-        "-y",
-        "@playwright/mcp"
-      ]
+      "args": ["-y", "@playwright/mcp"]
     },
     "context7": {
       "type": "http",

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2,8 +2,8 @@ lockfile_version: '1'
 generated_at: '2026-07-05T11:01:42.736986+00:00'
 dependencies: []
 mcp_servers:
-- context7
-- playwright
+  - context7
+  - playwright
 mcp_configs:
   context7:
     name: context7
@@ -14,240 +14,240 @@ mcp_configs:
     name: playwright
     transport: stdio
     args:
-    - -y
-    - '@playwright/mcp'
+      - -y
+      - '@playwright/mcp'
     registry: false
     command: npx
 local_deployed_files:
-- .agents/skills/agent-automation-recommender
-- .agents/skills/agent-introspection-debugging
-- .agents/skills/animation-best-practices
-- .agents/skills/babysit
-- .agents/skills/brainstorming
-- .agents/skills/canvas
-- .agents/skills/check
-- .agents/skills/create-hook
-- .agents/skills/create-rule
-- .agents/skills/create-skill
-- .agents/skills/create-subagent
-- .agents/skills/cursor-sdk
-- .agents/skills/dispatching-parallel-agents
-- .agents/skills/e2e-testing
-- .agents/skills/executing-plans
-- .agents/skills/find-skills
-- .agents/skills/finishing-a-development-branch
-- .agents/skills/git-staged-branch-commit-push
-- .agents/skills/github-issue-implementation
-- .agents/skills/grill-with-docs
-- .agents/skills/harness-evaluator
-- .agents/skills/harness-generator
-- .agents/skills/harness-optimizer
-- .agents/skills/harness-orchestrate
-- .agents/skills/harness-planner
-- .agents/skills/migrate-to-skills
-- .agents/skills/react-doctor
-- .agents/skills/receiving-code-review
-- .agents/skills/remotion-best-practices
-- .agents/skills/requesting-code-review
-- .agents/skills/security-review
-- .agents/skills/shell
-- .agents/skills/split-to-prs
-- .agents/skills/statusline
-- .agents/skills/subagent-driven-development
-- .agents/skills/systematic-debugging
-- .agents/skills/test-driven-development
-- .agents/skills/update-cli-config
-- .agents/skills/update-cursor-settings
-- .agents/skills/using-git-worktrees
-- .agents/skills/using-superpowers
-- .agents/skills/vercel-composition-patterns
-- .agents/skills/vercel-react-best-practices
-- .agents/skills/vercel-react-native-skills
-- .agents/skills/verification-before-completion
-- .agents/skills/web-design-guidelines
-- .agents/skills/writing-plans
-- .agents/skills/writing-skills
-- .claude/commands/agent-automation-recommendations.md
-- .claude/commands/code-style.md
-- .claude/commands/comment-rule.md
-- .claude/commands/harness-audit.md
-- .claude/commands/harness-evaluator.md
-- .claude/commands/harness-learn.md
-- .claude/commands/harness-loop-status.md
-- .claude/commands/harness-model-route.md
-- .claude/commands/harness-orchestrate.md
-- .claude/commands/harness-quality-gate.md
-- .claude/commands/harness-repo-status.md
-- .claude/commands/harness-security-audit.md
-- .claude/commands/harness-status.md
-- .claude/hooks/TABBIN/scripts/format-check-on-edit.sh
-- .claude/hooks/TABBIN/scripts/harness-activity-track.sh
-- .claude/hooks/TABBIN/scripts/harness-config-protection.sh
-- .claude/hooks/TABBIN/scripts/harness-first-edit-gate.sh
-- .claude/hooks/TABBIN/scripts/harness-postflight-capture.sh
-- .claude/hooks/TABBIN/scripts/harness-precompact.sh
-- .claude/hooks/TABBIN/scripts/harness-profile-gate.sh
-- .claude/hooks/TABBIN/scripts/harness-safety-warn.sh
-- .claude/hooks/TABBIN/scripts/harness-session-context.sh
-- .claude/hooks/TABBIN/scripts/publish-verify.sh
-- .claude/hooks/TABBIN/scripts/rtk-usage-replace.sh
-- .claude/hooks/TABBIN/scripts/stop-verify.sh
-- .claude/hooks/TABBIN/scripts/track-edit.sh
-- .claude/rules/00-context-mode.md
-- .claude/rules/01-rtk.md
-- .claude/rules/02-vitest-local-development.md
-- .claude/rules/harness.md
-- .claude/rules/repository-guidelines.md
-- .claude/skills/agent-automation-recommender
-- .claude/skills/agent-introspection-debugging
-- .claude/skills/animation-best-practices
-- .claude/skills/babysit
-- .claude/skills/brainstorming
-- .claude/skills/canvas
-- .claude/skills/check
-- .claude/skills/create-hook
-- .claude/skills/create-rule
-- .claude/skills/create-skill
-- .claude/skills/create-subagent
-- .claude/skills/cursor-sdk
-- .claude/skills/dispatching-parallel-agents
-- .claude/skills/e2e-testing
-- .claude/skills/executing-plans
-- .claude/skills/find-skills
-- .claude/skills/finishing-a-development-branch
-- .claude/skills/git-staged-branch-commit-push
-- .claude/skills/github-issue-implementation
-- .claude/skills/grill-with-docs
-- .claude/skills/harness-evaluator
-- .claude/skills/harness-generator
-- .claude/skills/harness-optimizer
-- .claude/skills/harness-orchestrate
-- .claude/skills/harness-planner
-- .claude/skills/migrate-to-skills
-- .claude/skills/react-doctor
-- .claude/skills/receiving-code-review
-- .claude/skills/remotion-best-practices
-- .claude/skills/requesting-code-review
-- .claude/skills/security-review
-- .claude/skills/shell
-- .claude/skills/split-to-prs
-- .claude/skills/statusline
-- .claude/skills/subagent-driven-development
-- .claude/skills/systematic-debugging
-- .claude/skills/test-driven-development
-- .claude/skills/update-cli-config
-- .claude/skills/update-cursor-settings
-- .claude/skills/using-git-worktrees
-- .claude/skills/using-superpowers
-- .claude/skills/vercel-composition-patterns
-- .claude/skills/vercel-react-best-practices
-- .claude/skills/vercel-react-native-skills
-- .claude/skills/verification-before-completion
-- .claude/skills/web-design-guidelines
-- .claude/skills/writing-plans
-- .claude/skills/writing-skills
-- .codex/hooks/TABBIN/scripts/format-check-on-edit.sh
-- .codex/hooks/TABBIN/scripts/harness-activity-track.sh
-- .codex/hooks/TABBIN/scripts/harness-config-protection.sh
-- .codex/hooks/TABBIN/scripts/harness-first-edit-gate.sh
-- .codex/hooks/TABBIN/scripts/harness-postflight-capture.sh
-- .codex/hooks/TABBIN/scripts/harness-precompact.sh
-- .codex/hooks/TABBIN/scripts/harness-profile-gate.sh
-- .codex/hooks/TABBIN/scripts/harness-safety-warn.sh
-- .codex/hooks/TABBIN/scripts/harness-session-context.sh
-- .codex/hooks/TABBIN/scripts/publish-verify.sh
-- .codex/hooks/TABBIN/scripts/rtk-usage-replace.sh
-- .codex/hooks/TABBIN/scripts/stop-verify.sh
-- .codex/hooks/TABBIN/scripts/track-edit.sh
-- .cursor/commands/agent-automation-recommendations.md
-- .cursor/commands/code-style.md
-- .cursor/commands/comment-rule.md
-- .cursor/commands/harness-audit.md
-- .cursor/commands/harness-evaluator.md
-- .cursor/commands/harness-learn.md
-- .cursor/commands/harness-loop-status.md
-- .cursor/commands/harness-model-route.md
-- .cursor/commands/harness-orchestrate.md
-- .cursor/commands/harness-quality-gate.md
-- .cursor/commands/harness-repo-status.md
-- .cursor/commands/harness-security-audit.md
-- .cursor/commands/harness-status.md
-- .cursor/hooks/TABBIN/scripts/format-check-on-edit.sh
-- .cursor/hooks/TABBIN/scripts/harness-activity-track.sh
-- .cursor/hooks/TABBIN/scripts/harness-config-protection.sh
-- .cursor/hooks/TABBIN/scripts/harness-first-edit-gate.sh
-- .cursor/hooks/TABBIN/scripts/harness-postflight-capture.sh
-- .cursor/hooks/TABBIN/scripts/harness-precompact.sh
-- .cursor/hooks/TABBIN/scripts/harness-profile-gate.sh
-- .cursor/hooks/TABBIN/scripts/harness-safety-warn.sh
-- .cursor/hooks/TABBIN/scripts/harness-session-context.sh
-- .cursor/hooks/TABBIN/scripts/publish-verify.sh
-- .cursor/hooks/TABBIN/scripts/rtk-usage-replace.sh
-- .cursor/hooks/TABBIN/scripts/stop-verify.sh
-- .cursor/hooks/TABBIN/scripts/track-edit.sh
-- .cursor/rules/00-context-mode.mdc
-- .cursor/rules/01-rtk.mdc
-- .cursor/rules/02-vitest-local-development.mdc
-- .cursor/rules/harness.mdc
-- .cursor/rules/repository-guidelines.mdc
-- .gemini/commands/agent-automation-recommendations.toml
-- .gemini/commands/code-style.toml
-- .gemini/commands/comment-rule.toml
-- .gemini/commands/harness-audit.toml
-- .gemini/commands/harness-evaluator.toml
-- .gemini/commands/harness-learn.toml
-- .gemini/commands/harness-loop-status.toml
-- .gemini/commands/harness-model-route.toml
-- .gemini/commands/harness-orchestrate.toml
-- .gemini/commands/harness-quality-gate.toml
-- .gemini/commands/harness-repo-status.toml
-- .gemini/commands/harness-security-audit.toml
-- .gemini/commands/harness-status.toml
-- .gemini/hooks/TABBIN/scripts/format-check-on-edit.sh
-- .gemini/hooks/TABBIN/scripts/harness-activity-track.sh
-- .gemini/hooks/TABBIN/scripts/harness-config-protection.sh
-- .gemini/hooks/TABBIN/scripts/harness-first-edit-gate.sh
-- .gemini/hooks/TABBIN/scripts/harness-postflight-capture.sh
-- .gemini/hooks/TABBIN/scripts/harness-precompact.sh
-- .gemini/hooks/TABBIN/scripts/harness-profile-gate.sh
-- .gemini/hooks/TABBIN/scripts/harness-safety-warn.sh
-- .gemini/hooks/TABBIN/scripts/harness-session-context.sh
-- .gemini/hooks/TABBIN/scripts/publish-verify.sh
-- .gemini/hooks/TABBIN/scripts/rtk-usage-replace.sh
-- .gemini/hooks/TABBIN/scripts/stop-verify.sh
-- .gemini/hooks/TABBIN/scripts/track-edit.sh
-- .github/hooks/TABBIN-claude-quality-hooks.json
-- .github/hooks/scripts/TABBIN/scripts/format-check-on-edit.sh
-- .github/hooks/scripts/TABBIN/scripts/harness-activity-track.sh
-- .github/hooks/scripts/TABBIN/scripts/harness-config-protection.sh
-- .github/hooks/scripts/TABBIN/scripts/harness-first-edit-gate.sh
-- .github/hooks/scripts/TABBIN/scripts/harness-postflight-capture.sh
-- .github/hooks/scripts/TABBIN/scripts/harness-precompact.sh
-- .github/hooks/scripts/TABBIN/scripts/harness-profile-gate.sh
-- .github/hooks/scripts/TABBIN/scripts/harness-safety-warn.sh
-- .github/hooks/scripts/TABBIN/scripts/harness-session-context.sh
-- .github/hooks/scripts/TABBIN/scripts/publish-verify.sh
-- .github/hooks/scripts/TABBIN/scripts/rtk-usage-replace.sh
-- .github/hooks/scripts/TABBIN/scripts/stop-verify.sh
-- .github/hooks/scripts/TABBIN/scripts/track-edit.sh
-- .github/instructions/00-context-mode.instructions.md
-- .github/instructions/01-rtk.instructions.md
-- .github/instructions/02-vitest-local-development.instructions.md
-- .github/instructions/harness.instructions.md
-- .github/instructions/repository-guidelines.instructions.md
-- .github/prompts/agent-automation-recommendations.prompt.md
-- .github/prompts/code-style.prompt.md
-- .github/prompts/comment-rule.prompt.md
-- .github/prompts/harness-audit.prompt.md
-- .github/prompts/harness-evaluator.prompt.md
-- .github/prompts/harness-learn.prompt.md
-- .github/prompts/harness-loop-status.prompt.md
-- .github/prompts/harness-model-route.prompt.md
-- .github/prompts/harness-orchestrate.prompt.md
-- .github/prompts/harness-quality-gate.prompt.md
-- .github/prompts/harness-repo-status.prompt.md
-- .github/prompts/harness-security-audit.prompt.md
-- .github/prompts/harness-status.prompt.md
+  - .agents/skills/agent-automation-recommender
+  - .agents/skills/agent-introspection-debugging
+  - .agents/skills/animation-best-practices
+  - .agents/skills/babysit
+  - .agents/skills/brainstorming
+  - .agents/skills/canvas
+  - .agents/skills/check
+  - .agents/skills/create-hook
+  - .agents/skills/create-rule
+  - .agents/skills/create-skill
+  - .agents/skills/create-subagent
+  - .agents/skills/cursor-sdk
+  - .agents/skills/dispatching-parallel-agents
+  - .agents/skills/e2e-testing
+  - .agents/skills/executing-plans
+  - .agents/skills/find-skills
+  - .agents/skills/finishing-a-development-branch
+  - .agents/skills/git-staged-branch-commit-push
+  - .agents/skills/github-issue-implementation
+  - .agents/skills/grill-with-docs
+  - .agents/skills/harness-evaluator
+  - .agents/skills/harness-generator
+  - .agents/skills/harness-optimizer
+  - .agents/skills/harness-orchestrate
+  - .agents/skills/harness-planner
+  - .agents/skills/migrate-to-skills
+  - .agents/skills/react-doctor
+  - .agents/skills/receiving-code-review
+  - .agents/skills/remotion-best-practices
+  - .agents/skills/requesting-code-review
+  - .agents/skills/security-review
+  - .agents/skills/shell
+  - .agents/skills/split-to-prs
+  - .agents/skills/statusline
+  - .agents/skills/subagent-driven-development
+  - .agents/skills/systematic-debugging
+  - .agents/skills/test-driven-development
+  - .agents/skills/update-cli-config
+  - .agents/skills/update-cursor-settings
+  - .agents/skills/using-git-worktrees
+  - .agents/skills/using-superpowers
+  - .agents/skills/vercel-composition-patterns
+  - .agents/skills/vercel-react-best-practices
+  - .agents/skills/vercel-react-native-skills
+  - .agents/skills/verification-before-completion
+  - .agents/skills/web-design-guidelines
+  - .agents/skills/writing-plans
+  - .agents/skills/writing-skills
+  - .claude/commands/agent-automation-recommendations.md
+  - .claude/commands/code-style.md
+  - .claude/commands/comment-rule.md
+  - .claude/commands/harness-audit.md
+  - .claude/commands/harness-evaluator.md
+  - .claude/commands/harness-learn.md
+  - .claude/commands/harness-loop-status.md
+  - .claude/commands/harness-model-route.md
+  - .claude/commands/harness-orchestrate.md
+  - .claude/commands/harness-quality-gate.md
+  - .claude/commands/harness-repo-status.md
+  - .claude/commands/harness-security-audit.md
+  - .claude/commands/harness-status.md
+  - .claude/hooks/TABBIN/scripts/format-check-on-edit.sh
+  - .claude/hooks/TABBIN/scripts/harness-activity-track.sh
+  - .claude/hooks/TABBIN/scripts/harness-config-protection.sh
+  - .claude/hooks/TABBIN/scripts/harness-first-edit-gate.sh
+  - .claude/hooks/TABBIN/scripts/harness-postflight-capture.sh
+  - .claude/hooks/TABBIN/scripts/harness-precompact.sh
+  - .claude/hooks/TABBIN/scripts/harness-profile-gate.sh
+  - .claude/hooks/TABBIN/scripts/harness-safety-warn.sh
+  - .claude/hooks/TABBIN/scripts/harness-session-context.sh
+  - .claude/hooks/TABBIN/scripts/publish-verify.sh
+  - .claude/hooks/TABBIN/scripts/rtk-usage-replace.sh
+  - .claude/hooks/TABBIN/scripts/stop-verify.sh
+  - .claude/hooks/TABBIN/scripts/track-edit.sh
+  - .claude/rules/00-context-mode.md
+  - .claude/rules/01-rtk.md
+  - .claude/rules/02-vitest-local-development.md
+  - .claude/rules/harness.md
+  - .claude/rules/repository-guidelines.md
+  - .claude/skills/agent-automation-recommender
+  - .claude/skills/agent-introspection-debugging
+  - .claude/skills/animation-best-practices
+  - .claude/skills/babysit
+  - .claude/skills/brainstorming
+  - .claude/skills/canvas
+  - .claude/skills/check
+  - .claude/skills/create-hook
+  - .claude/skills/create-rule
+  - .claude/skills/create-skill
+  - .claude/skills/create-subagent
+  - .claude/skills/cursor-sdk
+  - .claude/skills/dispatching-parallel-agents
+  - .claude/skills/e2e-testing
+  - .claude/skills/executing-plans
+  - .claude/skills/find-skills
+  - .claude/skills/finishing-a-development-branch
+  - .claude/skills/git-staged-branch-commit-push
+  - .claude/skills/github-issue-implementation
+  - .claude/skills/grill-with-docs
+  - .claude/skills/harness-evaluator
+  - .claude/skills/harness-generator
+  - .claude/skills/harness-optimizer
+  - .claude/skills/harness-orchestrate
+  - .claude/skills/harness-planner
+  - .claude/skills/migrate-to-skills
+  - .claude/skills/react-doctor
+  - .claude/skills/receiving-code-review
+  - .claude/skills/remotion-best-practices
+  - .claude/skills/requesting-code-review
+  - .claude/skills/security-review
+  - .claude/skills/shell
+  - .claude/skills/split-to-prs
+  - .claude/skills/statusline
+  - .claude/skills/subagent-driven-development
+  - .claude/skills/systematic-debugging
+  - .claude/skills/test-driven-development
+  - .claude/skills/update-cli-config
+  - .claude/skills/update-cursor-settings
+  - .claude/skills/using-git-worktrees
+  - .claude/skills/using-superpowers
+  - .claude/skills/vercel-composition-patterns
+  - .claude/skills/vercel-react-best-practices
+  - .claude/skills/vercel-react-native-skills
+  - .claude/skills/verification-before-completion
+  - .claude/skills/web-design-guidelines
+  - .claude/skills/writing-plans
+  - .claude/skills/writing-skills
+  - .codex/hooks/TABBIN/scripts/format-check-on-edit.sh
+  - .codex/hooks/TABBIN/scripts/harness-activity-track.sh
+  - .codex/hooks/TABBIN/scripts/harness-config-protection.sh
+  - .codex/hooks/TABBIN/scripts/harness-first-edit-gate.sh
+  - .codex/hooks/TABBIN/scripts/harness-postflight-capture.sh
+  - .codex/hooks/TABBIN/scripts/harness-precompact.sh
+  - .codex/hooks/TABBIN/scripts/harness-profile-gate.sh
+  - .codex/hooks/TABBIN/scripts/harness-safety-warn.sh
+  - .codex/hooks/TABBIN/scripts/harness-session-context.sh
+  - .codex/hooks/TABBIN/scripts/publish-verify.sh
+  - .codex/hooks/TABBIN/scripts/rtk-usage-replace.sh
+  - .codex/hooks/TABBIN/scripts/stop-verify.sh
+  - .codex/hooks/TABBIN/scripts/track-edit.sh
+  - .cursor/commands/agent-automation-recommendations.md
+  - .cursor/commands/code-style.md
+  - .cursor/commands/comment-rule.md
+  - .cursor/commands/harness-audit.md
+  - .cursor/commands/harness-evaluator.md
+  - .cursor/commands/harness-learn.md
+  - .cursor/commands/harness-loop-status.md
+  - .cursor/commands/harness-model-route.md
+  - .cursor/commands/harness-orchestrate.md
+  - .cursor/commands/harness-quality-gate.md
+  - .cursor/commands/harness-repo-status.md
+  - .cursor/commands/harness-security-audit.md
+  - .cursor/commands/harness-status.md
+  - .cursor/hooks/TABBIN/scripts/format-check-on-edit.sh
+  - .cursor/hooks/TABBIN/scripts/harness-activity-track.sh
+  - .cursor/hooks/TABBIN/scripts/harness-config-protection.sh
+  - .cursor/hooks/TABBIN/scripts/harness-first-edit-gate.sh
+  - .cursor/hooks/TABBIN/scripts/harness-postflight-capture.sh
+  - .cursor/hooks/TABBIN/scripts/harness-precompact.sh
+  - .cursor/hooks/TABBIN/scripts/harness-profile-gate.sh
+  - .cursor/hooks/TABBIN/scripts/harness-safety-warn.sh
+  - .cursor/hooks/TABBIN/scripts/harness-session-context.sh
+  - .cursor/hooks/TABBIN/scripts/publish-verify.sh
+  - .cursor/hooks/TABBIN/scripts/rtk-usage-replace.sh
+  - .cursor/hooks/TABBIN/scripts/stop-verify.sh
+  - .cursor/hooks/TABBIN/scripts/track-edit.sh
+  - .cursor/rules/00-context-mode.mdc
+  - .cursor/rules/01-rtk.mdc
+  - .cursor/rules/02-vitest-local-development.mdc
+  - .cursor/rules/harness.mdc
+  - .cursor/rules/repository-guidelines.mdc
+  - .gemini/commands/agent-automation-recommendations.toml
+  - .gemini/commands/code-style.toml
+  - .gemini/commands/comment-rule.toml
+  - .gemini/commands/harness-audit.toml
+  - .gemini/commands/harness-evaluator.toml
+  - .gemini/commands/harness-learn.toml
+  - .gemini/commands/harness-loop-status.toml
+  - .gemini/commands/harness-model-route.toml
+  - .gemini/commands/harness-orchestrate.toml
+  - .gemini/commands/harness-quality-gate.toml
+  - .gemini/commands/harness-repo-status.toml
+  - .gemini/commands/harness-security-audit.toml
+  - .gemini/commands/harness-status.toml
+  - .gemini/hooks/TABBIN/scripts/format-check-on-edit.sh
+  - .gemini/hooks/TABBIN/scripts/harness-activity-track.sh
+  - .gemini/hooks/TABBIN/scripts/harness-config-protection.sh
+  - .gemini/hooks/TABBIN/scripts/harness-first-edit-gate.sh
+  - .gemini/hooks/TABBIN/scripts/harness-postflight-capture.sh
+  - .gemini/hooks/TABBIN/scripts/harness-precompact.sh
+  - .gemini/hooks/TABBIN/scripts/harness-profile-gate.sh
+  - .gemini/hooks/TABBIN/scripts/harness-safety-warn.sh
+  - .gemini/hooks/TABBIN/scripts/harness-session-context.sh
+  - .gemini/hooks/TABBIN/scripts/publish-verify.sh
+  - .gemini/hooks/TABBIN/scripts/rtk-usage-replace.sh
+  - .gemini/hooks/TABBIN/scripts/stop-verify.sh
+  - .gemini/hooks/TABBIN/scripts/track-edit.sh
+  - .github/hooks/TABBIN-claude-quality-hooks.json
+  - .github/hooks/scripts/TABBIN/scripts/format-check-on-edit.sh
+  - .github/hooks/scripts/TABBIN/scripts/harness-activity-track.sh
+  - .github/hooks/scripts/TABBIN/scripts/harness-config-protection.sh
+  - .github/hooks/scripts/TABBIN/scripts/harness-first-edit-gate.sh
+  - .github/hooks/scripts/TABBIN/scripts/harness-postflight-capture.sh
+  - .github/hooks/scripts/TABBIN/scripts/harness-precompact.sh
+  - .github/hooks/scripts/TABBIN/scripts/harness-profile-gate.sh
+  - .github/hooks/scripts/TABBIN/scripts/harness-safety-warn.sh
+  - .github/hooks/scripts/TABBIN/scripts/harness-session-context.sh
+  - .github/hooks/scripts/TABBIN/scripts/publish-verify.sh
+  - .github/hooks/scripts/TABBIN/scripts/rtk-usage-replace.sh
+  - .github/hooks/scripts/TABBIN/scripts/stop-verify.sh
+  - .github/hooks/scripts/TABBIN/scripts/track-edit.sh
+  - .github/instructions/00-context-mode.instructions.md
+  - .github/instructions/01-rtk.instructions.md
+  - .github/instructions/02-vitest-local-development.instructions.md
+  - .github/instructions/harness.instructions.md
+  - .github/instructions/repository-guidelines.instructions.md
+  - .github/prompts/agent-automation-recommendations.prompt.md
+  - .github/prompts/code-style.prompt.md
+  - .github/prompts/comment-rule.prompt.md
+  - .github/prompts/harness-audit.prompt.md
+  - .github/prompts/harness-evaluator.prompt.md
+  - .github/prompts/harness-learn.prompt.md
+  - .github/prompts/harness-loop-status.prompt.md
+  - .github/prompts/harness-model-route.prompt.md
+  - .github/prompts/harness-orchestrate.prompt.md
+  - .github/prompts/harness-quality-gate.prompt.md
+  - .github/prompts/harness-repo-status.prompt.md
+  - .github/prompts/harness-security-audit.prompt.md
+  - .github/prompts/harness-status.prompt.md
 local_deployed_file_hashes:
   .claude/commands/agent-automation-recommendations.md: sha256:f6a4ff4422ee67a743a174f2eba7fd3d9f5571bc0b800344fb85e15e6e64f033
   .claude/commands/code-style.md: sha256:92e72362699c129acd601ee5d1f68291e5bd6376b7026f84b54deedc68cca2a4

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,236 +1,253 @@
 lockfile_version: '1'
-generated_at: '2026-05-03T00:00:00+09:00'
+generated_at: '2026-07-05T11:01:42.736986+00:00'
 dependencies: []
+mcp_servers:
+- context7
+- playwright
+mcp_configs:
+  context7:
+    name: context7
+    transport: http
+    registry: false
+    url: https://mcp.context7.com/mcp
+  playwright:
+    name: playwright
+    transport: stdio
+    args:
+    - -y
+    - '@playwright/mcp'
+    registry: false
+    command: npx
 local_deployed_files:
-  - .agents/skills/agent-automation-recommender
-  - .agents/skills/agent-introspection-debugging
-  - .agents/skills/animation-best-practices
-  - .agents/skills/babysit
-  - .agents/skills/brainstorming
-  - .agents/skills/canvas
-  - .agents/skills/check
-  - .agents/skills/create-hook
-  - .agents/skills/create-rule
-  - .agents/skills/create-skill
-  - .agents/skills/create-subagent
-  - .agents/skills/cursor-sdk
-  - .agents/skills/dispatching-parallel-agents
-  - .agents/skills/e2e-testing
-  - .agents/skills/executing-plans
-  - .agents/skills/find-skills
-  - .agents/skills/finishing-a-development-branch
-  - .agents/skills/git-staged-branch-commit-push
-  - .agents/skills/github-issue-implementation
-  - .agents/skills/grill-with-docs
-  - .agents/skills/harness-evaluator
-  - .agents/skills/harness-generator
-  - .agents/skills/harness-optimizer
-  - .agents/skills/harness-orchestrate
-  - .agents/skills/harness-planner
-  - .agents/skills/migrate-to-skills
-  - .agents/skills/react-doctor
-  - .agents/skills/receiving-code-review
-  - .agents/skills/remotion-best-practices
-  - .agents/skills/requesting-code-review
-  - .agents/skills/security-review
-  - .agents/skills/shell
-  - .agents/skills/split-to-prs
-  - .agents/skills/statusline
-  - .agents/skills/subagent-driven-development
-  - .agents/skills/systematic-debugging
-  - .agents/skills/test-driven-development
-  - .agents/skills/update-cli-config
-  - .agents/skills/update-cursor-settings
-  - .agents/skills/using-git-worktrees
-  - .agents/skills/using-superpowers
-  - .agents/skills/vercel-composition-patterns
-  - .agents/skills/vercel-react-best-practices
-  - .agents/skills/vercel-react-native-skills
-  - .agents/skills/verification-before-completion
-  - .agents/skills/web-design-guidelines
-  - .agents/skills/writing-plans
-  - .agents/skills/writing-skills
-  - .claude/commands/agent-automation-recommendations.md
-  - .claude/commands/code-style.md
-  - .claude/commands/comment-rule.md
-  - .claude/commands/harness-audit.md
-  - .claude/commands/harness-evaluator.md
-  - .claude/commands/harness-learn.md
-  - .claude/commands/harness-loop-status.md
-  - .claude/commands/harness-model-route.md
-  - .claude/commands/harness-orchestrate.md
-  - .claude/commands/harness-quality-gate.md
-  - .claude/commands/harness-repo-status.md
-  - .claude/commands/harness-security-audit.md
-  - .claude/commands/harness-status.md
-  - .claude/hooks/TABBIN/scripts/format-check-on-edit.sh
-  - .claude/hooks/TABBIN/scripts/harness-activity-track.sh
-  - .claude/hooks/TABBIN/scripts/harness-config-protection.sh
-  - .claude/hooks/TABBIN/scripts/harness-first-edit-gate.sh
-  - .claude/hooks/TABBIN/scripts/harness-postflight-capture.sh
-  - .claude/hooks/TABBIN/scripts/harness-precompact.sh
-  - .claude/hooks/TABBIN/scripts/harness-profile-gate.sh
-  - .claude/hooks/TABBIN/scripts/harness-safety-warn.sh
-  - .claude/hooks/TABBIN/scripts/harness-session-context.sh
-  - .claude/hooks/TABBIN/scripts/publish-verify.sh
-  - .claude/hooks/TABBIN/scripts/rtk-usage-replace.sh
-  - .claude/hooks/TABBIN/scripts/stop-verify.sh
-  - .claude/hooks/TABBIN/scripts/track-edit.sh
-  - .claude/rules/00-context-mode.md
-  - .claude/rules/01-rtk.md
-  - .claude/rules/02-vitest-local-development.md
-  - .claude/rules/harness.md
-  - .claude/rules/repository-guidelines.md
-  - .claude/skills/agent-automation-recommender
-  - .claude/skills/agent-introspection-debugging
-  - .claude/skills/animation-best-practices
-  - .claude/skills/babysit
-  - .claude/skills/brainstorming
-  - .claude/skills/canvas
-  - .claude/skills/check
-  - .claude/skills/create-hook
-  - .claude/skills/create-rule
-  - .claude/skills/create-skill
-  - .claude/skills/create-subagent
-  - .claude/skills/cursor-sdk
-  - .claude/skills/dispatching-parallel-agents
-  - .claude/skills/e2e-testing
-  - .claude/skills/executing-plans
-  - .claude/skills/find-skills
-  - .claude/skills/finishing-a-development-branch
-  - .claude/skills/git-staged-branch-commit-push
-  - .claude/skills/github-issue-implementation
-  - .claude/skills/grill-with-docs
-  - .claude/skills/harness-evaluator
-  - .claude/skills/harness-generator
-  - .claude/skills/harness-optimizer
-  - .claude/skills/harness-orchestrate
-  - .claude/skills/harness-planner
-  - .claude/skills/migrate-to-skills
-  - .claude/skills/react-doctor
-  - .claude/skills/receiving-code-review
-  - .claude/skills/remotion-best-practices
-  - .claude/skills/requesting-code-review
-  - .claude/skills/security-review
-  - .claude/skills/shell
-  - .claude/skills/split-to-prs
-  - .claude/skills/statusline
-  - .claude/skills/subagent-driven-development
-  - .claude/skills/systematic-debugging
-  - .claude/skills/test-driven-development
-  - .claude/skills/update-cli-config
-  - .claude/skills/update-cursor-settings
-  - .claude/skills/using-git-worktrees
-  - .claude/skills/using-superpowers
-  - .claude/skills/vercel-composition-patterns
-  - .claude/skills/vercel-react-best-practices
-  - .claude/skills/vercel-react-native-skills
-  - .claude/skills/verification-before-completion
-  - .claude/skills/web-design-guidelines
-  - .claude/skills/writing-plans
-  - .claude/skills/writing-skills
-  - .codex/hooks/TABBIN/scripts/format-check-on-edit.sh
-  - .codex/hooks/TABBIN/scripts/harness-activity-track.sh
-  - .codex/hooks/TABBIN/scripts/harness-config-protection.sh
-  - .codex/hooks/TABBIN/scripts/harness-first-edit-gate.sh
-  - .codex/hooks/TABBIN/scripts/harness-postflight-capture.sh
-  - .codex/hooks/TABBIN/scripts/harness-precompact.sh
-  - .codex/hooks/TABBIN/scripts/harness-profile-gate.sh
-  - .codex/hooks/TABBIN/scripts/harness-safety-warn.sh
-  - .codex/hooks/TABBIN/scripts/harness-session-context.sh
-  - .codex/hooks/TABBIN/scripts/publish-verify.sh
-  - .codex/hooks/TABBIN/scripts/rtk-usage-replace.sh
-  - .codex/hooks/TABBIN/scripts/stop-verify.sh
-  - .codex/hooks/TABBIN/scripts/track-edit.sh
-  - .cursor/commands/agent-automation-recommendations.md
-  - .cursor/commands/code-style.md
-  - .cursor/commands/comment-rule.md
-  - .cursor/commands/harness-audit.md
-  - .cursor/commands/harness-evaluator.md
-  - .cursor/commands/harness-learn.md
-  - .cursor/commands/harness-loop-status.md
-  - .cursor/commands/harness-model-route.md
-  - .cursor/commands/harness-orchestrate.md
-  - .cursor/commands/harness-quality-gate.md
-  - .cursor/commands/harness-repo-status.md
-  - .cursor/commands/harness-security-audit.md
-  - .cursor/commands/harness-status.md
-  - .cursor/hooks/TABBIN/scripts/format-check-on-edit.sh
-  - .cursor/hooks/TABBIN/scripts/harness-activity-track.sh
-  - .cursor/hooks/TABBIN/scripts/harness-config-protection.sh
-  - .cursor/hooks/TABBIN/scripts/harness-first-edit-gate.sh
-  - .cursor/hooks/TABBIN/scripts/harness-postflight-capture.sh
-  - .cursor/hooks/TABBIN/scripts/harness-precompact.sh
-  - .cursor/hooks/TABBIN/scripts/harness-profile-gate.sh
-  - .cursor/hooks/TABBIN/scripts/harness-safety-warn.sh
-  - .cursor/hooks/TABBIN/scripts/harness-session-context.sh
-  - .cursor/hooks/TABBIN/scripts/publish-verify.sh
-  - .cursor/hooks/TABBIN/scripts/rtk-usage-replace.sh
-  - .cursor/hooks/TABBIN/scripts/stop-verify.sh
-  - .cursor/hooks/TABBIN/scripts/track-edit.sh
-  - .cursor/rules/00-context-mode.mdc
-  - .cursor/rules/01-rtk.mdc
-  - .cursor/rules/02-vitest-local-development.mdc
-  - .cursor/rules/harness.mdc
-  - .cursor/rules/repository-guidelines.mdc
-  - .gemini/commands/agent-automation-recommendations.toml
-  - .gemini/commands/code-style.toml
-  - .gemini/commands/comment-rule.toml
-  - .gemini/commands/harness-audit.toml
-  - .gemini/commands/harness-evaluator.toml
-  - .gemini/commands/harness-learn.toml
-  - .gemini/commands/harness-loop-status.toml
-  - .gemini/commands/harness-model-route.toml
-  - .gemini/commands/harness-orchestrate.toml
-  - .gemini/commands/harness-quality-gate.toml
-  - .gemini/commands/harness-repo-status.toml
-  - .gemini/commands/harness-security-audit.toml
-  - .gemini/commands/harness-status.toml
-  - .gemini/hooks/TABBIN/scripts/format-check-on-edit.sh
-  - .gemini/hooks/TABBIN/scripts/harness-activity-track.sh
-  - .gemini/hooks/TABBIN/scripts/harness-config-protection.sh
-  - .gemini/hooks/TABBIN/scripts/harness-first-edit-gate.sh
-  - .gemini/hooks/TABBIN/scripts/harness-postflight-capture.sh
-  - .gemini/hooks/TABBIN/scripts/harness-precompact.sh
-  - .gemini/hooks/TABBIN/scripts/harness-profile-gate.sh
-  - .gemini/hooks/TABBIN/scripts/harness-safety-warn.sh
-  - .gemini/hooks/TABBIN/scripts/harness-session-context.sh
-  - .gemini/hooks/TABBIN/scripts/publish-verify.sh
-  - .gemini/hooks/TABBIN/scripts/rtk-usage-replace.sh
-  - .gemini/hooks/TABBIN/scripts/stop-verify.sh
-  - .gemini/hooks/TABBIN/scripts/track-edit.sh
-  - .github/hooks/TABBIN-claude-quality-hooks.json
-  - .github/hooks/scripts/TABBIN/scripts/format-check-on-edit.sh
-  - .github/hooks/scripts/TABBIN/scripts/harness-activity-track.sh
-  - .github/hooks/scripts/TABBIN/scripts/harness-config-protection.sh
-  - .github/hooks/scripts/TABBIN/scripts/harness-first-edit-gate.sh
-  - .github/hooks/scripts/TABBIN/scripts/harness-postflight-capture.sh
-  - .github/hooks/scripts/TABBIN/scripts/harness-precompact.sh
-  - .github/hooks/scripts/TABBIN/scripts/harness-profile-gate.sh
-  - .github/hooks/scripts/TABBIN/scripts/harness-safety-warn.sh
-  - .github/hooks/scripts/TABBIN/scripts/harness-session-context.sh
-  - .github/hooks/scripts/TABBIN/scripts/publish-verify.sh
-  - .github/hooks/scripts/TABBIN/scripts/rtk-usage-replace.sh
-  - .github/hooks/scripts/TABBIN/scripts/stop-verify.sh
-  - .github/hooks/scripts/TABBIN/scripts/track-edit.sh
-  - .github/instructions/00-context-mode.instructions.md
-  - .github/instructions/01-rtk.instructions.md
-  - .github/instructions/02-vitest-local-development.instructions.md
-  - .github/instructions/harness.instructions.md
-  - .github/instructions/repository-guidelines.instructions.md
-  - .github/prompts/agent-automation-recommendations.prompt.md
-  - .github/prompts/code-style.prompt.md
-  - .github/prompts/comment-rule.prompt.md
-  - .github/prompts/harness-audit.prompt.md
-  - .github/prompts/harness-evaluator.prompt.md
-  - .github/prompts/harness-learn.prompt.md
-  - .github/prompts/harness-loop-status.prompt.md
-  - .github/prompts/harness-model-route.prompt.md
-  - .github/prompts/harness-orchestrate.prompt.md
-  - .github/prompts/harness-quality-gate.prompt.md
-  - .github/prompts/harness-repo-status.prompt.md
-  - .github/prompts/harness-security-audit.prompt.md
-  - .github/prompts/harness-status.prompt.md
+- .agents/skills/agent-automation-recommender
+- .agents/skills/agent-introspection-debugging
+- .agents/skills/animation-best-practices
+- .agents/skills/babysit
+- .agents/skills/brainstorming
+- .agents/skills/canvas
+- .agents/skills/check
+- .agents/skills/create-hook
+- .agents/skills/create-rule
+- .agents/skills/create-skill
+- .agents/skills/create-subagent
+- .agents/skills/cursor-sdk
+- .agents/skills/dispatching-parallel-agents
+- .agents/skills/e2e-testing
+- .agents/skills/executing-plans
+- .agents/skills/find-skills
+- .agents/skills/finishing-a-development-branch
+- .agents/skills/git-staged-branch-commit-push
+- .agents/skills/github-issue-implementation
+- .agents/skills/grill-with-docs
+- .agents/skills/harness-evaluator
+- .agents/skills/harness-generator
+- .agents/skills/harness-optimizer
+- .agents/skills/harness-orchestrate
+- .agents/skills/harness-planner
+- .agents/skills/migrate-to-skills
+- .agents/skills/react-doctor
+- .agents/skills/receiving-code-review
+- .agents/skills/remotion-best-practices
+- .agents/skills/requesting-code-review
+- .agents/skills/security-review
+- .agents/skills/shell
+- .agents/skills/split-to-prs
+- .agents/skills/statusline
+- .agents/skills/subagent-driven-development
+- .agents/skills/systematic-debugging
+- .agents/skills/test-driven-development
+- .agents/skills/update-cli-config
+- .agents/skills/update-cursor-settings
+- .agents/skills/using-git-worktrees
+- .agents/skills/using-superpowers
+- .agents/skills/vercel-composition-patterns
+- .agents/skills/vercel-react-best-practices
+- .agents/skills/vercel-react-native-skills
+- .agents/skills/verification-before-completion
+- .agents/skills/web-design-guidelines
+- .agents/skills/writing-plans
+- .agents/skills/writing-skills
+- .claude/commands/agent-automation-recommendations.md
+- .claude/commands/code-style.md
+- .claude/commands/comment-rule.md
+- .claude/commands/harness-audit.md
+- .claude/commands/harness-evaluator.md
+- .claude/commands/harness-learn.md
+- .claude/commands/harness-loop-status.md
+- .claude/commands/harness-model-route.md
+- .claude/commands/harness-orchestrate.md
+- .claude/commands/harness-quality-gate.md
+- .claude/commands/harness-repo-status.md
+- .claude/commands/harness-security-audit.md
+- .claude/commands/harness-status.md
+- .claude/hooks/TABBIN/scripts/format-check-on-edit.sh
+- .claude/hooks/TABBIN/scripts/harness-activity-track.sh
+- .claude/hooks/TABBIN/scripts/harness-config-protection.sh
+- .claude/hooks/TABBIN/scripts/harness-first-edit-gate.sh
+- .claude/hooks/TABBIN/scripts/harness-postflight-capture.sh
+- .claude/hooks/TABBIN/scripts/harness-precompact.sh
+- .claude/hooks/TABBIN/scripts/harness-profile-gate.sh
+- .claude/hooks/TABBIN/scripts/harness-safety-warn.sh
+- .claude/hooks/TABBIN/scripts/harness-session-context.sh
+- .claude/hooks/TABBIN/scripts/publish-verify.sh
+- .claude/hooks/TABBIN/scripts/rtk-usage-replace.sh
+- .claude/hooks/TABBIN/scripts/stop-verify.sh
+- .claude/hooks/TABBIN/scripts/track-edit.sh
+- .claude/rules/00-context-mode.md
+- .claude/rules/01-rtk.md
+- .claude/rules/02-vitest-local-development.md
+- .claude/rules/harness.md
+- .claude/rules/repository-guidelines.md
+- .claude/skills/agent-automation-recommender
+- .claude/skills/agent-introspection-debugging
+- .claude/skills/animation-best-practices
+- .claude/skills/babysit
+- .claude/skills/brainstorming
+- .claude/skills/canvas
+- .claude/skills/check
+- .claude/skills/create-hook
+- .claude/skills/create-rule
+- .claude/skills/create-skill
+- .claude/skills/create-subagent
+- .claude/skills/cursor-sdk
+- .claude/skills/dispatching-parallel-agents
+- .claude/skills/e2e-testing
+- .claude/skills/executing-plans
+- .claude/skills/find-skills
+- .claude/skills/finishing-a-development-branch
+- .claude/skills/git-staged-branch-commit-push
+- .claude/skills/github-issue-implementation
+- .claude/skills/grill-with-docs
+- .claude/skills/harness-evaluator
+- .claude/skills/harness-generator
+- .claude/skills/harness-optimizer
+- .claude/skills/harness-orchestrate
+- .claude/skills/harness-planner
+- .claude/skills/migrate-to-skills
+- .claude/skills/react-doctor
+- .claude/skills/receiving-code-review
+- .claude/skills/remotion-best-practices
+- .claude/skills/requesting-code-review
+- .claude/skills/security-review
+- .claude/skills/shell
+- .claude/skills/split-to-prs
+- .claude/skills/statusline
+- .claude/skills/subagent-driven-development
+- .claude/skills/systematic-debugging
+- .claude/skills/test-driven-development
+- .claude/skills/update-cli-config
+- .claude/skills/update-cursor-settings
+- .claude/skills/using-git-worktrees
+- .claude/skills/using-superpowers
+- .claude/skills/vercel-composition-patterns
+- .claude/skills/vercel-react-best-practices
+- .claude/skills/vercel-react-native-skills
+- .claude/skills/verification-before-completion
+- .claude/skills/web-design-guidelines
+- .claude/skills/writing-plans
+- .claude/skills/writing-skills
+- .codex/hooks/TABBIN/scripts/format-check-on-edit.sh
+- .codex/hooks/TABBIN/scripts/harness-activity-track.sh
+- .codex/hooks/TABBIN/scripts/harness-config-protection.sh
+- .codex/hooks/TABBIN/scripts/harness-first-edit-gate.sh
+- .codex/hooks/TABBIN/scripts/harness-postflight-capture.sh
+- .codex/hooks/TABBIN/scripts/harness-precompact.sh
+- .codex/hooks/TABBIN/scripts/harness-profile-gate.sh
+- .codex/hooks/TABBIN/scripts/harness-safety-warn.sh
+- .codex/hooks/TABBIN/scripts/harness-session-context.sh
+- .codex/hooks/TABBIN/scripts/publish-verify.sh
+- .codex/hooks/TABBIN/scripts/rtk-usage-replace.sh
+- .codex/hooks/TABBIN/scripts/stop-verify.sh
+- .codex/hooks/TABBIN/scripts/track-edit.sh
+- .cursor/commands/agent-automation-recommendations.md
+- .cursor/commands/code-style.md
+- .cursor/commands/comment-rule.md
+- .cursor/commands/harness-audit.md
+- .cursor/commands/harness-evaluator.md
+- .cursor/commands/harness-learn.md
+- .cursor/commands/harness-loop-status.md
+- .cursor/commands/harness-model-route.md
+- .cursor/commands/harness-orchestrate.md
+- .cursor/commands/harness-quality-gate.md
+- .cursor/commands/harness-repo-status.md
+- .cursor/commands/harness-security-audit.md
+- .cursor/commands/harness-status.md
+- .cursor/hooks/TABBIN/scripts/format-check-on-edit.sh
+- .cursor/hooks/TABBIN/scripts/harness-activity-track.sh
+- .cursor/hooks/TABBIN/scripts/harness-config-protection.sh
+- .cursor/hooks/TABBIN/scripts/harness-first-edit-gate.sh
+- .cursor/hooks/TABBIN/scripts/harness-postflight-capture.sh
+- .cursor/hooks/TABBIN/scripts/harness-precompact.sh
+- .cursor/hooks/TABBIN/scripts/harness-profile-gate.sh
+- .cursor/hooks/TABBIN/scripts/harness-safety-warn.sh
+- .cursor/hooks/TABBIN/scripts/harness-session-context.sh
+- .cursor/hooks/TABBIN/scripts/publish-verify.sh
+- .cursor/hooks/TABBIN/scripts/rtk-usage-replace.sh
+- .cursor/hooks/TABBIN/scripts/stop-verify.sh
+- .cursor/hooks/TABBIN/scripts/track-edit.sh
+- .cursor/rules/00-context-mode.mdc
+- .cursor/rules/01-rtk.mdc
+- .cursor/rules/02-vitest-local-development.mdc
+- .cursor/rules/harness.mdc
+- .cursor/rules/repository-guidelines.mdc
+- .gemini/commands/agent-automation-recommendations.toml
+- .gemini/commands/code-style.toml
+- .gemini/commands/comment-rule.toml
+- .gemini/commands/harness-audit.toml
+- .gemini/commands/harness-evaluator.toml
+- .gemini/commands/harness-learn.toml
+- .gemini/commands/harness-loop-status.toml
+- .gemini/commands/harness-model-route.toml
+- .gemini/commands/harness-orchestrate.toml
+- .gemini/commands/harness-quality-gate.toml
+- .gemini/commands/harness-repo-status.toml
+- .gemini/commands/harness-security-audit.toml
+- .gemini/commands/harness-status.toml
+- .gemini/hooks/TABBIN/scripts/format-check-on-edit.sh
+- .gemini/hooks/TABBIN/scripts/harness-activity-track.sh
+- .gemini/hooks/TABBIN/scripts/harness-config-protection.sh
+- .gemini/hooks/TABBIN/scripts/harness-first-edit-gate.sh
+- .gemini/hooks/TABBIN/scripts/harness-postflight-capture.sh
+- .gemini/hooks/TABBIN/scripts/harness-precompact.sh
+- .gemini/hooks/TABBIN/scripts/harness-profile-gate.sh
+- .gemini/hooks/TABBIN/scripts/harness-safety-warn.sh
+- .gemini/hooks/TABBIN/scripts/harness-session-context.sh
+- .gemini/hooks/TABBIN/scripts/publish-verify.sh
+- .gemini/hooks/TABBIN/scripts/rtk-usage-replace.sh
+- .gemini/hooks/TABBIN/scripts/stop-verify.sh
+- .gemini/hooks/TABBIN/scripts/track-edit.sh
+- .github/hooks/TABBIN-claude-quality-hooks.json
+- .github/hooks/scripts/TABBIN/scripts/format-check-on-edit.sh
+- .github/hooks/scripts/TABBIN/scripts/harness-activity-track.sh
+- .github/hooks/scripts/TABBIN/scripts/harness-config-protection.sh
+- .github/hooks/scripts/TABBIN/scripts/harness-first-edit-gate.sh
+- .github/hooks/scripts/TABBIN/scripts/harness-postflight-capture.sh
+- .github/hooks/scripts/TABBIN/scripts/harness-precompact.sh
+- .github/hooks/scripts/TABBIN/scripts/harness-profile-gate.sh
+- .github/hooks/scripts/TABBIN/scripts/harness-safety-warn.sh
+- .github/hooks/scripts/TABBIN/scripts/harness-session-context.sh
+- .github/hooks/scripts/TABBIN/scripts/publish-verify.sh
+- .github/hooks/scripts/TABBIN/scripts/rtk-usage-replace.sh
+- .github/hooks/scripts/TABBIN/scripts/stop-verify.sh
+- .github/hooks/scripts/TABBIN/scripts/track-edit.sh
+- .github/instructions/00-context-mode.instructions.md
+- .github/instructions/01-rtk.instructions.md
+- .github/instructions/02-vitest-local-development.instructions.md
+- .github/instructions/harness.instructions.md
+- .github/instructions/repository-guidelines.instructions.md
+- .github/prompts/agent-automation-recommendations.prompt.md
+- .github/prompts/code-style.prompt.md
+- .github/prompts/comment-rule.prompt.md
+- .github/prompts/harness-audit.prompt.md
+- .github/prompts/harness-evaluator.prompt.md
+- .github/prompts/harness-learn.prompt.md
+- .github/prompts/harness-loop-status.prompt.md
+- .github/prompts/harness-model-route.prompt.md
+- .github/prompts/harness-orchestrate.prompt.md
+- .github/prompts/harness-quality-gate.prompt.md
+- .github/prompts/harness-repo-status.prompt.md
+- .github/prompts/harness-security-audit.prompt.md
+- .github/prompts/harness-status.prompt.md
 local_deployed_file_hashes:
   .claude/commands/agent-automation-recommendations.md: sha256:f6a4ff4422ee67a743a174f2eba7fd3d9f5571bc0b800344fb85e15e6e64f033
   .claude/commands/code-style.md: sha256:92e72362699c129acd601ee5d1f68291e5bd6376b7026f84b54deedc68cca2a4

--- a/apm.yml
+++ b/apm.yml
@@ -5,14 +5,26 @@ author: TarouTanakaYokohama
 license: UNLICENSED
 type: hybrid
 target:
-  - codex
-  - claude
-  - cursor
-  - gemini
-  - copilot
+- codex
+- claude
+- cursor
+- gemini
+- copilot
+- opencode
 dependencies:
   apm: []
-  mcp: []
+  mcp:
+  - name: playwright
+    registry: false
+    transport: stdio
+    command: npx
+    args:
+    - -y
+    - '@playwright/mcp'
+  - name: context7
+    registry: false
+    transport: http
+    url: https://mcp.context7.com/mcp
 includes: auto
 scripts:
   validate: apm compile --validate
@@ -23,8 +35,8 @@ compilation:
   strategy: distributed
   source_attribution: true
   exclude:
-    - apm_modules/**
-    - .output/**
-    - coverage/**
-    - playwright-report/**
-    - test-results/**
+  - apm_modules/**
+  - .output/**
+  - coverage/**
+  - playwright-report/**
+  - test-results/**

--- a/apm.yml
+++ b/apm.yml
@@ -5,26 +5,26 @@ author: TarouTanakaYokohama
 license: UNLICENSED
 type: hybrid
 target:
-- codex
-- claude
-- cursor
-- gemini
-- copilot
-- opencode
+  - codex
+  - claude
+  - cursor
+  - gemini
+  - copilot
+  - opencode
 dependencies:
   apm: []
   mcp:
-  - name: playwright
-    registry: false
-    transport: stdio
-    command: npx
-    args:
-    - -y
-    - '@playwright/mcp'
-  - name: context7
-    registry: false
-    transport: http
-    url: https://mcp.context7.com/mcp
+    - name: playwright
+      registry: false
+      transport: stdio
+      command: npx
+      args:
+        - -y
+        - '@playwright/mcp'
+    - name: context7
+      registry: false
+      transport: http
+      url: https://mcp.context7.com/mcp
 includes: auto
 scripts:
   validate: apm compile --validate
@@ -35,8 +35,8 @@ compilation:
   strategy: distributed
   source_attribution: true
   exclude:
-  - apm_modules/**
-  - .output/**
-  - coverage/**
-  - playwright-report/**
-  - test-results/**
+    - apm_modules/**
+    - .output/**
+    - coverage/**
+    - playwright-report/**
+    - test-results/**

--- a/opencode.json
+++ b/opencode.json
@@ -4,11 +4,7 @@
     "playwright": {
       "type": "local",
       "enabled": true,
-      "command": [
-        "npx",
-        "-y",
-        "@playwright/mcp"
-      ]
+      "command": ["npx", "-y", "@playwright/mcp"]
     },
     "context7": {
       "type": "remote",

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "playwright": {
+      "type": "local",
+      "enabled": true,
+      "command": [
+        "npx",
+        "-y",
+        "@playwright/mcp"
+      ]
+    },
+    "context7": {
+      "type": "remote",
+      "enabled": true,
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## 変更内容

APM 経由で MCP サーバーをインストールし、opencode を含む全ターゲットで利用できるようにしました。

### 追加した MCP サーバー
- **Playwright MCP** (`@playwright/mcp`) — ブラウザ操作・E2Eテスト
- **Context7 MCP** (`https://mcp.context7.com/mcp`) — 最新ドキュメントをLLMコンテキストに注入

### 設定変更
- `apm.yml`: targets に `opencode` を追加、`dependencies.mcp` に両サーバーを追加
- `apm.lock.yaml`: ロックファイル更新
- `.mcp.json`: Claude Code 用 MCP 設定 (自動生成)
- `opencode.json`: opencode 用 MCP 設定 (自動生成)

## 確認事項
- [x] ローカル環境でエラーになっていない