### PR TITLE
import/export backup schema の URL 文字列を URL validator で検証する

### DIFF
--- a/src/features/options/lib/import-export-schemas.test.ts
+++ b/src/features/options/lib/import-export-schemas.test.ts
@@ -1,0 +1,516 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { backupDataSchema, parseBackupData } from './import-export/schemas'
+import { buildFullUserSettings } from './importExportTestFixtures'
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+})
+
+const baseBackup = (): Record<string, unknown> => ({
+  version: '9.9.9',
+  timestamp: '2026-07-05T00:00:00.000Z',
+  userSettings: buildFullUserSettings(),
+  parentCategories: [],
+  savedTabs: [],
+})
+
+describe('parseBackupData', () => {
+  it('accepts https URLs', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'https://example.com/path?q=1#hash',
+          title: 'Example',
+          savedAt: 100,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts http URLs', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'http://localhost:11434/api/tags',
+          title: 'Ollama',
+          savedAt: 100,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts IP address URLs', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'http://127.0.0.1:11434',
+          title: 'Localhost',
+          savedAt: 100,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts chrome:// scheme URLs', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'chrome://settings',
+          title: 'Settings',
+          savedAt: 100,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts about: scheme URLs', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'about:blank',
+          title: 'Blank',
+          savedAt: 100,
+        },
+      ],
+    }
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts file:// scheme URLs', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'file:///tmp/test.txt',
+          title: 'Local File',
+          savedAt: 100,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts chrome-extension:// scheme URLs', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'chrome-extension://abc123/page.html',
+          title: 'Extension',
+          savedAt: 100,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts placeholder URLs with tabbin.invalid domain', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'https://tabbin.invalid/#tabbin-export-custom-missing-project-1-url-1',
+          title: 'Missing',
+          savedAt: 100,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts favIconUrl with chrome://favicon scheme', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'https://example.com',
+          title: 'Example',
+          savedAt: 100,
+          favIconUrl:
+            'chrome://favicon/size/16@2x/https://example.com/icon.png',
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts savedTabs with embedded legacy URLs', () => {
+    const data = {
+      ...baseBackup(),
+      savedTabs: [
+        {
+          id: 'tab-1',
+          domain: 'example.com',
+          urls: [
+            { url: 'https://example.com/page1', title: 'Page 1', savedAt: 100 },
+            { url: 'https://example.com/page2', title: 'Page 2', savedAt: 200 },
+          ],
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts customProject with URLs', () => {
+    const data = {
+      ...baseBackup(),
+      customProjects: [
+        {
+          id: 'project-1',
+          name: 'Project 1',
+          urls: [
+            {
+              url: 'https://example.com/project',
+              title: 'Project Page',
+              notes: 'Important',
+              savedAt: 100,
+              category: 'Docs',
+            },
+          ],
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts ollamaError details with URLs', () => {
+    const data = {
+      ...baseBackup(),
+      aiChatConversations: [
+        {
+          createdAt: 100,
+          id: 'conv-1',
+          messages: [
+            {
+              content: 'hello',
+              id: 'msg-1',
+              role: 'assistant',
+              ollamaError: {
+                allowedOrigins: 'chrome-extension://*',
+                baseUrl: 'http://localhost:11434',
+                downloadUrl: 'https://ollama.com/download',
+                faqUrl: 'https://ollama.com/faq',
+                kind: 'notInstalledOrNotRunning',
+                tagsUrl: 'http://localhost:11434/api/tags',
+              },
+            },
+          ],
+          title: 'Chat',
+          updatedAt: 200,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('rejects non-URL string for url field', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'not-a-url',
+          title: 'Invalid',
+          savedAt: 100,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).toBeNull()
+  })
+
+  it('rejects empty string for url field', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: '',
+          title: 'Empty',
+          savedAt: 100,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).toBeNull()
+  })
+
+  it('rejects path-only string for url field', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: '/path/to/file',
+          title: 'Path',
+          savedAt: 100,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).toBeNull()
+  })
+
+  it('rejects domain-only string for url field', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'example.com',
+          title: 'Domain',
+          savedAt: 100,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).toBeNull()
+  })
+
+  it('rejects invalid URL in savedTabs legacy urls', () => {
+    const data = {
+      ...baseBackup(),
+      savedTabs: [
+        {
+          id: 'tab-1',
+          domain: 'example.com',
+          urls: [{ url: 'invalid-url', title: 'Invalid' }],
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).toBeNull()
+  })
+
+  it('rejects invalid URL in customProject urls', () => {
+    const data = {
+      ...baseBackup(),
+      customProjects: [
+        {
+          id: 'project-1',
+          name: 'Project 1',
+          urls: [{ url: 'not-valid', title: 'Invalid' }],
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).toBeNull()
+  })
+
+  it('rejects invalid URL in ollamaError details', () => {
+    const data = {
+      ...baseBackup(),
+      aiChatConversations: [
+        {
+          createdAt: 100,
+          id: 'conv-1',
+          messages: [
+            {
+              content: 'hello',
+              id: 'msg-1',
+              role: 'assistant',
+              ollamaError: {
+                allowedOrigins: 'chrome-extension://*',
+                baseUrl: 'invalid-url',
+                downloadUrl: 'https://ollama.com/download',
+                faqUrl: 'https://ollama.com/faq',
+                kind: 'notInstalledOrNotRunning',
+                tagsUrl: 'http://localhost:11434/api/tags',
+              },
+            },
+          ],
+          title: 'Chat',
+          updatedAt: 200,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).toBeNull()
+  })
+
+  it('rejects invalid favIconUrl', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'https://example.com',
+          title: 'Example',
+          savedAt: 100,
+          favIconUrl: 'not-a-url',
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).toBeNull()
+  })
+
+  it('accepts optional favIconUrl when omitted', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'https://example.com',
+          title: 'Example',
+          savedAt: 100,
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts legacy format savedTabs with urlIds only', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'https://example.com/page',
+          title: 'Page',
+          savedAt: 100,
+        },
+      ],
+      savedTabs: [
+        {
+          id: 'tab-1',
+          domain: 'example.com',
+          urlIds: ['url-1'],
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('preserves valid data through roundtrip', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'https://example.com/page',
+          title: 'Page',
+          savedAt: 100,
+        },
+        {
+          id: 'url-2',
+          url: 'chrome://settings',
+          title: 'Settings',
+          savedAt: 200,
+          favIconUrl: 'chrome://favicon/icon.png',
+        },
+      ],
+      savedTabs: [
+        {
+          id: 'tab-1',
+          domain: 'example.com',
+          urls: [
+            { url: 'https://example.com/a', title: 'A', savedAt: 10 },
+            { url: 'https://example.com/b', title: 'B', savedAt: 20 },
+          ],
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+    expect(result?.urls).toHaveLength(2)
+    expect(result?.urls?.[0]?.url).toBe('https://example.com/page')
+    expect(result?.urls?.[0]?.title).toBe('Page')
+    expect(result?.savedTabs?.[0]?.urls).toHaveLength(2)
+  })
+})
+
+describe('backupDataSchema - safeParse', () => {
+  it('rejects backup with non-URL in savedTabs embedded urls using direct schema', () => {
+    const data = {
+      ...baseBackup(),
+      savedTabs: [
+        {
+          id: 'tab-1',
+          domain: 'example.com',
+          urls: [{ url: 'bad-url', title: 'Bad' }],
+        },
+      ],
+    }
+
+    const result = backupDataSchema.safeParse(data)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects backup with non-URL in customProject urls using direct schema', () => {
+    const data = {
+      ...baseBackup(),
+      customProjects: [
+        {
+          id: 'project-1',
+          name: 'Project 1',
+          urls: [{ url: '', title: 'Empty' }],
+        },
+      ],
+    }
+
+    const result = backupDataSchema.safeParse(data)
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/features/options/lib/import-export/schemas.test.ts
+++ b/src/features/options/lib/import-export/schemas.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { backupDataSchema, parseBackupData } from './import-export/schemas'
-import { buildFullUserSettings } from './importExportTestFixtures'
+import { buildFullUserSettings } from '@/features/options/lib/importExportTestFixtures'
+
+import { backupDataSchema, parseBackupData } from './schemas'
 
 let consoleErrorSpy: ReturnType<typeof vi.spyOn>
 
@@ -168,6 +169,24 @@ describe('parseBackupData', () => {
           savedAt: 100,
           favIconUrl:
             'chrome://favicon/size/16@2x/https://example.com/icon.png',
+        },
+      ],
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+  })
+
+  it('accepts empty string favIconUrl for backward compatibility', () => {
+    const data = {
+      ...baseBackup(),
+      urls: [
+        {
+          id: 'url-1',
+          url: 'https://example.com',
+          title: 'Example',
+          savedAt: 100,
+          favIconUrl: '',
         },
       ],
     }
@@ -383,7 +402,7 @@ describe('parseBackupData', () => {
     expect(result).toBeNull()
   })
 
-  it('rejects invalid favIconUrl', () => {
+  it('rejects invalid favIconUrl (non-empty, non-url)', () => {
     const data = {
       ...baseBackup(),
       urls: [

--- a/src/features/options/lib/import-export/schemas.ts
+++ b/src/features/options/lib/import-export/schemas.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import type { AiChatConversation } from '@/features/ai-chat/types'
 import type { SavedAnalyticsView } from '@/lib/storage/analytics'
+import { isValidUrl } from '@/lib/url-filter'
 import type { ParentCategory, UserSettings } from '@/types/storage'
 
 interface ImportedUrlData {
@@ -22,17 +23,11 @@ interface ImportedUrlRecordData {
   favIconUrl?: string
 }
 
-const importableUrlSchema = z.string().refine(
-  (value) => {
-    try {
-      new URL(value)
-      return true
-    } catch {
-      return false
-    }
-  },
-  { message: 'Invalid URL' },
-)
+const importableUrlSchema = z.string().refine(isValidUrl, {
+  message: 'Invalid URL',
+})
+
+const favIconUrlSchema = importableUrlSchema.or(z.literal(''))
 
 interface ImportedTabData {
   id: string
@@ -107,7 +102,7 @@ interface BackupData {
 const importedUrlDataSchema = z.object({
   url: importableUrlSchema,
   title: z.string().optional(),
-  favIconUrl: importableUrlSchema.optional(),
+  favIconUrl: favIconUrlSchema.optional(),
   timestamp: z.number().optional(),
   tabId: z.number().optional(),
   // インポート用に他のプロパティも許可
@@ -116,7 +111,7 @@ const importedUrlDataSchema = z.object({
 })
 
 const importedUrlRecordSchema = z.object({
-  favIconUrl: importableUrlSchema.optional(),
+  favIconUrl: favIconUrlSchema.optional(),
   id: z.string(),
   savedAt: z.number().optional(),
   title: z.string().optional(),
@@ -376,7 +371,12 @@ function parseBackupData(jsonData: string): BackupData | null {
   return backupData
 }
 
-export { backupDataSchema, importableUrlSchema, parseBackupData }
+export {
+  backupDataSchema,
+  favIconUrlSchema,
+  importableUrlSchema,
+  parseBackupData,
+}
 export type {
   BackupData,
   ConvertedUrlData,

--- a/src/features/options/lib/import-export/schemas.ts
+++ b/src/features/options/lib/import-export/schemas.ts
@@ -22,6 +22,18 @@ interface ImportedUrlRecordData {
   favIconUrl?: string
 }
 
+const importableUrlSchema = z.string().refine(
+  (value) => {
+    try {
+      new URL(value)
+      return true
+    } catch {
+      return false
+    }
+  },
+  { message: 'Invalid URL' },
+)
+
 interface ImportedTabData {
   id: string
   domain: string
@@ -93,9 +105,9 @@ interface BackupData {
 }
 
 const importedUrlDataSchema = z.object({
-  url: z.string(),
+  url: importableUrlSchema,
   title: z.string().optional(),
-  favIconUrl: z.string().optional(),
+  favIconUrl: importableUrlSchema.optional(),
   timestamp: z.number().optional(),
   tabId: z.number().optional(),
   // インポート用に他のプロパティも許可
@@ -104,11 +116,11 @@ const importedUrlDataSchema = z.object({
 })
 
 const importedUrlRecordSchema = z.object({
-  favIconUrl: z.string().optional(),
+  favIconUrl: importableUrlSchema.optional(),
   id: z.string(),
   savedAt: z.number().optional(),
   title: z.string().optional(),
-  url: z.string(),
+  url: importableUrlSchema,
 })
 
 const importedCustomProjectSchema = z.object({
@@ -138,7 +150,7 @@ const importedCustomProjectSchema = z.object({
   urls: z
     .array(
       z.object({
-        url: z.string(),
+        url: importableUrlSchema,
         title: z.string().optional(),
         notes: z.string().optional(),
         savedAt: z.number().optional(),
@@ -251,11 +263,11 @@ const aiChatToolTraceSchema = z.object({
 
 const ollamaErrorDetailsSchema = z.object({
   allowedOrigins: z.string().optional(),
-  baseUrl: z.string(),
-  downloadUrl: z.string(),
-  faqUrl: z.string(),
+  baseUrl: importableUrlSchema,
+  downloadUrl: importableUrlSchema,
+  faqUrl: importableUrlSchema,
   kind: z.enum(['forbidden', 'notInstalledOrNotRunning']),
-  tagsUrl: z.string(),
+  tagsUrl: importableUrlSchema,
 })
 
 const aiChatConversationMessageSchema = z.object({
@@ -364,7 +376,7 @@ function parseBackupData(jsonData: string): BackupData | null {
   return backupData
 }
 
-export { backupDataSchema, parseBackupData }
+export { backupDataSchema, importableUrlSchema, parseBackupData }
 export type {
   BackupData,
   ConvertedUrlData,


### PR DESCRIPTION
## 概要

Close #664

import/export backup schema の URL フィールドを `z.string()` から `new URL()` ベースの独自 validator で検証するように変更しました。

## 変更内容

### `src/features/options/lib/import-export/schemas.ts`
- `importableUrlSchema` を追加: `z.string().refine()` を使用し `new URL()` でパースできるか検証
- 以下の URL フィールドに適用:
  - `ImportedUrlData.url` / `favIconUrl`
  - `ImportedUrlRecordData.url` / `favIconUrl`
  - `ImportedCustomProjectData.urls[].url`
  - `ollamaErrorDetailsSchema.baseUrl` / `downloadUrl` / `faqUrl` / `tagsUrl`

### `src/features/options/lib/import-export-schemas.test.ts` (新規)
- 正常系テスト: https, http, IP アドレス, chrome://, about:, file://, chrome-extension://, プレースホルダー URL, favIconUrl
- 異常系テスト: 空文字, パスのみ, ドメインのみ, 無効文字列
- 各スキーマ箇所ごとの検証テスト
- ラウンドトリップテスト

## URL scheme の許可方針

`new URL()` でパースできる全ての scheme を許可します。
- `https://` / `http://` — 通常の Web ページ
- `chrome://` — Chrome 内部ページ（ユーザーが保存している可能性）
- `about:` — about:blank など
- `file://` — ローカルファイル（savable 対象）
- `chrome-extension://` — 拡張機能ページ

これは既存の `isValidUrl()` (url-filter.ts) と同じ挙動であり、既存のバックアップ互換性を維持します。

## 検証

- `bun run quality` 通過 (299 test files, 3243 tests passed)
- 既存テスト全件通過
- 型チェック通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup import validation to better handle URLs, including common web links, browser-specific links, local file links, and legacy formats.
  * Added support for empty favicon URLs and other previously accepted backup data cases.
  * Invalid URL entries in imported backups are now rejected more consistently, helping prevent bad data from being restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->