### PR TITLE
feat: Chrome拡張E2Eテストを追加 (saved-tabs/options/AI chat)

### DIFF
--- a/e2e/ai-chat.extension.spec.ts
+++ b/e2e/ai-chat.extension.spec.ts
@@ -1,33 +1,10 @@
-import { expect, getExtensionUrl, seedStorage, test } from './helpers/extension'
-
-const createBaseSeed = () => ({
-  customProjectOrder: [],
-  customProjects: [],
-  domainCategoryMappings: [],
-  domainCategorySettings: [],
-  parentCategories: [],
-  savedTabs: [],
-  'tab-manager-theme': 'system',
-  urls: [],
-  userSettings: {
-    autoDeletePeriod: 'never',
-    clickBehavior: 'saveSameDomainTabs',
-    colors: {},
-    confirmDeleteAll: false,
-    confirmDeleteEach: false,
-    enableCategories: true,
-    excludePatterns: ['chrome-extension://', 'chrome://'],
-    excludePinnedTabs: true,
-    language: 'en',
-    ollamaModel: '',
-    openAllInNewWindow: false,
-    openUrlInBackground: true,
-    removeTabAfterExternalDrop: true,
-    removeTabAfterOpen: true,
-    showSavedTime: false,
-  },
-  viewMode: 'domain',
-})
+import {
+  createBaseSeed,
+  expect,
+  getExtensionUrl,
+  seedStorage,
+  test,
+} from './helpers/extension'
 
 interface RuntimeLike {
   sendMessage?: (message: unknown) => Promise<unknown>
@@ -75,10 +52,14 @@ const installOllamaListFailureMock = async (page: InitScriptPage) => {
       try {
         runtime.sendMessage = nextSendMessage
       } catch {
-        Object.defineProperty(runtime, 'sendMessage', {
-          configurable: true,
-          value: nextSendMessage,
-        })
+        try {
+          Object.defineProperty(runtime, 'sendMessage', {
+            configurable: true,
+            value: nextSendMessage,
+          })
+        } catch {
+          // Both assignment and defineProperty failed; silently continue
+        }
       }
     }
 

--- a/e2e/ai-chat.extension.spec.ts
+++ b/e2e/ai-chat.extension.spec.ts
@@ -34,7 +34,7 @@ interface RuntimeLike {
 }
 
 interface InitScriptPage {
-  addInitScript(script: () => void): Promise<unknown>
+  addInitScript: (script: () => void) => Promise<unknown>
 }
 
 const installOllamaListFailureMock = async (page: InitScriptPage) => {

--- a/e2e/ai-chat.extension.spec.ts
+++ b/e2e/ai-chat.extension.spec.ts
@@ -1,0 +1,145 @@
+import {
+  expect,
+  getExtensionUrl,
+  seedStorage,
+  test,
+} from './helpers/extension'
+
+const createBaseSeed = () => ({
+  customProjectOrder: [],
+  customProjects: [],
+  domainCategoryMappings: [],
+  domainCategorySettings: [],
+  parentCategories: [],
+  savedTabs: [],
+  'tab-manager-theme': 'system',
+  urls: [],
+  userSettings: {
+    autoDeletePeriod: 'never',
+    clickBehavior: 'saveSameDomainTabs',
+    colors: {},
+    confirmDeleteAll: false,
+    confirmDeleteEach: false,
+    enableCategories: true,
+    excludePatterns: ['chrome-extension://', 'chrome://'],
+    excludePinnedTabs: true,
+    language: 'en',
+    ollamaModel: '',
+    openAllInNewWindow: false,
+    openUrlInBackground: true,
+    removeTabAfterExternalDrop: true,
+    removeTabAfterOpen: true,
+    showSavedTime: false,
+  },
+  viewMode: 'domain',
+})
+
+interface RuntimeLike {
+  sendMessage?: (message: unknown) => Promise<unknown>
+}
+
+interface InitScriptPage {
+  addInitScript(script: () => void): Promise<unknown>
+}
+
+const installOllamaListFailureMock = async (page: InitScriptPage) => {
+  await page.addInitScript(() => {
+    const install = (runtime?: {
+      sendMessage?: (message: unknown) => Promise<unknown>
+    }) => {
+      if (!runtime?.sendMessage) {
+        return
+      }
+
+      const originalSendMessage = runtime.sendMessage.bind(runtime)
+      const nextSendMessage = async (message: unknown) => {
+        if (
+          typeof message === 'object' &&
+          message !== null &&
+          'action' in message &&
+          message.action === 'listOllamaModels'
+        ) {
+          return {
+            error: 'Could not connect to Ollama.',
+            ollamaError: {
+              allowedOrigins: 'chrome-extension://test-extension-id',
+              baseUrl: 'http://localhost:11434',
+              downloadUrl: 'https://ollama.com/download',
+              faqUrl:
+                'https://docs.ollama.com/faq#how-do-i-configure-ollama-server',
+              kind: 'notInstalledOrNotRunning',
+              tagsUrl: 'http://localhost:11434/api/tags',
+            },
+            status: 'error',
+          }
+        }
+
+        return originalSendMessage(message)
+      }
+
+      try {
+        runtime.sendMessage = nextSendMessage
+      } catch {
+        Object.defineProperty(runtime, 'sendMessage', {
+          configurable: true,
+          value: nextSendMessage,
+        })
+      }
+    }
+
+    const runtimeGlobals = globalThis as typeof globalThis & {
+      browser?: {
+        runtime?: RuntimeLike
+      }
+      chrome?: {
+        runtime?: RuntimeLike
+      }
+    }
+
+    install(runtimeGlobals.browser?.runtime)
+    install(runtimeGlobals.chrome?.runtime)
+  })
+}
+
+test.describe('extension ai-chat', () => {
+  test('AIチャットページが表示できる', async ({
+    extensionId,
+    page,
+    serviceWorker,
+  }) => {
+    await seedStorage(serviceWorker, createBaseSeed())
+
+    await page.goto(getExtensionUrl(extensionId, 'app.html#/ai-chat'))
+
+    await expect(page.getByRole('combobox', { name: 'Select a model' })).toBeVisible()
+  })
+
+  test('Ollama が未設定の状態でエラーガイダンスを表示する', async ({
+    extensionId,
+    page,
+    serviceWorker,
+  }) => {
+    await seedStorage(serviceWorker, createBaseSeed())
+    await installOllamaListFailureMock(page)
+
+    await page.goto(getExtensionUrl(extensionId, 'app.html#/ai-chat'))
+
+    await expect(page.getByLabel('Ask AI')).toBeDisabled()
+
+    await page.getByRole('combobox', { name: 'Select a model' }).click()
+
+    await expect(page.getByText('Could not connect to Ollama.')).toBeVisible()
+    await expect(
+      page.getByText('If you have not installed Ollama yet, download it.'),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('textbox', { name: 'Copy command value' }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Copy command' }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'Copy check command' }),
+    ).toBeVisible()
+  })
+})

--- a/e2e/ai-chat.extension.spec.ts
+++ b/e2e/ai-chat.extension.spec.ts
@@ -1,9 +1,4 @@
-import {
-  expect,
-  getExtensionUrl,
-  seedStorage,
-  test,
-} from './helpers/extension'
+import { expect, getExtensionUrl, seedStorage, test } from './helpers/extension'
 
 const createBaseSeed = () => ({
   customProjectOrder: [],
@@ -111,7 +106,9 @@ test.describe('extension ai-chat', () => {
 
     await page.goto(getExtensionUrl(extensionId, 'app.html#/ai-chat'))
 
-    await expect(page.getByRole('combobox', { name: 'Select a model' })).toBeVisible()
+    await expect(
+      page.getByRole('combobox', { name: 'Select a model' }),
+    ).toBeVisible()
   })
 
   test('Ollama が未設定の状態でエラーガイダンスを表示する', async ({

--- a/e2e/helpers/extension.ts
+++ b/e2e/helpers/extension.ts
@@ -65,6 +65,38 @@ export const test = base.extend<ExtensionFixtures>({
 
 export { expect }
 
+export const defaultUserSettings = {
+  autoDeletePeriod: 'never',
+  clickBehavior: 'saveSameDomainTabs',
+  colors: {},
+  confirmDeleteAll: false,
+  confirmDeleteEach: false,
+  enableCategories: true,
+  excludePatterns: ['chrome-extension://', 'chrome://'],
+  excludePinnedTabs: true,
+  language: 'en',
+  ollamaModel: '',
+  openAllInNewWindow: false,
+  openUrlInBackground: true,
+  removeTabAfterExternalDrop: true,
+  removeTabAfterOpen: true,
+  showSavedTime: false,
+}
+
+export const createBaseSeed = (overrides?: Record<string, unknown>) => ({
+  customProjectOrder: [],
+  customProjects: [],
+  domainCategoryMappings: [],
+  domainCategorySettings: [],
+  parentCategories: [],
+  savedTabs: [],
+  'tab-manager-theme': 'system',
+  urls: [],
+  userSettings: { ...defaultUserSettings },
+  viewMode: 'domain',
+  ...overrides,
+})
+
 export const getExtensionUrl = (extensionId: string, pathname: string) =>
   `chrome-extension://${extensionId}/${pathname}`
 

--- a/e2e/options.extension.spec.ts
+++ b/e2e/options.extension.spec.ts
@@ -69,7 +69,7 @@ test.describe('extension options', () => {
     const downloadPath = await download.path()
     expect(downloadPath).toBeTruthy()
 
-    const fileContent = await readFile(downloadPath!, 'utf-8')
+    const fileContent = await readFile(downloadPath as string, 'utf8')
     const backupData = JSON.parse(fileContent)
 
     expect(backupData.version).toBeDefined()
@@ -94,7 +94,7 @@ test.describe('extension options', () => {
     const downloadPath = await download.path()
     expect(downloadPath).toBeTruthy()
 
-    const fileContent = await readFile(downloadPath!, 'utf-8')
+    const fileContent = await readFile(downloadPath as string, 'utf8')
     const backupData = JSON.parse(fileContent)
     expect(backupData.urls).toHaveLength(1)
     expect(backupData.savedTabs).toHaveLength(1)

--- a/e2e/options.extension.spec.ts
+++ b/e2e/options.extension.spec.ts
@@ -1,0 +1,160 @@
+import { readFile } from 'node:fs/promises'
+
+import {
+  expect,
+  getExtensionUrl,
+  readStorage,
+  seedStorage,
+  test,
+} from './helpers/extension'
+
+const now = Date.now()
+
+const createSeedWithUrls = () => ({
+  customProjectOrder: [],
+  customProjects: [],
+  domainCategoryMappings: [],
+  domainCategorySettings: [],
+  parentCategories: [],
+  savedTabs: [
+    {
+      domain: 'example.com',
+      id: 'group-example',
+      urlIds: ['url-example'],
+    },
+  ],
+  'tab-manager-theme': 'system',
+  urls: [
+    {
+      id: 'url-example',
+      savedAt: now,
+      title: 'Example Home',
+      url: 'https://example.com/',
+    },
+  ],
+  userSettings: {
+    autoDeletePeriod: 'never',
+    clickBehavior: 'saveCurrentTab',
+    colors: {},
+    confirmDeleteAll: false,
+    confirmDeleteEach: false,
+    enableCategories: true,
+    excludePatterns: ['chrome-extension://', 'chrome://'],
+    excludePinnedTabs: true,
+    language: 'en',
+    ollamaModel: '',
+    openAllInNewWindow: false,
+    openUrlInBackground: true,
+    removeTabAfterExternalDrop: true,
+    removeTabAfterOpen: true,
+    showSavedTime: false,
+  },
+  viewMode: 'domain',
+})
+
+test.describe('extension options', () => {
+  test('設定をエクスポートしてエクスポートデータの内容を確認できる', async ({
+    extensionId,
+    page,
+    serviceWorker,
+  }) => {
+    await seedStorage(serviceWorker, createSeedWithUrls())
+
+    await page.goto(getExtensionUrl(extensionId, 'app.html#/options'))
+
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByRole('button', { name: /export/i }).click()
+    const download = await downloadPromise
+
+    const downloadPath = await download.path()
+    expect(downloadPath).toBeTruthy()
+
+    const fileContent = await readFile(downloadPath!, 'utf-8')
+    const backupData = JSON.parse(fileContent)
+
+    expect(backupData.version).toBeDefined()
+    expect(backupData.urls).toHaveLength(1)
+    expect(backupData.urls[0].url).toBe('https://example.com/')
+    expect(backupData.savedTabs).toHaveLength(1)
+    expect(backupData.savedTabs[0].domain).toBe('example.com')
+  })
+
+  test('エクスポートした設定からインポート相当のストレージ復元ができる', async ({
+    extensionId,
+    page,
+    serviceWorker,
+  }) => {
+    await seedStorage(serviceWorker, createSeedWithUrls())
+
+    await page.goto(getExtensionUrl(extensionId, 'app.html#/options'))
+
+    const downloadPromise = page.waitForEvent('download')
+    await page.getByRole('button', { name: /export/i }).click()
+    const download = await downloadPromise
+    const downloadPath = await download.path()
+    expect(downloadPath).toBeTruthy()
+
+    const fileContent = await readFile(downloadPath!, 'utf-8')
+    const backupData = JSON.parse(fileContent)
+    expect(backupData.urls).toHaveLength(1)
+    expect(backupData.savedTabs).toHaveLength(1)
+
+    await serviceWorker.evaluate(async () => {
+      await chrome.storage.local.clear()
+      await chrome.storage.local.set({
+        userSettings: {
+          autoDeletePeriod: 'never',
+          clickBehavior: 'saveSameDomainTabs',
+          colors: {},
+          confirmDeleteAll: false,
+          confirmDeleteEach: false,
+          enableCategories: true,
+          excludePatterns: ['chrome-extension://', 'chrome://'],
+          excludePinnedTabs: true,
+          language: 'en',
+          ollamaModel: '',
+          openAllInNewWindow: false,
+          openUrlInBackground: true,
+          removeTabAfterExternalDrop: true,
+          removeTabAfterOpen: true,
+          showSavedTime: false,
+        },
+      })
+    })
+
+    await serviceWorker.evaluate(async (data: {
+      savedTabs: unknown[]
+      urls: unknown[]
+      customProjects: unknown[]
+      parentCategories: unknown[]
+      customProjectOrder: unknown[]
+    }) => {
+      await chrome.storage.local.set({
+        savedTabs: data.savedTabs,
+        urls: data.urls,
+        customProjects: data.customProjects,
+        parentCategories: data.parentCategories,
+        customProjectOrder: data.customProjectOrder,
+      })
+    }, {
+      savedTabs: backupData.savedTabs,
+      urls: backupData.urls,
+      customProjects: backupData.customProjects ?? [],
+      parentCategories: backupData.parentCategories ?? [],
+      customProjectOrder: backupData.customProjectOrder ?? [],
+    })
+
+    await page.goto(
+      getExtensionUrl(extensionId, 'app.html#/saved-tabs?mode=domain'),
+    )
+
+    await expect(page.getByText('Example Home')).toBeVisible()
+
+    const data = await readStorage<{
+      savedTabs: { domain: string }[]
+      urls: { url: string }[]
+    }>(serviceWorker, ['savedTabs', 'urls'])
+    expect(data.savedTabs[0].domain).toBe('example.com')
+    expect(data.urls[0].url).toBe('https://example.com/')
+  })
+})

--- a/e2e/options.extension.spec.ts
+++ b/e2e/options.extension.spec.ts
@@ -1,6 +1,10 @@
-import { readFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
 
 import {
+  createBaseSeed,
+  defaultUserSettings,
   expect,
   getExtensionUrl,
   readStorage,
@@ -10,47 +14,25 @@ import {
 
 const now = Date.now()
 
-const createSeedWithUrls = () => ({
-  customProjectOrder: [],
-  customProjects: [],
-  domainCategoryMappings: [],
-  domainCategorySettings: [],
-  parentCategories: [],
-  savedTabs: [
-    {
-      domain: 'example.com',
-      id: 'group-example',
-      urlIds: ['url-example'],
-    },
-  ],
-  'tab-manager-theme': 'system',
-  urls: [
-    {
-      id: 'url-example',
-      savedAt: now,
-      title: 'Example Home',
-      url: 'https://example.com/',
-    },
-  ],
-  userSettings: {
-    autoDeletePeriod: 'never',
-    clickBehavior: 'saveCurrentTab',
-    colors: {},
-    confirmDeleteAll: false,
-    confirmDeleteEach: false,
-    enableCategories: true,
-    excludePatterns: ['chrome-extension://', 'chrome://'],
-    excludePinnedTabs: true,
-    language: 'en',
-    ollamaModel: '',
-    openAllInNewWindow: false,
-    openUrlInBackground: true,
-    removeTabAfterExternalDrop: true,
-    removeTabAfterOpen: true,
-    showSavedTime: false,
-  },
-  viewMode: 'domain',
-})
+const createSeedWithUrls = () =>
+  createBaseSeed({
+    savedTabs: [
+      {
+        domain: 'example.com',
+        id: 'group-example',
+        urlIds: ['url-example'],
+      },
+    ],
+    urls: [
+      {
+        id: 'url-example',
+        savedAt: now,
+        title: 'Example Home',
+        url: 'https://example.com/',
+      },
+    ],
+    userSettings: { ...defaultUserSettings, clickBehavior: 'saveCurrentTab' },
+  })
 
 test.describe('extension options', () => {
   test('設定をエクスポートしてエクスポートデータの内容を確認できる', async ({
@@ -79,7 +61,7 @@ test.describe('extension options', () => {
     expect(backupData.savedTabs[0].domain).toBe('example.com')
   })
 
-  test('エクスポートした設定からインポート相当のストレージ復元ができる', async ({
+  test('エクスポートしたファイルを実際のインポートUIで復元できる', async ({
     extensionId,
     page,
     serviceWorker,
@@ -99,53 +81,25 @@ test.describe('extension options', () => {
     expect(backupData.urls).toHaveLength(1)
     expect(backupData.savedTabs).toHaveLength(1)
 
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'tabbin-import-'))
+    const tmpFilePath = path.join(tmpDir, 'tabbin-backup.json')
+    await writeFile(tmpFilePath, fileContent)
+
     await serviceWorker.evaluate(async () => {
       await chrome.storage.local.clear()
-      await chrome.storage.local.set({
-        userSettings: {
-          autoDeletePeriod: 'never',
-          clickBehavior: 'saveSameDomainTabs',
-          colors: {},
-          confirmDeleteAll: false,
-          confirmDeleteEach: false,
-          enableCategories: true,
-          excludePatterns: ['chrome-extension://', 'chrome://'],
-          excludePinnedTabs: true,
-          language: 'en',
-          ollamaModel: '',
-          openAllInNewWindow: false,
-          openUrlInBackground: true,
-          removeTabAfterExternalDrop: true,
-          removeTabAfterOpen: true,
-          showSavedTime: false,
-        },
-      })
     })
 
-    await serviceWorker.evaluate(
-      async (data: {
-        savedTabs: unknown[]
-        urls: unknown[]
-        customProjects: unknown[]
-        parentCategories: unknown[]
-        customProjectOrder: unknown[]
-      }) => {
-        await chrome.storage.local.set({
-          savedTabs: data.savedTabs,
-          urls: data.urls,
-          customProjects: data.customProjects,
-          parentCategories: data.parentCategories,
-          customProjectOrder: data.customProjectOrder,
-        })
-      },
-      {
-        savedTabs: backupData.savedTabs,
-        urls: backupData.urls,
-        customProjects: backupData.customProjects ?? [],
-        parentCategories: backupData.parentCategories ?? [],
-        customProjectOrder: backupData.customProjectOrder ?? [],
-      },
-    )
+    await page.getByRole('button', { name: /import/i }).click()
+    await page
+      .locator('[data-testid="hidden-file-input"]')
+      .setInputFiles(tmpFilePath)
+    await expect(
+      page.getByRole('button', { name: /confirm.*import/i }),
+    ).toBeVisible()
+    await page.getByRole('button', { name: /confirm.*import/i }).click()
+    await expect(
+      page.getByRole('button', { name: /confirm.*import/i }),
+    ).toBeHidden()
 
     await page.goto(
       getExtensionUrl(extensionId, 'app.html#/saved-tabs?mode=domain'),
@@ -159,5 +113,7 @@ test.describe('extension options', () => {
     }>(serviceWorker, ['savedTabs', 'urls'])
     expect(data.savedTabs[0].domain).toBe('example.com')
     expect(data.urls[0].url).toBe('https://example.com/')
+
+    await rm(tmpDir, { force: true, recursive: true })
   })
 })

--- a/e2e/options.extension.spec.ts
+++ b/e2e/options.extension.spec.ts
@@ -122,27 +122,30 @@ test.describe('extension options', () => {
       })
     })
 
-    await serviceWorker.evaluate(async (data: {
-      savedTabs: unknown[]
-      urls: unknown[]
-      customProjects: unknown[]
-      parentCategories: unknown[]
-      customProjectOrder: unknown[]
-    }) => {
-      await chrome.storage.local.set({
-        savedTabs: data.savedTabs,
-        urls: data.urls,
-        customProjects: data.customProjects,
-        parentCategories: data.parentCategories,
-        customProjectOrder: data.customProjectOrder,
-      })
-    }, {
-      savedTabs: backupData.savedTabs,
-      urls: backupData.urls,
-      customProjects: backupData.customProjects ?? [],
-      parentCategories: backupData.parentCategories ?? [],
-      customProjectOrder: backupData.customProjectOrder ?? [],
-    })
+    await serviceWorker.evaluate(
+      async (data: {
+        savedTabs: unknown[]
+        urls: unknown[]
+        customProjects: unknown[]
+        parentCategories: unknown[]
+        customProjectOrder: unknown[]
+      }) => {
+        await chrome.storage.local.set({
+          savedTabs: data.savedTabs,
+          urls: data.urls,
+          customProjects: data.customProjects,
+          parentCategories: data.parentCategories,
+          customProjectOrder: data.customProjectOrder,
+        })
+      },
+      {
+        savedTabs: backupData.savedTabs,
+        urls: backupData.urls,
+        customProjects: backupData.customProjects ?? [],
+        parentCategories: backupData.parentCategories ?? [],
+        customProjectOrder: backupData.customProjectOrder ?? [],
+      },
+    )
 
     await page.goto(
       getExtensionUrl(extensionId, 'app.html#/saved-tabs?mode=domain'),

--- a/e2e/saved-tabs.extension.spec.ts
+++ b/e2e/saved-tabs.extension.spec.ts
@@ -1,4 +1,6 @@
 import {
+  createBaseSeed,
+  defaultUserSettings,
   expect,
   getExtensionUrl,
   readStorage,
@@ -8,47 +10,25 @@ import {
 
 const now = Date.now()
 
-const createSeedWithUrls = () => ({
-  customProjectOrder: [],
-  customProjects: [],
-  domainCategoryMappings: [],
-  domainCategorySettings: [],
-  parentCategories: [],
-  savedTabs: [
-    {
-      domain: 'example.com',
-      id: 'group-example',
-      urlIds: ['url-example'],
-    },
-  ],
-  'tab-manager-theme': 'system',
-  urls: [
-    {
-      id: 'url-example',
-      savedAt: now,
-      title: 'Example Home',
-      url: 'https://example.com/',
-    },
-  ],
-  userSettings: {
-    autoDeletePeriod: 'never',
-    clickBehavior: 'saveCurrentTab',
-    colors: {},
-    confirmDeleteAll: false,
-    confirmDeleteEach: false,
-    enableCategories: true,
-    excludePatterns: ['chrome-extension://', 'chrome://'],
-    excludePinnedTabs: true,
-    language: 'en',
-    ollamaModel: '',
-    openAllInNewWindow: false,
-    openUrlInBackground: true,
-    removeTabAfterExternalDrop: true,
-    removeTabAfterOpen: true,
-    showSavedTime: false,
-  },
-  viewMode: 'domain',
-})
+const createSeedWithUrls = () =>
+  createBaseSeed({
+    savedTabs: [
+      {
+        domain: 'example.com',
+        id: 'group-example',
+        urlIds: ['url-example'],
+      },
+    ],
+    urls: [
+      {
+        id: 'url-example',
+        savedAt: now,
+        title: 'Example Home',
+        url: 'https://example.com/',
+      },
+    ],
+    userSettings: { ...defaultUserSettings, clickBehavior: 'saveCurrentTab' },
+  })
 
 const createCustomProjectSeed = () => {
   const base = createSeedWithUrls()

--- a/e2e/saved-tabs.extension.spec.ts
+++ b/e2e/saved-tabs.extension.spec.ts
@@ -1,0 +1,228 @@
+import {
+  expect,
+  getExtensionUrl,
+  readStorage,
+  seedStorage,
+  test,
+} from './helpers/extension'
+
+const now = Date.now()
+
+const createSeedWithUrls = () => ({
+  customProjectOrder: [],
+  customProjects: [],
+  domainCategoryMappings: [],
+  domainCategorySettings: [],
+  parentCategories: [],
+  savedTabs: [
+    {
+      domain: 'example.com',
+      id: 'group-example',
+      urlIds: ['url-example'],
+    },
+  ],
+  'tab-manager-theme': 'system',
+  urls: [
+    {
+      id: 'url-example',
+      savedAt: now,
+      title: 'Example Home',
+      url: 'https://example.com/',
+    },
+  ],
+  userSettings: {
+    autoDeletePeriod: 'never',
+    clickBehavior: 'saveCurrentTab',
+    colors: {},
+    confirmDeleteAll: false,
+    confirmDeleteEach: false,
+    enableCategories: true,
+    excludePatterns: ['chrome-extension://', 'chrome://'],
+    excludePinnedTabs: true,
+    language: 'en',
+    ollamaModel: '',
+    openAllInNewWindow: false,
+    openUrlInBackground: true,
+    removeTabAfterExternalDrop: true,
+    removeTabAfterOpen: true,
+    showSavedTime: false,
+  },
+  viewMode: 'domain',
+})
+
+const createCustomProjectSeed = () => {
+  const base = createSeedWithUrls()
+  return {
+    ...base,
+    customProjects: [
+      {
+        id: 'project-1',
+        name: 'Test Project',
+        urlIds: ['url-example'],
+        categories: [],
+        createdAt: now,
+        updatedAt: now,
+      },
+    ],
+    customProjectOrder: ['project-1'],
+    viewMode: 'custom',
+  }
+}
+
+test.describe('extension saved-tabs', () => {
+  test('extension が起動し service worker が利用可能', async ({
+    serviceWorker,
+    extensionId,
+  }) => {
+    expect(serviceWorker).toBeDefined()
+    expect(serviceWorker.url()).toContain('chrome-extension://')
+    expect(extensionId).toBeTruthy()
+    expect(typeof extensionId).toBe('string')
+  })
+
+  test('saved-tabs ページに保存済みタブが表示される', async ({
+    extensionId,
+    page,
+    serviceWorker,
+  }) => {
+    await seedStorage(serviceWorker, createSeedWithUrls())
+
+    await page.goto(
+      getExtensionUrl(extensionId, 'app.html#/saved-tabs?mode=domain'),
+    )
+
+    await expect(page.getByText('example.com', { exact: true })).toBeVisible()
+    await expect(page.getByText('Example Home')).toBeVisible()
+  })
+
+  test('ドメインモードで保存済みURLを削除できる', async ({
+    extensionId,
+    page,
+    serviceWorker,
+  }) => {
+    await seedStorage(serviceWorker, createSeedWithUrls())
+
+    await page.goto(
+      getExtensionUrl(extensionId, 'app.html#/saved-tabs?mode=domain'),
+    )
+
+    await expect(page.getByText('Example Home')).toBeVisible()
+
+    await page.locator('[data-testid="sortable-url-item"]').hover()
+    await page.locator('[aria-label="Delete tab"]').click()
+
+    await expect(page.getByText('Example Home')).toBeHidden()
+
+    await expect
+      .poll(async () => {
+        const data = await readStorage<{
+          savedTabs: { urlIds?: string[] }[]
+        }>(serviceWorker, ['savedTabs'])
+        return data.savedTabs.filter((g) => g.urlIds?.length).length
+      })
+      .toBe(0)
+  })
+
+  test('カスタムモードで保存済みURLを削除できる', async ({
+    extensionId,
+    page,
+    serviceWorker,
+  }) => {
+    await seedStorage(serviceWorker, createCustomProjectSeed())
+
+    await page.goto(
+      getExtensionUrl(extensionId, 'app.html#/saved-tabs?mode=custom'),
+    )
+
+    await expect(page.getByText('Example Home')).toBeVisible()
+
+    await page.locator('[data-testid="project-url-item"]').hover()
+    await page.locator('[aria-label="Delete tab"]').click()
+
+    await expect(page.getByText('Example Home')).toBeHidden()
+
+    await expect
+      .poll(async () => {
+        const data = await readStorage<{
+          savedTabs: { urlIds?: string[] }[]
+        }>(serviceWorker, ['savedTabs'])
+        return data.savedTabs.filter((g) => g.urlIds?.length).length
+      })
+      .toBe(0)
+  })
+
+  test('removeUrlFromStorage メッセージでバックグラウンド経由でURLを削除できる', async ({
+    extensionId,
+    page,
+    serviceWorker,
+  }) => {
+    await seedStorage(serviceWorker, createSeedWithUrls())
+
+    await page.goto(
+      getExtensionUrl(extensionId, 'app.html#/saved-tabs?mode=domain'),
+    )
+
+    await expect(page.getByText('Example Home')).toBeVisible()
+
+    await page.evaluate(async () => {
+      await chrome.runtime.sendMessage({
+        action: 'removeUrlFromStorage',
+        url: 'https://example.com/',
+      })
+    })
+
+    await expect(page.getByText('Example Home')).toBeHidden()
+
+    await expect
+      .poll(async () => {
+        const data = await readStorage<{
+          savedTabs: { urlIds?: string[] }[]
+        }>(serviceWorker, ['savedTabs'])
+        return data.savedTabs.filter((g) => g.urlIds?.length).length
+      })
+      .toBe(0)
+  })
+
+  test('外部ドロップシミュレーションでURLが削除される', async ({
+    extensionId,
+    page,
+    serviceWorker,
+  }) => {
+    await seedStorage(serviceWorker, createSeedWithUrls())
+
+    await page.goto(
+      getExtensionUrl(extensionId, 'app.html#/saved-tabs?mode=domain'),
+    )
+
+    await expect(page.getByText('Example Home')).toBeVisible()
+
+    await page.evaluate(async () => {
+      await chrome.runtime.sendMessage({
+        action: 'urlDragStarted',
+        groupId: 'group-example',
+        url: 'https://example.com/',
+      })
+    })
+
+    const response = await page.evaluate(async () => {
+      return chrome.runtime.sendMessage({
+        action: 'urlDropped',
+        fromExternal: true,
+        groupId: 'group-example',
+        url: 'https://example.com/',
+      })
+    })
+    expect(response).toMatchObject({ status: 'removed' })
+
+    await expect(page.getByText('Example Home')).toBeHidden()
+
+    await expect
+      .poll(async () => {
+        const data = await readStorage<{
+          savedTabs: { urlIds?: string[] }[]
+        }>(serviceWorker, ['savedTabs'])
+        return data.savedTabs.filter((g) => g.urlIds?.length).length
+      })
+      .toBe(0)
+  })
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,22 +8,17 @@ export default defineConfig({
     {
       name: 'storybook',
       testMatch: '**/*.story.spec.ts',
-      use: {
-        ...devices['Desktop Chrome'],
-      },
     },
     {
       name: 'extension',
       testMatch: '**/*.extension.spec.ts',
-      use: {
-        ...devices['Desktop Chrome'],
-      },
     },
   ],
   reporter: 'html',
   retries: process.env.CI ? 2 : 0,
   testDir: './e2e',
   use: {
+    ...devices['Desktop Chrome'],
     trace: 'on-first-retry',
   },
   workers: process.env.CI ? 1 : undefined,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,15 @@ export default defineConfig({
   globalSetup: './e2e/global-setup.ts',
   projects: [
     {
-      name: 'chromium',
+      name: 'storybook',
+      testMatch: '**/*.story.spec.ts',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+    {
+      name: 'extension',
+      testMatch: '**/*.extension.spec.ts',
       use: {
         ...devices['Desktop Chrome'],
       },
@@ -15,7 +23,6 @@ export default defineConfig({
   reporter: 'html',
   retries: process.env.CI ? 2 : 0,
   testDir: './e2e',
-  testMatch: '**/*.story.spec.ts',
   use: {
     trace: 'on-first-retry',
   },


### PR DESCRIPTION
### 変更内容
- playwright.config.ts を分割し、storybook と extension の 2 プロジェクト構成に変更
- saved-tabs E2Eテスト (削除/ドラッグ&ドロップ/メッセージパッシング/起動確認)
- options E2Eテスト (エクスポートデータ検証/インポート復元)
- AI chat E2Eテスト (ページロード/Ollamaエラーガイダンス)

### 検証
- `npx playwright test e2e --project=extension`: 10 tests passed ✅
- `npx playwright test e2e --project=storybook`: 7 tests passed ✅ (既存テストに影響なし)

Closes #669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the AI chat page, including model loading and the disabled state when AI services are unavailable.
  * Added export/import coverage for extension options to verify saved data can be downloaded and restored correctly.
  * Added saved-tabs coverage for viewing entries and removing items through multiple interaction paths.
* **Chores**
  * Split browser testing into separate storybook and extension test runs for clearer coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->