### PR TITLE
typescript/consistent-type-definitions ルールを追加し interface を type に統一

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -262,6 +262,7 @@
         "arrayLiteralTypeAssertions": "never"
       }
     ],
+    "typescript/consistent-type-definitions": ["error", "type"],
     "typescript/consistent-type-imports": "error",
     "typescript/method-signature-style": "error",
     "typescript/no-base-to-string": "error",
@@ -971,6 +972,12 @@
       ],
       "rules": {
         "storybook/no-uninstalled-addons": "error"
+      }
+    },
+    {
+      "files": ["src/**/*.d.ts"],
+      "rules": {
+        "typescript/consistent-type-definitions": "off"
       }
     }
   ]

--- a/e2e/ai-chat.extension.spec.ts
+++ b/e2e/ai-chat.extension.spec.ts
@@ -6,11 +6,11 @@ import {
   test,
 } from './helpers/extension'
 
-interface RuntimeLike {
+type RuntimeLike = {
   sendMessage?: (message: unknown) => Promise<unknown>
 }
 
-interface InitScriptPage {
+type InitScriptPage = {
   addInitScript: (script: () => void) => Promise<unknown>
 }
 

--- a/e2e/extension-entrypoints.story.spec.ts
+++ b/e2e/extension-entrypoints.story.spec.ts
@@ -9,11 +9,11 @@ import {
 
 const now = 1_763_600_000_000
 
-interface RuntimeLike {
+type RuntimeLike = {
   sendMessage?: (message: unknown) => Promise<unknown>
 }
 
-interface InitScriptPage {
+type InitScriptPage = {
   addInitScript(script: () => void): Promise<unknown>
 }
 

--- a/e2e/helpers/extension.ts
+++ b/e2e/helpers/extension.ts
@@ -7,7 +7,7 @@ import path from 'node:path'
 import { test as base, chromium, expect } from '@playwright/test'
 import type { BrowserContext, Page, Worker } from '@playwright/test'
 
-interface ExtensionFixtures {
+type ExtensionFixtures = {
   extensionContext: BrowserContext
   extensionId: string
   serviceWorker: Worker

--- a/src/app/composition/createSavedTabsPorts.ts
+++ b/src/app/composition/createSavedTabsPorts.ts
@@ -22,7 +22,7 @@ import { getChromeGlobal, isObjectLike } from '@/lib/browser/chrome-global'
  * `SonnerNotificationAdapter` で実装する。`application/ports/` の
  * interface を満たすため、use-case 側からは adapter の詳細を隠せる。
  */
-export interface SavedTabsPorts {
+export type SavedTabsPorts = {
   readonly browserTabPort: BrowserTabPort
   readonly browserWindowPort: BrowserWindowPort
   readonly notificationPort: NotificationPort
@@ -43,11 +43,11 @@ export interface SavedTabsPorts {
  * 反映するための関数。`true` を返すと新規タブを active で開き、`false` を返すと
  * バックグラウンド (`active: false`) で開く。未指定なら `active: true` 既定。
  */
-export interface CreateSavedTabsPortsOptions {
+export type CreateSavedTabsPortsOptions = {
   readonly resolveActive?: () => boolean
 }
 
-interface ChromeApi extends ChromeApiLike {
+type ChromeApi = ChromeApiLike & {
   readonly tabs?: ChromeApiLike['tabs'] & {
     readonly create?: NonNullable<NonNullable<ChromeApiLike['tabs']>['create']>
   }

--- a/src/app/composition/createSavedTabsRepositories.ts
+++ b/src/app/composition/createSavedTabsRepositories.ts
@@ -24,7 +24,7 @@ import { getChromeStorageLocal } from '@/lib/browser/chrome-storage'
  * が利用できない環境で repository 関数を呼び出すと
  * `SavedTabsRepositoryUnavailableError` が投げられる。
  */
-export interface SavedTabsRepositories {
+export type SavedTabsRepositories = {
   readonly tabGroupRepository: TabGroupRepository
   readonly urlRecordRepository: UrlRecordRepository
   readonly parentCategoryRepository: ParentCategoryRepository

--- a/src/components/ai-elements/attachments.tsx
+++ b/src/components/ai-elements/attachments.tsx
@@ -111,13 +111,13 @@ const renderAttachmentImage = (
 // Contexts
 // ============================================================================
 
-interface AttachmentsContextValue {
+type AttachmentsContextValue = {
   variant: AttachmentVariant
 }
 
 const AttachmentsContext = createContext<AttachmentsContextValue | null>(null)
 
-interface AttachmentContextValue {
+type AttachmentContextValue = {
   data: AttachmentData
   mediaCategory: AttachmentMediaCategory
   onRemove?: () => void

--- a/src/components/ai-elements/chain-of-thought.tsx
+++ b/src/components/ai-elements/chain-of-thought.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/collapsible'
 import { cn } from '@/lib/utils'
 
-interface ChainOfThoughtContextValue {
+type ChainOfThoughtContextValue = {
   isOpen: boolean
   setIsOpen: (open: boolean) => void
 }

--- a/src/components/ai-elements/code-block.tsx
+++ b/src/components/ai-elements/code-block.tsx
@@ -40,11 +40,11 @@ const isUnderline = (fontStyle: number | undefined) =>
   fontStyle && fontStyle & FONT_STYLE_UNDERLINE
 
 // Transform tokens to include pre-computed keys to avoid noArrayIndexKey lint
-interface KeyedToken {
+type KeyedToken = {
   token: ThemedToken
   key: string
 }
-interface KeyedLine {
+type KeyedLine = {
   tokens: KeyedToken[]
   key: string
 }
@@ -121,13 +121,13 @@ type SupportedCodeLanguage =
 
 type HighlightLanguage = Exclude<SupportedCodeLanguage, 'text'>
 
-interface TokenizedCode {
+type TokenizedCode = {
   tokens: ThemedToken[][]
   fg: string
   bg: string
 }
 
-interface CodeBlockContextType {
+type CodeBlockContextType = {
   code: string
 }
 

--- a/src/components/ai-elements/confirmation.tsx
+++ b/src/components/ai-elements/confirmation.tsx
@@ -36,7 +36,7 @@ type ToolUIPartApproval =
     }
   | undefined
 
-interface ConfirmationContextValue {
+type ConfirmationContextValue = {
   approval: ToolUIPartApproval
   state: ToolUIPart['state']
 }
@@ -86,7 +86,7 @@ export const ConfirmationTitle = ({
   <AlertDescription className={cn('inline', className)} {...props} />
 )
 
-export interface ConfirmationRequestProps {
+export type ConfirmationRequestProps = {
   children?: ReactNode
 }
 
@@ -101,7 +101,7 @@ export const ConfirmationRequest = ({ children }: ConfirmationRequestProps) => {
   return children
 }
 
-export interface ConfirmationAcceptedProps {
+export type ConfirmationAcceptedProps = {
   children?: ReactNode
 }
 
@@ -123,7 +123,7 @@ export const ConfirmationAccepted = ({
   return children
 }
 
-export interface ConfirmationRejectedProps {
+export type ConfirmationRejectedProps = {
   children?: ReactNode
 }
 

--- a/src/components/ai-elements/context.tsx
+++ b/src/components/ai-elements/context.tsx
@@ -34,7 +34,7 @@ const USD_FORMATTER = new Intl.NumberFormat('en-US', {
 
 type ModelId = string
 
-interface ContextSchema {
+type ContextSchema = {
   usedTokens: number
   maxTokens: number
   usage?: LanguageModelUsage

--- a/src/components/ai-elements/conversation.tsx
+++ b/src/components/ai-elements/conversation.tsx
@@ -100,7 +100,7 @@ export const ConversationScrollButton = ({
   )
 }
 
-export interface ConversationMessage {
+export type ConversationMessage = {
   role: 'user' | 'assistant' | 'system' | 'data' | 'tool'
   content: string
 }

--- a/src/components/ai-elements/environment-variables.tsx
+++ b/src/components/ai-elements/environment-variables.tsx
@@ -12,7 +12,7 @@ import { cn } from '@/lib/utils'
 
 import { useCopyState } from './use-copy-state'
 
-interface EnvironmentVariablesContextType {
+type EnvironmentVariablesContextType = {
   showValues: boolean
   setShowValues: (show: boolean) => void
 }
@@ -137,7 +137,7 @@ export const EnvironmentVariablesContent = ({
   </div>
 )
 
-interface EnvironmentVariableContextType {
+type EnvironmentVariableContextType = {
   name: string
   value: string
 }

--- a/src/components/ai-elements/file-tree.tsx
+++ b/src/components/ai-elements/file-tree.tsx
@@ -20,7 +20,7 @@ const EMPTY_EXPANDED_PATHS = new Set<string>()
 
 import { cn } from '@/lib/utils'
 
-interface FileTreeContextType {
+type FileTreeContextType = {
   expandedPaths: Set<string>
   togglePath: (path: string) => void
   selectedPath?: string
@@ -94,7 +94,7 @@ export const FileTree = ({
   )
 }
 
-interface FileTreeFolderContextType {
+type FileTreeFolderContextType = {
   path: string
   name: string
   isExpanded: boolean
@@ -179,7 +179,7 @@ export const FileTreeFolder = ({
   )
 }
 
-interface FileTreeFileContextType {
+type FileTreeFileContextType = {
   path: string
   name: string
 }

--- a/src/components/ai-elements/jsx-preview.tsx
+++ b/src/components/ai-elements/jsx-preview.tsx
@@ -17,7 +17,7 @@ import JsxParser from 'react-jsx-parser'
 
 import { cn } from '@/lib/utils'
 
-interface JSXPreviewContextValue {
+type JSXPreviewContextValue = {
   jsx: string
   processedJsx: string
   error: Error | null
@@ -29,7 +29,7 @@ interface JSXPreviewContextValue {
 
 const JSXPreviewContext = createContext<JSXPreviewContextValue | null>(null)
 
-interface JSXPreviewErrorState {
+type JSXPreviewErrorState = {
   processedJsx: string
   error: Error
 }

--- a/src/components/ai-elements/message.tsx
+++ b/src/components/ai-elements/message.tsx
@@ -110,7 +110,7 @@ export const MessageAction = ({
   return button
 }
 
-interface MessageBranchContextType {
+type MessageBranchContextType = {
   currentBranch: number
   totalBranches: number
   goToPrevious: () => void

--- a/src/components/ai-elements/mic-selector.tsx
+++ b/src/components/ai-elements/mic-selector.tsx
@@ -33,7 +33,7 @@ const DEFAULT_MIC_SELECTOR_WIDTH = 200
 
 const deviceIdRegex = /\(([\da-fA-F]{4}:[\da-fA-F]{4})\)$/
 
-interface MicSelectorContextType {
+type MicSelectorContextType = {
   data: MediaDeviceInfo[]
   value: string | undefined
   onValueChange?: (value: string) => void

--- a/src/components/ai-elements/package-info.tsx
+++ b/src/components/ai-elements/package-info.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils'
 
 type ChangeType = 'major' | 'minor' | 'patch' | 'added' | 'removed'
 
-interface PackageInfoContextType {
+type PackageInfoContextType = {
   name: string
   currentVersion?: string
   newVersion?: string

--- a/src/components/ai-elements/persona.tsx
+++ b/src/components/ai-elements/persona.tsx
@@ -23,7 +23,7 @@ export type PersonaState =
   | 'speaking'
   | 'asleep'
 
-interface PersonaProps {
+type PersonaProps = {
   state: PersonaState
   onLoad?: RiveParameters['onLoad']
   onLoadError?: RiveParameters['onLoadError']
@@ -129,7 +129,7 @@ const useTheme = (enabled: boolean) => {
   return theme
 }
 
-interface PersonaWithModelProps {
+type PersonaWithModelProps = {
   rive: ReturnType<typeof useRive>['rive']
   source: (typeof sources)[keyof typeof sources]
   children: React.ReactNode
@@ -166,7 +166,7 @@ const PersonaWithModel = memo(
 
 PersonaWithModel.displayName = 'PersonaWithModel'
 
-interface PersonaWithoutModelProps {
+type PersonaWithoutModelProps = {
   children: ReactNode
 }
 

--- a/src/components/ai-elements/plan.tsx
+++ b/src/components/ai-elements/plan.tsx
@@ -24,7 +24,7 @@ import { cn } from '@/lib/utils'
 
 import { Shimmer } from './shimmer'
 
-interface PlanContextValue {
+type PlanContextValue = {
   isStreaming: boolean
 }
 

--- a/src/components/ai-elements/prompt-input.tsx
+++ b/src/components/ai-elements/prompt-input.tsx
@@ -105,7 +105,7 @@ const convertBlobUrlToDataUrl = async (url: string): Promise<string | null> => {
 // Provider Context & Types
 // ============================================================================
 
-export interface AttachmentsContext {
+export type AttachmentsContext = {
   files: (FileUIPart & { id: string })[]
   add: (files: File[] | FileList) => void
   remove: (id: string) => void
@@ -114,13 +114,13 @@ export interface AttachmentsContext {
   fileInputRef: RefObject<HTMLInputElement | null>
 }
 
-export interface TextInputContext {
+export type TextInputContext = {
   value: string
   setInput: (v: string) => void
   clear: () => void
 }
 
-export interface PromptInputControllerProps {
+export type PromptInputControllerProps = {
   textInput: TextInputContext
   attachments: AttachmentsContext
   /** INTERNAL: Allows PromptInput to register its file textInput + "open" callback */
@@ -317,7 +317,7 @@ export const usePromptInputAttachments = () => {
 // Referenced Sources (Local to PromptInput)
 // ============================================================================
 
-export interface ReferencedSourcesContext {
+export type ReferencedSourcesContext = {
   sources: (SourceDocumentUIPart & { id: string })[]
   add: (sources: SourceDocumentUIPart[] | SourceDocumentUIPart) => void
   remove: (id: string) => void
@@ -363,7 +363,7 @@ export const PromptInputActionAddAttachments = ({
   )
 }
 
-export interface PromptInputMessage {
+export type PromptInputMessage = {
   text: string
   files: FileUIPart[]
 }

--- a/src/components/ai-elements/queue.tsx
+++ b/src/components/ai-elements/queue.tsx
@@ -12,7 +12,7 @@ import {
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/lib/utils'
 
-export interface QueueMessagePart {
+export type QueueMessagePart = {
   type: string
   text?: string
   url?: string
@@ -20,12 +20,12 @@ export interface QueueMessagePart {
   mediaType?: string
 }
 
-export interface QueueMessage {
+export type QueueMessage = {
   id: string
   parts: QueueMessagePart[]
 }
 
-export interface QueueTodo {
+export type QueueTodo = {
   id: string
   title: string
   description?: string

--- a/src/components/ai-elements/reasoning.tsx
+++ b/src/components/ai-elements/reasoning.tsx
@@ -24,7 +24,7 @@ import { cn } from '@/lib/utils'
 import { Shimmer } from './shimmer'
 import { StreamdownMarkdown } from './streamdown-renderer'
 
-interface ReasoningContextValue {
+type ReasoningContextValue = {
   isStreaming: boolean
   isOpen: boolean
   setIsOpen: (open: boolean) => void

--- a/src/components/ai-elements/sandbox.tsx
+++ b/src/components/ai-elements/sandbox.tsx
@@ -27,7 +27,7 @@ export const Sandbox = ({ className, ...props }: SandboxRootProps) => (
   />
 )
 
-export interface SandboxHeaderProps {
+export type SandboxHeaderProps = {
   title?: string
   state: ToolUIPart['state']
   className?: string

--- a/src/components/ai-elements/schema-display.tsx
+++ b/src/components/ai-elements/schema-display.tsx
@@ -19,7 +19,7 @@ const SCHEMA_DESCRIPTION_INDENT = 24
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 
-interface SchemaParameter {
+type SchemaParameter = {
   name: string
   type: string
   required?: boolean
@@ -27,7 +27,7 @@ interface SchemaParameter {
   location?: 'path' | 'query' | 'header'
 }
 
-interface SchemaProperty {
+type SchemaProperty = {
   name: string
   type: string
   required?: boolean
@@ -36,7 +36,7 @@ interface SchemaProperty {
   items?: SchemaProperty
 }
 
-interface SchemaDisplayContextType {
+type SchemaDisplayContextType = {
   method: HttpMethod
   path: string
   description?: string

--- a/src/components/ai-elements/shimmer.tsx
+++ b/src/components/ai-elements/shimmer.tsx
@@ -6,7 +6,7 @@ import { memo, useMemo } from 'react'
 
 import { cn } from '@/lib/utils'
 
-export interface TextShimmerProps {
+export type TextShimmerProps = {
   children?: string
   as?: ElementType
   className?: string

--- a/src/components/ai-elements/snippet.tsx
+++ b/src/components/ai-elements/snippet.tsx
@@ -16,7 +16,7 @@ import { cn } from '@/lib/utils'
 
 import { useCopyState } from './use-copy-state'
 
-interface SnippetContextType {
+type SnippetContextType = {
   code: string
 }
 

--- a/src/components/ai-elements/speech-input.tsx
+++ b/src/components/ai-elements/speech-input.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
 import { cn } from '@/lib/utils'
 
-interface SpeechRecognition extends EventTarget {
+type SpeechRecognition = EventTarget & {
   continuous: boolean
   interimResults: boolean
   lang: string
@@ -25,25 +25,25 @@ interface SpeechRecognition extends EventTarget {
     | null
 }
 
-interface SpeechRecognitionEvent extends Event {
+type SpeechRecognitionEvent = Event & {
   results: SpeechRecognitionResultList
   resultIndex: number
 }
 
-interface SpeechRecognitionResultList {
+type SpeechRecognitionResultList = {
   readonly length: number
   item(index: number): SpeechRecognitionResult
   [index: number]: SpeechRecognitionResult
 }
 
-interface SpeechRecognitionResult {
+type SpeechRecognitionResult = {
   readonly length: number
   item(index: number): SpeechRecognitionAlternative
   [index: number]: SpeechRecognitionAlternative
   isFinal: boolean
 }
 
-interface SpeechRecognitionAlternative {
+type SpeechRecognitionAlternative = {
   transcript: string
   confidence: number
 }
@@ -82,7 +82,7 @@ const getRecordingErrorMessage = (error: unknown, fallback: string) => {
   return fallback
 }
 
-interface SpeechRecognitionErrorEvent extends Event {
+type SpeechRecognitionErrorEvent = Event & {
   error: string
 }
 
@@ -129,7 +129,7 @@ const detectSpeechInputMode = (): SpeechInputMode => {
   return 'none'
 }
 
-interface RecordingState {
+type RecordingState = {
   isListening: boolean
   isProcessing: boolean
   errorMessage: string | null
@@ -168,7 +168,7 @@ const recordingReducer = (
   }
 }
 
-interface RecordingButtonProps extends ComponentProps<typeof Button> {
+type RecordingButtonProps = ComponentProps<typeof Button> & {
   isListening: boolean
   isProcessing: boolean
 }

--- a/src/components/ai-elements/stack-trace.tsx
+++ b/src/components/ai-elements/stack-trace.tsx
@@ -34,7 +34,7 @@ const STACK_FRAME_WITHOUT_FN_REGEX = /^at\s+(.+):(\d+):(\d+)$/
 const ERROR_TYPE_REGEX = /^(\w+Error|Error):\s*(.*)$/
 const AT_PREFIX_REGEX = /^at\s+/
 
-interface StackFrame {
+type StackFrame = {
   raw: string
   functionName: string | null
   filePath: string | null
@@ -43,14 +43,14 @@ interface StackFrame {
   isInternal: boolean
 }
 
-interface ParsedStackTrace {
+type ParsedStackTrace = {
   errorType: string | null
   errorMessage: string
   frames: StackFrame[]
   raw: string
 }
 
-interface StackTraceContextValue {
+type StackTraceContextValue = {
   trace: ParsedStackTrace
   raw: string
   isOpen: boolean
@@ -439,7 +439,7 @@ export type StackTraceFramesProps = ComponentProps<'div'> & {
   showInternalFrames?: boolean
 }
 
-interface FilePathButtonProps {
+type FilePathButtonProps = {
   frame: StackFrame
   onFilePathClick?: (
     filePath: string,

--- a/src/components/ai-elements/terminal.tsx
+++ b/src/components/ai-elements/terminal.tsx
@@ -11,7 +11,7 @@ import { cn } from '@/lib/utils'
 import { Shimmer } from './shimmer'
 import { useCopyState } from './use-copy-state'
 
-interface TerminalContextType {
+type TerminalContextType = {
   output: string
   isStreaming: boolean
   autoScroll: boolean

--- a/src/components/ai-elements/test-results.tsx
+++ b/src/components/ai-elements/test-results.tsx
@@ -20,7 +20,7 @@ import { cn } from '@/lib/utils'
 
 type TestStatus = 'passed' | 'failed' | 'skipped' | 'running'
 
-interface TestResultsSummary {
+type TestResultsSummary = {
   passed: number
   failed: number
   skipped: number
@@ -28,7 +28,7 @@ interface TestResultsSummary {
   duration?: number
 }
 
-interface TestResultsContextType {
+type TestResultsContextType = {
   summary?: TestResultsSummary
 }
 
@@ -217,7 +217,7 @@ export const TestResultsContent = ({
   </div>
 )
 
-interface TestSuiteContextType {
+type TestSuiteContextType = {
   name: string
   status: TestStatus
 }
@@ -326,7 +326,7 @@ export const TestSuiteContent = ({
   </CollapsibleContent>
 )
 
-interface TestContextType {
+type TestContextType = {
   name: string
   status: TestStatus
   duration?: number

--- a/src/components/ai-elements/transcription.tsx
+++ b/src/components/ai-elements/transcription.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils'
 
 type TranscriptionSegment = TranscriptionResult['segments'][number]
 
-interface TranscriptionContextValue {
+type TranscriptionContextValue = {
   segments: TranscriptionSegment[]
   currentTime: number
   onTimeUpdate: (time: number) => void

--- a/src/components/ai-elements/use-copy-state.ts
+++ b/src/components/ai-elements/use-copy-state.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-export interface UseCopyStateOptions {
+export type UseCopyStateOptions = {
   onCopy?: () => void
   onError?: (error: Error) => void
   timeout?: number

--- a/src/components/ai-elements/voice-selector.tsx
+++ b/src/components/ai-elements/voice-selector.tsx
@@ -36,7 +36,7 @@ import { Spinner } from '@/components/ui/spinner'
 import { useI18nText } from '@/features/i18n/lib/useI18nText'
 import { cn } from '@/lib/utils'
 
-interface VoiceSelectorContextValue {
+type VoiceSelectorContextValue = {
   value: string | undefined
   setValue: (value: string | undefined) => void
   open: boolean

--- a/src/components/ai-elements/web-preview.tsx
+++ b/src/components/ai-elements/web-preview.tsx
@@ -28,7 +28,7 @@ import {
 import { useI18nText } from '@/features/i18n/lib/useI18nText'
 import { cn } from '@/lib/utils'
 
-export interface WebPreviewContextValue {
+export type WebPreviewContextValue = {
   url: string
   setUrl: (url: string) => void
   consoleOpen: boolean

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -24,12 +24,12 @@ type Theme = 'dark' | 'light' | 'system' | 'user'
 const isTheme = (v: unknown): v is Theme =>
   typeof v === 'string' &&
   (v === 'dark' || v === 'light' || v === 'system' || v === 'user')
-interface ThemeProviderProps {
+type ThemeProviderProps = {
   children: React.ReactNode
   defaultTheme?: Theme
   storageKey?: string
 }
-interface ThemeProviderState {
+type ThemeProviderState = {
   theme: Theme
   setTheme: (theme: Theme) => void
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -24,10 +24,8 @@ const badgeVariants = cva(
   },
 )
 
-export interface BadgeProps
-  extends
-    React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+export type BadgeProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof badgeVariants>
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -37,13 +37,11 @@ const buttonVariants = cva(
   },
 )
 
-export interface ButtonProps
-  extends
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean
-  ref?: React.Ref<HTMLButtonElement>
-}
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+    ref?: React.Ref<HTMLButtonElement>
+  }
 
 const Button = ({
   asChild = false,

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -12,7 +12,7 @@ type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
 type CarouselOptions = UseCarouselParameters[0]
 type CarouselPlugin = UseCarouselParameters[1]
 
-interface CarouselProps {
+type CarouselProps = {
   opts?: CarouselOptions
   plugins?: CarouselPlugin
   orientation?: 'horizontal' | 'vertical'

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -21,7 +21,7 @@ export type ChartConfig = Record<
   )
 >
 
-interface ChartContextProps {
+type ChartContextProps = {
   config: ChartConfig
 }
 

--- a/src/components/ui/loading-state.tsx
+++ b/src/components/ui/loading-state.tsx
@@ -1,7 +1,7 @@
 import { Spinner } from '@/components/ui/spinner'
 import { cn } from '@/lib/utils'
 
-interface LoadingStateProps {
+type LoadingStateProps = {
   className?: string
   minHeightClassName?: string
   spinnerClassName?: string

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -52,10 +52,8 @@ const sheetVariants = cva(
   },
 )
 
-interface SheetContentProps
-  extends
-    React.ComponentProps<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+type SheetContentProps = React.ComponentProps<typeof SheetPrimitive.Content> &
+  VariantProps<typeof sheetVariants>
 
 const SheetContent = ({
   children,

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -79,7 +79,7 @@ const persistSidebarWidth = (width: number): void => {
   }
 }
 
-interface SidebarContextProps {
+type SidebarContextProps = {
   state: 'expanded' | 'collapsed'
   open: boolean
   setOpen: (open: boolean) => void

--- a/src/constants/aiChatTools.ts
+++ b/src/constants/aiChatTools.ts
@@ -1,7 +1,7 @@
 import { getMessage } from '@/features/i18n/lib/language'
 import type { AppLanguage } from '@/features/i18n/messages'
 
-interface AiChatToolDefinition {
+type AiChatToolDefinition = {
   descriptionKey: string
   name: string
   titleKey: string
@@ -75,7 +75,7 @@ const getAiChatToolDescription = (
   return getMessage(language, toolDefinition.descriptionKey, toolName)
 }
 
-interface ResolvedAiChatToolDefinition {
+type ResolvedAiChatToolDefinition = {
   description: string
   name: string
   title: string

--- a/src/contexts/saved-tabs/application/SavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/application/SavedTabsUseCases.ts
@@ -74,7 +74,7 @@ import type { UpdateCustomProjectNameUseCase } from './use-cases/UpdateCustomPro
  * 実装は `src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCases.ts`
  * および `src/app/composition/createSavedTabsUseCases.ts` が提供する。
  */
-export interface SavedTabsUseCases {
+export type SavedTabsUseCases = {
   readonly openSavedUrl: OpenSavedUrlUseCase
   readonly openAllSavedUrls: OpenAllSavedUrlsUseCase
   readonly deleteTabGroup: DeleteTabGroupUseCase

--- a/src/contexts/saved-tabs/application/SavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/application/SavedTabsUseCasesDeps.ts
@@ -21,7 +21,7 @@ import type { SetCategoryKeywordsPort } from './ports/SetCategoryKeywordsPort'
 import type { StorageChangePort } from './ports/StorageChangePort'
 
 /** Dependencies required to construct and present the saved-tabs use cases. */
-export interface SavedTabsUseCasesDeps {
+export type SavedTabsUseCasesDeps = {
   readonly browserTabPort: BrowserTabPort
   readonly browserWindowPort: BrowserWindowPort
   readonly categoriesCommandService: CategoriesCommandService

--- a/src/contexts/saved-tabs/application/commands/AddCategoryToCustomProjectCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/AddCategoryToCustomProjectCommand.ts
@@ -15,7 +15,7 @@
  * }
  * ```
  */
-export interface AddCategoryToCustomProjectCommand {
+export type AddCategoryToCustomProjectCommand = {
   readonly projectId: string
   readonly categoryName: string
 }

--- a/src/contexts/saved-tabs/application/commands/AddDomainToParentCategoryCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/AddDomainToParentCategoryCommand.ts
@@ -14,7 +14,7 @@
  * }
  * ```
  */
-export interface AddDomainToParentCategoryCommand {
+export type AddDomainToParentCategoryCommand = {
   readonly categoryId: string
   readonly domainId: string
   readonly domainName: string

--- a/src/contexts/saved-tabs/application/commands/AddUrlToCustomProjectCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/AddUrlToCustomProjectCommand.ts
@@ -16,7 +16,7 @@
  * }
  * ```
  */
-export interface AddUrlToCustomProjectCommand {
+export type AddUrlToCustomProjectCommand = {
   readonly projectId: string
   readonly title: string
   readonly url: string

--- a/src/contexts/saved-tabs/application/commands/BuildSavedTabsSnapshotCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/BuildSavedTabsSnapshotCommand.ts
@@ -11,6 +11,6 @@ import type { SavedTabsParentCategoryDto } from '@/contexts/saved-tabs/applicati
  * 旧 `SavedTabsApp.tsx` の `chrome.storage.local.get([...])` を
  * repository 経由へ移す目的（issue #494）。
  */
-export interface BuildSavedTabsSnapshotCommand {
+export type BuildSavedTabsSnapshotCommand = {
   readonly parentCategories?: readonly SavedTabsParentCategoryDto[]
 }

--- a/src/contexts/saved-tabs/application/commands/DeleteSavedUrlCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/DeleteSavedUrlCommand.ts
@@ -18,7 +18,7 @@
  * const result = await deleteSavedUrlUseCase(command)
  * ```
  */
-export interface DeleteSavedUrlCommand {
+export type DeleteSavedUrlCommand = {
   readonly tabGroupId: string
   readonly url: string
 }

--- a/src/contexts/saved-tabs/application/commands/DeleteSavedUrlsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/DeleteSavedUrlsCommand.ts
@@ -17,7 +17,7 @@
  * const result = await deleteSavedUrlsUseCase(command)
  * ```
  */
-export interface DeleteSavedUrlsCommand {
+export type DeleteSavedUrlsCommand = {
   readonly tabGroupId: string
   readonly urls: readonly string[]
 }

--- a/src/contexts/saved-tabs/application/commands/DeleteTabGroupCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/DeleteTabGroupCommand.ts
@@ -11,6 +11,6 @@
  * const result = await deleteTabGroupUseCase(command)
  * ```
  */
-export interface DeleteTabGroupCommand {
+export type DeleteTabGroupCommand = {
   readonly tabGroupId: string
 }

--- a/src/contexts/saved-tabs/application/commands/DeleteTabGroupsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/DeleteTabGroupsCommand.ts
@@ -16,6 +16,6 @@
  * const result = await deleteTabGroupsUseCase(command)
  * ```
  */
-export interface DeleteTabGroupsCommand {
+export type DeleteTabGroupsCommand = {
   readonly tabGroupIds: readonly string[]
 }

--- a/src/contexts/saved-tabs/application/commands/FindUrlRecordByUrlCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/FindUrlRecordByUrlCommand.ts
@@ -7,6 +7,6 @@
  * 等価物。presentation 層は use-case 経由で取得する
  * （issue #501）。
  */
-export interface FindUrlRecordByUrlCommand {
+export type FindUrlRecordByUrlCommand = {
   readonly url: string
 }

--- a/src/contexts/saved-tabs/application/commands/LoadTabGroupUrlsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/LoadTabGroupUrlsCommand.ts
@@ -12,6 +12,6 @@ import type { SavedTabsDisplayTabGroupDto } from '@/contexts/saved-tabs/applicat
  * `@/types/storage` には依存せず、domain DTO `TabGroupDto` を
  * 受け取る (issue #511)。
  */
-export interface LoadTabGroupUrlsCommand {
+export type LoadTabGroupUrlsCommand = {
   readonly tabGroup: SavedTabsDisplayTabGroupDto
 }

--- a/src/contexts/saved-tabs/application/commands/LoadTabGroupsWithUrlsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/LoadTabGroupsWithUrlsCommand.ts
@@ -18,6 +18,6 @@ import type { SavedTabsDisplayTabGroupDto } from '@/contexts/saved-tabs/applicat
  * `resolveGroupUrls` 側で吸収する（domain 層 widening は
  * `TabGroupUrlResolver.ts` 内で行う）。
  */
-export interface LoadTabGroupsWithUrlsCommand {
+export type LoadTabGroupsWithUrlsCommand = {
   readonly tabGroups: readonly SavedTabsDisplayTabGroupDto[]
 }

--- a/src/contexts/saved-tabs/application/commands/MoveDomainBetweenCategoriesCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/MoveDomainBetweenCategoriesCommand.ts
@@ -23,7 +23,7 @@
  */
 import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
-export interface MoveDomainBetweenCategoriesCommand {
+export type MoveDomainBetweenCategoriesCommand = {
   /** 移動する `TabGroupId`（生文字列）。 */
   readonly domainId: string
   /**

--- a/src/contexts/saved-tabs/application/commands/MoveDomainToCategoryCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/MoveDomainToCategoryCommand.ts
@@ -16,7 +16,7 @@
  * }
  * ```
  */
-export interface MoveDomainToCategoryCommand {
+export type MoveDomainToCategoryCommand = {
   readonly domain: string
   readonly parentCategoryId: string
 }

--- a/src/contexts/saved-tabs/application/commands/MoveUrlBetweenCustomProjectsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/MoveUrlBetweenCustomProjectsCommand.ts
@@ -17,7 +17,7 @@
  * }
  * ```
  */
-export interface MoveUrlBetweenCustomProjectsCommand {
+export type MoveUrlBetweenCustomProjectsCommand = {
   readonly sourceProjectId: string
   readonly targetProjectId: string
   readonly url: string

--- a/src/contexts/saved-tabs/application/commands/OpenAllSavedUrlsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/OpenAllSavedUrlsCommand.ts
@@ -25,7 +25,7 @@
  */
 export type OpenAllSavedUrlsMode = 'newWindow' | 'backgroundTabs'
 
-export interface OpenAllSavedUrlsCommand {
+export type OpenAllSavedUrlsCommand = {
   readonly urls: readonly string[]
   readonly mode: OpenAllSavedUrlsMode
   /**

--- a/src/contexts/saved-tabs/application/commands/OpenSavedUrlCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/OpenSavedUrlCommand.ts
@@ -16,7 +16,7 @@
  * const result = await openSavedUrlUseCase(command)
  * ```
  */
-export interface OpenSavedUrlCommand {
+export type OpenSavedUrlCommand = {
   readonly urlRecordId: string
   readonly origin: 'click' | 'externalDrop'
   /**

--- a/src/contexts/saved-tabs/application/commands/PrepareTabGroupDeletionCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/PrepareTabGroupDeletionCommand.ts
@@ -27,6 +27,6 @@
  * }
  * ```
  */
-export interface PrepareTabGroupDeletionCommand {
+export type PrepareTabGroupDeletionCommand = {
   readonly tabGroupId: string
 }

--- a/src/contexts/saved-tabs/application/commands/PrepareTabGroupsDeletionCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/PrepareTabGroupsDeletionCommand.ts
@@ -26,6 +26,6 @@
  * }
  * ```
  */
-export interface PrepareTabGroupsDeletionCommand {
+export type PrepareTabGroupsDeletionCommand = {
   readonly tabGroupIds: readonly string[]
 }

--- a/src/contexts/saved-tabs/application/commands/RemoveCategoryFromCustomProjectCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/RemoveCategoryFromCustomProjectCommand.ts
@@ -15,7 +15,7 @@
  * }
  * ```
  */
-export interface RemoveCategoryFromCustomProjectCommand {
+export type RemoveCategoryFromCustomProjectCommand = {
   readonly projectId: string
   readonly categoryName: string
 }

--- a/src/contexts/saved-tabs/application/commands/RemoveDomainFromParentCategoryCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/RemoveDomainFromParentCategoryCommand.ts
@@ -14,7 +14,7 @@
  * }
  * ```
  */
-export interface RemoveDomainFromParentCategoryCommand {
+export type RemoveDomainFromParentCategoryCommand = {
   readonly categoryId: string
   readonly domainId: string
   readonly domainName: string

--- a/src/contexts/saved-tabs/application/commands/RemoveDomainsFromParentCategoriesCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/RemoveDomainsFromParentCategoriesCommand.ts
@@ -23,6 +23,6 @@
  * }
  * ```
  */
-export interface RemoveDomainsFromParentCategoriesCommand {
+export type RemoveDomainsFromParentCategoriesCommand = {
   readonly domainIds: readonly string[]
 }

--- a/src/contexts/saved-tabs/application/commands/RemoveSubCategoryFromTabGroupsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/RemoveSubCategoryFromTabGroupsCommand.ts
@@ -15,7 +15,7 @@
  */
 import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
-export interface RemoveSubCategoryFromTabGroupsCommand {
+export type RemoveSubCategoryFromTabGroupsCommand = {
   readonly groupId: string
   readonly categoryName: string
 }
@@ -27,6 +27,6 @@ export interface RemoveSubCategoryFromTabGroupsCommand {
  * `refreshTabGroupsWithUrls(updatedGroups)` で UI state へ反映できる
  * ようにする。
  */
-export interface RemoveSubCategoryFromTabGroupsResult {
+export type RemoveSubCategoryFromTabGroupsResult = {
   readonly tabGroups: readonly TabGroup[]
 }

--- a/src/contexts/saved-tabs/application/commands/RemoveUrlFromCustomProjectCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/RemoveUrlFromCustomProjectCommand.ts
@@ -14,7 +14,7 @@
  * }
  * ```
  */
-export interface RemoveUrlFromCustomProjectCommand {
+export type RemoveUrlFromCustomProjectCommand = {
   readonly projectId: string
   readonly url: string
 }

--- a/src/contexts/saved-tabs/application/commands/RemoveUrlsFromCustomProjectCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/RemoveUrlsFromCustomProjectCommand.ts
@@ -18,7 +18,7 @@
  * }
  * ```
  */
-export interface RemoveUrlsFromCustomProjectCommand {
+export type RemoveUrlsFromCustomProjectCommand = {
   readonly projectId: string
   readonly urls: readonly string[]
 }

--- a/src/contexts/saved-tabs/application/commands/RemoveUrlsFromCustomProjectsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/RemoveUrlsFromCustomProjectsCommand.ts
@@ -17,6 +17,6 @@ import type { SavedTabsDisplayTabGroupDto } from '@/contexts/saved-tabs/applicat
  * `@/types/storage` には依存せず、domain DTO `TabGroupDto` だけを
  * 受け取る (issue #511)。
  */
-export interface RemoveUrlsFromCustomProjectsCommand {
+export type RemoveUrlsFromCustomProjectsCommand = {
   readonly tabGroups: readonly SavedTabsDisplayTabGroupDto[]
 }

--- a/src/contexts/saved-tabs/application/commands/RenameCustomProjectCategoryCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/RenameCustomProjectCategoryCommand.ts
@@ -15,7 +15,7 @@
  * }
  * ```
  */
-export interface RenameCustomProjectCategoryCommand {
+export type RenameCustomProjectCategoryCommand = {
   readonly projectId: string
   readonly oldCategoryName: string
   readonly newCategoryName: string

--- a/src/contexts/saved-tabs/application/commands/RenameParentCategoryCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/RenameParentCategoryCommand.ts
@@ -16,7 +16,7 @@
  * }
  * ```
  */
-export interface RenameParentCategoryCommand {
+export type RenameParentCategoryCommand = {
   readonly categoryId: string
   readonly newName: string
 }

--- a/src/contexts/saved-tabs/application/commands/ReorderCustomProjectUrlsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/ReorderCustomProjectUrlsCommand.ts
@@ -18,7 +18,7 @@
  */
 import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
-export interface ReorderCustomProjectUrlsCommand {
+export type ReorderCustomProjectUrlsCommand = {
   readonly projectId: string
   readonly urls: CustomProject['urls']
 }

--- a/src/contexts/saved-tabs/application/commands/ReorderDomainsInCategoryCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/ReorderDomainsInCategoryCommand.ts
@@ -15,7 +15,7 @@
  */
 import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
-export interface ReorderDomainsInCategoryCommand {
+export type ReorderDomainsInCategoryCommand = {
   /** 並び替え対象カテゴリの `ParentCategoryId`。 */
   readonly categoryId: string
   /**

--- a/src/contexts/saved-tabs/application/commands/ReorderParentCategoriesCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/ReorderParentCategoriesCommand.ts
@@ -16,6 +16,6 @@
  */
 import type { SavedTabsParentCategoryDto as ParentCategory } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
-export interface ReorderParentCategoriesCommand {
+export type ReorderParentCategoriesCommand = {
   readonly categories: readonly ParentCategory[]
 }

--- a/src/contexts/saved-tabs/application/commands/ReorderTabGroupUrlsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/ReorderTabGroupUrlsCommand.ts
@@ -16,7 +16,7 @@
  * })
  * ```
  */
-export interface ReorderTabGroupUrlsCommand {
+export type ReorderTabGroupUrlsCommand = {
   readonly tabGroupId: string
   readonly newUrlOrder: readonly string[]
 }

--- a/src/contexts/saved-tabs/application/commands/ReorderTabGroupsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/ReorderTabGroupsCommand.ts
@@ -8,6 +8,6 @@ import type { SavedTabsTabGroupDto } from '@/contexts/saved-tabs/application/dto
  * 並べ替えた完全な一覧を渡す。use-case はそのまま
  * `TabGroupRepository.saveAll` に委譲する（issue #494）。
  */
-export interface ReorderTabGroupsCommand {
+export type ReorderTabGroupsCommand = {
   readonly tabGroups: readonly SavedTabsTabGroupDto[]
 }

--- a/src/contexts/saved-tabs/application/commands/RestoreOpenedUrlsSnapshotCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/RestoreOpenedUrlsSnapshotCommand.ts
@@ -25,7 +25,7 @@ import type {
  * })
  * ```
  */
-export interface OpenedUrlsRestoreSnapshot {
+export type OpenedUrlsRestoreSnapshot = {
   readonly savedTabs?: readonly SavedTabsTabGroupDto[]
   readonly urlRecords?: readonly SavedTabsUrlRecordDto[]
   readonly customProjects?: readonly SavedTabsCustomProjectDto[]
@@ -39,6 +39,6 @@ export interface OpenedUrlsRestoreSnapshot {
  * snapshot は use-case の DTO から渡されることを想定。UI 側で
  * 「Undo」ボタンを押す前に `useState` などで保持しておく。
  */
-export interface RestoreOpenedUrlsSnapshotCommand {
+export type RestoreOpenedUrlsSnapshotCommand = {
   readonly snapshot: OpenedUrlsRestoreSnapshot
 }

--- a/src/contexts/saved-tabs/application/commands/SetCategoryKeywordsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/SetCategoryKeywordsCommand.ts
@@ -18,7 +18,7 @@
  * })
  * ```
  */
-export interface SetCategoryKeywordsCommand {
+export type SetCategoryKeywordsCommand = {
   readonly tabGroupId: string
   readonly categoryName: string
   readonly keywords: readonly string[]

--- a/src/contexts/saved-tabs/application/commands/SetCustomProjectUrlCategoryCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/SetCustomProjectUrlCategoryCommand.ts
@@ -15,7 +15,7 @@
  * }
  * ```
  */
-export interface SetCustomProjectUrlCategoryCommand {
+export type SetCustomProjectUrlCategoryCommand = {
   readonly projectId: string
   readonly url: string
   readonly category?: string

--- a/src/contexts/saved-tabs/application/commands/UpdateCustomProjectCategoryOrderCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/UpdateCustomProjectCategoryOrderCommand.ts
@@ -14,7 +14,7 @@
  * }
  * ```
  */
-export interface UpdateCustomProjectCategoryOrderCommand {
+export type UpdateCustomProjectCategoryOrderCommand = {
   readonly projectId: string
   readonly newOrder: readonly string[]
 }

--- a/src/contexts/saved-tabs/application/commands/UpdateCustomProjectKeywordsCommand.ts
+++ b/src/contexts/saved-tabs/application/commands/UpdateCustomProjectKeywordsCommand.ts
@@ -20,7 +20,7 @@
  */
 import type { SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
-export interface UpdateCustomProjectKeywordsCommand {
+export type UpdateCustomProjectKeywordsCommand = {
   readonly projectId: string
   readonly projectKeywords: ProjectKeywordSettings
 }

--- a/src/contexts/saved-tabs/application/dto/CategorySyncDto.ts
+++ b/src/contexts/saved-tabs/application/dto/CategorySyncDto.ts
@@ -9,7 +9,7 @@
  * 既存の `TabGroup.parentCategoryId` が変わらなかった場合は
  * `assignedTabGroupIds` にも `unassignedTabGroupIds` にも含めない。
  */
-export interface CategorySyncDto {
+export type CategorySyncDto = {
   /**
    * 新たにカテゴリへ割り当てられた `TabGroupId` 一覧。
    */

--- a/src/contexts/saved-tabs/application/dto/DeletedSavedUrlDto.ts
+++ b/src/contexts/saved-tabs/application/dto/DeletedSavedUrlDto.ts
@@ -18,7 +18,7 @@ import type { SavedTabsUrlRecordDto } from './SavedTabsPresentationDto'
  * 削除前スナップショットを、`urlRecords` には実際に削除された
  * `UrlRecord` の配列を格納する。1 件も削除されなかったケースでは `null`。
  */
-export interface DeletedSavedUrlDto {
+export type DeletedSavedUrlDto = {
   readonly removedUrlRecordId: string | null
   readonly removedTabGroupId: string | null
   readonly removedUrlRecord: SavedTabsUrlRecordDto | null

--- a/src/contexts/saved-tabs/application/dto/DeletedSavedUrlsDto.ts
+++ b/src/contexts/saved-tabs/application/dto/DeletedSavedUrlsDto.ts
@@ -21,7 +21,7 @@ import type { SavedTabsUrlRecordDto } from './SavedTabsPresentationDto'
  * 削除前スナップショットを、`urlRecords` には実際に削除された
  * `UrlRecord` の配列を格納する。1 件も削除されなかったケースでは `null`。
  */
-export interface DeletedSavedUrlsDto {
+export type DeletedSavedUrlsDto = {
   readonly removedUrlRecordIds: readonly string[]
   readonly removedUrlRecords: readonly SavedTabsUrlRecordDto[]
   readonly removedTabGroupIds: readonly string[]

--- a/src/contexts/saved-tabs/application/dto/DeletedTabGroupDto.ts
+++ b/src/contexts/saved-tabs/application/dto/DeletedTabGroupDto.ts
@@ -12,7 +12,7 @@ import type { OpenedUrlsRestoreSnapshot } from '@/contexts/saved-tabs/applicatio
  * UI で「他で参照されていなかった URL が N 件削除されました」を
  * 表示する用途を想定。
  */
-export interface DeletedTabGroupDto {
+export type DeletedTabGroupDto = {
   readonly removedTabGroupId: string
   /**
    * 削除対象 TabGroup 内に含まれていた URL のうち、削除後に

--- a/src/contexts/saved-tabs/application/dto/DeletedTabGroupsDto.ts
+++ b/src/contexts/saved-tabs/application/dto/DeletedTabGroupsDto.ts
@@ -17,7 +17,7 @@ import type { SavedTabsTabGroupDto } from './SavedTabsPresentationDto'
  * うち、削除後にどの TabGroup / CustomProject からも参照されなくなった
  * もの。空配列なら「他で参照されていたため UrlRecord は保持された」ことを示す。
  */
-export interface DeletedTabGroupsDto {
+export type DeletedTabGroupsDto = {
   readonly removedTabGroupIds: readonly string[]
   readonly removedUrlRecordIds: readonly string[]
   /**

--- a/src/contexts/saved-tabs/application/dto/FindUrlRecordByUrlDto.ts
+++ b/src/contexts/saved-tabs/application/dto/FindUrlRecordByUrlDto.ts
@@ -7,7 +7,7 @@
  * 旧 `getUrlRecords().find((record) => record.url === url)` の
  * 結果を use-case 経由に置き換えたもの（issue #501）。
  */
-export interface FindUrlRecordByUrlDto {
+export type FindUrlRecordByUrlDto = {
   readonly record: {
     readonly id: string
     readonly url: string

--- a/src/contexts/saved-tabs/application/dto/LoadTabGroupUrlsDto.ts
+++ b/src/contexts/saved-tabs/application/dto/LoadTabGroupUrlsDto.ts
@@ -9,6 +9,6 @@ import type { SavedTabsDisplayUrlDto } from './SavedTabsPresentationDto'
  * `@/types/storage` には依存せず、domain DTO `ResolvedTabGroupUrlDto`
  * だけを返す (issue #511)。
  */
-export interface LoadTabGroupUrlsDto {
+export type LoadTabGroupUrlsDto = {
   readonly urls: readonly SavedTabsDisplayUrlDto[]
 }

--- a/src/contexts/saved-tabs/application/dto/LoadTabGroupsWithUrlsDto.ts
+++ b/src/contexts/saved-tabs/application/dto/LoadTabGroupsWithUrlsDto.ts
@@ -14,6 +14,6 @@ import type { SavedTabsDisplayTabGroupDto } from './SavedTabsPresentationDto'
  * `@/types/storage` には依存せず、domain DTO `TabGroupDto` だけを
  * 返す (issue #511)。
  */
-export interface LoadTabGroupsWithUrlsDto {
+export type LoadTabGroupsWithUrlsDto = {
   readonly tabGroups: readonly SavedTabsDisplayTabGroupDto[]
 }

--- a/src/contexts/saved-tabs/application/dto/OpenedUrlDto.ts
+++ b/src/contexts/saved-tabs/application/dto/OpenedUrlDto.ts
@@ -17,7 +17,7 @@ import type { SavedTabsUrlRecordDto } from './SavedTabsPresentationDto'
  * port 戻り値が `string` であり、presentation 側で再パースして
  * 値オブジェクト化する責務を presentation に寄せたいため。
  */
-export interface OpenedUrlDto {
+export type OpenedUrlDto = {
   readonly openedUrl: string
   readonly removedUrlRecordId: string | null
   /**

--- a/src/contexts/saved-tabs/application/dto/OpenedUrlsDto.ts
+++ b/src/contexts/saved-tabs/application/dto/OpenedUrlsDto.ts
@@ -16,7 +16,7 @@ import type { SavedTabsUrlRecordDto } from './SavedTabsPresentationDto'
  * `snapshot` は `RestoreOpenedUrlsSnapshotCommand` へそのまま渡せる形。
  * 削除が発生しなかったケースでは `null`。
  */
-export interface OpenedUrlsDto {
+export type OpenedUrlsDto = {
   readonly openedUrls: readonly string[]
   readonly removedUrlRecordIds: readonly string[]
   readonly removedUrlRecords: readonly SavedTabsUrlRecordDto[]

--- a/src/contexts/saved-tabs/application/dto/RemovedUrlRecordsDto.ts
+++ b/src/contexts/saved-tabs/application/dto/RemovedUrlRecordsDto.ts
@@ -6,7 +6,7 @@
  * 通知すればよいケースと、ID 一覧が欲しいケースの両方に対応するため
  * 両方持つ。
  */
-export interface RemovedUrlRecordsDto {
+export type RemovedUrlRecordsDto = {
   readonly removedCount: number
   readonly removedUrlRecordIds: readonly string[]
 }

--- a/src/contexts/saved-tabs/application/dto/RemovedUrlsFromCustomProjectsDto.ts
+++ b/src/contexts/saved-tabs/application/dto/RemovedUrlsFromCustomProjectsDto.ts
@@ -12,7 +12,7 @@
  * - `removedUrlCount`: `removeUrlsFromAllCustomProjects` で
  *   同期削除した URL 文字列の件数 (legacy 形式グループ由来)。
  */
-export interface RemovedUrlsFromCustomProjectsDto {
+export type RemovedUrlsFromCustomProjectsDto = {
   readonly removedUrlIdCount: number
   readonly removedUrlCount: number
 }

--- a/src/contexts/saved-tabs/application/dto/RestoredSnapshotDto.ts
+++ b/src/contexts/saved-tabs/application/dto/RestoredSnapshotDto.ts
@@ -18,7 +18,7 @@ import type {
  * 既存データ（`order` 未保存の snapshot）と後方互換を保つため、
  * 必須フィールドにはしない。
  */
-export interface RestoredSnapshotDto {
+export type RestoredSnapshotDto = {
   readonly restoredTabGroups: readonly SavedTabsTabGroupDto[]
   readonly restoredUrlRecords: readonly SavedTabsUrlRecordDto[]
   readonly restoredCustomProjects: readonly SavedTabsCustomProjectDto[]

--- a/src/contexts/saved-tabs/application/dto/SavedTabsCustomProjectRawSnapshotDto.ts
+++ b/src/contexts/saved-tabs/application/dto/SavedTabsCustomProjectRawSnapshotDto.ts
@@ -2,7 +2,7 @@
  * Custom project の undo に必要な rich field を保持する application DTO。
  * storage/repository の raw 型を presentation へ公開しないための境界型。
  */
-export interface SavedTabsCustomProjectRawSnapshotDto {
+export type SavedTabsCustomProjectRawSnapshotDto = {
   readonly id: string
   readonly name: string
   readonly categories: readonly string[]

--- a/src/contexts/saved-tabs/application/dto/SavedTabsPresentationDto.ts
+++ b/src/contexts/saved-tabs/application/dto/SavedTabsPresentationDto.ts
@@ -1,4 +1,4 @@
-export interface SavedTabsAiSystemPromptDto {
+export type SavedTabsAiSystemPromptDto = {
   readonly id: string
   readonly name: string
   readonly template: string
@@ -6,13 +6,13 @@ export interface SavedTabsAiSystemPromptDto {
   readonly updatedAt: number
 }
 
-export interface SavedTabsProjectKeywordSettingsDto {
+export type SavedTabsProjectKeywordSettingsDto = {
   titleKeywords: string[]
   urlKeywords: string[]
   domainKeywords: string[]
 }
 
-export interface SavedTabsCustomProjectUrlDto {
+export type SavedTabsCustomProjectUrlDto = {
   id?: string
   url: string
   title: string
@@ -21,7 +21,7 @@ export interface SavedTabsCustomProjectUrlDto {
   category?: string
 }
 
-export interface SavedTabsUserSettingsDto {
+export type SavedTabsUserSettingsDto = {
   language?: 'system' | 'ja' | 'en'
   removeTabAfterOpen: boolean
   removeTabAfterExternalDrop: boolean
@@ -46,7 +46,7 @@ export interface SavedTabsUserSettingsDto {
   activeAiSystemPromptId?: string
 }
 
-export interface SavedTabsCustomProjectDto {
+export type SavedTabsCustomProjectDto = {
   id: string
   name: string
   urlIds?: string[]
@@ -59,19 +59,19 @@ export interface SavedTabsCustomProjectDto {
   categoryOrder?: string[]
 }
 
-export interface SavedTabsParentCategoryDto {
+export type SavedTabsParentCategoryDto = {
   readonly id: string
   readonly name: string
   readonly domains: readonly string[]
   readonly domainNames: readonly string[]
 }
 
-export interface SavedTabsCategoryKeywordDto {
+export type SavedTabsCategoryKeywordDto = {
   categoryName: string
   keywords: string[]
 }
 
-export interface SavedTabsTabGroupDto {
+export type SavedTabsTabGroupDto = {
   id: string
   domain: string
   urlIds?: string[]
@@ -85,7 +85,7 @@ export interface SavedTabsTabGroupDto {
   urls?: SavedTabsDisplayUrlDto[]
 }
 
-export interface SavedTabsDisplayUrlDto {
+export type SavedTabsDisplayUrlDto = {
   id?: string
   url: string
   title: string
@@ -93,7 +93,7 @@ export interface SavedTabsDisplayUrlDto {
   savedAt?: number
 }
 
-export interface SavedTabsDisplayCategoryKeywordDto {
+export type SavedTabsDisplayCategoryKeywordDto = {
   categoryName: string
   keywords: string[]
 }
@@ -103,7 +103,7 @@ export interface SavedTabsDisplayCategoryKeywordDto {
  * This is separate from `SavedTabsTabGroupDto`, whose `urlIds` are guaranteed
  * by the domain entity mapper.
  */
-export interface SavedTabsDisplayTabGroupDto {
+export type SavedTabsDisplayTabGroupDto = {
   id: string
   domain: string
   parentCategoryId?: string
@@ -117,7 +117,7 @@ export interface SavedTabsDisplayTabGroupDto {
   savedAt?: number
 }
 
-export interface SavedTabsUrlRecordDto {
+export type SavedTabsUrlRecordDto = {
   readonly id: string
   readonly url: string
   readonly title: string

--- a/src/contexts/saved-tabs/application/ports/BrowserTabPort.ts
+++ b/src/contexts/saved-tabs/application/ports/BrowserTabPort.ts
@@ -16,7 +16,7 @@
  * console.log(opened.url)
  * ```
  */
-export interface BrowserTabPort {
+export type BrowserTabPort = {
   /**
    * 指定 URL を新規タブ / 既存タブで開き、開いた URL を返す。
    *

--- a/src/contexts/saved-tabs/application/ports/BrowserWindowPort.ts
+++ b/src/contexts/saved-tabs/application/ports/BrowserWindowPort.ts
@@ -17,7 +17,7 @@
  * console.log(result.urls)
  * ```
  */
-export interface BrowserWindowPort {
+export type BrowserWindowPort = {
   /**
    * 指定 URL 群を 1 つの新規ウィンドウでまとめて開き、
    * 開いた URL 配列を返す。

--- a/src/contexts/saved-tabs/application/ports/CategoriesCommandService.ts
+++ b/src/contexts/saved-tabs/application/ports/CategoriesCommandService.ts
@@ -26,7 +26,7 @@ import type { SubCategoryKeywordDto } from '@/contexts/saved-tabs/domain/dto/Dom
  * `@/types/storage.SubCategoryKeyword` ではなく domain DTO
  * `SubCategoryKeywordDto` を使う (issue #511)。
  */
-export interface CategoriesCommandService {
+export type CategoriesCommandService = {
   /**
    * 旧 `lib/storage/categories.updateDomainCategorySettings` の port 版。
    * 単一ドメインの `DomainCategorySettings` を upsert する。

--- a/src/contexts/saved-tabs/application/ports/CategoryAssignmentPort.ts
+++ b/src/contexts/saved-tabs/application/ports/CategoryAssignmentPort.ts
@@ -31,7 +31,7 @@ import type {
  * / `TabGroup`) の配列を永続化する。entity バリデーションや storage shape
  * への写像は実装側に閉じ込め、presentation 層は配列をそのまま渡せる。
  */
-export interface CategoryAssignmentPort {
+export type CategoryAssignmentPort = {
   /**
    * 旧 `@/lib/storage/categories.saveParentCategories` の port 版。
    * `parentCategoryRepository.saveAll` へ委譲する薄いラッパ。

--- a/src/contexts/saved-tabs/application/ports/ClockPort.ts
+++ b/src/contexts/saved-tabs/application/ports/ClockPort.ts
@@ -16,6 +16,6 @@
  * const savedAt = createSavedAt(now)
  * ```
  */
-export interface ClockPort {
+export type ClockPort = {
   readonly now: () => number
 }

--- a/src/contexts/saved-tabs/application/ports/CustomProjectsCommandService.ts
+++ b/src/contexts/saved-tabs/application/ports/CustomProjectsCommandService.ts
@@ -24,7 +24,7 @@ import type {
   SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings,
 } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
-export interface CustomProjectsCommandService {
+export type CustomProjectsCommandService = {
   /**
    * 旧 `addCategoryToProject` の port 版。カテゴリが既に存在する場合は
    * no-op。`categoryOrder` 末尾に追加する。

--- a/src/contexts/saved-tabs/application/ports/MessagingPort.ts
+++ b/src/contexts/saved-tabs/application/ports/MessagingPort.ts
@@ -63,7 +63,7 @@ export type ExternalDragMessage = UrlDragStartedMessage | UrlDroppedMessage
  * 留める。`removedCount` / `error` などを必要になった時点で
  * discriminated union として拡張する。
  */
-export interface MessagingPortResponse {
+export type MessagingPortResponse = {
   readonly status: string
   readonly success?: boolean
 }
@@ -79,7 +79,7 @@ export interface MessagingPortResponse {
  * ようにする。`getApi` が undefined を返した environment では
  * 早期 return で `undefined` を返す。
  */
-export interface MessagingPort {
+export type MessagingPort = {
   /**
    * `chrome` 由来の port 実装に付くマーカー。
    *

--- a/src/contexts/saved-tabs/application/ports/MigrationPort.ts
+++ b/src/contexts/saved-tabs/application/ports/MigrationPort.ts
@@ -9,7 +9,7 @@
  * 実装は `infrastructure/persistence/chrome-storage/ChromeMigrationAdapter`
  * 側に置く。テストでは in-memory adapter を注入できる。
  */
-export interface MigrationPort {
+export type MigrationPort = {
   /**
    * `urls` 形式へのマイグレーションを冪等に実行する。`urlsMigrationCompleted`
    * フラグを見て未実行なら storage データを更新する。

--- a/src/contexts/saved-tabs/application/ports/NotificationPort.ts
+++ b/src/contexts/saved-tabs/application/ports/NotificationPort.ts
@@ -19,7 +19,7 @@
  * })
  * ```
  */
-export interface NotificationAction {
+export type NotificationAction = {
   readonly label: string
   /**
    * ユーザーが通知の action をクリックしたときに呼ばれる副作用。
@@ -28,7 +28,7 @@ export interface NotificationAction {
   readonly onClick: () => void | Promise<void>
 }
 
-export interface NotificationMessage {
+export type NotificationMessage = {
   readonly message: string
   readonly action?: NotificationAction
 }
@@ -40,7 +40,7 @@ export interface NotificationMessage {
  * 分ける。port 実装が `success` を `info` に丸めても問題ないが、info を
  * success に昇格させないこと（呼び出し側の意図が変わる）。
  */
-export interface NotificationPort {
+export type NotificationPort = {
   info: (input: NotificationMessage) => void
   success: (input: NotificationMessage) => void
   error: (input: NotificationMessage) => void

--- a/src/contexts/saved-tabs/application/ports/RemoveSubCategoryFromTabGroupPort.ts
+++ b/src/contexts/saved-tabs/application/ports/RemoveSubCategoryFromTabGroupPort.ts
@@ -26,7 +26,7 @@
  */
 import type { SavedTabsTabGroupDto as TabGroup } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
-export interface RemoveSubCategoryFromTabGroupPort {
+export type RemoveSubCategoryFromTabGroupPort = {
   /**
    * 指定 `groupId` の `TabGroup` から `categoryName` を 1 件削除し、
    * 永続化する。

--- a/src/contexts/saved-tabs/application/ports/SavedTabsPresentationPorts.ts
+++ b/src/contexts/saved-tabs/application/ports/SavedTabsPresentationPorts.ts
@@ -5,7 +5,7 @@ import type { MigrationPort } from './MigrationPort'
 import type { StorageChangePort } from './StorageChangePort'
 
 /** Non-persistence ports that the saved-tabs presentation layer may invoke. */
-export interface SavedTabsPresentationPorts {
+export type SavedTabsPresentationPorts = {
   readonly browserTabPort: BrowserTabPort
   readonly categoryAssignmentPort: CategoryAssignmentPort
   readonly messagingPort: MessagingPort

--- a/src/contexts/saved-tabs/application/ports/SavedTabsTabGroupReadPort.ts
+++ b/src/contexts/saved-tabs/application/ports/SavedTabsTabGroupReadPort.ts
@@ -1,6 +1,6 @@
 import type { SavedTabsDisplayTabGroupDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
 /** Read-only projection that preserves saved-tabs display metadata. */
-export interface SavedTabsTabGroupReadPort {
+export type SavedTabsTabGroupReadPort = {
   readonly findAll: () => Promise<readonly SavedTabsDisplayTabGroupDto[]>
 }

--- a/src/contexts/saved-tabs/application/ports/SetCategoryKeywordsPort.ts
+++ b/src/contexts/saved-tabs/application/ports/SetCategoryKeywordsPort.ts
@@ -20,7 +20,7 @@
  * 実装は `src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/`
  * 配下に置く。
  */
-export interface SetCategoryKeywordsPort {
+export type SetCategoryKeywordsPort = {
   /**
    * 旧 `src/lib/storage/tabs.setCategoryKeywords` の port 版。
    *

--- a/src/contexts/saved-tabs/application/ports/StorageChangePort.ts
+++ b/src/contexts/saved-tabs/application/ports/StorageChangePort.ts
@@ -72,7 +72,7 @@ export type SavedTabsStorageChangeKey =
  * `TypedSavedTabsStorageChange` を使う。新規実装では unknown 形のこの型を
  * 直接扱わないこと。
  */
-export interface SavedTabsStorageChange {
+export type SavedTabsStorageChange = {
   readonly key: SavedTabsStorageChangeKey
   readonly oldValue: unknown
   readonly newValue: unknown
@@ -144,7 +144,7 @@ export type TypedSavedTabsStorageChange =
  * 持つ場合はリークしないよう、返り値の unsubscribe 関数を必ず
  * 呼び出すこと。
  */
-export interface StorageChangePort {
+export type StorageChangePort = {
   /**
    * `chrome` 由来の port 実装に付くマーカー。
    *

--- a/src/contexts/saved-tabs/application/queries/GetCustomProjectOrderQuery.ts
+++ b/src/contexts/saved-tabs/application/queries/GetCustomProjectOrderQuery.ts
@@ -19,7 +19,7 @@ export type GetCustomProjectOrderQuery = () => Promise<readonly string[]>
 /**
  * `GetCustomProjectOrderQuery` が依存する repository 群。
  */
-export interface GetCustomProjectOrderQueryDeps {
+export type GetCustomProjectOrderQueryDeps = {
   readonly customProjectRepository: CustomProjectRepository
 }
 

--- a/src/contexts/saved-tabs/application/queries/GetCustomProjectRawsQuery.ts
+++ b/src/contexts/saved-tabs/application/queries/GetCustomProjectRawsQuery.ts
@@ -26,7 +26,7 @@ export type GetCustomProjectRawsQuery = () => Promise<
 /**
  * `GetCustomProjectRawsQuery` が依存する repository 群。
  */
-export interface GetCustomProjectRawsQueryDeps {
+export type GetCustomProjectRawsQueryDeps = {
   readonly customProjectRepository: CustomProjectRepository
 }
 

--- a/src/contexts/saved-tabs/application/queries/GetCustomProjectUndoSnapshotQuery.ts
+++ b/src/contexts/saved-tabs/application/queries/GetCustomProjectUndoSnapshotQuery.ts
@@ -22,7 +22,7 @@ import type {
  * `RestoreCustomProjectsSnapshotUseCase` 側で payload 化してから
  * `customProjectRepository.restoreAllRaw` / `saveAll` に渡す。
  */
-export interface CustomProjectUndoSnapshot {
+export type CustomProjectUndoSnapshot = {
   customProjectOrder?: readonly string[]
   customProjects?: readonly SavedTabsCustomProjectDto[]
   customProjectsRaw?: readonly SavedTabsCustomProjectRawSnapshotDto[]
@@ -48,7 +48,7 @@ export type GetCustomProjectUndoSnapshotQuery =
 /**
  * `GetCustomProjectUndoSnapshotQuery` が依存する repository 群。
  */
-export interface GetCustomProjectUndoSnapshotQueryDeps {
+export type GetCustomProjectUndoSnapshotQueryDeps = {
   readonly customProjectRepository: CustomProjectRepository
 }
 

--- a/src/contexts/saved-tabs/application/queries/GetCustomProjectsQuery.ts
+++ b/src/contexts/saved-tabs/application/queries/GetCustomProjectsQuery.ts
@@ -22,7 +22,7 @@ export type GetCustomProjectsQuery = () => Promise<
 /**
  * `GetCustomProjectsQuery` が依存する repository 群。
  */
-export interface GetCustomProjectsQueryDeps {
+export type GetCustomProjectsQueryDeps = {
   readonly customProjectRepository: CustomProjectRepository
 }
 

--- a/src/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery.ts
+++ b/src/contexts/saved-tabs/application/queries/GetSavedTabsPageDataQuery.ts
@@ -24,7 +24,7 @@ import type { UserSettingsRepository } from '@/contexts/saved-tabs/domain/reposi
  * domain DTO `UserSettingsDto` を返す (issue #511)。
  * `tabGroups` / `parentCategories` は branded domain entity のまま。
  */
-export interface SavedTabsPageDataDto {
+export type SavedTabsPageDataDto = {
   readonly tabGroups: readonly SavedTabsDisplayTabGroupDto[]
   readonly parentCategories: readonly SavedTabsParentCategoryDto[]
   readonly userSettings: SavedTabsUserSettingsDto
@@ -38,7 +38,7 @@ export type GetSavedTabsPageDataQuery = () => Promise<SavedTabsPageDataDto>
 /**
  * `GetSavedTabsPageDataQuery` が依存する repository 群。
  */
-export interface GetSavedTabsPageDataQueryDeps {
+export type GetSavedTabsPageDataQueryDeps = {
   readonly tabGroupReadPort: SavedTabsTabGroupReadPort
   readonly parentCategoryRepository: ParentCategoryRepository
   readonly userSettingsRepository: UserSettingsRepository

--- a/src/contexts/saved-tabs/application/queries/GetSavedTabsQuery.ts
+++ b/src/contexts/saved-tabs/application/queries/GetSavedTabsQuery.ts
@@ -22,7 +22,7 @@ export type GetSavedTabsQuery = () => Promise<readonly SavedTabsTabGroupDto[]>
 /**
  * `GetSavedTabsQuery` が依存する repository 群。
  */
-export interface GetSavedTabsQueryDeps {
+export type GetSavedTabsQueryDeps = {
   readonly tabGroupRepository: TabGroupRepository
 }
 

--- a/src/contexts/saved-tabs/application/services/ParentCategoryReorderService.ts
+++ b/src/contexts/saved-tabs/application/services/ParentCategoryReorderService.ts
@@ -11,7 +11,7 @@
  * 「並び替えモードの一時配列」または「確定済み配列」のどちらから
  * 読み出すかを引数で切り替える。
  */
-export interface BuildReorderedCategoryOrderParams {
+export type BuildReorderedCategoryOrderParams = {
   readonly activeId: string
   readonly overId: string
   /**

--- a/src/contexts/saved-tabs/application/services/SavedTabsCategorizationService.ts
+++ b/src/contexts/saved-tabs/application/services/SavedTabsCategorizationService.ts
@@ -21,7 +21,7 @@ import type {
  * `@/types/storage` への依存を避け、domain DTO のみで lookup を構築
  * する (issue #511)。
  */
-export interface PresentationCategoryLookup {
+export type PresentationCategoryLookup = {
   readonly byId: ReadonlyMap<string, ParentCategoryDto>
   readonly byGroupId: ReadonlyMap<string, ParentCategoryDto>
   readonly byDomainName: ReadonlyMap<string, ParentCategoryDto>

--- a/src/contexts/saved-tabs/application/use-cases/AddCategoryToCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/AddCategoryToCustomProjectUseCase.ts
@@ -4,7 +4,7 @@ import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/applica
 /**
  * `AddCategoryToCustomProjectUseCase` が依存する port。
  */
-export interface AddCategoryToCustomProjectUseCaseDeps {
+export type AddCategoryToCustomProjectUseCaseDeps = {
   readonly customProjectsCommandService: CustomProjectsCommandService
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/AddDomainToParentCategoryUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/AddDomainToParentCategoryUseCase.ts
@@ -12,7 +12,7 @@ import { createTabGroupId } from '@/contexts/saved-tabs/domain/value-objects/Tab
 /**
  * `AddDomainToParentCategoryUseCase` が依存する repository 群。
  */
-export interface AddDomainToParentCategoryUseCaseDeps {
+export type AddDomainToParentCategoryUseCaseDeps = {
   readonly parentCategoryRepository: ParentCategoryRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/AddUrlToCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/AddUrlToCustomProjectUseCase.ts
@@ -4,7 +4,7 @@ import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/applica
 /**
  * `AddUrlToCustomProjectUseCase` が依存する port。
  */
-export interface AddUrlToCustomProjectUseCaseDeps {
+export type AddUrlToCustomProjectUseCaseDeps = {
   readonly customProjectsCommandService: CustomProjectsCommandService
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/AssignDomainToCategoryUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/AssignDomainToCategoryUseCase.ts
@@ -16,7 +16,7 @@ import { createTabGroupId } from '@/contexts/saved-tabs/domain/value-objects/Tab
  * 取り除きのみを行い、対象カテゴリの `domains` / `domainNames` には
  * 追加しない。
  */
-export interface AssignDomainToCategoryCommand {
+export type AssignDomainToCategoryCommand = {
   readonly domainId: string
   readonly categoryId: string
 }
@@ -27,7 +27,7 @@ export interface AssignDomainToCategoryCommand {
  */
 const UNCATEGORIZED_SENTINEL = 'none'
 
-export interface AssignDomainToCategoryResult {
+export type AssignDomainToCategoryResult = {
   readonly all: readonly SavedTabsParentCategoryDto[]
   readonly mappings: readonly { domain: string; categoryId: string }[]
 }
@@ -42,7 +42,7 @@ export type AssignDomainToCategoryUseCase = (
 /**
  * `AssignDomainToCategoryUseCase` が必要とする依存。
  */
-export interface AssignDomainToCategoryUseCaseDeps {
+export type AssignDomainToCategoryUseCaseDeps = {
   readonly parentCategoryRepository: ParentCategoryRepository
   readonly domainCategoryMappingRepository: DomainCategoryMappingRepository
   readonly tabGroupRepository: TabGroupRepository

--- a/src/contexts/saved-tabs/application/use-cases/BuildSavedTabsSnapshotUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/BuildSavedTabsSnapshotUseCase.test.ts
@@ -13,7 +13,7 @@ import { createCustomProjectId } from '@/contexts/saved-tabs/domain/value-object
 import type { BuildSavedTabsSnapshotUseCaseDeps } from './BuildSavedTabsSnapshotUseCase'
 import { createBuildSavedTabsSnapshotUseCase } from './BuildSavedTabsSnapshotUseCase'
 
-interface Repositories extends BuildSavedTabsSnapshotUseCaseDeps {
+type Repositories = BuildSavedTabsSnapshotUseCaseDeps & {
   tabGroups: ReturnType<typeof createTabGroup>[]
   customProjects: ReturnType<typeof createCustomProject>[]
   customProjectOrder: ReturnType<typeof createCustomProjectId>[]

--- a/src/contexts/saved-tabs/application/use-cases/BuildSavedTabsSnapshotUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/BuildSavedTabsSnapshotUseCase.ts
@@ -20,7 +20,7 @@ import type { UrlRecordRepository } from '@/contexts/saved-tabs/domain/repositor
  * `urlRecordRepository` は Undo 時に削除された `UrlRecord` を復元するため
  * 必須 (Codex レビュー対応: P1 / issue #494)。
  */
-export interface BuildSavedTabsSnapshotUseCaseDeps {
+export type BuildSavedTabsSnapshotUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly customProjectRepository: CustomProjectRepository
   readonly parentCategoryRepository: ParentCategoryRepository

--- a/src/contexts/saved-tabs/application/use-cases/CreateCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/CreateCustomProjectUseCase.ts
@@ -10,11 +10,11 @@ import type { CustomProjectRepository } from '@/contexts/saved-tabs/domain/repos
 /**
  * `CreateCustomProjectUseCase` の入力。
  */
-export interface CreateCustomProjectCommand {
+export type CreateCustomProjectCommand = {
   readonly name: string
 }
 
-export interface CreateCustomProjectResult {
+export type CreateCustomProjectResult = {
   readonly all: readonly SavedTabsCustomProjectDto[]
   readonly project: SavedTabsCustomProjectDto
 }
@@ -23,7 +23,7 @@ export type CreateCustomProjectUseCase = (
   command: CreateCustomProjectCommand,
 ) => Promise<CreateCustomProjectResult>
 
-export interface CreateCustomProjectUseCaseDeps {
+export type CreateCustomProjectUseCaseDeps = {
   readonly customProjectRepository: CustomProjectRepository
   readonly clock: ClockPort
   readonly generateId?: () => string

--- a/src/contexts/saved-tabs/application/use-cases/CreateParentCategoryUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/CreateParentCategoryUseCase.ts
@@ -12,11 +12,11 @@ import { createParentCategoryId } from '@/contexts/saved-tabs/domain/value-objec
  * `ParentCategory` を生成する。重複チェックは use-case 側で行う
  * （同名カテゴリの存在を `findAll` で確認）。
  */
-export interface CreateParentCategoryCommand {
+export type CreateParentCategoryCommand = {
   readonly name: string
 }
 
-export interface CreateParentCategoryResult {
+export type CreateParentCategoryResult = {
   readonly category: SavedTabsParentCategoryDto
   readonly all: readonly SavedTabsParentCategoryDto[]
 }
@@ -33,7 +33,7 @@ export type CreateParentCategoryUseCase = (
 /**
  * `CreateParentCategoryUseCase` が必要とする依存。
  */
-export interface CreateParentCategoryUseCaseDeps {
+export type CreateParentCategoryUseCaseDeps = {
   readonly parentCategoryRepository: ParentCategoryRepository
   /**
    * 新しい `ParentCategory.id` を採番する port。`uuid v4` 固定だと

--- a/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteCustomProjectUseCase.ts
@@ -16,11 +16,11 @@ import type {
  * 「未分類」プロジェクトへマージされ、storage 上から消えるわけではない
  * （旧 `lib/storage/projects.deleteCustomProject` の挙動を踏襲）。
  */
-export interface DeleteCustomProjectCommand {
+export type DeleteCustomProjectCommand = {
   readonly projectId: string
 }
 
-export interface DeleteCustomProjectResult {
+export type DeleteCustomProjectResult = {
   readonly all: readonly SavedTabsCustomProjectDto[]
 }
 
@@ -28,7 +28,7 @@ export type DeleteCustomProjectUseCase = (
   command: DeleteCustomProjectCommand,
 ) => Promise<DeleteCustomProjectResult>
 
-export interface DeleteCustomProjectUseCaseDeps {
+export type DeleteCustomProjectUseCaseDeps = {
   readonly customProjectRepository: CustomProjectRepository
   readonly uncategorizedProjectId: string
   /**

--- a/src/contexts/saved-tabs/application/use-cases/DeleteParentCategoryUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteParentCategoryUseCase.ts
@@ -11,11 +11,11 @@ import type { ParentCategoryId } from '@/contexts/saved-tabs/domain/value-object
  *
  * 削除対象カテゴリの ID のみを受け取る。
  */
-export interface DeleteParentCategoryCommand {
+export type DeleteParentCategoryCommand = {
   readonly categoryId: string
 }
 
-export interface DeleteParentCategoryResult {
+export type DeleteParentCategoryResult = {
   readonly all: readonly SavedTabsParentCategoryDto[]
   readonly removedCategory: SavedTabsParentCategoryDto
 }
@@ -36,7 +36,7 @@ export type DeleteParentCategoryUseCase = (
  * `parentCategoryRepository.removeByIds` と同じ最小削除挙動を維持する
  * （presentation 側の既存挙動との互換性確保）。
  */
-export interface DeleteParentCategoryUseCaseDeps {
+export type DeleteParentCategoryUseCaseDeps = {
   readonly parentCategoryRepository: ParentCategoryRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.test.ts
@@ -11,7 +11,7 @@ import type { UrlRecordRepository } from '@/contexts/saved-tabs/domain/repositor
 import type { DeleteSavedUrlUseCaseDeps } from './DeleteSavedUrlUseCase'
 import { createDeleteSavedUrlUseCase } from './DeleteSavedUrlUseCase'
 
-interface Repositories {
+type Repositories = {
   tabGroupRepository: TabGroupRepository
   urlRecordRepository: UrlRecordRepository
   customProjectRepository: CustomProjectRepository

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlUseCase.ts
@@ -19,7 +19,7 @@ import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/Url
 /**
  * `DeleteSavedUrlUseCase` が依存する repository 群。
  */
-export interface DeleteSavedUrlUseCaseDeps {
+export type DeleteSavedUrlUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly urlRecordRepository: UrlRecordRepository
   readonly customProjectRepository: CustomProjectRepository

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.test.ts
@@ -11,7 +11,7 @@ import type { UrlRecordRepository } from '@/contexts/saved-tabs/domain/repositor
 import type { DeleteSavedUrlsUseCaseDeps } from './DeleteSavedUrlsUseCase'
 import { createDeleteSavedUrlsUseCase } from './DeleteSavedUrlsUseCase'
 
-interface Repositories {
+type Repositories = {
   tabGroupRepository: TabGroupRepository
   urlRecordRepository: UrlRecordRepository
   customProjectRepository: CustomProjectRepository

--- a/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteSavedUrlsUseCase.ts
@@ -19,7 +19,7 @@ import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/Url
 /**
  * `DeleteSavedUrlsUseCase` が依存する repository 群。
  */
-export interface DeleteSavedUrlsUseCaseDeps {
+export type DeleteSavedUrlsUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly urlRecordRepository: UrlRecordRepository
   readonly customProjectRepository: CustomProjectRepository

--- a/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupUseCase.ts
@@ -18,7 +18,7 @@ import { createTabGroupId } from '@/contexts/saved-tabs/domain/value-objects/Tab
  * テスト時は in-memory mock を注入する。`chrome.storage.local` への
  * 依存を排除した unit test を書けるように、interface のみを公開する。
  */
-export interface DeleteTabGroupUseCaseDeps {
+export type DeleteTabGroupUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly urlRecordRepository: UrlRecordRepository
   readonly customProjectRepository: CustomProjectRepository

--- a/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupsUseCase.test.ts
@@ -12,7 +12,7 @@ import type { UrlRecordRepository } from '@/contexts/saved-tabs/domain/repositor
 import type { DeleteTabGroupsUseCaseDeps } from './DeleteTabGroupsUseCase'
 import { createDeleteTabGroupsUseCase } from './DeleteTabGroupsUseCase'
 
-interface Repositories {
+type Repositories = {
   tabGroupRepository: TabGroupRepository
   urlRecordRepository: UrlRecordRepository
   customProjectRepository: CustomProjectRepository

--- a/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/DeleteTabGroupsUseCase.ts
@@ -18,7 +18,7 @@ import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabG
 /**
  * `DeleteTabGroupsUseCase` が依存する repository 群。
  */
-export interface DeleteTabGroupsUseCaseDeps {
+export type DeleteTabGroupsUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly urlRecordRepository: UrlRecordRepository
   readonly customProjectRepository: CustomProjectRepository

--- a/src/contexts/saved-tabs/application/use-cases/FindUrlRecordByUrlUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/FindUrlRecordByUrlUseCase.ts
@@ -5,7 +5,7 @@ import type { UrlRecordRepository } from '@/contexts/saved-tabs/domain/repositor
 /**
  * `FindUrlRecordByUrlUseCase` が依存する repository 群。
  */
-export interface FindUrlRecordByUrlUseCaseDeps {
+export type FindUrlRecordByUrlUseCaseDeps = {
   readonly urlRecordRepository: UrlRecordRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase.ts
@@ -14,7 +14,7 @@ import { createUrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/Ur
  * 結合した presentation 形。`@/lib/storage/projects.getProjectUrls` の
  * 出力型を DDD 化した。
  */
-export interface ProjectUrlEntry {
+export type ProjectUrlEntry = {
   readonly id: string
   readonly url: string
   readonly title: string
@@ -43,7 +43,7 @@ export type GetProjectUrlsUseCase = (
 /**
  * `GetProjectUrlsUseCase` が必要とする依存。
  */
-export interface GetProjectUrlsUseCaseDeps {
+export type GetProjectUrlsUseCaseDeps = {
   readonly urlRecordRepository: UrlRecordRepository
   /**
    * `project.urlMetadata` を取得するために必要。`findAllRaw` を持つ

--- a/src/contexts/saved-tabs/application/use-cases/LoadTabGroupUrlsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/LoadTabGroupUrlsUseCase.ts
@@ -10,7 +10,7 @@ import { urlRecordIdToString } from '@/contexts/saved-tabs/domain/value-objects/
  * テスト時は in-memory mock を注入する。`chrome.storage.local` への
  * 依存を排除した unit test を書けるように、interface のみを公開する。
  */
-export interface LoadTabGroupUrlsUseCaseDeps {
+export type LoadTabGroupUrlsUseCaseDeps = {
   readonly urlRecordRepository: UrlRecordRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/LoadTabGroupsWithUrlsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/LoadTabGroupsWithUrlsUseCase.ts
@@ -9,7 +9,7 @@ import { resolveTabGroupsWithUrls } from '@/contexts/saved-tabs/domain/services/
  * テスト時は in-memory mock を注入する。`chrome.storage.local` への
  * 依存を排除した unit test を書けるように、interface のみを公開する。
  */
-export interface LoadTabGroupsWithUrlsUseCaseDeps {
+export type LoadTabGroupsWithUrlsUseCaseDeps = {
   readonly urlRecordRepository: UrlRecordRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/MoveDomainBetweenCategoriesUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/MoveDomainBetweenCategoriesUseCase.ts
@@ -9,7 +9,7 @@ import { createTabGroupId } from '@/contexts/saved-tabs/domain/value-objects/Tab
 /**
  * `MoveDomainBetweenCategoriesUseCase` が依存する repository 群。
  */
-export interface MoveDomainBetweenCategoriesUseCaseDeps {
+export type MoveDomainBetweenCategoriesUseCaseDeps = {
   readonly parentCategoryRepository: ParentCategoryRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/MoveUrlBetweenCustomProjectsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/MoveUrlBetweenCustomProjectsUseCase.ts
@@ -4,7 +4,7 @@ import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/applica
 /**
  * `MoveUrlBetweenCustomProjectsUseCase` が依存する port。
  */
-export interface MoveUrlBetweenCustomProjectsUseCaseDeps {
+export type MoveUrlBetweenCustomProjectsUseCaseDeps = {
   readonly customProjectsCommandService: CustomProjectsCommandService
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/OpenAllSavedUrlsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/OpenAllSavedUrlsUseCase.test.ts
@@ -11,7 +11,7 @@ import type { UrlRecordRepository } from '@/contexts/saved-tabs/domain/repositor
 
 import { createOpenAllSavedUrlsUseCase } from './OpenAllSavedUrlsUseCase'
 
-interface Repositories {
+type Repositories = {
   tabGroupRepository: TabGroupRepository
   urlRecordRepository: UrlRecordRepository
   customProjectRepository: CustomProjectRepository

--- a/src/contexts/saved-tabs/application/use-cases/OpenAllSavedUrlsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/OpenAllSavedUrlsUseCase.ts
@@ -24,7 +24,7 @@ import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/Url
 /**
  * `OpenAllSavedUrlsUseCase` が依存する repository / port 群。
  */
-export interface OpenAllSavedUrlsUseCaseDeps {
+export type OpenAllSavedUrlsUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly urlRecordRepository: UrlRecordRepository
   readonly customProjectRepository: CustomProjectRepository
@@ -39,7 +39,7 @@ export type OpenAllSavedUrlsUseCase = (
   command: OpenAllSavedUrlsCommand,
 ) => Promise<OpenedUrlsDto>
 
-interface RemovalPlan {
+type RemovalPlan = {
   readonly previousTabGroups: readonly TabGroup[]
   readonly previousCustomProjects: readonly CustomProject[]
   readonly removedUrlRecords: readonly UrlRecord[]

--- a/src/contexts/saved-tabs/application/use-cases/OpenSavedUrlUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/OpenSavedUrlUseCase.test.ts
@@ -11,7 +11,7 @@ import type { UrlRecordRepository } from '@/contexts/saved-tabs/domain/repositor
 
 import { createOpenSavedUrlUseCase } from './OpenSavedUrlUseCase'
 
-interface Repositories {
+type Repositories = {
   tabGroupRepository: TabGroupRepository
   urlRecordRepository: UrlRecordRepository
   customProjectRepository: CustomProjectRepository

--- a/src/contexts/saved-tabs/application/use-cases/OpenSavedUrlUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/OpenSavedUrlUseCase.ts
@@ -22,7 +22,7 @@ import { createUrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/Ur
 /**
  * `OpenSavedUrlUseCase` が依存する repository / port 群。
  */
-export interface OpenSavedUrlUseCaseDeps {
+export type OpenSavedUrlUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly urlRecordRepository: UrlRecordRepository
   readonly customProjectRepository: CustomProjectRepository

--- a/src/contexts/saved-tabs/application/use-cases/PrepareTabGroupDeletionUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/PrepareTabGroupDeletionUseCase.test.ts
@@ -113,7 +113,7 @@ const createCategoriesCommandServiceMock = (): {
   return { service, updateDomainCategorySettings }
 }
 
-interface Bundle {
+type Bundle = {
   readonly deps: PrepareTabGroupDeletionUseCaseDeps
   readonly tabGroupRepository: TabGroupRepository
   readonly parentCategoryRepository: ParentCategoryRepository

--- a/src/contexts/saved-tabs/application/use-cases/PrepareTabGroupDeletionUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/PrepareTabGroupDeletionUseCase.ts
@@ -13,7 +13,7 @@ import { createTabGroupId } from '@/contexts/saved-tabs/domain/value-objects/Tab
  * テスト時は in-memory mock を注入する。`chrome.storage.local` への
  * 依存を排除した unit test を書けるように、interface のみを公開する。
  */
-export interface PrepareTabGroupDeletionUseCaseDeps {
+export type PrepareTabGroupDeletionUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly parentCategoryRepository: ParentCategoryRepository
   readonly domainCategoryMappingRepository: DomainCategoryMappingRepository

--- a/src/contexts/saved-tabs/application/use-cases/RemoveCategoryFromCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveCategoryFromCustomProjectUseCase.ts
@@ -4,7 +4,7 @@ import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/applica
 /**
  * `RemoveCategoryFromCustomProjectUseCase` が依存する port。
  */
-export interface RemoveCategoryFromCustomProjectUseCaseDeps {
+export type RemoveCategoryFromCustomProjectUseCaseDeps = {
   readonly customProjectsCommandService: CustomProjectsCommandService
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/RemoveDomainFromParentCategoryUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveDomainFromParentCategoryUseCase.ts
@@ -12,7 +12,7 @@ import { createTabGroupId } from '@/contexts/saved-tabs/domain/value-objects/Tab
 /**
  * `RemoveDomainFromParentCategoryUseCase` が依存する repository 群。
  */
-export interface RemoveDomainFromParentCategoryUseCaseDeps {
+export type RemoveDomainFromParentCategoryUseCaseDeps = {
   readonly parentCategoryRepository: ParentCategoryRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/RemoveDomainsFromParentCategoriesUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveDomainsFromParentCategoriesUseCase.ts
@@ -8,7 +8,7 @@ import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabG
 /**
  * `RemoveDomainsFromParentCategoriesUseCase` が依存する repository 群。
  */
-export interface RemoveDomainsFromParentCategoriesUseCaseDeps {
+export type RemoveDomainsFromParentCategoriesUseCaseDeps = {
   readonly parentCategoryRepository: ParentCategoryRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/RemoveSubCategoryFromTabGroupsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveSubCategoryFromTabGroupsUseCase.ts
@@ -11,7 +11,7 @@ import type { RemoveSubCategoryFromTabGroupPort } from '@/contexts/saved-tabs/ap
  * への依存を排除した unit test を書けるように、 port interface のみ
  * を公開する。
  */
-export interface RemoveSubCategoryFromTabGroupsUseCaseDeps {
+export type RemoveSubCategoryFromTabGroupsUseCaseDeps = {
   readonly removeSubCategoryFromTabGroupPort: RemoveSubCategoryFromTabGroupPort
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/RemoveUnreferencedUrlRecordsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveUnreferencedUrlRecordsUseCase.test.ts
@@ -10,7 +10,7 @@ import type { UrlRecordRepository } from '@/contexts/saved-tabs/domain/repositor
 import type { RemoveUnreferencedUrlRecordsUseCaseDeps } from './RemoveUnreferencedUrlRecordsUseCase'
 import { createRemoveUnreferencedUrlRecordsUseCase } from './RemoveUnreferencedUrlRecordsUseCase'
 
-interface Repositories extends RemoveUnreferencedUrlRecordsUseCaseDeps {
+type Repositories = RemoveUnreferencedUrlRecordsUseCaseDeps & {
   urlRecords: ReturnType<typeof createUrlRecord>[]
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/RemoveUnreferencedUrlRecordsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveUnreferencedUrlRecordsUseCase.ts
@@ -7,7 +7,7 @@ import { filterUnreferencedUrlRecords } from '@/contexts/saved-tabs/domain/servi
 /**
  * `RemoveUnreferencedUrlRecordsUseCase` が依存する repository 群。
  */
-export interface RemoveUnreferencedUrlRecordsUseCaseDeps {
+export type RemoveUnreferencedUrlRecordsUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly urlRecordRepository: UrlRecordRepository
   readonly customProjectRepository: CustomProjectRepository

--- a/src/contexts/saved-tabs/application/use-cases/RemoveUrlFromCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveUrlFromCustomProjectUseCase.ts
@@ -4,7 +4,7 @@ import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/applica
 /**
  * `RemoveUrlFromCustomProjectUseCase` が依存する port。
  */
-export interface RemoveUrlFromCustomProjectUseCaseDeps {
+export type RemoveUrlFromCustomProjectUseCaseDeps = {
   readonly customProjectsCommandService: CustomProjectsCommandService
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/RemoveUrlsFromCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveUrlsFromCustomProjectUseCase.ts
@@ -4,7 +4,7 @@ import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/applica
 /**
  * `RemoveUrlsFromCustomProjectUseCase` が依存する port。
  */
-export interface RemoveUrlsFromCustomProjectUseCaseDeps {
+export type RemoveUrlsFromCustomProjectUseCaseDeps = {
   readonly customProjectsCommandService: CustomProjectsCommandService
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/RemoveUrlsFromCustomProjectsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RemoveUrlsFromCustomProjectsUseCase.ts
@@ -16,7 +16,7 @@ import type { LoadTabGroupUrlsUseCase } from './LoadTabGroupUrlsUseCase'
  * URL 文字列を引くために使う (issue #501 対応で
  * `@/lib/storage/tabs.getTabGroupUrls` 直叩きを撤去した経緯)。
  */
-export interface RemoveUrlsFromCustomProjectsUseCaseDeps {
+export type RemoveUrlsFromCustomProjectsUseCaseDeps = {
   readonly customProjectsCommandService: CustomProjectsCommandService
   readonly loadTabGroupUrls: LoadTabGroupUrlsUseCase
 }

--- a/src/contexts/saved-tabs/application/use-cases/RenameCustomProjectCategoryUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RenameCustomProjectCategoryUseCase.ts
@@ -4,7 +4,7 @@ import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/applica
 /**
  * `RenameCustomProjectCategoryUseCase` が依存する port。
  */
-export interface RenameCustomProjectCategoryUseCaseDeps {
+export type RenameCustomProjectCategoryUseCaseDeps = {
   readonly customProjectsCommandService: CustomProjectsCommandService
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/RenameParentCategoryUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RenameParentCategoryUseCase.ts
@@ -10,7 +10,7 @@ import { createParentCategoryId } from '@/contexts/saved-tabs/domain/value-objec
 /**
  * `RenameParentCategoryUseCase` が依存する repository 群。
  */
-export interface RenameParentCategoryUseCaseDeps {
+export type RenameParentCategoryUseCaseDeps = {
   readonly parentCategoryRepository: ParentCategoryRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/ReorderCustomProjectUrlsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderCustomProjectUrlsUseCase.ts
@@ -4,7 +4,7 @@ import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/applica
 /**
  * `ReorderCustomProjectUrlsUseCase` が依存する port。
  */
-export interface ReorderCustomProjectUrlsUseCaseDeps {
+export type ReorderCustomProjectUrlsUseCaseDeps = {
   readonly customProjectsCommandService: CustomProjectsCommandService
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/ReorderDomainsInCategoryUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderDomainsInCategoryUseCase.ts
@@ -8,7 +8,7 @@ import { createTabGroupId } from '@/contexts/saved-tabs/domain/value-objects/Tab
 /**
  * `ReorderDomainsInCategoryUseCase` が依存する repository 群。
  */
-export interface ReorderDomainsInCategoryUseCaseDeps {
+export type ReorderDomainsInCategoryUseCaseDeps = {
   readonly parentCategoryRepository: ParentCategoryRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/ReorderParentCategoriesUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderParentCategoriesUseCase.ts
@@ -9,7 +9,7 @@ import type { ParentCategoryRepository } from '@/contexts/saved-tabs/domain/repo
  * テスト時は in-memory mock を注入する。`chrome.storage.local` への
  * 依存を排除した unit test を書けるように、interface のみを公開する。
  */
-export interface ReorderParentCategoriesUseCaseDeps {
+export type ReorderParentCategoriesUseCaseDeps = {
   readonly parentCategoryRepository: ParentCategoryRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/ReorderTabGroupUrlsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderTabGroupUrlsUseCase.ts
@@ -10,7 +10,7 @@ import { createUrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/Ur
 /**
  * `ReorderTabGroupUrlsUseCase` が依存する repository 群。
  */
-export interface ReorderTabGroupUrlsUseCaseDeps {
+export type ReorderTabGroupUrlsUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly urlRecordRepository: UrlRecordRepository
 }

--- a/src/contexts/saved-tabs/application/use-cases/ReorderTabGroupsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderTabGroupsUseCase.test.ts
@@ -7,7 +7,7 @@ import type { TabGroupRepository } from '@/contexts/saved-tabs/domain/repositori
 import type { ReorderTabGroupsUseCaseDeps } from './ReorderTabGroupsUseCase'
 import { createReorderTabGroupsUseCase } from './ReorderTabGroupsUseCase'
 
-interface Repositories extends ReorderTabGroupsUseCaseDeps {
+type Repositories = ReorderTabGroupsUseCaseDeps & {
   tabGroups: ReturnType<typeof createTabGroup>[]
   saveAllSpy: ReturnType<typeof vi.fn>
 }

--- a/src/contexts/saved-tabs/application/use-cases/ReorderTabGroupsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ReorderTabGroupsUseCase.ts
@@ -9,7 +9,7 @@ import type { TabGroupRepository } from '@/contexts/saved-tabs/domain/repositori
  * テスト時は in-memory mock を注入する。`chrome.storage.local` への
  * 依存を排除した unit test を書けるように、interface のみを公開する。
  */
-export interface ReorderTabGroupsUseCaseDeps {
+export type ReorderTabGroupsUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/RepairTabGroupParentCategoryIdsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RepairTabGroupParentCategoryIdsUseCase.test.ts
@@ -9,7 +9,7 @@ import type { TabGroupRepository } from '@/contexts/saved-tabs/domain/repositori
 import { createRepairTabGroupParentCategoryIdsUseCase } from './RepairTabGroupParentCategoryIdsUseCase'
 import type { RepairTabGroupParentCategoryIdsUseCaseDeps } from './RepairTabGroupParentCategoryIdsUseCase'
 
-interface Repositories extends RepairTabGroupParentCategoryIdsUseCaseDeps {
+type Repositories = RepairTabGroupParentCategoryIdsUseCaseDeps & {
   tabGroups: ReturnType<typeof createTabGroup>[]
   parentCategories: ReturnType<typeof createParentCategory>[]
 }

--- a/src/contexts/saved-tabs/application/use-cases/RepairTabGroupParentCategoryIdsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RepairTabGroupParentCategoryIdsUseCase.ts
@@ -19,7 +19,7 @@ import { normalizeDomainString } from '@/contexts/saved-tabs/domain/value-object
  * から取得する。`useTabData` 内の初回ロードでは `GetSavedTabsPageDataQuery`
  * で取得した値をそのまま渡す運用を推奨。
  */
-export interface RepairTabGroupParentCategoryIdsCommand {
+export type RepairTabGroupParentCategoryIdsCommand = {
   readonly tabGroups?: readonly SavedTabsDisplayTabGroupDto[]
   readonly parentCategories?: readonly SavedTabsParentCategoryDto[]
 }
@@ -32,7 +32,7 @@ export interface RepairTabGroupParentCategoryIdsCommand {
  * - `updated` : 実際に永続化層の `savedTabs` を書き換えたかどうか。
  *   `false` のときは storage への副作用を発生させない。
  */
-export interface RepairTabGroupParentCategoryIdsDto {
+export type RepairTabGroupParentCategoryIdsDto = {
   readonly tabGroups: readonly SavedTabsDisplayTabGroupDto[]
   readonly updated: boolean
 }
@@ -40,7 +40,7 @@ export interface RepairTabGroupParentCategoryIdsDto {
 /**
  * `RepairTabGroupParentCategoryIdsUseCase` が依存する repository 群。
  */
-export interface RepairTabGroupParentCategoryIdsUseCaseDeps {
+export type RepairTabGroupParentCategoryIdsUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly parentCategoryRepository: ParentCategoryRepository
 }

--- a/src/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreCustomProjectsSnapshotUseCase.ts
@@ -16,7 +16,7 @@ import { createCustomProjectId } from '@/contexts/saved-tabs/domain/value-object
  * 「全消去」セマンティクスを明示するため、呼び出し側で
  * `customProjectOrder ?? []` ではなく省略有無を意識する。
  */
-export interface RestoreCustomProjectsSnapshotPayload {
+export type RestoreCustomProjectsSnapshotPayload = {
   readonly customProjectOrder?: readonly string[]
   readonly customProjects: readonly SavedTabsCustomProjectDto[]
   readonly customProjectsRaw?: readonly SavedTabsCustomProjectRawSnapshotDto[]
@@ -25,7 +25,7 @@ export interface RestoreCustomProjectsSnapshotPayload {
 /**
  * `RestoreCustomProjectsSnapshotUseCase` の入力。
  */
-export interface RestoreCustomProjectsSnapshotCommand {
+export type RestoreCustomProjectsSnapshotCommand = {
   readonly payload: RestoreCustomProjectsSnapshotPayload
 }
 
@@ -41,7 +41,7 @@ export type RestoreCustomProjectsSnapshotUseCase = (
 /**
  * `RestoreCustomProjectsSnapshotUseCase` が依存する repository 群。
  */
-export interface RestoreCustomProjectsSnapshotUseCaseDeps {
+export type RestoreCustomProjectsSnapshotUseCaseDeps = {
   readonly customProjectRepository: CustomProjectRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.test.ts
@@ -19,7 +19,7 @@ import { createCustomProjectId } from '@/contexts/saved-tabs/domain/value-object
 import type { RestoreOpenedUrlsSnapshotUseCaseDeps } from './RestoreOpenedUrlsSnapshotUseCase'
 import { createRestoreOpenedUrlsSnapshotUseCase } from './RestoreOpenedUrlsSnapshotUseCase'
 
-interface Repositories extends RestoreOpenedUrlsSnapshotUseCaseDeps {
+type Repositories = RestoreOpenedUrlsSnapshotUseCaseDeps & {
   tabGroups: ReturnType<typeof createTabGroup>[]
   urlRecords: ReturnType<typeof createUrlRecord>[]
   customProjects: ReturnType<typeof createCustomProject>[]

--- a/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotUseCase.ts
@@ -21,7 +21,7 @@ import type { CustomProjectId } from '@/contexts/saved-tabs/domain/value-objects
  * `ParentCategoryRepository` もオプション扱いとし、snapshot に
  * `parentCategories` が含まれる場合のみ保存する。
  */
-export interface RestoreOpenedUrlsSnapshotUseCaseDeps {
+export type RestoreOpenedUrlsSnapshotUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly urlRecordRepository: UrlRecordRepository
   readonly customProjectRepository: CustomProjectRepository

--- a/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotViewUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/RestoreOpenedUrlsSnapshotViewUseCase.ts
@@ -22,7 +22,7 @@ import type { RestoreOpenedUrlsSnapshotUseCase } from './RestoreOpenedUrlsSnapsh
  * 存在しないとき `undefined` を維持し、UI が意図せず「空配列で全消し」
  * しないよう presenter 層に通知する (issue #512)。
  */
-export interface RestoredSnapshotViewDto {
+export type RestoredSnapshotViewDto = {
   readonly customProjects?: readonly CustomProject[]
   readonly parentCategories?: readonly ParentCategory[]
   readonly savedTabs: readonly TabGroup[]
@@ -36,7 +36,7 @@ export interface RestoredSnapshotViewDto {
  * storage 形に詰め替えることで、presentation 層が mapper の役割を
  * helper 側に持たなくて済むようにする (issue #512)。
  */
-export interface RestoreOpenedUrlsSnapshotViewUseCaseDeps {
+export type RestoreOpenedUrlsSnapshotViewUseCaseDeps = {
   readonly restoreOpenedUrlsSnapshot: RestoreOpenedUrlsSnapshotUseCase
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/SaveCustomProjectOrderUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/SaveCustomProjectOrderUseCase.ts
@@ -7,7 +7,7 @@ import { createCustomProjectId } from '@/contexts/saved-tabs/domain/value-object
  * `newOrder` は表示順の `CustomProjectId` 配列。UI 側で並び替え後に
  * presentation hook から渡される。
  */
-export interface SaveCustomProjectOrderCommand {
+export type SaveCustomProjectOrderCommand = {
   readonly newOrder: readonly string[]
 }
 
@@ -25,7 +25,7 @@ export type SaveCustomProjectOrderUseCase = (
 /**
  * `SaveCustomProjectOrderUseCase` が依存する repository 群。
  */
-export interface SaveCustomProjectOrderUseCaseDeps {
+export type SaveCustomProjectOrderUseCaseDeps = {
   readonly customProjectRepository: CustomProjectRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/SaveCustomProjectsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/SaveCustomProjectsUseCase.ts
@@ -9,7 +9,7 @@ import type { CustomProjectRepository } from '@/contexts/saved-tabs/domain/repos
  * `projects` は application DTO として受け取り、use-case 内で domain
  * entity に変換して保存する。
  */
-export interface SaveCustomProjectsCommand {
+export type SaveCustomProjectsCommand = {
   readonly projects: readonly SavedTabsCustomProjectDto[]
 }
 
@@ -20,7 +20,7 @@ export type SaveCustomProjectsUseCase = (
 /**
  * `SaveCustomProjectsUseCase` が依存する repository 群。
  */
-export interface SaveCustomProjectsUseCaseDeps {
+export type SaveCustomProjectsUseCaseDeps = {
   readonly customProjectRepository: CustomProjectRepository
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/SetCategoryKeywordsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/SetCategoryKeywordsUseCase.ts
@@ -9,7 +9,7 @@ import type { SetCategoryKeywordsPort } from '@/contexts/saved-tabs/application/
  * `DomainCategorySettings` 同期 / `urlSubCategories` 再計算）を
  * まとめて実行する。
  */
-export interface SetCategoryKeywordsUseCaseDeps {
+export type SetCategoryKeywordsUseCaseDeps = {
   readonly setCategoryKeywordsPort: SetCategoryKeywordsPort
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/SetCustomProjectUrlCategoryUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/SetCustomProjectUrlCategoryUseCase.ts
@@ -4,7 +4,7 @@ import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/applica
 /**
  * `SetCustomProjectUrlCategoryUseCase` が依存する port。
  */
-export interface SetCustomProjectUrlCategoryUseCaseDeps {
+export type SetCustomProjectUrlCategoryUseCaseDeps = {
   readonly customProjectsCommandService: CustomProjectsCommandService
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/SyncCategoryAssignmentsUseCase.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/SyncCategoryAssignmentsUseCase.test.ts
@@ -11,7 +11,7 @@ import { createParentCategoryId } from '@/contexts/saved-tabs/domain/value-objec
 import type { SyncCategoryAssignmentsUseCaseDeps } from './SyncCategoryAssignmentsUseCase'
 import { createSyncCategoryAssignmentsUseCase } from './SyncCategoryAssignmentsUseCase'
 
-interface Repositories extends SyncCategoryAssignmentsUseCaseDeps {
+type Repositories = SyncCategoryAssignmentsUseCaseDeps & {
   tabGroups: ReturnType<typeof createTabGroup>[]
   parentCategories: ReturnType<typeof createParentCategory>[]
 }

--- a/src/contexts/saved-tabs/application/use-cases/SyncCategoryAssignmentsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/SyncCategoryAssignmentsUseCase.ts
@@ -24,14 +24,14 @@ import { createParentCategoryId } from '@/contexts/saved-tabs/domain/value-objec
  * `command` が指定された場合はそのドメインのみを処理し、
  * 未指定なら全 TabGroup を再判定する。
  */
-export interface SyncCategoryAssignmentsCommand {
+export type SyncCategoryAssignmentsCommand = {
   readonly command?: MoveDomainToCategoryCommand
 }
 
 /**
  * `SyncCategoryAssignmentsUseCase` が依存する repository 群。
  */
-export interface SyncCategoryAssignmentsUseCaseDeps {
+export type SyncCategoryAssignmentsUseCaseDeps = {
   readonly tabGroupRepository: TabGroupRepository
   readonly parentCategoryRepository: ParentCategoryRepository
 }

--- a/src/contexts/saved-tabs/application/use-cases/UpdateCustomProjectCategoryOrderUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/UpdateCustomProjectCategoryOrderUseCase.ts
@@ -4,7 +4,7 @@ import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/applica
 /**
  * `UpdateCustomProjectCategoryOrderUseCase` が依存する port。
  */
-export interface UpdateCustomProjectCategoryOrderUseCaseDeps {
+export type UpdateCustomProjectCategoryOrderUseCaseDeps = {
   readonly customProjectsCommandService: CustomProjectsCommandService
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/UpdateCustomProjectKeywordsUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/UpdateCustomProjectKeywordsUseCase.ts
@@ -4,7 +4,7 @@ import type { CustomProjectsCommandService } from '@/contexts/saved-tabs/applica
 /**
  * `UpdateCustomProjectKeywordsUseCase` が依存する port。
  */
-export interface UpdateCustomProjectKeywordsUseCaseDeps {
+export type UpdateCustomProjectKeywordsUseCaseDeps = {
   readonly customProjectsCommandService: CustomProjectsCommandService
 }
 

--- a/src/contexts/saved-tabs/application/use-cases/UpdateCustomProjectNameUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/UpdateCustomProjectNameUseCase.ts
@@ -7,12 +7,12 @@ import { createCategoryName } from '@/contexts/saved-tabs/domain/value-objects/C
 import { createCustomProjectId } from '@/contexts/saved-tabs/domain/value-objects/CustomProjectId'
 import { createSavedAt } from '@/contexts/saved-tabs/domain/value-objects/SavedAt'
 
-export interface UpdateCustomProjectNameCommand {
+export type UpdateCustomProjectNameCommand = {
   readonly projectId: string
   readonly newName: string
 }
 
-export interface UpdateCustomProjectNameResult {
+export type UpdateCustomProjectNameResult = {
   readonly all: readonly SavedTabsCustomProjectDto[]
   readonly project: SavedTabsCustomProjectDto
 }
@@ -21,7 +21,7 @@ export type UpdateCustomProjectNameUseCase = (
   command: UpdateCustomProjectNameCommand,
 ) => Promise<UpdateCustomProjectNameResult>
 
-export interface UpdateCustomProjectNameUseCaseDeps {
+export type UpdateCustomProjectNameUseCaseDeps = {
   readonly customProjectRepository: CustomProjectRepository
   readonly clock: ClockPort
 }

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -5,12 +5,12 @@ import { describe, expect, it } from 'vitest'
 
 type RuleEntry = string | [string, ...unknown[]]
 
-interface OxlintOverride {
+type OxlintOverride = {
   files?: string[]
   rules?: Record<string, RuleEntry>
 }
 
-interface OxlintConfig {
+type OxlintConfig = {
   overrides?: OxlintOverride[]
 }
 
@@ -1351,7 +1351,7 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
         ),
         'utf8',
       )
-      expect(source).toContain('interface ClockPort')
+      expect(source).toContain('type ClockPort')
       expect(source).toContain('now:')
     })
 
@@ -1482,7 +1482,7 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
     //   application/services/    -> *Service.ts
     //   presentation/view-models/ -> *ViewModel.ts
 
-    interface NamingConvention {
+    type NamingConvention = {
       readonly layer: string
       readonly subdirectory: string
       readonly suffixes: readonly string[]

--- a/src/contexts/saved-tabs/domain/dto/DomainCategoryMappingDto.ts
+++ b/src/contexts/saved-tabs/domain/dto/DomainCategoryMappingDto.ts
@@ -5,7 +5,7 @@
  * plain object。`domain` を主キー、`categoryId` を値とする
  * 1:N 風マッピングを domain 側で扱うために使う。
  */
-export interface DomainCategoryMappingDto {
+export type DomainCategoryMappingDto = {
   domain: string
   categoryId: string
 }

--- a/src/contexts/saved-tabs/domain/dto/DomainCategorySettingsDto.ts
+++ b/src/contexts/saved-tabs/domain/dto/DomainCategorySettingsDto.ts
@@ -6,12 +6,12 @@
  * `SubCategoryKeywordDto` として再定義し、`@/types/storage` への
  * 依存を断つ。
  */
-export interface SubCategoryKeywordDto {
+export type SubCategoryKeywordDto = {
   categoryName: string
   keywords: string[]
 }
 
-export interface DomainCategorySettingsDto {
+export type DomainCategorySettingsDto = {
   domain: string
   subCategories: string[]
   categoryKeywords: SubCategoryKeywordDto[]

--- a/src/contexts/saved-tabs/domain/dto/ParentCategoryDto.ts
+++ b/src/contexts/saved-tabs/domain/dto/ParentCategoryDto.ts
@@ -17,7 +17,7 @@
  * 配列フィールドは `@/types/storage.ParentCategory` との structural
  * 互換のため readonly 修飾を敢えて付けず、mutable として公開する。
  */
-export interface ParentCategoryDto {
+export type ParentCategoryDto = {
   id: string
   name: string
   domains: string[]

--- a/src/contexts/saved-tabs/domain/dto/ResolvedTabGroupUrlDto.ts
+++ b/src/contexts/saved-tabs/domain/dto/ResolvedTabGroupUrlDto.ts
@@ -6,7 +6,7 @@
  * `id` と `savedAt` は URL 解決後に必ず存在するが、storage 形の
  * `urls` 要素型では optional のため optional 維持とする。
  */
-export interface ResolvedTabGroupUrlDto {
+export type ResolvedTabGroupUrlDto = {
   id?: string
   url: string
   title: string

--- a/src/contexts/saved-tabs/domain/dto/SavedTabRawSummaryDto.ts
+++ b/src/contexts/saved-tabs/domain/dto/SavedTabRawSummaryDto.ts
@@ -1,4 +1,4 @@
-export interface SavedTabRawSubCategoryKeywordDto {
+export type SavedTabRawSubCategoryKeywordDto = {
   readonly categoryName: string
   readonly keywords: readonly string[]
 }
@@ -23,7 +23,7 @@ export interface SavedTabRawSubCategoryKeywordDto {
  * から `findRawTabGroupById` で 4 フィールドだけを抜き出して
  * 投影する。
  */
-export interface SavedTabRawSummaryDto {
+export type SavedTabRawSummaryDto = {
   readonly id: string
   readonly domain: string
   readonly parentCategoryId: string | undefined

--- a/src/contexts/saved-tabs/domain/dto/TabGroupDto.ts
+++ b/src/contexts/saved-tabs/domain/dto/TabGroupDto.ts
@@ -25,7 +25,7 @@ import type { ResolvedTabGroupUrlDto } from './ResolvedTabGroupUrlDto'
  * `urlIds?: string[]` を props として受け取る既存コンポーネント
  * との代入互換を取る)。
  */
-export interface TabGroupDto {
+export type TabGroupDto = {
   id: string
   domain: string
   parentCategoryId?: string

--- a/src/contexts/saved-tabs/domain/dto/UserSettingsDto.ts
+++ b/src/contexts/saved-tabs/domain/dto/UserSettingsDto.ts
@@ -3,7 +3,7 @@
  *
  * `@/types/storage.AiSystemPromptPreset` と構造互換。
  */
-export interface AiSystemPromptPresetDto {
+export type AiSystemPromptPresetDto = {
   readonly id: string
   readonly name: string
   readonly template: string
@@ -30,7 +30,7 @@ export interface AiSystemPromptPresetDto {
  * 形の `excludePatterns: string[]` を props として受け取る既存
  * コンポーネントとの代入互換を取る)。
  */
-export interface UserSettingsDto {
+export type UserSettingsDto = {
   language?: 'system' | 'ja' | 'en'
   removeTabAfterOpen: boolean
   removeTabAfterExternalDrop: boolean

--- a/src/contexts/saved-tabs/domain/entities/CustomProject.ts
+++ b/src/contexts/saved-tabs/domain/entities/CustomProject.ts
@@ -28,7 +28,7 @@ import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/Url
  * })
  * ```
  */
-export interface CustomProject {
+export type CustomProject = {
   readonly id: CustomProjectId
   readonly name: CategoryName
   readonly urlIds: readonly UrlRecordId[]
@@ -37,7 +37,7 @@ export interface CustomProject {
   readonly updatedAt: SavedAt
 }
 
-interface CreateCustomProjectInput {
+type CreateCustomProjectInput = {
   id: string
   name: string
   urlIds: readonly string[]

--- a/src/contexts/saved-tabs/domain/entities/ParentCategory.ts
+++ b/src/contexts/saved-tabs/domain/entities/ParentCategory.ts
@@ -28,14 +28,14 @@ import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabG
  * })
  * ```
  */
-export interface ParentCategory {
+export type ParentCategory = {
   readonly id: ParentCategoryId
   readonly name: CategoryName
   readonly domains: readonly TabGroupId[]
   readonly domainNames: readonly string[]
 }
 
-interface CreateParentCategoryInput {
+type CreateParentCategoryInput = {
   id: string
   name: string
   domains: readonly string[]

--- a/src/contexts/saved-tabs/domain/entities/TabGroup.ts
+++ b/src/contexts/saved-tabs/domain/entities/TabGroup.ts
@@ -31,7 +31,7 @@ import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/Url
  * tabGroupUrlCount(group) // 2
  * ```
  */
-export interface TabGroup {
+export type TabGroup = {
   readonly id: TabGroupId
   readonly domain: DomainName
   readonly urlIds: readonly UrlRecordId[]
@@ -47,7 +47,7 @@ export interface TabGroup {
   readonly savedAt?: SavedAt
 }
 
-interface CreateTabGroupInput {
+type CreateTabGroupInput = {
   id: string
   domain: string
   urlIds: readonly string[]

--- a/src/contexts/saved-tabs/domain/entities/UrlRecord.ts
+++ b/src/contexts/saved-tabs/domain/entities/UrlRecord.ts
@@ -25,7 +25,7 @@ import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/Url
  * })
  * ```
  */
-export interface UrlRecord {
+export type UrlRecord = {
   readonly id: UrlRecordId
   readonly url: Url
   readonly title: string
@@ -33,7 +33,7 @@ export interface UrlRecord {
   readonly favIconUrl?: string
 }
 
-interface CreateUrlRecordInput {
+type CreateUrlRecordInput = {
   id: string
   url: string
   title: string

--- a/src/contexts/saved-tabs/domain/repositories/CustomProjectRepository.ts
+++ b/src/contexts/saved-tabs/domain/repositories/CustomProjectRepository.ts
@@ -12,7 +12,7 @@ import type { CustomProjectId } from '@/contexts/saved-tabs/domain/value-objects
  * 結果をこの shape で返す。domain interface は実装の zod スキーマへの
  * 直接依存を避けるため、structural な interface として公開する。
  */
-export interface CustomProjectRawSnapshot {
+export type CustomProjectRawSnapshot = {
   id: string
   name: string
   categories: readonly string[]
@@ -66,7 +66,7 @@ export interface CustomProjectRawSnapshot {
  * const target = projects.find((project) => project.id === projectId)
  * ```
  */
-export interface CustomProjectRepository {
+export type CustomProjectRepository = {
   findAll: () => Promise<readonly CustomProject[]>
   findById: (id: CustomProjectId) => Promise<CustomProject | null>
   saveAll: (projects: readonly CustomProject[]) => Promise<void>

--- a/src/contexts/saved-tabs/domain/repositories/DomainCategoryMappingRepository.ts
+++ b/src/contexts/saved-tabs/domain/repositories/DomainCategoryMappingRepository.ts
@@ -24,7 +24,7 @@ import type { DomainCategoryMappingDto } from '@/contexts/saved-tabs/domain/dto/
  * )
  * ```
  */
-export interface DomainCategoryMappingRepository {
+export type DomainCategoryMappingRepository = {
   findAll: () => Promise<readonly DomainCategoryMappingDto[]>
   saveAll: (mappings: readonly DomainCategoryMappingDto[]) => Promise<void>
 }

--- a/src/contexts/saved-tabs/domain/repositories/DomainCategorySettingsRepository.ts
+++ b/src/contexts/saved-tabs/domain/repositories/DomainCategorySettingsRepository.ts
@@ -29,7 +29,7 @@ import type { DomainCategorySettingsDto } from '@/contexts/saved-tabs/domain/dto
  * )
  * ```
  */
-export interface DomainCategorySettingsRepository {
+export type DomainCategorySettingsRepository = {
   findAll: () => Promise<readonly DomainCategorySettingsDto[]>
   saveAll: (settings: readonly DomainCategorySettingsDto[]) => Promise<void>
 }

--- a/src/contexts/saved-tabs/domain/repositories/ParentCategoryRepository.ts
+++ b/src/contexts/saved-tabs/domain/repositories/ParentCategoryRepository.ts
@@ -17,7 +17,7 @@ import type { ParentCategoryId } from '@/contexts/saved-tabs/domain/value-object
  * const docs = categories.find((category) => category.name === 'Docs')
  * ```
  */
-export interface ParentCategoryRepository {
+export type ParentCategoryRepository = {
   findAll: () => Promise<readonly ParentCategory[]>
   findById: (id: ParentCategoryId) => Promise<ParentCategory | null>
   saveAll: (categories: readonly ParentCategory[]) => Promise<void>

--- a/src/contexts/saved-tabs/domain/repositories/TabGroupRepository.ts
+++ b/src/contexts/saved-tabs/domain/repositories/TabGroupRepository.ts
@@ -22,7 +22,7 @@ import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabG
  * const target = groups.find((group) => group.domain === 'example.com')
  * ```
  */
-export interface TabGroupRepository {
+export type TabGroupRepository = {
   findAll: () => Promise<readonly TabGroup[]>
   findById: (id: TabGroupId) => Promise<TabGroup | null>
   saveAll: (groups: readonly TabGroup[]) => Promise<void>

--- a/src/contexts/saved-tabs/domain/repositories/UrlRecordRepository.ts
+++ b/src/contexts/saved-tabs/domain/repositories/UrlRecordRepository.ts
@@ -17,7 +17,7 @@ import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/Url
  * const target = records.find((record) => record.url === 'https://example.com')
  * ```
  */
-export interface UrlRecordRepository {
+export type UrlRecordRepository = {
   findAll: () => Promise<readonly UrlRecord[]>
   findById: (id: UrlRecordId) => Promise<UrlRecord | null>
   saveAll: (records: readonly UrlRecord[]) => Promise<void>

--- a/src/contexts/saved-tabs/domain/repositories/UserSettingsRepository.ts
+++ b/src/contexts/saved-tabs/domain/repositories/UserSettingsRepository.ts
@@ -21,7 +21,7 @@ import type { UserSettingsDto } from '@/contexts/saved-tabs/domain/dto/UserSetti
  * await userSettingsRepository.save({ ...settings, removeTabAfterOpen: true })
  * ```
  */
-export interface UserSettingsRepository {
+export type UserSettingsRepository = {
   findAll: () => Promise<UserSettingsDto>
   save: (settings: UserSettingsDto) => Promise<void>
 }

--- a/src/contexts/saved-tabs/domain/services/CategoryAssignmentPolicy.ts
+++ b/src/contexts/saved-tabs/domain/services/CategoryAssignmentPolicy.ts
@@ -13,7 +13,7 @@ import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabG
  * 同じ `TabGroupId` / `DomainName` を複数カテゴリが宣言している場合は
  * 最初に出現したカテゴリを優先する（先勝ち）。
  */
-export interface CategoryLookup {
+export type CategoryLookup = {
   readonly byId: ReadonlyMap<ParentCategoryId, ParentCategory>
   readonly byTabGroupId: ReadonlyMap<TabGroupId, ParentCategory>
   readonly byDomainName: ReadonlyMap<string, ParentCategory>

--- a/src/contexts/saved-tabs/domain/services/CategoryDomainMoveService.ts
+++ b/src/contexts/saved-tabs/domain/services/CategoryDomainMoveService.ts
@@ -22,7 +22,7 @@ import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabG
  * 禁止、`@dnd-kit/sortable` 依存禁止) を満たすため、副作用・永続化・
  * ロギングは含めない。
  */
-export interface MoveDomainBetweenCategoriesParams {
+export type MoveDomainBetweenCategoriesParams = {
   readonly categories: readonly ParentCategory[]
   readonly domainId: TabGroupId
   readonly domainName: DomainName
@@ -35,7 +35,7 @@ export interface MoveDomainBetweenCategoriesParams {
   readonly toCategoryId: string
 }
 
-export interface MoveDomainBetweenCategoriesResult {
+export type MoveDomainBetweenCategoriesResult = {
   readonly moved: boolean
   readonly updatedCategories: readonly ParentCategory[]
 }

--- a/src/contexts/saved-tabs/domain/services/CategoryDomainOrderingService.ts
+++ b/src/contexts/saved-tabs/domain/services/CategoryDomainOrderingService.ts
@@ -30,7 +30,7 @@ import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabG
  *   ドメイン」が explicit な `domains` 順序へ昇格する。
  * - 対象カテゴリが見つからない場合は no-op として現在値を返す。
  */
-export interface ReorderDomainsInCategoryParams {
+export type ReorderDomainsInCategoryParams = {
   readonly categories: readonly ParentCategory[]
   /** 並び替え対象カテゴリの `ParentCategoryId`。 */
   readonly categoryId: string
@@ -44,7 +44,7 @@ export interface ReorderDomainsInCategoryParams {
   readonly domainIds: readonly TabGroupId[]
 }
 
-export interface ReorderDomainsInCategoryResult {
+export type ReorderDomainsInCategoryResult = {
   readonly targetFound: boolean
   readonly updatedCategories: readonly ParentCategory[]
   readonly domainIdOrder: readonly TabGroupId[]

--- a/src/contexts/saved-tabs/domain/services/OpenedUrlRemovalPolicy.ts
+++ b/src/contexts/saved-tabs/domain/services/OpenedUrlRemovalPolicy.ts
@@ -19,7 +19,7 @@ import type { UrlRecordId } from '@/contexts/saved-tabs/domain/value-objects/Url
  * `removeTabAfterOpen`: 通常クリックで開いた URL を削除するか
  * `removeTabAfterExternalDrop`: 外部アプリへドラッグして開いた URL を削除するか
  */
-export interface OpenedUrlRemovalSettings {
+export type OpenedUrlRemovalSettings = {
   readonly removeTabAfterOpen: boolean
   readonly removeTabAfterExternalDrop: boolean
 }
@@ -35,7 +35,7 @@ export type OpenedUrlOrigin = 'click' | 'externalDrop'
 /**
  * 開いた URL の入力情報。
  */
-export interface OpenedUrlInput {
+export type OpenedUrlInput = {
   readonly urlRecordId: UrlRecordId
   readonly origin: OpenedUrlOrigin
 }

--- a/src/contexts/saved-tabs/domain/services/SavedTabsSearchService.ts
+++ b/src/contexts/saved-tabs/domain/services/SavedTabsSearchService.ts
@@ -14,7 +14,7 @@ import type { CategoryLookup } from './CategoryAssignmentPolicy'
  * `query` は前後の空白を許容するが、内部では trim + lowercase した値で比較する。
  * 空クエリは「全件マッチ」として扱う。
  */
-export interface SavedTabsSearchInput {
+export type SavedTabsSearchInput = {
   readonly query: string
 }
 
@@ -24,7 +24,7 @@ export interface SavedTabsSearchInput {
  * `urls` は `UrlRecord` の参照解決済みリスト。infrastructure 側で
  * `TabGroup.urlIds` → `UrlRecord` への解決を済ませてから渡す前提。
  */
-export interface SavedTabsSearchContext {
+export type SavedTabsSearchContext = {
   readonly group: TabGroup
   readonly urls: readonly UrlRecord[]
 }
@@ -34,7 +34,7 @@ export interface SavedTabsSearchContext {
  *
  * `categoryMatched` は親カテゴリ名がマッチしたケース（URL は元配列まま）。
  */
-export interface SavedTabsSearchResult {
+export type SavedTabsSearchResult = {
   readonly group: TabGroup
   readonly urls: readonly UrlRecord[]
   readonly categoryMatched: boolean

--- a/src/contexts/saved-tabs/domain/services/TabGroupCategorizationService.ts
+++ b/src/contexts/saved-tabs/domain/services/TabGroupCategorizationService.ts
@@ -27,7 +27,7 @@ export type CategorizedKey = ParentCategoryId | typeof UNCATEGORIZED_KEY
  * `key` はカテゴリ ID または `UNCATEGORIZED_KEY`、`category` は
  * カテゴリ ID の場合のみ参照可能（未分類では undefined）。
  */
-export interface CategorizedTabGroups {
+export type CategorizedTabGroups = {
   readonly key: CategorizedKey
   readonly category?: ParentCategory
   readonly groups: readonly TabGroup[]

--- a/src/contexts/saved-tabs/domain/services/userSettingsDefaultsMerge.ts
+++ b/src/contexts/saved-tabs/domain/services/userSettingsDefaultsMerge.ts
@@ -22,7 +22,7 @@ export const mergeExcludePatterns = (
   return [...mergedPatterns]
 }
 
-interface UserSettingsDefaultsShape {
+type UserSettingsDefaultsShape = {
   excludePatterns: string[]
 }
 

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserTabAdapter.ts
@@ -16,7 +16,7 @@
  * ```
  */
 
-export interface ChromeBrowserTabAdapterDeps {
+export type ChromeBrowserTabAdapterDeps = {
   /**
    * `chrome.tabs` を提供する chrome API 全体。テスト時は
    * `chrome.tabs.create` を持つモックオブジェクトを渡す。
@@ -24,18 +24,18 @@ export interface ChromeBrowserTabAdapterDeps {
   readonly getApi: () => ChromeApiLike | undefined
 }
 
-export interface ChromeApiLike {
+export type ChromeApiLike = {
   readonly tabs?: ChromeTabsLike
 }
 
-export interface ChromeTabsLike {
+export type ChromeTabsLike = {
   readonly create?: (createProperties: {
     readonly active?: boolean
     readonly url: string
   }) => Promise<{ readonly url?: string } | undefined> | undefined
 }
 
-interface ChromeBrowserTabAdapterOptions {
+type ChromeBrowserTabAdapterOptions = {
   /**
    * 新規タブをアクティブ（前面）にするかを port 利用側（open saved url use-case）が
    * 決められるよう、`active` を返す関数を委譲できる。

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserWindowAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeBrowserWindowAdapter.ts
@@ -16,7 +16,7 @@
  * ```
  */
 
-export interface ChromeBrowserWindowAdapterDeps {
+export type ChromeBrowserWindowAdapterDeps = {
   /**
    * `chrome.windows` を提供する chrome API 全体。テスト時は
    * `chrome.windows.create` を持つモックオブジェクトを渡す。
@@ -24,11 +24,11 @@ export interface ChromeBrowserWindowAdapterDeps {
   readonly getApi: () => ChromeWindowsApiLike | undefined
 }
 
-export interface ChromeWindowsApiLike {
+export type ChromeWindowsApiLike = {
   readonly windows?: ChromeWindowsLike
 }
 
-export interface ChromeWindowsLike {
+export type ChromeWindowsLike = {
   readonly create?: (createProperties: {
     readonly focused?: boolean
     readonly url?: readonly string[] | string
@@ -39,7 +39,7 @@ export interface ChromeWindowsLike {
     | undefined
 }
 
-export interface ChromeBrowserWindowAdapterOptions {
+export type ChromeBrowserWindowAdapterOptions = {
   /**
    * 新規ウィンドウを前面に表示するかを port 利用側（open all saved urls use-case）が
    * 決められるよう、`focused` の既定値を委譲できる。

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeMessagingAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeMessagingAdapter.ts
@@ -37,7 +37,7 @@ import type {
 } from '@/contexts/saved-tabs/application/ports/MessagingPort'
 import { getChromeGlobal, isObjectLike } from '@/lib/browser/chrome-global'
 
-export interface ChromeRuntimeSendMessageLike {
+export type ChromeRuntimeSendMessageLike = {
   /**
    * `chrome.runtime.sendMessage` 互換の最小 API。
    * callback 受け取りは port 側で `Promise` 化する。
@@ -48,16 +48,16 @@ export interface ChromeRuntimeSendMessageLike {
   ) => void
 }
 
-export interface ChromeRuntimeLike {
+export type ChromeRuntimeLike = {
   readonly sendMessage?: ChromeRuntimeSendMessageLike['sendMessage']
   readonly lastError?: { readonly message?: string } | undefined
 }
 
-export interface ChromeApiLike {
+export type ChromeApiLike = {
   readonly runtime?: ChromeRuntimeLike
 }
 
-export interface ChromeMessagingAdapterDeps {
+export type ChromeMessagingAdapterDeps = {
   /**
    * `chrome.runtime` を含む chrome API 全体。テスト時は
    * `runtime.sendMessage` を持つモックオブジェクトを渡す。

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.ts
@@ -54,16 +54,16 @@ import {
 import { getChromeStorageOnChanged } from '@/lib/browser/chrome-storage'
 import type { CustomProject } from '@/types/storage'
 
-export interface ChromeStorageOnChangedLike {
+export type ChromeStorageOnChangedLike = {
   readonly addListener: (callback: ChromeOnChangedListener) => void
   readonly removeListener: (callback: ChromeOnChangedListener) => void
 }
 
-export interface ChromeStorageLike {
+export type ChromeStorageLike = {
   readonly onChanged?: ChromeStorageOnChangedLike
 }
 
-export interface ChromeApiLike {
+export type ChromeApiLike = {
   readonly storage?: ChromeStorageLike
 }
 
@@ -72,7 +72,7 @@ type ChromeOnChangedListener = (
   areaName: string,
 ) => void
 
-export interface ChromeStorageChangeAdapterDeps {
+export type ChromeStorageChangeAdapterDeps = {
   /**
    * `chrome.storage.onChanged` を含む chrome API 全体。テスト時は
    * `storage.onChanged.addListener` / `removeListener` を持つ
@@ -88,7 +88,7 @@ export interface ChromeStorageChangeAdapterDeps {
   readonly getOnChanged?: () => ChromeStorageOnChangedLike | null
 }
 
-export interface ChromeStorageChangeAdapterOptions {
+export type ChromeStorageChangeAdapterOptions = {
   /**
    * 購読対象とする storage エリア名。`chrome.storage.onChanged` は
    * グローバルに発火するため、port 側で areaName を絞り込む。

--- a/src/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createSonnerNotificationAdapter } from './SonnerNotificationAdapter'
 import type { SonnerNotificationAdapterDeps } from './SonnerNotificationAdapter'
 
-interface ToastMock {
+type ToastMock = {
   error: ReturnType<typeof vi.fn>
   info: ReturnType<typeof vi.fn>
   success: ReturnType<typeof vi.fn>

--- a/src/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter.ts
@@ -17,7 +17,7 @@ import type {
  * `console.warn` にフォールバックする。port 仕様は「失敗を throw しない」
  * 方針のため、UI 通知の失敗で use-case 全体が落ちないようにする。
  */
-export interface SonnerNotificationAdapterDeps {
+export type SonnerNotificationAdapterDeps = {
   /**
    * テストや差し替えで `toast` 自体をモックしたい場合に注入する。
    * 未指定なら `sonner` から `toast` を直接 import したものを使う。

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
@@ -39,11 +39,11 @@ export type { SavedTabsUseCasesDeps } from '@/contexts/saved-tabs/application/Sa
  *   実行時に解決する関数。presentation 層が `openUrlInBackground` 設定を
  *   ref 経由で読むために利用。未指定なら active 固定。
  */
-export interface CreateSavedTabsUseCasesDepsOptions {
+export type CreateSavedTabsUseCasesDepsOptions = {
   readonly resolveActive?: () => boolean
 }
 
-interface ChromeLike extends ChromeApiLikeBase {
+type ChromeLike = ChromeApiLikeBase & {
   readonly tabs?: {
     readonly create?: (createProperties: {
       readonly active?: boolean

--- a/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts
+++ b/src/contexts/saved-tabs/infrastructure/mappers/ChromeSavedTabsStorageMapper.ts
@@ -453,7 +453,7 @@ const parseCustomProjects = (raw: unknown): CustomProject[] => {
  *
  * repository 実装が「N 件スキップした」をログに出したいケースで使う。
  */
-interface ParseResult<T> {
+type ParseResult<T> = {
   entities: T[]
   skippedCount: number
 }

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUrlRecordRepository.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUrlRecordRepository.ts
@@ -17,7 +17,7 @@ import type { UrlRecordRaw } from './savedTabsStorageSchema'
  * 返し、`set` / `remove` は `Promise<void>` を返す。テストでは in-memory モック
  * を注入できるよう、`get(key)` の戻り値型を `Record<string, unknown>` に統一している。
  */
-export interface ChromeStorageLocalPort {
+export type ChromeStorageLocalPort = {
   get: (key: string) => Promise<Record<string, unknown>>
   remove: (key: string) => Promise<void>
   set: (value: Record<string, unknown>) => Promise<void>

--- a/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
@@ -41,7 +41,7 @@ const createPort = (state: StorageState): ChromeStorageLocalPort => {
   /* eslint-enable typescript/require-await */
 }
 
-interface SpyBrowserTabPort {
+type SpyBrowserTabPort = {
   readonly port: BrowserTabPort
   readonly open: ReturnType<typeof vi.fn>
   readonly opened: { active: boolean; url: string }[]
@@ -62,7 +62,7 @@ const createSpyBrowserTabPort = (
   }
 }
 
-interface SpyBrowserWindowPort {
+type SpyBrowserWindowPort = {
   readonly port: BrowserWindowPort
   readonly openWithUrls: ReturnType<typeof vi.fn>
   readonly opened: { focused?: boolean; urls: readonly string[] }[]
@@ -102,7 +102,7 @@ const createCaptureNotificationPort = (): {
   }
 }
 
-interface Bundle {
+type Bundle = {
   readonly deps: SavedTabsUseCasesDeps
   readonly port: ChromeStorageLocalPort
   readonly portState: StorageState

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.test.tsx
@@ -458,7 +458,7 @@ const createStorageGetMock = (
     return result
   })
 
-interface MockSpy {
+type MockSpy = {
   mock: { calls: unknown[][] }
 }
 

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -48,7 +48,7 @@ import {
 // eslint-disable-next-line import/no-unassigned-import
 import '@/assets/global.css'
 
-interface SavedTabsAppProps {
+type SavedTabsAppProps = {
   readonly controller: UseSavedTabsControllerReturn
   readonly deps: SavedTabsPresentationPorts
   readonly initialViewMode?: ViewMode

--- a/src/contexts/saved-tabs/presentation/app/handlers/useProjectMoveHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/app/handlers/useProjectMoveHandlers.ts
@@ -8,7 +8,7 @@ import { moveCustomProjectUrlAndSyncState } from '@/contexts/saved-tabs/presenta
 import type { TranslateFn } from '@/features/i18n/context/I18nProvider'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
 
-interface UseProjectMoveHandlersDeps {
+type UseProjectMoveHandlersDeps = {
   savedTabsUseCases: SavedTabsUseCases
   setCustomProjects: Dispatch<SetStateAction<CustomProject[]>>
   t: TranslateFn

--- a/src/contexts/saved-tabs/presentation/app/handlers/useTabGroupDeletionHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/app/handlers/useTabGroupDeletionHandlers.ts
@@ -20,7 +20,7 @@ import type { OpenedUrlsStorageSnapshot } from '@/contexts/saved-tabs/presentati
 import type { TranslateFn } from '@/features/i18n/context/I18nProvider'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
 
-interface UseTabGroupDeletionHandlersDeps {
+type UseTabGroupDeletionHandlersDeps = {
   isUncategorizedReorderMode: boolean
   setTempUncategorizedOrder: Dispatch<SetStateAction<TabGroup[]>>
   categories: ParentCategory[]

--- a/src/contexts/saved-tabs/presentation/app/handlers/useTabOpeningHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/app/handlers/useTabOpeningHandlers.ts
@@ -16,7 +16,7 @@ import {
 import type { TranslateFn } from '@/features/i18n/context/I18nProvider'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
 
-interface UseTabOpeningHandlersDeps {
+type UseTabOpeningHandlersDeps = {
   savedTabsUseCases: SavedTabsUseCases
   deps: SavedTabsPresentationPorts
   settings: UserSettingsDto

--- a/src/contexts/saved-tabs/presentation/app/handlers/useUncategorizedReorderHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/app/handlers/useUncategorizedReorderHandlers.ts
@@ -10,7 +10,7 @@ import { toSavedTabsTabGroupDto } from '@/contexts/saved-tabs/application/mapper
 import { toDomainTabGroupsForReorder } from '@/contexts/saved-tabs/presentation/app/savedTabsApp.helpers'
 import type { TranslateFn } from '@/features/i18n/context/I18nProvider'
 
-interface UseUncategorizedReorderHandlersDeps {
+type UseUncategorizedReorderHandlersDeps = {
   isUncategorizedReorderMode: boolean
   setIsUncategorizedReorderMode: Dispatch<SetStateAction<boolean>>
   tempUncategorizedOrder: TabGroup[]

--- a/src/contexts/saved-tabs/presentation/app/savedTabsProfiler.ts
+++ b/src/contexts/saved-tabs/presentation/app/savedTabsProfiler.ts
@@ -1,6 +1,6 @@
 import type { ProfilerOnRenderCallback } from 'react'
 
-interface SavedTabsProfilerStats {
+type SavedTabsProfilerStats = {
   actualDuration: number
   commits: number
   phase: string

--- a/src/contexts/saved-tabs/presentation/components/CategoryKeywordModal.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryKeywordModal.tsx
@@ -16,7 +16,7 @@ const EMPTY_PARENT_CATEGORIES: ParentCategory[] = []
  * 複合コンポーネントパターンで構成される薄いラッパー
  * @param props CategoryKeywordModalProps
  */
-interface CategoryKeywordModalExtraProps {
+type CategoryKeywordModalExtraProps = {
   readonly storageChangePort?: StorageChangePort
   /** 永続化依存 (issue #510)。`CategoryAssignmentPort` +
    * `GetSavedTabsPageDataQuery` の 2 つへ集約する。 */

--- a/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.test.tsx
@@ -313,7 +313,7 @@ const createUseCases = (persistence: {
   },
 })
 
-interface SetupMocksOptions {
+type SetupMocksOptions = {
   useCases?: Partial<CategoryManagementModalUseCases>
   state?: Partial<{ savedTabs: TabGroup[]; parentCategories: ParentCategory[] }>
 }

--- a/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.tsx
@@ -43,7 +43,7 @@ export type {
 } from './CategoryManagementModal.types'
 
 // 型定義
-interface AvailableDomain {
+type AvailableDomain = {
   id: string
   domain: string
 }
@@ -57,7 +57,7 @@ interface AvailableDomain {
  * 実行する。
  */
 // 親カテゴリ管理モーダルの型定義
-interface CategoryManagementModalProps {
+type CategoryManagementModalProps = {
   isOpen: boolean
   onClose: () => void
   category: {

--- a/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.types.ts
+++ b/src/contexts/saved-tabs/presentation/components/CategoryManagementModal.types.ts
@@ -5,12 +5,12 @@ import type { DeleteParentCategoryUseCase } from '@/contexts/saved-tabs/applicat
 import type { RemoveDomainFromParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RemoveDomainFromParentCategoryUseCase'
 import type { RenameParentCategoryUseCase } from '@/contexts/saved-tabs/application/use-cases/RenameParentCategoryUseCase'
 
-export interface CategoryManagementModalDeps {
+export type CategoryManagementModalDeps = {
   readonly categoryAssignmentPort: CategoryAssignmentPort
   readonly getSavedTabsPageDataQuery: GetSavedTabsPageDataQuery
 }
 
-export interface CategoryManagementModalUseCases {
+export type CategoryManagementModalUseCases = {
   readonly renameParentCategory: RenameParentCategoryUseCase
   readonly addDomainToParentCategory: AddDomainToParentCategoryUseCase
   readonly removeDomainFromParentCategory: RemoveDomainFromParentCategoryUseCase

--- a/src/contexts/saved-tabs/presentation/components/CategoryModal.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CategoryModal.tsx
@@ -10,7 +10,7 @@ import { CategorySelector } from './category-modal/CategorySelector'
 import { DomainSelectionList } from './category-modal/DomainSelectionList'
 
 /** CategoryModal コンポーネントの props */
-interface CategoryModalProps {
+type CategoryModalProps = {
   /** モーダルを閉じるハンドラ */
   onClose: () => void
   /** タブグループ一覧 */

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectCategory.tsx
@@ -54,7 +54,7 @@ const getReorderStyle = (isReorderTarget: boolean): React.CSSProperties => {
   }
 }
 
-interface CategoryHeaderMainProps {
+type CategoryHeaderMainProps = {
   attributes: ReturnType<typeof useSortable>['attributes']
   listeners: ReturnType<typeof useSortable>['listeners']
   category: string
@@ -119,7 +119,7 @@ const CategoryHeaderMain = ({
 
 const CATEGORY_SELECT_OPTIONS: string[] = ['undefined']
 
-interface CategoryContentProps {
+type CategoryContentProps = {
   urls: CategoryUrl[]
   urlIds: string[]
   isOver: boolean

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectCategoryBulkConfirmDialogs.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectCategoryBulkConfirmDialogs.tsx
@@ -14,7 +14,7 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 
 import { OpenAllTabsConfirmDialog } from './shared/OpenAllTabsConfirmDialog'
 
-interface CategoryBulkConfirmDialogsProps {
+type CategoryBulkConfirmDialogsProps = {
   isOpenAllConfirmOpen: boolean
   setIsOpenAllConfirmOpen: (open: boolean) => void
   isDeleteAllConfirmOpen: boolean

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectCategoryHeaderActions.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectCategoryHeaderActions.tsx
@@ -9,7 +9,7 @@ import {
   SavedTabsResponsiveTooltipContent,
 } from './shared/SavedTabsResponsive'
 
-interface CategoryHeaderActionsProps {
+type CategoryHeaderActionsProps = {
   showManageActions: boolean
   showBulkActions: boolean
   onOpenManageDialog: () => void

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectCategoryManageDialog.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectCategoryManageDialog.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 
-interface CategoryManageDialogProps {
+type CategoryManageDialogProps = {
   category: string
   showManageDialog: boolean
   setShowManageDialog: (open: boolean) => void

--- a/src/contexts/saved-tabs/presentation/components/CustomProjectSection.tsx
+++ b/src/contexts/saved-tabs/presentation/components/CustomProjectSection.tsx
@@ -44,17 +44,17 @@ import { CardCollapseControl } from './shared/CardCollapseControl'
 import { CardGroupTitle } from './shared/CardGroupTitle'
 import { CardSortControl } from './shared/CardSortControl'
 
-interface CreateProjectFormValues {
+type CreateProjectFormValues = {
   name: string
 }
 
-interface ActiveDragData {
+type ActiveDragData = {
   projectId?: string
   type?: string
   title?: string
   url?: string
 }
-interface DragDebugPayload {
+type DragDebugPayload = {
   activeId: string
   activeType: string | null
   sourceProjectId: string | null

--- a/src/contexts/saved-tabs/presentation/components/DragHandlersContext.tsx
+++ b/src/contexts/saved-tabs/presentation/components/DragHandlersContext.tsx
@@ -1,7 +1,7 @@
 import type { DragEndEvent, DragOverEvent, DragStartEvent } from '@dnd-kit/core'
 import { createContext, use } from 'react'
 
-export interface ProjectDragHandlers {
+export type ProjectDragHandlers = {
   handleDragStart: (event: DragStartEvent) => void
   handleDragOver: (event: DragOverEvent, project: { id: string }) => void
   handleCategoryDragEnd: (event: DragEndEvent) => void
@@ -9,7 +9,7 @@ export interface ProjectDragHandlers {
   clearDragState: () => void
 }
 
-export interface DragHandlersContextType {
+export type DragHandlersContextType = {
   registerHandlers: (projectId: string, handlers: ProjectDragHandlers) => void
   unregisterHandlers: (projectId: string) => void
 }

--- a/src/contexts/saved-tabs/presentation/components/Footer.tsx
+++ b/src/contexts/saved-tabs/presentation/components/Footer.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/tooltip'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 
-interface CategoryReorderFooterProps {
+type CategoryReorderFooterProps = {
   onConfirmCategoryReorder?: () => void
   onCancelCategoryReorder?: () => void
 }

--- a/src/contexts/saved-tabs/presentation/components/Header.tsx
+++ b/src/contexts/saved-tabs/presentation/components/Header.tsx
@@ -32,7 +32,7 @@ import { ViewModeToggle } from './ViewModeToggle'
 const EMPTY_CUSTOM_PROJECTS: CustomProject[] = []
 const noopCreateProject = () => {}
 
-interface HeaderProps {
+type HeaderProps = {
   tabGroups: TabGroup[]
   filteredTabGroups?: TabGroup[]
   currentMode: ViewMode

--- a/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx
@@ -28,7 +28,7 @@ if (typeof window !== 'undefined') {
   })
 }
 
-interface ProjectUrlItemProps {
+type ProjectUrlItemProps = {
   item: NonNullable<CustomProject['urls']>[0]
   projectId: string
   handleOpenUrl: (url: string) => void

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsChatWidgetBridge.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsChatWidgetBridge.tsx
@@ -9,7 +9,7 @@ import { LazySavedTabsChatWidget } from '@/features/ai-chat/components/LazySaved
  * rendering する責務だけを切り出し、mode 別 (dropdown / sidebar-toggle)
  * の差分を contexts 側で拡張できる土台にする。
  */
-export interface SavedTabsChatWidgetBridgeProps {
+export type SavedTabsChatWidgetBridgeProps = {
   readonly onOpenChange: (isOpen: boolean) => void
 }
 

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
@@ -203,7 +203,7 @@ const buildLayoutComposition = () => {
   return { deps, resolveActiveRef, useCases }
 }
 
-interface CompositionContext {
+type CompositionContext = {
   readonly controller: UseSavedTabsControllerReturn
   readonly deps: SavedTabsUseCasesDeps
   readonly resolveActiveRef: ResolveActiveRef

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.tsx
@@ -38,7 +38,7 @@ import { SavedTabsScrollControls } from './SavedTabsScrollControls'
  *   use-case バンドルと controller。`SavedTabsApp` 内部での
  *   use-case 再生成を避けるため props 注入する。
  */
-export interface SavedTabsPresentationLayoutProps {
+export type SavedTabsPresentationLayoutProps = {
   readonly attachLeftPaneRef: (node: HTMLDivElement | null) => void
   readonly controller: UseSavedTabsControllerReturn
   readonly deps: SavedTabsPresentationPorts

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsResponsiveLayoutContext.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsResponsiveLayoutContext.tsx
@@ -8,7 +8,7 @@ import type { PropsWithChildren } from 'react'
  * 配下の component は compact モード時のみ別レイアウトへ切り替えるなどの
  * responsive 制御に利用する。
  */
-export interface SavedTabsResponsiveLayoutContextValue {
+export type SavedTabsResponsiveLayoutContextValue = {
   isCompactLayout: boolean
 }
 
@@ -17,7 +17,7 @@ const SavedTabsResponsiveLayoutContext =
     isCompactLayout: false,
   })
 
-interface SavedTabsResponsiveLayoutProviderProps extends PropsWithChildren {
+type SavedTabsResponsiveLayoutProviderProps = PropsWithChildren & {
   isCompactLayout: boolean
 }
 

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsScrollControls.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsScrollControls.tsx
@@ -49,12 +49,12 @@ const initialAvailability: ScrollControlAvailability = {
   top: false,
 }
 
-interface SavedTabsScrollControlsProps {
+type SavedTabsScrollControlsProps = {
   scrollContainerRef: RefObject<HTMLDivElement | null>
   viewMode: ViewMode
 }
 
-interface ScrollControlButtonProps {
+type ScrollControlButtonProps = {
   ariaLabel: string
   children: React.ReactNode
   disabled: boolean

--- a/src/contexts/saved-tabs/presentation/components/ViewModeToggle.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ViewModeToggle.tsx
@@ -17,7 +17,7 @@ import {
   SavedTabsResponsiveTooltipContent,
 } from './shared/SavedTabsResponsive'
 
-interface ViewModeToggleProps {
+type ViewModeToggleProps = {
   currentMode: ViewMode
   onChange: (mode: ViewMode) => void
 }

--- a/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupContext.ts
+++ b/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupContext.ts
@@ -7,7 +7,7 @@ import type { CategoryGroupProps } from '@/contexts/saved-tabs/presentation/type
 import { createCompoundContext } from '@/lib/ui/createCompoundContext'
 
 /** CategoryGroup のコンテキスト型 */
-export interface CategoryGroupContextType {
+export type CategoryGroupContextType = {
   /** フック戻り値 */
   state: ReturnType<typeof useCategoryGroupState>
   /** 親カテゴリデータ */

--- a/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-group/CategoryGroupRoot.tsx
@@ -18,7 +18,7 @@ import { CategoryGroupContext } from './CategoryGroupContext'
 import type { CategoryGroupContextType } from './CategoryGroupContext'
 
 /** CategoryGroupRoot の props */
-interface CategoryGroupRootProps {
+type CategoryGroupRootProps = {
   /** 親カテゴリデータ */
   category: CategoryGroupProps['category']
   /** ドメイングループ配列 */

--- a/src/contexts/saved-tabs/presentation/components/category-modal/CategoryModalContext.ts
+++ b/src/contexts/saved-tabs/presentation/components/category-modal/CategoryModalContext.ts
@@ -3,7 +3,7 @@ import type { useCategoryModal } from '@/contexts/saved-tabs/presentation/hooks/
 import { createCompoundContext } from '@/lib/ui/createCompoundContext'
 
 /** CategoryModal のコンテキスト型 */
-export interface CategoryModalContextType {
+export type CategoryModalContextType = {
   /** フック戻り値 */
   state: ReturnType<typeof useCategoryModal>
   /** タブグループ一覧 */

--- a/src/contexts/saved-tabs/presentation/components/category-modal/CategoryModalRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-modal/CategoryModalRoot.tsx
@@ -18,7 +18,7 @@ import { CategoryModalContext } from './CategoryModalContext'
 import type { CategoryModalContextType } from './CategoryModalContext'
 
 /** CategoryModalRoot の props */
-interface CategoryModalRootProps {
+type CategoryModalRootProps = {
   /** モーダルを閉じるハンドラ */
   onClose: () => void
   /** タブグループ一覧 */

--- a/src/contexts/saved-tabs/presentation/components/category-modal/DomainSelectionList.tsx
+++ b/src/contexts/saved-tabs/presentation/components/category-modal/DomainSelectionList.tsx
@@ -9,16 +9,16 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 
 import { useCategoryModalContext } from './CategoryModalContext'
 
-interface DomainCategoryInfo {
+type DomainCategoryInfo = {
   id: string
   name: string
 }
 
-interface DomainSelectionState {
+type DomainSelectionState = {
   selectedCategoryId: string | null
 }
 
-interface DomainState {
+type DomainState = {
   domainCategories: Record<string, DomainCategoryInfo | null>
   selectedDomains: Record<string, boolean>
   toggleDomainSelection: (domainId: string) => void
@@ -123,7 +123,7 @@ const DomainCategoryStatus = ({
   )
 }
 
-interface DomainRowProps {
+type DomainRowProps = {
   group: TabGroup
   selection: DomainSelectionState
   domains: DomainState

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardContent.tsx
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardContent.tsx
@@ -28,7 +28,7 @@ import { useDomainCard } from './DomainCardContext'
 /* eslint-disable react/jsx-handler-names -- handlers from context use handle* naming */
 const EMPTY_CATEGORY_URLS: TabGroup['urls'] = []
 
-interface CategorySectionItemProps {
+type CategorySectionItemProps = {
   categoryName: string
   urls: TabGroup['urls']
   groupId: string

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardContext.ts
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardContext.ts
@@ -7,7 +7,7 @@ import type { SortableDomainCardProps } from '@/contexts/saved-tabs/presentation
 import { createCompoundContext } from '@/lib/ui/createCompoundContext'
 
 /** DomainCard のコンテキスト型 */
-export interface DomainCardContextType {
+export type DomainCardContextType = {
   /** フック戻り値 */
   state: ReturnType<typeof useDomainCardState>
   /** タブグループデータ */

--- a/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/domain-card/DomainCardRoot.tsx
@@ -12,7 +12,7 @@ import { DomainCardContext } from './DomainCardContext'
 import type { DomainCardContextType } from './DomainCardContext'
 
 /** DomainCardRoot の props */
-interface DomainCardRootProps {
+type DomainCardRootProps = {
   /** タブグループデータ */
   group: SortableDomainCardProps['group']
   /** 設定 */

--- a/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordEditor.tsx
+++ b/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordEditor.tsx
@@ -9,7 +9,7 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 
 import { useKeywordModal } from './KeywordModalContext'
 
-interface KeywordBadgeProps {
+type KeywordBadgeProps = {
   keyword: string
   onRemove: (keyword: string) => Promise<void>
   isDisabled: boolean

--- a/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordModalContext.ts
+++ b/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordModalContext.ts
@@ -3,7 +3,7 @@ import type { useCategoryKeywordModal } from '@/contexts/saved-tabs/presentation
 import { createCompoundContext } from '@/lib/ui/createCompoundContext'
 
 /** KeywordModal のコンテキスト型 */
-export interface KeywordModalContextType {
+export type KeywordModalContextType = {
   /** フック戻り値 */
   state: ReturnType<typeof useCategoryKeywordModal>
   /** タブグループデータ */

--- a/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordModalRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/keyword-modal/KeywordModalRoot.tsx
@@ -21,7 +21,7 @@ const EMPTY_PARENT_CATEGORIES: NonNullable<
 > = []
 
 /** KeywordModalRoot の props */
-interface KeywordModalRootProps {
+type KeywordModalRootProps = {
   /** タブグループデータ */
   group: CategoryKeywordModalProps['group']
   /** モーダル開閉状態 */

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardContext.ts
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardContext.ts
@@ -7,7 +7,7 @@ import type { CustomProjectCardProps } from '@/contexts/saved-tabs/presentation/
 import { createCompoundContext } from '@/lib/ui/createCompoundContext'
 
 /** ProjectCard のコンテキスト型 */
-export interface ProjectCardContextType {
+export type ProjectCardContextType = {
   /** フック戻り値 */
   hookState: ReturnType<typeof useCustomProjectCard>
   /** プロジェクトデータ */

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardRoot.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardRoot.tsx
@@ -46,7 +46,7 @@ const sortProjectUrls = <
 }
 
 /** ProjectCardRoot の props */
-interface ProjectCardRootProps {
+type ProjectCardRootProps = {
   /** プロジェクトデータ */
   project: CustomProjectCardProps['project']
   /** 設定 */

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardUncategorizedArea.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectCardUncategorizedArea.test.tsx
@@ -51,12 +51,12 @@ vi.mock('@/contexts/saved-tabs/presentation/components/ProjectUrlItem', () => ({
 
 import { ProjectCardUncategorizedArea } from './ProjectCardUncategorizedArea'
 
-interface TestProjectUrl {
+type TestProjectUrl = {
   readonly title: string
   readonly url: string
 }
 
-interface TestProjectCardContextValue {
+type TestProjectCardContextValue = {
   readonly handlers: {
     readonly handleDeleteUrl: ReturnType<typeof vi.fn>
     readonly handleOpenUrl: ReturnType<typeof vi.fn>
@@ -79,7 +79,7 @@ interface TestProjectCardContextValue {
   }
 }
 
-interface TestProjectCardContextOverrides {
+type TestProjectCardContextOverrides = {
   readonly handlers?: Partial<TestProjectCardContextValue['handlers']>
   readonly hookState?: {
     readonly urls?: Partial<TestProjectCardContextValue['hookState']['urls']>

--- a/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.tsx
+++ b/src/contexts/saved-tabs/presentation/components/project-card/ProjectManagementModal.tsx
@@ -27,7 +27,7 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { useProjectModalState } from './useProjectModalState'
 import { createProjectNameSchema } from './useProjectNameSchema'
 
-interface ProjectManagementModalProps {
+type ProjectManagementModalProps = {
   isOpen: boolean
   onClose: () => void
   project: CustomProject
@@ -39,7 +39,7 @@ interface ProjectManagementModalProps {
   onDeleteProject?: (projectId: string) => Promise<void> | void
 }
 
-interface ProjectKeywordSectionProps {
+type ProjectKeywordSectionProps = {
   label: string
   description: string
   inputId: string

--- a/src/contexts/saved-tabs/presentation/components/project-card/useProjectModalState.ts
+++ b/src/contexts/saved-tabs/presentation/components/project-card/useProjectModalState.ts
@@ -11,7 +11,7 @@ import type { ProjectNameSchema } from './useProjectNameSchema'
 
 const normalizeKeyword = (value: string): string => value.trim()
 
-export interface ProjectManagementModalState {
+export type ProjectManagementModalState = {
   isRenaming: boolean
   newProjectName: string
   isProcessing: boolean
@@ -45,7 +45,7 @@ const createProjectManagementModalState = (
   urlKeywords: project.projectKeywords?.urlKeywords ?? [],
 })
 
-export interface KeywordUpdateParams {
+export type KeywordUpdateParams = {
   keyword: string
   keywords: string[]
   section: keyof ProjectKeywordSettings

--- a/src/contexts/saved-tabs/presentation/components/shared/CardCollapseControl.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/CardCollapseControl.tsx
@@ -9,7 +9,7 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { SavedTabsResponsiveTooltipContent } from './SavedTabsResponsive'
 
 /** CardCollapseControl の props */
-interface CardCollapseControlProps {
+type CardCollapseControlProps = {
   /** 折りたたみ状態 */
   isCollapsed: boolean
   /** 折りたたみ状態を設定する関数 */

--- a/src/contexts/saved-tabs/presentation/components/shared/CardGroupActions.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/CardGroupActions.tsx
@@ -20,7 +20,7 @@ import {
   SavedTabsResponsiveTooltipContent,
 } from './SavedTabsResponsive'
 
-interface CardGroupActionsProps {
+type CardGroupActionsProps = {
   onOpenAll?: () => void
   onDeleteAll?: () => void
   onManage?: () => void

--- a/src/contexts/saved-tabs/presentation/components/shared/CardGroupTitle.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/CardGroupTitle.tsx
@@ -4,7 +4,7 @@ import type {
 } from '@dnd-kit/core'
 import { GripVertical } from 'lucide-react'
 
-interface CardGroupTitleProps {
+type CardGroupTitleProps = {
   title: string
   badges?: React.ReactNode
   sortableAttributes?: DraggableAttributes

--- a/src/contexts/saved-tabs/presentation/components/shared/CardReorderControls.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/CardReorderControls.tsx
@@ -11,7 +11,7 @@ import {
 } from './SavedTabsResponsive'
 
 /** CardReorderControls の props */
-interface CardReorderControlsProps {
+type CardReorderControlsProps = {
   /** 並び替えモード */
   isReorderMode: boolean
   /** 並び替えキャンセル */

--- a/src/contexts/saved-tabs/presentation/components/shared/CardSortControl.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/CardSortControl.tsx
@@ -10,7 +10,7 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { SavedTabsResponsiveTooltipContent } from './SavedTabsResponsive'
 
 /** CardSortControl の props */
-interface CardSortControlProps {
+type CardSortControlProps = {
   /** 現在のソート順 */
   sortOrder: SortOrder
   /** ソート順を設定する関数 */

--- a/src/contexts/saved-tabs/presentation/components/shared/CategoryBulkActionButtons.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/CategoryBulkActionButtons.tsx
@@ -11,7 +11,7 @@ import {
 
 const RELATIVE_POSITION_STYLE: CSSProperties = { position: 'relative' }
 
-interface CategoryBulkActionButtonsProps {
+type CategoryBulkActionButtonsProps = {
   isDeleting: boolean
   showDeleteAction: boolean
   openLabel: string

--- a/src/contexts/saved-tabs/presentation/components/shared/DeleteEntityConfirmPanel.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/DeleteEntityConfirmPanel.tsx
@@ -8,7 +8,7 @@ import {
   SavedTabsResponsiveTooltipContent,
 } from '@/contexts/saved-tabs/presentation/components/shared/SavedTabsResponsive'
 
-interface DeleteEntityConfirmPanelProps {
+type DeleteEntityConfirmPanelProps = {
   description: ReactNode
   cancelLabel: string
   deleteLabel: string

--- a/src/contexts/saved-tabs/presentation/components/shared/DeleteUrlConfirmDialog.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/DeleteUrlConfirmDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 
-interface DeleteUrlConfirmDialogProps {
+type DeleteUrlConfirmDialogProps = {
   isOpen: boolean
   onOpenChange: (open: boolean) => void
   onConfirm: () => void

--- a/src/contexts/saved-tabs/presentation/components/shared/OpenAllTabsConfirmDialog.tsx
+++ b/src/contexts/saved-tabs/presentation/components/shared/OpenAllTabsConfirmDialog.tsx
@@ -9,7 +9,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 
-interface OpenAllTabsConfirmDialogProps {
+type OpenAllTabsConfirmDialogProps = {
   open: boolean
   title: string
   description: string

--- a/src/contexts/saved-tabs/presentation/components/useCategoryActions.ts
+++ b/src/contexts/saved-tabs/presentation/components/useCategoryActions.ts
@@ -8,12 +8,12 @@ import type {
 
 import type { CategoryManagementModalUseCases } from './CategoryManagementModal.types'
 
-interface AvailableDomain {
+type AvailableDomain = {
   id: string
   domain: string
 }
 
-export interface UseCategoryActionsParams {
+export type UseCategoryActionsParams = {
   categoryNameError: string | null
   isProcessing: boolean
   isRenaming: boolean
@@ -43,7 +43,7 @@ export interface UseCategoryActionsParams {
   t: (key: string, fallback?: string, values?: Record<string, string>) => string
 }
 
-export interface UseCategoryActionsReturn {
+export type UseCategoryActionsReturn = {
   handleStartRenaming: () => void
   handleCancelRenaming: () => void
   handleCategoryNameChange: (e: React.ChangeEvent<HTMLInputElement>) => void

--- a/src/contexts/saved-tabs/presentation/components/useCategoryFormState.ts
+++ b/src/contexts/saved-tabs/presentation/components/useCategoryFormState.ts
@@ -7,7 +7,7 @@ import {
   createCategoryNameSchema,
 } from './categoryNameSchema'
 
-interface CategoryManagementFormState {
+type CategoryManagementFormState = {
   categoryNameError: string | null
   isProcessing: boolean
   isRenaming: boolean
@@ -25,7 +25,7 @@ const createCategoryManagementFormState = (
   newCategoryName: categoryName,
 })
 
-export interface UseCategoryFormStateReturn {
+export type UseCategoryFormStateReturn = {
   categoryNameError: string | null
   isProcessing: boolean
   isRenaming: boolean

--- a/src/contexts/saved-tabs/presentation/containers/CustomModeContainer.tsx
+++ b/src/contexts/saved-tabs/presentation/containers/CustomModeContainer.tsx
@@ -7,7 +7,7 @@ import type {
 import type { GetProjectUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase'
 import { CustomProjectSection } from '@/contexts/saved-tabs/presentation/components/CustomProjectSection'
 
-interface CustomModeContainerProps {
+type CustomModeContainerProps = {
   isLoading: boolean
   projects: CustomProject[]
   settings: UserSettingsDto

--- a/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.tsx
+++ b/src/contexts/saved-tabs/presentation/containers/DomainModeContainer.tsx
@@ -107,7 +107,7 @@ const UncategorizedReorderActions = ({
 
 type DndSensors = ComponentProps<typeof DndKitContext>['sensors']
 
-interface DomainModeContainerProps {
+type DomainModeContainerProps = {
   state: {
     hasVisibleCategoryGroups: boolean
     isCategoryReorderMode: boolean
@@ -184,7 +184,7 @@ const deleteVisibleUrlsForGroups = async (
   )
 }
 
-interface UncategorizedDomainSectionState {
+type UncategorizedDomainSectionState = {
   shouldShowSectionHeader: boolean
   hasVisibleCategoryGroups: boolean
   confirmDeleteAll: boolean
@@ -192,7 +192,7 @@ interface UncategorizedDomainSectionState {
   shouldShowList: boolean
 }
 
-interface UncategorizedDomainSectionProps {
+type UncategorizedDomainSectionProps = {
   state: UncategorizedDomainSectionState
   displayedDomainCount: number
   displayedTabCount: number

--- a/src/contexts/saved-tabs/presentation/controllers/SavedTabsUseCasesContext.tsx
+++ b/src/contexts/saved-tabs/presentation/controllers/SavedTabsUseCasesContext.tsx
@@ -11,7 +11,7 @@ import type { SavedTabsPresentationPorts } from '@/contexts/saved-tabs/applicati
  * 「components から use-case を直接呼ぶ」設計は濫用禁止のため、controller hook
  * 側の拡張（`useDomainModeController` / `useCustomModeController`）を優先する。
  */
-export interface SavedTabsUseCasesContextValue {
+export type SavedTabsUseCasesContextValue = {
   readonly deps: SavedTabsPresentationPorts
   readonly useCases: SavedTabsUseCases
 }

--- a/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useCustomModeController.ts
@@ -13,7 +13,7 @@ import type { UseSavedTabsControllerReturn } from './useSavedTabsController'
  * `useSavedTabsController` の戻り値を必須で受け取り、その上に
  * Custom モード固有の state / handler を組み立てる。
  */
-export interface UseCustomModeControllerInput {
+export type UseCustomModeControllerInput = {
   readonly controller: UseSavedTabsControllerReturn
   readonly initialCustomProjects?: readonly CustomProject[]
 }
@@ -26,7 +26,7 @@ export interface UseCustomModeControllerInput {
  *   へ変換する
  * - `setSearchQuery` は controller がローカルに持つ検索 state の setter
  */
-export interface UseCustomModeControllerReturn {
+export type UseCustomModeControllerReturn = {
   readonly viewModel: CustomModeViewModel
   readonly projects: readonly CustomProjectViewModel[]
   readonly searchQuery: string

--- a/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useDomainModeController.ts
@@ -26,7 +26,7 @@ import type { UseSavedTabsControllerReturn } from './useSavedTabsController'
  * presentation 層が repository を持たないため、呼び出し側が
  * `parentCategories` を持っていればそのまま合成する。
  */
-export interface UseDomainModeControllerInput {
+export type UseDomainModeControllerInput = {
   readonly controller: UseSavedTabsControllerReturn
   readonly initialTabGroups?: readonly TabGroup[]
   readonly initialParentCategories?: readonly ParentCategory[]
@@ -42,7 +42,7 @@ export interface UseDomainModeControllerInput {
  * - `setSearchQuery` / `setParentCategories` は controller がローカルに持つ
  *   派生 state の setter
  */
-export interface UseDomainModeControllerReturn {
+export type UseDomainModeControllerReturn = {
   readonly viewModel: DomainModeViewModel
   readonly categories: readonly ParentCategoryViewModel[]
   readonly setParentCategories: (

--- a/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.ts
+++ b/src/contexts/saved-tabs/presentation/controllers/useSavedTabsController.ts
@@ -23,7 +23,7 @@ import { toTabGroupViewModel } from '@/contexts/saved-tabs/presentation/view-mod
  * - テストや SSR 用に `initialTabGroups` / `initialCustomProjects` を渡せる。
  *   省略時は use-case / repository の readAll を初回マウント時に行う。
  */
-export interface UseSavedTabsControllerInput {
+export type UseSavedTabsControllerInput = {
   readonly deps: SavedTabsPresentationPorts
   readonly useCases: SavedTabsUseCases
   readonly initialTabGroups?: readonly TabGroup[]
@@ -37,7 +37,7 @@ export interface UseSavedTabsControllerInput {
  * `useCustomModeController`) が個別 use-case を直接参照するための導線。
  * 既存 features (`SavedTabsApp`) からも暫定的に参照可能。
  */
-export interface UseSavedTabsControllerReturn {
+export type UseSavedTabsControllerReturn = {
   readonly viewModel: SavedTabsViewModel
   readonly deps: SavedTabsPresentationPorts
   readonly useCases: SavedTabsUseCases
@@ -59,7 +59,7 @@ export interface UseSavedTabsControllerReturn {
   readonly refresh: () => Promise<void>
 }
 
-export interface OpenSavedUrlControllerInput {
+export type OpenSavedUrlControllerInput = {
   readonly urlRecordId: string
   readonly origin: 'click' | 'externalDrop'
   readonly settings: {
@@ -68,21 +68,21 @@ export interface OpenSavedUrlControllerInput {
   }
 }
 
-export interface OpenSavedUrlControllerResult {
+export type OpenSavedUrlControllerResult = {
   readonly openedUrl: string
   readonly removedUrlRecordId: string | null
 }
 
-export interface DeleteTabGroupControllerInput {
+export type DeleteTabGroupControllerInput = {
   readonly tabGroupId: string
 }
 
-export interface DeleteTabGroupControllerResult {
+export type DeleteTabGroupControllerResult = {
   readonly removedTabGroupId: string
   readonly removedUrlRecordIds: readonly string[]
 }
 
-export interface RestoreSnapshotControllerInput {
+export type RestoreSnapshotControllerInput = {
   readonly snapshot: {
     readonly savedTabs?: readonly TabGroup[]
     readonly urlRecords?: readonly {
@@ -101,25 +101,25 @@ export interface RestoreSnapshotControllerInput {
   }
 }
 
-export interface RestoreSnapshotControllerResult {
+export type RestoreSnapshotControllerResult = {
   readonly restoredTabGroupCount: number
   readonly restoredUrlRecordCount: number
 }
 
-export interface SyncCategoryControllerInput {
+export type SyncCategoryControllerInput = {
   readonly command?: {
     readonly domain: string
     readonly parentCategoryId: string
   }
 }
 
-export interface SyncCategoryControllerResult {
+export type SyncCategoryControllerResult = {
   readonly assignedTabGroupCount: number
   readonly unassignedTabGroupCount: number
   readonly updatedCategoryCount: number
 }
 
-interface ControllerState {
+type ControllerState = {
   loading: boolean
   error: string | null
   tabGroups: readonly TabGroupViewModel[]

--- a/src/contexts/saved-tabs/presentation/hooks/projectManagementDefaults.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/projectManagementDefaults.ts
@@ -211,7 +211,7 @@ const showCustomProjectDeleteUndoToast = ({
 }
 
 /** UseProjectManagement フックの戻り値型 */
-interface UseProjectManagementReturn {
+type UseProjectManagementReturn = {
   /** カスタムプロジェクト一覧 */
   customProjects: CustomProject[]
   /** CustomProjects を直接更新するセッター */

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryGroupState.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryGroupState.ts
@@ -13,7 +13,7 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { useSortOrder } from './useSortOrder'
 
 /** UseCategoryGroupState フックの引数 */
-interface UseCategoryGroupStateParams {
+type UseCategoryGroupStateParams = {
   /** 親カテゴリデータ */
   category: ParentCategory
   /** ドメイン一覧 */

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.test.tsx
@@ -52,7 +52,7 @@ vi.mock('@/features/i18n/context/I18nProvider', async () => {
   }
 })
 
-interface StorageState {
+type StorageState = {
   parentCategories?: ParentCategory[]
   savedTabs?: TabGroup[]
 }

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryKeywordModal.ts
@@ -31,7 +31,7 @@ const createCategoryNameSchema = (t: ReturnType<typeof useI18n>['t']) =>
     })
 
 /** UseCategoryKeywordModal フックの依存 (issue #510) */
-interface UseCategoryKeywordModalDeps {
+type UseCategoryKeywordModalDeps = {
   /** カテゴリ / タブグループの永続化 port */
   categoryAssignmentPort: CategoryAssignmentPort
   /** 保存タブページ全体 query (parentCategories 読み取り) */
@@ -39,7 +39,7 @@ interface UseCategoryKeywordModalDeps {
 }
 
 /** UseCategoryKeywordModal フックの引数 */
-interface UseCategoryKeywordModalParams {
+type UseCategoryKeywordModalParams = {
   /** タブグループデータ */
   group: TabGroup
   /** モーダル開閉状態 */
@@ -64,7 +64,7 @@ interface UseCategoryKeywordModalParams {
    */
   readonly storageChangePort?: StorageChangePort
 }
-interface CategoryEditState {
+type CategoryEditState = {
   isRenaming: boolean
   keywords: string[]
   newCategoryName: string

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryManagement.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryManagement.ts
@@ -21,7 +21,7 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
 
 /** UseCategoryManagement フックの戻り値型 */
-interface UseCategoryManagementReturn {
+type UseCategoryManagementReturn = {
   /** 親カテゴリ一覧 */
   categories: ParentCategory[]
   /** Categories を直接更新するセッター */
@@ -88,7 +88,7 @@ const resolveStateValue = <T>(
 ): T => (isStateSetter(nextValue) ? nextValue(previousValue) : nextValue)
 
 /** UseCategoryManagement フックの引数 */
-interface UseCategoryManagementParams {
+type UseCategoryManagementParams = {
   /**
    * 親カテゴリの並び替え保存 use-case (issue #519)。
    * 旧 `categoryAssignmentPort.saveParentCategories` 直叩きを

--- a/src/contexts/saved-tabs/presentation/hooks/useCategoryModal.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCategoryModal.ts
@@ -15,7 +15,7 @@ import type { DeleteParentCategoryUseCase } from '@/contexts/saved-tabs/applicat
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 
 /** UseCategoryModal フックの引数 */
-interface UseCategoryModalParams {
+type UseCategoryModalParams = {
   /** タブグループ一覧 */
   tabGroups: TabGroup[]
   /** 保存タブページ全体 query。`parentCategoryRepository.findAll` 直叩きを置換 (issue #510)。*/

--- a/src/contexts/saved-tabs/presentation/hooks/useCustomProjectCard.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useCustomProjectCard.ts
@@ -16,7 +16,7 @@ import { getMessage } from '@/features/i18n/lib/language'
 import { useCategoryDnD } from './useCategoryDnD'
 
 /** UseCustomProjectCard フックの引数 */
-interface UseCustomProjectCardParams {
+type UseCustomProjectCardParams = {
   /** プロジェクトデータ */
   project: CustomProject
   /** URL削除ハンドラ */
@@ -43,7 +43,7 @@ type ProjectUrlItem = UrlRecord & {
   notes?: string
   category?: string
 }
-interface UrlState {
+type UrlState = {
   isLoadingUrls: boolean
   projectUrls: ProjectUrlItem[]
 }

--- a/src/contexts/saved-tabs/presentation/hooks/useDomainCardState.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useDomainCardState.ts
@@ -17,7 +17,7 @@ import type { CreateParentCategoryUseCase } from '@/contexts/saved-tabs/applicat
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 
 /** UseDomainCardState フックの引数 */
-interface UseDomainCardStateParams {
+type UseDomainCardStateParams = {
   /** タブグループデータ */
   group: TabGroup
   /** 複数URL削除ハンドラ */
@@ -55,7 +55,7 @@ interface UseDomainCardStateParams {
    */
   assignDomainToCategoryUseCase?: AssignDomainToCategoryUseCase
 }
-interface CategorizedUrlItem {
+type CategorizedUrlItem = {
   id?: string
   url: string
   title: string

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectCategoryHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectCategoryHandlers.ts
@@ -8,7 +8,7 @@ import type { ViewMode } from '@/contexts/saved-tabs/presentation/types/mode'
 import { toRawStorageCustomProject } from './projectManagementDefaults'
 import type { ProjectManagementRefs } from './useProjectManagementRefs'
 
-interface ProjectCategoryHandlerDeps {
+type ProjectCategoryHandlerDeps = {
   refs: ProjectManagementRefs
   setCustomProjects: Dispatch<SetStateAction<CustomProject[]>>
   setViewMode: Dispatch<SetStateAction<ViewMode>>

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectCrudHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectCrudHandlers.ts
@@ -16,7 +16,7 @@ import {
 } from './projectManagementDefaults'
 import type { ProjectManagementRefs } from './useProjectManagementRefs'
 
-interface ProjectCrudHandlerDeps {
+type ProjectCrudHandlerDeps = {
   refs: ProjectManagementRefs
   setCustomProjects: Dispatch<SetStateAction<CustomProject[]>>
   setViewMode: Dispatch<SetStateAction<ViewMode>>

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx
@@ -10,7 +10,7 @@ import type {
 
 import { useProjectManagement } from './useProjectManagement'
 
-interface CustomProjectRawSnapshot {
+type CustomProjectRawSnapshot = {
   id: string
   name: string
   categories: readonly string[]

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectManagementRefs.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectManagementRefs.ts
@@ -24,7 +24,7 @@ import type { UpdateCustomProjectCategoryOrderUseCase } from '@/contexts/saved-t
 import type { UpdateCustomProjectKeywordsUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectKeywordsUseCase'
 import type { UpdateCustomProjectNameUseCase } from '@/contexts/saved-tabs/application/use-cases/UpdateCustomProjectNameUseCase'
 
-interface ProjectManagementRefs {
+type ProjectManagementRefs = {
   getCustomProjectOrderQueryRef: {
     readonly current: GetCustomProjectOrderQuery
   }

--- a/src/contexts/saved-tabs/presentation/hooks/useSortOrder.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useSortOrder.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest' // eslint-disable-line
 
 import { useSortOrder } from './useSortOrder'
 
-interface Item {
+type Item = {
   domain: string
 }
 

--- a/src/contexts/saved-tabs/presentation/hooks/useTabData.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useTabData.ts
@@ -23,7 +23,7 @@ import type {
 } from '@/contexts/saved-tabs/application/use-cases/RepairTabGroupParentCategoryIdsUseCase'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
 /** UseTabData フックの引数 */
-interface UseTabDataParams {
+type UseTabDataParams = {
   /** URL 解決用 use-case。presentation 層が `loadTabGroupsWithUrls` 相当の操作で `@/lib/storage/tabs` を直接呼ばないようにするための依存注入ポイント。 */
   readonly loadTabGroupsWithUrlsUseCase: LoadTabGroupsWithUrlsUseCase
   /**
@@ -57,7 +57,7 @@ interface UseTabDataParams {
 }
 
 /** UseTabData フックの戻り値型 */
-interface UseTabDataReturn {
+type UseTabDataReturn = {
   /** 保存済みタブグループ一覧（URLデータなし・rawデータ） */
   tabGroups: TabGroup[]
   /** TabGroups を直接更新するセッター */
@@ -78,7 +78,7 @@ interface UseTabDataReturn {
    */
   refreshTabGroupsWithUrls: (nextGroups?: TabGroup[]) => Promise<TabGroup[]>
 }
-interface TabDataState {
+type TabDataState = {
   isLoading: boolean
   tabGroups: TabGroup[]
   tabGroupsWithUrls: TabGroup[]

--- a/src/contexts/saved-tabs/presentation/lib/categorized-display.ts
+++ b/src/contexts/saved-tabs/presentation/lib/categorized-display.ts
@@ -16,7 +16,7 @@ import { shouldShowUncategorizedHeader } from './uncategorized-display'
  *
  * React / chrome API / storage には依存しない (issue #504)。
  */
-export interface CreateCategorizedDisplayStateInput {
+export type CreateCategorizedDisplayStateInput = {
   readonly categorized: Readonly<Record<string, readonly TabGroup[]>>
   readonly uncategorized: readonly TabGroup[]
   readonly tempUncategorizedOrder: readonly TabGroup[]
@@ -48,7 +48,7 @@ export interface CreateCategorizedDisplayStateInput {
  * 旧 `SavedTabsApp.tsx` 内の同名の useMemo / 計算式を
  * domain-independent な pure 関数として切り出したもの (issue #504)。
  */
-export interface CategorizedDisplayState {
+export type CategorizedDisplayState = {
   readonly hasContentTabGroups: TabGroup[]
   readonly visibleUncategorizedGroups: TabGroup[]
   readonly hasVisibleCategoryGroups: boolean

--- a/src/contexts/saved-tabs/presentation/lib/custom-project-move.ts
+++ b/src/contexts/saved-tabs/presentation/lib/custom-project-move.ts
@@ -4,7 +4,7 @@ import type { MoveUrlBetweenCustomProjectsCommand } from '@/contexts/saved-tabs/
 import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { MoveUrlBetweenCustomProjectsUseCase } from '@/contexts/saved-tabs/application/use-cases/MoveUrlBetweenCustomProjectsUseCase'
 
-interface MoveCustomProjectUrlAndSyncStateParams {
+type MoveCustomProjectUrlAndSyncStateParams = {
   sourceProjectId: string
   targetProjectId: string
   url: string

--- a/src/contexts/saved-tabs/presentation/lib/custom-project-search.ts
+++ b/src/contexts/saved-tabs/presentation/lib/custom-project-search.ts
@@ -8,7 +8,7 @@ import type {
 
 type ProjectUrlItem = ProjectUrlEntry
 
-interface FilterCustomProjectsByQueryParams {
+type FilterCustomProjectsByQueryParams = {
   customProjects: CustomProject[]
   searchQuery: string
   loadProjectUrls: GetProjectUrlsUseCase

--- a/src/contexts/saved-tabs/presentation/lib/project-state.ts
+++ b/src/contexts/saved-tabs/presentation/lib/project-state.ts
@@ -4,7 +4,7 @@ import type { SavedTabsCustomProjectDto as CustomProject } from '@/contexts/save
 
 type ProjectUrl = NonNullable<CustomProject['urls']>[number]
 
-interface MoveUrlBetweenProjectsStateParams {
+type MoveUrlBetweenProjectsStateParams = {
   projects: CustomProject[]
   sourceProjectId: string
   targetProjectId: string

--- a/src/contexts/saved-tabs/presentation/lib/scroll-controls.ts
+++ b/src/contexts/saved-tabs/presentation/lib/scroll-controls.ts
@@ -1,7 +1,7 @@
 type ScrollTargetType = 'parent' | 'project' | 'domain' | 'child'
 type ScrollDirection = 'previous' | 'next'
 
-interface ScrollControlAvailability {
+type ScrollControlAvailability = {
   bottom: boolean
   nextChild: boolean
   nextDomain: boolean

--- a/src/contexts/saved-tabs/presentation/lib/tab-group-state.ts
+++ b/src/contexts/saved-tabs/presentation/lib/tab-group-state.ts
@@ -144,7 +144,7 @@ export const buildUpdatedGroupAfterUrlIdRemoval = (
  * ままだが、これは `urlSubCategories` 等の presentation 専用
  * 補助フィールドを含むため。
  */
-interface CategorySyncState {
+type CategorySyncState = {
   categoriesChanged: boolean
   savedTabsChanged: boolean
   updatedCategories: ParentCategoryDto[]

--- a/src/contexts/saved-tabs/presentation/lib/uncategorized-display.ts
+++ b/src/contexts/saved-tabs/presentation/lib/uncategorized-display.ts
@@ -1,4 +1,4 @@
-interface ShouldShowUncategorizedHeaderInput {
+type ShouldShowUncategorizedHeaderInput = {
   searchQuery: string
   uncategorizedCount: number
   visibleUncategorizedCount: number

--- a/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
+++ b/src/contexts/saved-tabs/presentation/pages/SavedTabsPage.tsx
@@ -38,7 +38,7 @@ export type { ResolveActiveRef } from '@/contexts/saved-tabs/presentation/types/
  * - `search` を渡すと `initialViewMode` より優先して URL の mode クエリ
  *   を読む。`SavedTabsRoute` からの呼び出し時は `search` を渡す。
  */
-export interface SavedTabsPageProps {
+export type SavedTabsPageProps = {
   readonly deps: SavedTabsPresentationPorts
   readonly initialCustomProjects?: readonly CustomProject[]
   readonly initialTabGroups?: readonly TabGroup[]
@@ -70,7 +70,7 @@ export interface SavedTabsPageProps {
  * ページ → controller フック → use-case → repository / port の流れを
  * 一度だけ確立し、その戻り値を layout へ流す。
  */
-export interface SavedTabsPageState {
+export type SavedTabsPageState = {
   readonly viewModel: SavedTabsViewModel
   readonly refresh: () => Promise<void>
   readonly controller: UseSavedTabsControllerReturn

--- a/src/contexts/saved-tabs/presentation/routes/SavedTabsRoute.tsx
+++ b/src/contexts/saved-tabs/presentation/routes/SavedTabsRoute.tsx
@@ -21,7 +21,7 @@ export type SavedTabsDepsFactory = (options: {
  * - `search` : URL の search string。`SavedTabsPage` 内で
  *   `initialViewMode` の解決に利用する
  */
-export interface SavedTabsRouteProps {
+export type SavedTabsRouteProps = {
   readonly createDeps: SavedTabsDepsFactory
   readonly onViewModeNavigate?: (mode: ViewMode) => void
   readonly search?: string

--- a/src/contexts/saved-tabs/presentation/services/modeSyncService.ts
+++ b/src/contexts/saved-tabs/presentation/services/modeSyncService.ts
@@ -12,7 +12,7 @@ import type {
   ModeSyncEvent,
 } from '@/contexts/saved-tabs/presentation/types/mode'
 
-interface SyncStorageChangesParams {
+type SyncStorageChangesParams = {
   changes: readonly TypedSavedTabsStorageChange[]
   viewModeRef: RefObject<ViewMode>
   refreshTabGroupsWithUrls: (nextGroups?: TabGroup[]) => Promise<TabGroup[]>

--- a/src/contexts/saved-tabs/presentation/services/savedTabsUndoNotificationService.ts
+++ b/src/contexts/saved-tabs/presentation/services/savedTabsUndoNotificationService.ts
@@ -21,7 +21,7 @@ import type {
  * UI state 反映 (`setCategories` / `setCustomProjects`) と
  * `refreshTabGroupsWithUrls` への委譲は呼び出し元から注入する。
  */
-interface UndoNotificationContext {
+type UndoNotificationContext = {
   readonly refreshTabGroupsWithUrls: (
     nextGroups?: TabGroup[],
   ) => Promise<TabGroup[] | undefined> | TabGroup[] | undefined
@@ -37,7 +37,7 @@ interface UndoNotificationContext {
  * 復元後の payload (storage 形配列) を `setCustomProjects` /
  * `setCategories` / `refreshTabGroupsWithUrls` へ反映する。
  */
-interface ShowOpenedUrlsUndoToastParams extends UndoNotificationContext {
+type ShowOpenedUrlsUndoToastParams = UndoNotificationContext & {
   readonly count: number
   readonly messageKey?: string
   readonly snapshot: OpenedUrlsRestoreSnapshot
@@ -98,7 +98,7 @@ const showOpenedUrlsUndoToast = ({
   })
 }
 
-interface NotifyDeleteFailureParams extends UndoNotificationContext {
+type NotifyDeleteFailureParams = UndoNotificationContext & {
   readonly snapshot?: OpenedUrlsRestoreSnapshot
   readonly t: (key: string, fallback?: string) => string
 }

--- a/src/contexts/saved-tabs/presentation/types/CustomProjectCard.types.ts
+++ b/src/contexts/saved-tabs/presentation/types/CustomProjectCard.types.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { GetProjectUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase'
 
-export interface CustomProjectCardProps {
+export type CustomProjectCardProps = {
   project: CustomProject
   handleOpenUrl: (url: string) => void
   handleDeleteUrl: (projectId: string, url: string) => void

--- a/src/contexts/saved-tabs/presentation/types/CustomProjectCategory.types.ts
+++ b/src/contexts/saved-tabs/presentation/types/CustomProjectCategory.types.ts
@@ -4,7 +4,7 @@ import type {
   SavedTabsUserSettingsDto as UserSettingsDto,
 } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
-export interface CustomProjectCategoryProps {
+export type CustomProjectCategoryProps = {
   projectId: string
   category: string
   urls: CustomProject['urls']

--- a/src/contexts/saved-tabs/presentation/types/CustomProjectSection.types.ts
+++ b/src/contexts/saved-tabs/presentation/types/CustomProjectSection.types.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import type { GetProjectUrlsUseCase } from '@/contexts/saved-tabs/application/use-cases/GetProjectUrlsUseCase'
 
-export interface CustomProjectSectionProps {
+export type CustomProjectSectionProps = {
   projects: CustomProject[]
   handleOpenUrl: (url: string) => void
   handleDeleteUrl: (projectId: string, url: string) => void

--- a/src/contexts/saved-tabs/presentation/types/ResolveActiveRef.ts
+++ b/src/contexts/saved-tabs/presentation/types/ResolveActiveRef.ts
@@ -1,4 +1,4 @@
 /** BrowserTabPort の active 判定を最新設定へ接続する関数 ref。 */
-export interface ResolveActiveRef {
+export type ResolveActiveRef = {
   current: () => boolean
 }

--- a/src/contexts/saved-tabs/presentation/types/SavedTabsComponentProps.ts
+++ b/src/contexts/saved-tabs/presentation/types/SavedTabsComponentProps.ts
@@ -12,7 +12,7 @@ import type {
   SavedTabsUserSettingsDto as UserSettings,
 } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 
-export interface DomainCardActionHandlers {
+export type DomainCardActionHandlers = {
   handleOpenAllTabs: (urls: { url: string; title: string }[]) => void
   handleDeleteGroup: (id: string) => void
   handleDeleteGroups?: (ids: string[]) => void
@@ -24,7 +24,7 @@ export interface DomainCardActionHandlers {
 }
 
 // カテゴリグループコンポーネント
-export interface CategoryGroupProps extends DomainCardActionHandlers {
+export type CategoryGroupProps = DomainCardActionHandlers & {
   category: ParentCategory
   domains: TabGroup[]
   handleUpdateDomainsOrder?: (
@@ -42,7 +42,7 @@ export interface CategoryGroupProps extends DomainCardActionHandlers {
 }
 
 // ドメインカード用のソータブルコンポーネントの型
-export interface SortableDomainCardProps extends DomainCardActionHandlers {
+export type SortableDomainCardProps = DomainCardActionHandlers & {
   group: TabGroup
   categoryId?: string // 親カテゴリID
   isDraggingOver?: boolean // ドラッグオーバー状態
@@ -52,7 +52,7 @@ export interface SortableDomainCardProps extends DomainCardActionHandlers {
 }
 
 // カテゴリセクションコンポーネント
-export interface CategorySectionProps {
+export type CategorySectionProps = {
   categoryName: string
   urls: TabGroup['urls']
   groupId: string
@@ -65,7 +65,7 @@ export interface CategorySectionProps {
 }
 
 // 並び替え可能なカテゴリセクションコンポーネント
-export interface SortableCategorySectionProps extends CategorySectionProps {
+export type SortableCategorySectionProps = CategorySectionProps & {
   id: string // ソート用の一意のID
   handleOpenAllTabs: (urls: { url: string; title: string }[]) => void // すべて開く処理
   stickyTop?: string // Sticky位置のクラス名（オプション）
@@ -73,7 +73,7 @@ export interface SortableCategorySectionProps extends CategorySectionProps {
 }
 
 // URL項目用のソータブルコンポーネント
-export interface SortableUrlItemProps {
+export type SortableUrlItemProps = {
   url: string
   title: string
   id: string
@@ -98,7 +98,7 @@ export interface SortableUrlItemProps {
 }
 
 // カード内のURL一覧
-export interface UrlListProps {
+export type UrlListProps = {
   items: TabGroup['urls']
   groupId: string
   subCategories?: string[]
@@ -114,7 +114,7 @@ export interface UrlListProps {
 }
 
 // カテゴリキーワード管理モーダルコンポーネント
-export interface CategoryKeywordModalProps {
+export type CategoryKeywordModalProps = {
   group: TabGroup
   isOpen: boolean
   onClose: () => void

--- a/src/contexts/saved-tabs/presentation/types/mode.ts
+++ b/src/contexts/saved-tabs/presentation/types/mode.ts
@@ -14,11 +14,11 @@ export type ModeSyncEventType =
   | 'settingsUpdated'
   | 'categoriesUpdated'
 
-export interface ModeSyncEvent {
+export type ModeSyncEvent = {
   type: ModeSyncEventType
 }
 
-export interface SavedTabsModeAdapter {
+export type SavedTabsModeAdapter = {
   readonly mode: ViewMode
   getGroups: () => Promise<TabGroup[]>
   getProjects: () => Promise<CustomProject[]>

--- a/src/contexts/saved-tabs/presentation/view-models/CustomModeViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/CustomModeViewModel.ts
@@ -9,7 +9,7 @@ import { toCustomProjectViewModel } from './CustomProjectViewModel'
  * カスタムプロジェクト一覧と検索クエリ、合計 URL 数を保持する。
  * `useCustomModeController` が組み立て、`CustomModeContainer` が受け取る。
  */
-export interface CustomModeViewModel {
+export type CustomModeViewModel = {
   readonly loading: boolean
   readonly error: string | null
   readonly projects: readonly CustomProjectViewModel[]
@@ -18,7 +18,7 @@ export interface CustomModeViewModel {
   readonly hasContent: boolean
 }
 
-export interface CreateCustomModeViewModelInput {
+export type CreateCustomModeViewModelInput = {
   readonly loading: boolean
   readonly error: string | null
   readonly projects: readonly CustomProject[]

--- a/src/contexts/saved-tabs/presentation/view-models/CustomProjectViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/CustomProjectViewModel.ts
@@ -5,7 +5,7 @@
  * 既存の `CustomProjectCard` / `CustomProjectSection` が要求する形に揃え、
  * コンポーネントへそのまま props として渡せることを目標にする。
  */
-export interface CustomProjectViewModel {
+export type CustomProjectViewModel = {
   readonly id: string
   readonly name: string
   readonly urlIds: readonly string[]

--- a/src/contexts/saved-tabs/presentation/view-models/DomainModeViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/DomainModeViewModel.ts
@@ -14,7 +14,7 @@ import { toTabGroupViewModel } from './TabGroupViewModel'
  * category 割当・検索フィルタ・並び替え状態などの UI 派生値を含める。
  * `useDomainModeController` が組み立て、`DomainModeContainer` が受け取る。
  */
-export interface DomainModeViewModel {
+export type DomainModeViewModel = {
   readonly loading: boolean
   readonly error: string | null
   readonly tabGroups: readonly TabGroupViewModel[]
@@ -25,7 +25,7 @@ export interface DomainModeViewModel {
   readonly categories: readonly ParentCategoryViewModel[]
 }
 
-export interface ParentCategoryViewModel {
+export type ParentCategoryViewModel = {
   readonly id: string
   readonly name: string
   readonly domains: readonly string[]
@@ -52,7 +52,7 @@ export const toParentCategoryViewModel = (
  * (branded 型なし) を扱うケースも、controller 側で entity へ詰め替えるか
  * `unknown` キャストで吸収する。
  */
-export interface CreateDomainModeViewModelInput {
+export type CreateDomainModeViewModelInput = {
   readonly loading: boolean
   readonly error: string | null
   readonly tabGroups: readonly TabGroup[]

--- a/src/contexts/saved-tabs/presentation/view-models/SavedTabsViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/SavedTabsViewModel.ts
@@ -11,7 +11,7 @@ import type { TabGroupViewModel } from './TabGroupViewModel'
  * domain entity を直接参照しない。これにより presentation 層が
  * application 層 interface 変更に振り回されにくくなる。
  */
-export interface SavedTabsViewModel {
+export type SavedTabsViewModel = {
   readonly loading: boolean
   readonly error: string | null
   readonly tabGroups: readonly TabGroupViewModel[]

--- a/src/contexts/saved-tabs/presentation/view-models/TabGroupViewModel.ts
+++ b/src/contexts/saved-tabs/presentation/view-models/TabGroupViewModel.ts
@@ -11,7 +11,7 @@
  * - `subCategoryCount` は CategoryModal / CategoryGroup で「カテゴリ N 件」を
  *   表示するための派生値。
  */
-export interface TabGroupViewModel {
+export type TabGroupViewModel = {
   readonly id: string
   readonly domain: string
   readonly parentCategoryId: string | undefined

--- a/src/contexts/saved-tabs/testing/createMockParentCategoryRepository.ts
+++ b/src/contexts/saved-tabs/testing/createMockParentCategoryRepository.ts
@@ -14,7 +14,7 @@ import type { ParentCategory } from '@/contexts/saved-tabs/domain/entities/Paren
 import type { ParentCategoryRepository } from '@/contexts/saved-tabs/domain/repositories/ParentCategoryRepository'
 import type { ParentCategoryId } from '@/contexts/saved-tabs/domain/value-objects/ParentCategoryId'
 
-export interface MockParentCategoryRepositoryState {
+export type MockParentCategoryRepositoryState = {
   readonly parentCategories: readonly ParentCategory[]
 }
 

--- a/src/contexts/saved-tabs/testing/createMockTabGroupRepository.ts
+++ b/src/contexts/saved-tabs/testing/createMockTabGroupRepository.ts
@@ -30,7 +30,7 @@ import type { TabGroup } from '@/contexts/saved-tabs/domain/entities/TabGroup'
 import type { TabGroupRepository } from '@/contexts/saved-tabs/domain/repositories/TabGroupRepository'
 import type { TabGroupId } from '@/contexts/saved-tabs/domain/value-objects/TabGroupId'
 
-export interface MockTabGroupRepositoryState {
+export type MockTabGroupRepositoryState = {
   readonly savedTabs: readonly TabGroup[]
 }
 

--- a/src/entrypoints/shared/legacyRedirect.ts
+++ b/src/entrypoints/shared/legacyRedirect.ts
@@ -23,7 +23,7 @@ const redirectToApp = (
   return nextHref
 }
 
-interface LegacyRedirectOptions {
+type LegacyRedirectOptions = {
   replace: (href: string) => void
 }
 

--- a/src/features/ai-chat/components/AiChartRenderer.tsx
+++ b/src/features/ai-chat/components/AiChartRenderer.tsx
@@ -28,7 +28,7 @@ import {
   YAxis,
 } from '@/lib/lazy-recharts'
 
-interface AiChartPointSelection {
+type AiChartPointSelection = {
   label: string
   seriesKey?: string
   spec: AiChartSpec
@@ -242,14 +242,14 @@ const renderPieChart = ({
   </PieChart>
 )
 
-interface CartesianChartRenderProps {
+type CartesianChartRenderProps = {
   onChartPointClick?: (selection: AiChartPointSelection) => void
   primarySeries: AiChartSeries
   shouldShowLegend: boolean
   spec: AiChartSpec
 }
 
-interface CartesianChartContentProps {
+type CartesianChartContentProps = {
   children: ReactNode
   shouldShowLegend: boolean
   spec: AiChartSpec

--- a/src/features/ai-chat/components/ConversationPreviewTooltip.tsx
+++ b/src/features/ai-chat/components/ConversationPreviewTooltip.tsx
@@ -5,7 +5,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 
-interface ConversationPreviewTooltipProps {
+type ConversationPreviewTooltipProps = {
   id: string
   preview: string
 }

--- a/src/features/ai-chat/components/LazySavedTabsChatWidget.tsx
+++ b/src/features/ai-chat/components/LazySavedTabsChatWidget.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 import type { AiChatConversationMessage } from '@/features/ai-chat/types'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 
-interface LazySavedTabsChatWidgetProps {
+type LazySavedTabsChatWidgetProps = {
   defaultOpen?: boolean
   historyVariant?: 'dropdown' | 'none' | 'sidebar-toggle'
   mode?: 'floating' | 'page'

--- a/src/features/ai-chat/components/OllamaErrorNotice.tsx
+++ b/src/features/ai-chat/components/OllamaErrorNotice.tsx
@@ -29,7 +29,7 @@ const getClipboard = (): Pick<Clipboard, 'writeText'> | null => {
   return hasClipboardWrite(clipboard) ? clipboard : null
 }
 
-interface OllamaErrorNoticeProps {
+type OllamaErrorNoticeProps = {
   className?: string
   error: OllamaErrorDetails
   platform: OllamaErrorPlatform

--- a/src/features/ai-chat/components/OllamaModelSelector.tsx
+++ b/src/features/ai-chat/components/OllamaModelSelector.tsx
@@ -15,12 +15,12 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { cn } from '@/lib/utils'
 import type { OllamaErrorDetails } from '@/types/background'
 
-interface OllamaModelOption {
+type OllamaModelOption = {
   label: string
   name: string
 }
 
-interface OllamaModelSelectorProps {
+type OllamaModelSelectorProps = {
   behavior?: {
     fetchOnOpen?: boolean
     hideFetchButton?: boolean

--- a/src/features/ai-chat/components/SavedTabsChatHeaderTooltipButton.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatHeaderTooltipButton.tsx
@@ -8,7 +8,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 
-interface SavedTabsChatHeaderTooltipButtonProps {
+type SavedTabsChatHeaderTooltipButtonProps = {
   ariaLabel: string
   children: ReactNode
   dataState?: 'copied' | 'idle'

--- a/src/features/ai-chat/components/SavedTabsChatHistoryItemCard.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatHistoryItemCard.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils'
 
 import type { TranslateFn } from './savedTabsChat/messages'
 
-interface SavedTabsChatHistoryItemCardProps {
+type SavedTabsChatHistoryItemCardProps = {
   historyItem: AiChatHistoryItem
   isActive: boolean
   onDeleteHistoryItem?: (conversationId: string) => void

--- a/src/features/ai-chat/components/SavedTabsChatWidget.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.tsx
@@ -158,7 +158,7 @@ import { useChatPromptManager } from './savedTabsChat/useChatPromptManager'
 import { useChatStreamHandlers } from './savedTabsChat/useChatStreamHandlers'
 import { getSavedTabsChatAttachmentId } from './savedTabsChatAttachmentItem.helpers'
 
-interface ClipboardWriter {
+type ClipboardWriter = {
   writeText: (text: string) => Promise<void>
 }
 
@@ -185,7 +185,7 @@ const getClipboardWriter = (): ClipboardWriter | null => {
 const getConversationClipboard = (): ClipboardWriter | null =>
   typeof window === 'undefined' ? null : getClipboardWriter()
 
-interface SavedTabsChatPanelProps {
+type SavedTabsChatPanelProps = {
   activeSystemPromptId: string
   chatErrorMessage: string
   chatOllamaError?: OllamaErrorDetails
@@ -235,7 +235,7 @@ interface SavedTabsChatPanelProps {
   systemPrompts: AiSystemPromptPreset[]
 }
 
-interface SavedTabsChatWidgetProps {
+type SavedTabsChatWidgetProps = {
   conversationId?: string
   defaultOpen?: boolean
   historyItems?: AiChatHistoryItem[]

--- a/src/features/ai-chat/components/SystemPromptManagerDialog.tsx
+++ b/src/features/ai-chat/components/SystemPromptManagerDialog.tsx
@@ -25,7 +25,7 @@ import type { AiSystemPromptPreset } from '@/types/storage'
 
 import { getSelectedPrompt } from './savedTabsChat/prompts'
 
-export interface SystemPromptManagerDialogProps {
+export type SystemPromptManagerDialogProps = {
   activePromptId: string
   errorMessage: string
   isOpen: boolean

--- a/src/features/ai-chat/components/savedTabsChat/messages.ts
+++ b/src/features/ai-chat/components/savedTabsChat/messages.ts
@@ -9,7 +9,7 @@ type TranslateFn = (
   values?: Record<string, string>,
 ) => string
 
-interface ChatMessageSource {
+type ChatMessageSource = {
   title: string
   url: string
 }

--- a/src/features/ai-chat/components/savedTabsChat/streaming.ts
+++ b/src/features/ai-chat/components/savedTabsChat/streaming.ts
@@ -42,7 +42,7 @@ const getAiChatOllamaError = (
   response: AiChatResponse | undefined,
 ): OllamaErrorDetails | undefined => response?.ollamaError
 
-interface RuntimePlatformApi {
+type RuntimePlatformApi = {
   getPlatformInfo: (
     callback: (info: chrome.runtime.PlatformInfo) => void,
   ) => void

--- a/src/features/ai-chat/components/savedTabsChat/useChatStreamHandlers.ts
+++ b/src/features/ai-chat/components/savedTabsChat/useChatStreamHandlers.ts
@@ -24,7 +24,7 @@ import {
   requestAssistantAnswer,
 } from './streaming'
 
-interface UseChatStreamHandlersParams {
+type UseChatStreamHandlersParams = {
   messages: ChatMessage[]
   activePortRef: {
     current: {

--- a/src/features/ai-chat/hooks/useSharedAiChatHistory.ts
+++ b/src/features/ai-chat/hooks/useSharedAiChatHistory.ts
@@ -13,12 +13,12 @@ import type {
 } from '@/features/ai-chat/types'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 
-interface ConversationHistoryState {
+type ConversationHistoryState = {
   activeConversationId: string
   conversations: AiChatConversation[]
 }
 
-interface UseSharedAiChatHistoryResult {
+type UseSharedAiChatHistoryResult = {
   activeConversation: AiChatConversation | null
   createConversation: () => void
   deleteConversation: (conversationId: string) => void

--- a/src/features/ai-chat/lib/buildAiContext.ts
+++ b/src/features/ai-chat/lib/buildAiContext.ts
@@ -10,7 +10,7 @@ import { isTimestampInLocalMonth } from '@/utils/localDateTime'
 
 const unique = (values: string[]): string[] => [...new Set(values)]
 
-interface BuildAiSavedUrlRecordsInput {
+type BuildAiSavedUrlRecordsInput = {
   urlRecords: UrlRecord[]
   savedTabs: TabGroup[]
   customProjects: CustomProject[]

--- a/src/features/ai-chat/lib/conversation-history.ts
+++ b/src/features/ai-chat/lib/conversation-history.ts
@@ -11,7 +11,7 @@ import {
 const AI_CHAT_CONVERSATIONS_KEY = 'aiChatConversations'
 const ACTIVE_AI_CHAT_CONVERSATION_ID_KEY = 'activeAiChatConversationId'
 
-interface ConversationHistoryState {
+type ConversationHistoryState = {
   activeConversationId: string
   conversations: AiChatConversation[]
 }

--- a/src/features/ai-chat/types.ts
+++ b/src/features/ai-chat/types.ts
@@ -16,7 +16,7 @@ export type {
   OllamaErrorDetails,
 } from '@/types/ai-chat-protocol'
 
-export interface AiSavedUrlRecord {
+export type AiSavedUrlRecord = {
   id: string
   url: string
   title: string
@@ -31,13 +31,13 @@ export interface AiSavedUrlRecord {
 
 export type AiSavedUrlSortDirection = 'asc' | 'desc'
 
-export interface AiSavedUrlPageOptions {
+export type AiSavedUrlPageOptions = {
   page?: number
   pageSize?: number
   sortDirection?: AiSavedUrlSortDirection
 }
 
-export interface AiSavedUrlToolItem {
+export type AiSavedUrlToolItem = {
   url: string
   title: string
   domain: string
@@ -46,7 +46,7 @@ export interface AiSavedUrlToolItem {
   parentCategories: string[]
 }
 
-export interface AiSavedUrlPage<T> {
+export type AiSavedUrlPage<T> = {
   items: T[]
   page: number
   pageSize: number
@@ -57,7 +57,7 @@ export interface AiSavedUrlPage<T> {
   sortDirection: AiSavedUrlSortDirection
 }
 
-export interface AiChatConversationMessage {
+export type AiChatConversationMessage = {
   attachments?: AiChatAttachment[]
   charts?: AiChartSpec[]
   content: string
@@ -69,7 +69,7 @@ export interface AiChatConversationMessage {
   toolTraces?: AiChatToolTrace[]
 }
 
-export interface AiChatConversation {
+export type AiChatConversation = {
   createdAt: number
   id: string
   messages: AiChatConversationMessage[]
@@ -77,34 +77,19 @@ export interface AiChatConversation {
   updatedAt: number
 }
 
-export interface AiChatHistoryItem {
+export type AiChatHistoryItem = {
   id: string
   isActive: boolean
   preview: string
   title: string
 }
 
-export interface InterestEvidenceEntry {
+export type InterestEvidenceEntry = {
   value: string
   count: number
 }
 
-export interface AiChatConversation {
-  createdAt: number
-  id: string
-  messages: AiChatConversationMessage[]
-  title: string
-  updatedAt: number
-}
-
-export interface AiChatHistoryItem {
-  id: string
-  isActive: boolean
-  preview: string
-  title: string
-}
-
-export interface InterestInferenceResult {
+export type InterestInferenceResult = {
   summary: string
   isTentative: boolean
   evidence: {

--- a/src/features/analytics/lib/analytics.ts
+++ b/src/features/analytics/lib/analytics.ts
@@ -24,12 +24,12 @@ type AnalyticsTimeBucket = 'day' | 'month' | 'week'
 type AnalyticsSort = 'label-asc' | 'label-desc' | 'value-asc' | 'value-desc'
 type AnalyticsCompareBy = 'mode' | 'none'
 
-interface AnalyticsDateRange {
+type AnalyticsDateRange = {
   from?: string
   to?: string
 }
 
-interface AnalyticsFilters {
+type AnalyticsFilters = {
   excludedDomains: string[]
   excludedParentCategories: string[]
   excludedProjectCategories: string[]
@@ -42,7 +42,7 @@ interface AnalyticsFilters {
   includedSubCategories: string[]
 }
 
-interface AnalyticsQuery {
+type AnalyticsQuery = {
   chartType: AiChartType
   compareBy: AnalyticsCompareBy
   customDateRange?: AnalyticsDateRange
@@ -64,7 +64,7 @@ type AnalyticsQueryInput = Omit<AnalyticsQuery, 'groupBy'> & {
   groupBy: LegacyAnalyticsGroupBy
 }
 
-interface AnalyticsPreset {
+type AnalyticsPreset = {
   id: string
   description: string
   isReadonly: true
@@ -72,20 +72,20 @@ interface AnalyticsPreset {
   query: AnalyticsQuery
 }
 
-interface AnalyticsResult {
+type AnalyticsResult = {
   chartSpecs: AiChartSpec[]
   filteredRecordCount: number
   query: AnalyticsQuery
   summary: string
 }
 
-interface GenerateAnalyticsResultOptions {
+type GenerateAnalyticsResultOptions = {
   messages?: Partial<AnalyticsMessages>
   now?: number
   timeZone?: string
 }
 
-interface AnalyticsMessages {
+type AnalyticsMessages = {
   chartDescriptionAggregated: string
   chartDescriptionCompareMode: string
   chartMonthlySavedTrend: string

--- a/src/features/analytics/routes/AnalyticsDialogs.tsx
+++ b/src/features/analytics/routes/AnalyticsDialogs.tsx
@@ -13,7 +13,7 @@ import {
 import type { AiSavedUrlRecord } from '@/features/ai-chat/types'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 
-interface AnalyticsDialogsProps {
+type AnalyticsDialogsProps = {
   isBulkDeleteConfirmOpen: boolean
   isOpenAllConfirmOpen: boolean
   deleteTarget: AiSavedUrlRecord | null

--- a/src/features/analytics/routes/AnalyticsDrilldownPanel.tsx
+++ b/src/features/analytics/routes/AnalyticsDrilldownPanel.tsx
@@ -138,7 +138,7 @@ const DrilldownRecordCard = ({
   )
 }
 
-interface AnalyticsDrilldownPanelProps {
+type AnalyticsDrilldownPanelProps = {
   drilldownSelection: AnalyticsDrilldownSelection | null
   onOpenAllClick: () => void
   onDeleteAllClick: () => void

--- a/src/features/analytics/routes/AnalyticsRecordActionButtons.tsx
+++ b/src/features/analytics/routes/AnalyticsRecordActionButtons.tsx
@@ -73,7 +73,7 @@ const DeleteRecordButton = ({
   )
 }
 
-interface AnalyticsRecordActionButtonsProps {
+type AnalyticsRecordActionButtonsProps = {
   deletingUrl: string | null
   handleDeleteClick: (record: AiSavedUrlRecord) => void
   isDeleteActionDisabled: boolean

--- a/src/features/analytics/routes/AnalyticsSidebar.tsx
+++ b/src/features/analytics/routes/AnalyticsSidebar.tsx
@@ -29,7 +29,7 @@ import type { ViewNameValidationError } from '@/features/analytics/routes/analyt
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import type { SavedAnalyticsView } from '@/lib/storage/analytics'
 
-interface AnalyticsSidebarProps {
+type AnalyticsSidebarProps = {
   query: AnalyticsQuery
   viewName: string
   viewNameError: ViewNameValidationError | null

--- a/src/features/analytics/routes/analyticsRoute.helpers.ts
+++ b/src/features/analytics/routes/analyticsRoute.helpers.ts
@@ -327,7 +327,7 @@ const removeUrlRecordsFromStorage = async (urlIds: string[]): Promise<void> =>
     )
   })
 
-interface AnalyticsDeleteUndoSnapshot {
+type AnalyticsDeleteUndoSnapshot = {
   customProjectOrder?: string[]
   customProjects?: CustomProject[]
   parentCategories?: ParentCategory[]
@@ -335,7 +335,7 @@ interface AnalyticsDeleteUndoSnapshot {
   urls?: UrlRecord[]
 }
 
-interface AnalyticsDeleteUndoPayload {
+type AnalyticsDeleteUndoPayload = {
   customProjectOrder?: string[]
   customProjects?: CustomProject[]
   parentCategories?: ParentCategory[]
@@ -391,7 +391,7 @@ const normalizeAnalyticsRouteQuery = (
   mode: 'both',
 })
 
-interface AnalyticsDrilldownSelection {
+type AnalyticsDrilldownSelection = {
   label: string
   matchingRecords: AiSavedUrlRecord[]
   seriesKey?: string

--- a/src/features/i18n/components/DocumentTitleSync.tsx
+++ b/src/features/i18n/components/DocumentTitleSync.tsx
@@ -4,7 +4,7 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 import type { TitlePageKey } from '@/features/i18n/lib/title'
 import { getDocumentTitle } from '@/features/i18n/lib/title'
 
-interface DocumentTitleSyncProps {
+type DocumentTitleSyncProps = {
   page: TitlePageKey
 }
 

--- a/src/features/i18n/context/I18nProvider.tsx
+++ b/src/features/i18n/context/I18nProvider.tsx
@@ -17,7 +17,7 @@ import {
   saveUserSettings,
 } from '@/lib/storage/settings'
 
-interface I18nContextValue {
+type I18nContextValue = {
   language: AppLanguage
   languageSetting: LanguageSetting
   setLanguageSetting: (language: LanguageSetting) => Promise<void>

--- a/src/features/i18n/messages.ts
+++ b/src/features/i18n/messages.ts
@@ -1693,12 +1693,12 @@ const getMessages = (language: AppLanguage) => messages[language]
 type AppLanguage = 'ja' | 'en'
 type LanguageSetting = 'system' | AppLanguage
 
-interface ChangelogFeature {
+type ChangelogFeature = {
   text: string
   highlight?: boolean
 }
 
-interface ChangelogItem {
+type ChangelogItem = {
   version: string
   date: string
   features: ChangelogFeature[]

--- a/src/features/navigation/app/AppRouter.tsx
+++ b/src/features/navigation/app/AppRouter.tsx
@@ -17,11 +17,11 @@ import {
 
 import { AppLayout } from './AppLayout'
 
-interface AppRouterProps {
+type AppRouterProps = {
   initialEntries?: string[]
 }
 
-interface StorageLocalRemove {
+type StorageLocalRemove = {
   remove: (key: string) => Promise<void>
 }
 

--- a/src/features/navigation/components/ExtensionPageHeader.tsx
+++ b/src/features/navigation/components/ExtensionPageHeader.tsx
@@ -1,4 +1,4 @@
-interface ExtensionPageHeaderProps {
+type ExtensionPageHeaderProps = {
   description?: string
   title: string
 }

--- a/src/features/navigation/components/ExtensionPageShell.tsx
+++ b/src/features/navigation/components/ExtensionPageShell.tsx
@@ -2,7 +2,7 @@ import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
 import { ExtensionSidebar } from '@/features/navigation/components/ExtensionSidebar'
 import { getSidebarStateFromLocation } from '@/features/navigation/lib/pageNavigation'
 
-interface ExtensionPageShellProps {
+type ExtensionPageShellProps = {
   children: React.ReactNode
   pathname?: string
   search?: string

--- a/src/features/navigation/components/ExtensionSidebar.tsx
+++ b/src/features/navigation/components/ExtensionSidebar.tsx
@@ -44,7 +44,7 @@ import type {
 } from '@/features/navigation/lib/pageNavigation'
 import { cn } from '@/lib/utils'
 
-interface ExtensionSidebarProps {
+type ExtensionSidebarProps = {
   state: SidebarState
 }
 
@@ -144,7 +144,7 @@ const ICON_RAIL_WIDTH_PX = 48
 const EXPANDED_SIDEBAR_WIDTH_PX = 256
 const SIDEBAR_WIDTH_STORAGE_KEY = 'tabbin-extension-sidebar-width'
 
-interface RailItem {
+type RailItem = {
   icon: React.ComponentType<{ className?: string }>
   isActive: boolean
   label: string

--- a/src/features/navigation/lib/pageNavigation.ts
+++ b/src/features/navigation/lib/pageNavigation.ts
@@ -8,7 +8,7 @@ type SidebarItemId =
   | 'saved-tabs-domain'
   | 'saved-tabs-custom'
 
-interface SidebarState {
+type SidebarState = {
   expandedGroup: 'tab-list'
   item: SidebarItemId
 }

--- a/src/features/options/ImportFileDialog.tsx
+++ b/src/features/options/ImportFileDialog.tsx
@@ -31,7 +31,7 @@ import {
 } from './importFileDialog.helpers'
 import type { PreviewData } from './importFileDialog.helpers'
 
-interface ImportSelectStepProps {
+type ImportSelectStepProps = {
   mergeData: boolean
   onMergeChange: (mergeData: boolean) => void
   isDragActive: boolean
@@ -99,7 +99,7 @@ const ImportSelectStep: React.FC<ImportSelectStepProps> = ({
   )
 }
 
-interface ImportPreviewStepProps {
+type ImportPreviewStepProps = {
   previewData: PreviewData
   mergeData: boolean
 }
@@ -176,7 +176,7 @@ const ImportPreviewStep: React.FC<ImportPreviewStepProps> = ({
   )
 }
 
-interface ImportFileDialogProps {
+type ImportFileDialogProps = {
   onImportSuccess: () => Promise<void>
 }
 

--- a/src/features/options/OptionsColorPickerRow.tsx
+++ b/src/features/options/OptionsColorPickerRow.tsx
@@ -3,7 +3,7 @@ import { Label } from '@/components/ui/label'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import type { UserSettings } from '@/types/storage'
 
-interface OptionsColorPickerRowProps {
+type OptionsColorPickerRowProps = {
   colorKey: keyof NonNullable<UserSettings['colors']>
   color: string
   label: string

--- a/src/features/options/OptionsExcludePatternBadge.tsx
+++ b/src/features/options/OptionsExcludePatternBadge.tsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 
-interface OptionsExcludePatternBadgeProps {
+type OptionsExcludePatternBadgeProps = {
   pattern: string
   onRemove: (pattern: string) => void
 }

--- a/src/features/options/OptionsExcludePatternInputRow.tsx
+++ b/src/features/options/OptionsExcludePatternInputRow.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 
-interface OptionsExcludePatternInputRowProps {
+type OptionsExcludePatternInputRowProps = {
   excludePatternInput: string
   onInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onBlur: () => void

--- a/src/features/options/OptionsFontSizeInputColumn.tsx
+++ b/src/features/options/OptionsFontSizeInputColumn.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/constants/fontSize'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 
-interface OptionsFontSizeInputColumnProps {
+type OptionsFontSizeInputColumnProps = {
   value: string
   onValueChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onBlur: () => void

--- a/src/features/options/SubCategoryButton.tsx
+++ b/src/features/options/SubCategoryButton.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 
 import { Button } from '@/components/ui/button'
 
-interface SubCategoryButtonProps {
+type SubCategoryButtonProps = {
   category: string
   activeCategory: string | null
   onSelect: (category: string) => void

--- a/src/features/options/SubCategoryKeywordManager.tsx
+++ b/src/features/options/SubCategoryKeywordManager.tsx
@@ -19,7 +19,7 @@ import {
   updateTabGroup,
 } from './subCategoryKeywordManager.helpers'
 
-interface NewSubCategoryFieldProps {
+type NewSubCategoryFieldProps = {
   value: string
   label: string
   placeholder: string

--- a/src/features/options/SubCategoryKeywordTag.tsx
+++ b/src/features/options/SubCategoryKeywordTag.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 
 import { Button } from '@/components/ui/button'
 
-interface SubCategoryKeywordTagProps {
+type SubCategoryKeywordTagProps = {
   keyword: string
   onRemove: (keyword: string) => void | Promise<void>
   deleteAriaLabel: string

--- a/src/features/options/SubCategoryRenameSection.tsx
+++ b/src/features/options/SubCategoryRenameSection.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 
-interface SubCategoryRenameSectionProps {
+type SubCategoryRenameSectionProps = {
   renameInputRef: React.RefObject<HTMLInputElement | null>
   newCategoryName: string
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void

--- a/src/features/options/hooks/useAutoDeletePeriod.ts
+++ b/src/features/options/hooks/useAutoDeletePeriod.ts
@@ -6,7 +6,7 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 import type { UserSettings } from '@/types/storage'
 import { isPeriodShortening } from '@/utils/isPeriodShortening'
 
-interface ConfirmationState {
+type ConfirmationState = {
   isVisible: boolean
   message: string
   onConfirm: () => void

--- a/src/features/options/hooks/useSettings.additional.test.tsx
+++ b/src/features/options/hooks/useSettings.additional.test.tsx
@@ -47,7 +47,7 @@ type StorageListener = (
   areaName: string,
 ) => void
 
-interface RetryToastOptions {
+type RetryToastOptions = {
   action?: {
     label: string
     onClick: () => Promise<void> | void

--- a/src/features/options/importFileDialog.helpers.ts
+++ b/src/features/options/importFileDialog.helpers.ts
@@ -1,6 +1,6 @@
 import type { Dispatch } from 'react'
 
-interface PreviewData {
+type PreviewData = {
   version: string
   timestamp: string
   categoriesCount: number
@@ -10,7 +10,7 @@ interface PreviewData {
   hasAnalytics: boolean
 }
 
-interface ImportDialogState {
+type ImportDialogState = {
   isOpen: boolean
   step: 'select' | 'preview'
   previewData: PreviewData | null

--- a/src/features/options/lib/import-export/flows.ts
+++ b/src/features/options/lib/import-export/flows.ts
@@ -56,7 +56,7 @@ import {
   resolveCurrentLanguage,
 } from './url-conversion'
 
-interface ImportResult {
+type ImportResult = {
   success: boolean
   message: string
 }
@@ -72,7 +72,7 @@ type NormalizedImportedTab =
   NormalizedImportResult['normalizedImportedTabs'][number]
 type UnresolvedImportTab = NormalizedImportResult['unresolvedTabs'][number]
 
-interface ImportExecutionParams {
+type ImportExecutionParams = {
   importedData: BackupData
   normalizedImportedTabs: NormalizedImportedTab[]
   unresolvedTabs: UnresolvedImportTab[]

--- a/src/features/options/lib/import-export/schemas.ts
+++ b/src/features/options/lib/import-export/schemas.ts
@@ -5,7 +5,7 @@ import type { SavedAnalyticsView } from '@/lib/storage/analytics'
 import { isValidUrl } from '@/lib/url-filter'
 import type { ParentCategory, UserSettings } from '@/types/storage'
 
-interface ImportedUrlData {
+type ImportedUrlData = {
   url: string
   title?: string
   favIconUrl?: string
@@ -15,7 +15,7 @@ interface ImportedUrlData {
   savedAt?: number
 }
 
-interface ImportedUrlRecordData {
+type ImportedUrlRecordData = {
   id: string
   url: string
   title?: string
@@ -29,7 +29,7 @@ const importableUrlSchema = z.string().refine(isValidUrl, {
 
 const favIconUrlSchema = importableUrlSchema.or(z.literal(''))
 
-interface ImportedTabData {
+type ImportedTabData = {
   id: string
   domain: string
   urls?: ImportedUrlData[]
@@ -43,7 +43,7 @@ interface ImportedTabData {
   savedAt?: number
 }
 
-interface ImportedCustomProjectData {
+type ImportedCustomProjectData = {
   id: string
   name: string
   projectKeywords?: {
@@ -72,7 +72,7 @@ interface ImportedCustomProjectData {
   updatedAt?: number
 }
 
-interface ImportedCustomProjectUrlData {
+type ImportedCustomProjectUrlData = {
   url: string
   title?: string
   notes?: string
@@ -80,12 +80,12 @@ interface ImportedCustomProjectUrlData {
   category?: string
 }
 
-interface ConvertedUrlData {
+type ConvertedUrlData = {
   urlIds: string[]
   urlSubCategories?: Record<string, string>
 }
 
-interface BackupData {
+type BackupData = {
   version: string
   timestamp: string
   userSettings: Partial<UserSettings>

--- a/src/features/options/lib/import-export/settings-merge.ts
+++ b/src/features/options/lib/import-export/settings-merge.ts
@@ -46,7 +46,7 @@ import {
 
 const BULK_URL_CONVERSION_THRESHOLD = 100
 
-interface NormalizedImportResult {
+type NormalizedImportResult = {
   normalizedImportedTabs: (ImportedTabData & { urls: ImportedUrlData[] })[]
   unresolvedTabs: {
     domain: string

--- a/src/features/options/routes/OptionsRoute.tsx
+++ b/src/features/options/routes/OptionsRoute.tsx
@@ -63,7 +63,7 @@ const applyFontSizePreview = (value: number) => {
   )
 }
 
-interface ClickBehaviorSelectProps {
+type ClickBehaviorSelectProps = {
   value: string
   onValueChange: (value: string) => void
 }

--- a/src/features/periodic-execution/components/AutoDeleteSettingsCard.tsx
+++ b/src/features/periodic-execution/components/AutoDeleteSettingsCard.tsx
@@ -14,13 +14,13 @@ import {
 import { autoDeleteOptions } from '@/constants/autoDeleteOptions'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 
-interface ConfirmationState {
+type ConfirmationState = {
   isVisible: boolean
   message: string
   onConfirm: () => void
 }
 
-interface AutoDeleteSettingsCardProps {
+type AutoDeleteSettingsCardProps = {
   confirmationState: ConfirmationState
   hideConfirmation: () => void
   pendingAutoDeletePeriod: string | null | undefined

--- a/src/lib/architecture/oxlintConfig.test.ts
+++ b/src/lib/architecture/oxlintConfig.test.ts
@@ -132,6 +132,51 @@ describe('oxlint configuration', () => {
     ])
   })
 
+  it('enforces type over interface for object type definitions', () => {
+    const config = JSON.parse(readFileSync(oxlintConfigPath, 'utf8'))
+
+    expect(config.rules['typescript/consistent-type-definitions']).toEqual([
+      'error',
+      'type',
+    ])
+  })
+
+  it('reports interface declarations as consistent-type-definitions errors', () => {
+    const result = runOxlint(`
+interface SavedTab {
+  title: string
+}
+
+export const tab: SavedTab = { title: 'test' }
+`)
+
+    expect(result.status).not.toBe(0)
+    expect(result.output).toContain('typescript/consistent-type-definitions')
+  })
+
+  it('accepts type alias declarations for object types', () => {
+    const result = runOxlint(`
+type SavedTab = {
+  title: string
+}
+
+export const tab: SavedTab = { title: 'test' }
+`)
+
+    expect(result).toEqual({ status: 0, output: '' })
+  })
+
+  it('disables consistent-type-definitions for .d.ts files', () => {
+    const config = JSON.parse(readFileSync(oxlintConfigPath, 'utf8'))
+
+    expect(config.overrides).toContainEqual({
+      files: ['src/**/*.d.ts'],
+      rules: {
+        'typescript/consistent-type-definitions': 'off',
+      },
+    })
+  })
+
   it('disallows parameter reassignment in contexts domain and application layers', () => {
     const config = JSON.parse(readFileSync(oxlintConfigPath, 'utf8'))
 
@@ -163,7 +208,7 @@ export const firstStatus = statuses[0]
 
   it('reports non-const type assertions as errors', () => {
     const result = runOxlint(`
-interface User {
+type User = {
   id: string
 }
 
@@ -182,7 +227,7 @@ export const user = rawUser as User
     const result = runOxlint(`
 type Props = {}
 
-interface Options {}
+type Options = {}
 
 export const props: Props = {}
 export const options: Options = {}
@@ -195,7 +240,7 @@ export const options: Options = {}
   it('reports parameter property mutation in contexts domain files', () => {
     const result = runOxlint(
       `
-interface SavedTab {
+type SavedTab = {
   title: string
 }
 
@@ -215,7 +260,7 @@ export const renameTab = (tab: SavedTab): SavedTab => {
   it('does not apply parameter reassignment restrictions to presentation files', () => {
     const result = runOxlint(
       `
-interface SavedTab {
+type SavedTab = {
   title: string
 }
 

--- a/src/lib/background/ai-chat.ts
+++ b/src/lib/background/ai-chat.ts
@@ -69,25 +69,25 @@ const parseRecord = (v: unknown): Record<string, unknown> => {
   return result
 }
 
-interface OllamaModelOption {
+type OllamaModelOption = {
   name: string
   label: string
   modifiedAt?: string
 }
 
-interface AiChatHistoryMessage {
+type AiChatHistoryMessage = {
   role: 'user' | 'assistant'
   content: string
   attachments?: AiChatAttachment[]
 }
 
-interface AiChatRequest {
+type AiChatRequest = {
   prompt: string
   history: AiChatHistoryMessage[]
   attachments?: AiChatAttachment[]
 }
 
-interface AiChatResult {
+type AiChatResult = {
   answer: string
   charts: AiChartSpec[]
   recordCount: number
@@ -95,13 +95,13 @@ interface AiChatResult {
   toolTraces: AiChatToolTrace[]
 }
 
-interface AiChatStepUpdate {
+type AiChatStepUpdate = {
   charts?: AiChartSpec[]
   reasoning: string
   toolTraces: AiChatToolTrace[]
 }
 
-interface RunAiChatRequestOptions {
+type RunAiChatRequestOptions = {
   onStepUpdate?: (update: AiChatStepUpdate) => void
 }
 
@@ -330,18 +330,18 @@ const getPaginatedToolTotalCount = (output: unknown): number | null => {
 
 const getToolListSeparator = (language: AppLanguage) =>
   language === 'en' ? ', ' : '、'
-interface GenerateTextToolCallLike {
+type GenerateTextToolCallLike = {
   input: unknown
   toolCallId: string
   toolName: string
 }
 
-interface GenerateTextToolResultLike {
+type GenerateTextToolResultLike = {
   output?: unknown
   toolCallId: string
 }
 
-interface GenerateTextResultLike {
+type GenerateTextResultLike = {
   steps?: {
     toolCalls?: GenerateTextToolCallLike[]
     toolResults?: GenerateTextToolResultLike[]

--- a/src/lib/background/background-entrypoint.test.ts
+++ b/src/lib/background/background-entrypoint.test.ts
@@ -45,7 +45,7 @@ type InstalledListener = (details: {
   reason: 'install' | 'update' | 'chrome_update'
 }) => void | Promise<void>
 type StartupListener = () => void | Promise<void>
-interface ChromeHarness {
+type ChromeHarness = {
   onInstalledListeners: InstalledListener[]
   onStartupListeners: StartupListener[]
   storageSet: ReturnType<typeof vi.fn>
@@ -159,7 +159,7 @@ const flushMicrotasks = async (): Promise<void> => {
   await Promise.resolve()
   await new Promise((resolve) => setTimeout(resolve, 0))
 }
-interface LoadBackgroundOptions {
+type LoadBackgroundOptions = {
   initialStorage?: Record<string, unknown>
   clearAfterImport?: boolean
   setupMocks?: () => void

--- a/src/lib/background/expired-tabs.test.ts
+++ b/src/lib/background/expired-tabs.test.ts
@@ -9,7 +9,7 @@ import {
   updateTabTimestamps,
 } from './expired-tabs'
 
-interface Store {
+type Store = {
   userSettings?: {
     autoDeletePeriod?: string
   }

--- a/src/lib/background/extension-actions.test.ts
+++ b/src/lib/background/extension-actions.test.ts
@@ -35,7 +35,7 @@ import {
   handleSaveWindowTabs,
 } from './extension-actions'
 
-interface TabsHarness {
+type TabsHarness = {
   query: ReturnType<typeof vi.fn>
   remove: ReturnType<typeof vi.fn>
   getAllWindows: ReturnType<typeof vi.fn>

--- a/src/lib/background/message-handler.ts
+++ b/src/lib/background/message-handler.ts
@@ -62,7 +62,7 @@ const getOllamaErrorDetails = (
   return isOllamaErrorDetails(maybeOllamaError) ? maybeOllamaError : undefined
 }
 
-interface RuntimeOnConnect {
+type RuntimeOnConnect = {
   addListener: (listener: (port: chrome.runtime.Port) => void) => void
 }
 

--- a/src/lib/background/saved-tabs-page.test.ts
+++ b/src/lib/background/saved-tabs-page.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-
 
 import { openSavedTabsPage, resetSavedTabsPageId } from './saved-tabs-page'
 
-interface TabsHarness {
+type TabsHarness = {
   create: ReturnType<typeof vi.fn>
   get: ReturnType<typeof vi.fn>
   query: ReturnType<typeof vi.fn>

--- a/src/lib/background/url-storage.test.ts
+++ b/src/lib/background/url-storage.test.ts
@@ -49,7 +49,7 @@ const createSettings = (overrides: Record<string, unknown> = {}) =>
     ...overrides,
   }) as Awaited<ReturnType<typeof getUserSettings>>
 
-interface StorageState {
+type StorageState = {
   customProjects?: {
     id: string
     name: string
@@ -76,7 +76,7 @@ interface StorageState {
   }[]
 }
 
-interface ChromeMockOptions {
+type ChromeMockOptions = {
   cloneReads?: boolean
   rejectGet?: boolean
   rejectSet?: boolean

--- a/src/lib/background/url-storage.ts
+++ b/src/lib/background/url-storage.ts
@@ -46,7 +46,7 @@ const getDraggedUrlInfo = (): DraggedUrlInfo | null => draggedUrlInfo
 const clearDraggedUrlInfo = (): void => {
   draggedUrlInfo = null
 }
-interface ComparableUrlKeyOptions {
+type ComparableUrlKeyOptions = {
   readonly ignoreHash?: boolean
   readonly ignoreSearch?: boolean
 }
@@ -181,25 +181,25 @@ const updateGroupAfterUrlRemoval = (
   return removeLegacyUrlFromGroup(group, targetUrlKey, removedGroupIds)
 }
 
-interface BulkUrlRemovalStorage {
+type BulkUrlRemovalStorage = {
   customProjects?: CustomProject[]
   parentCategories?: ParentCategory[]
   savedTabs?: TabGroup[]
   urls?: UrlRecord[]
 }
 
-interface BulkSavedTabsRemovalResult {
+type BulkSavedTabsRemovalResult = {
   hasChanges: boolean
   removedGroupIds: string[]
   savedTabs: TabGroup[]
 }
 
-interface BulkCustomProjectsRemovalResult {
+type BulkCustomProjectsRemovalResult = {
   customProjects: CustomProject[]
   hasChanges: boolean
 }
 
-interface BulkParentCategoriesRemovalResult {
+type BulkParentCategoriesRemovalResult = {
   hasChanges: boolean
   parentCategories: ParentCategory[]
 }

--- a/src/lib/browser/runtime.ts
+++ b/src/lib/browser/runtime.ts
@@ -1,15 +1,15 @@
 import { isObjectLike } from './chrome-global'
 
-interface BrowserRuntime {
+type BrowserRuntime = {
   connect?: (connectInfo?: { name?: string }) => RuntimePort
   sendMessage?: (message: unknown) => Promise<unknown>
 }
 
-interface BrowserApi {
+type BrowserApi = {
   runtime?: BrowserRuntime
 }
 
-interface ChromeRuntime {
+type ChromeRuntime = {
   connect?: (connectInfo?: { name?: string }) => RuntimePort
   sendMessage?: (
     message: unknown,
@@ -17,7 +17,7 @@ interface ChromeRuntime {
   ) => void
 }
 
-interface RuntimePort {
+type RuntimePort = {
   disconnect: () => void
   onDisconnect: {
     addListener: (listener: () => void) => void
@@ -28,7 +28,7 @@ interface RuntimePort {
   postMessage: (message: unknown) => void
 }
 
-interface BrowserModule {
+type BrowserModule = {
   default?: BrowserApi
 }
 

--- a/src/lib/harness/harnessState/types.ts
+++ b/src/lib/harness/harnessState/types.ts
@@ -20,11 +20,11 @@ const stateStatuses = [
 export type HarnessStateStatus = (typeof stateStatuses)[number]
 export type JsonPrimitive = string | number | boolean | null
 export type JsonValue = JsonPrimitive | JsonObject | JsonValue[]
-export interface JsonObject {
+export type JsonObject = {
   [key: string]: JsonValue
 }
 
-export interface JsonSchema {
+export type JsonSchema = {
   additionalProperties?: boolean
   enum?: JsonValue[]
   items?: JsonSchema
@@ -42,38 +42,38 @@ export type HarnessFileName =
   | 'scorecard.json'
   | 'learning.json'
 
-export interface HarnessValidationIssue {
+export type HarnessValidationIssue = {
   file: HarnessFileName | 'ACTIVE' | 'run'
   message: string
   path: string
 }
 
-export interface HarnessValidationResult {
+export type HarnessValidationResult = {
   issues: HarnessValidationIssue[]
   ok: boolean
   runDirectory: string | null
   runId: string | null
 }
 
-export interface VerificationRecord {
+export type VerificationRecord = {
   command?: string
   notes?: string
   status?: string
 }
 
-export interface FindingRecord {
+export type FindingRecord = {
   evidence?: string
   severity?: string
   summary?: string
 }
 
-export interface ChecklistRecord {
+export type ChecklistRecord = {
   evidence?: string
   requirement?: string
   status?: string
 }
 
-export interface ScorecardRecord {
+export type ScorecardRecord = {
   evidence?: string
   findings?: string[]
   max_score?: number
@@ -83,20 +83,20 @@ export interface ScorecardRecord {
   status?: string
 }
 
-export interface LearningRecord {
+export type LearningRecord = {
   target?: string
   source?: string
   status?: string
   summary?: string
 }
 
-export interface SecurityFinding {
+export type SecurityFinding = {
   file: string
   severity: string
   summary: string
 }
 
-export interface HarnessStateFile {
+export type HarnessStateFile = {
   agents?: AgentRecord[]
   candidates?: LearningRecord[]
   categories?: ScorecardRecord[]
@@ -113,14 +113,14 @@ export interface HarnessStateFile {
   verification?: VerificationRecord[]
 }
 
-export interface AgentRecord {
+export type AgentRecord = {
   name?: string
   responsibility?: string
   role?: string
   status?: string
 }
 
-export interface PlanRecord {
+export type PlanRecord = {
   files?: string[]
   id?: string
   owner?: string
@@ -128,7 +128,7 @@ export interface PlanRecord {
   title?: string
 }
 
-export interface HarnessSnapshot {
+export type HarnessSnapshot = {
   decision: HarnessStateFile | null
   evaluator: HarnessStateFile | null
   generator: HarnessStateFile | null
@@ -141,40 +141,40 @@ export interface HarnessSnapshot {
   task: string | null
 }
 
-export interface HarnessRunOptions {
+export type HarnessRunOptions = {
   projectRoot: string
   runId?: string
 }
 
-export interface InitializeHarnessRunOptions {
+export type InitializeHarnessRunOptions = {
   projectRoot: string
   runId?: string
   task: string
 }
 
-export interface InitializeHarnessRunResult {
+export type InitializeHarnessRunResult = {
   runDirectory: string
   runId: string
 }
 
-export interface HarnessGovernanceEvent {
+export type HarnessGovernanceEvent = {
   kind: string
   message: string
   severity: string
   source: string
 }
 
-export interface HarnessFileResult {
+export type HarnessFileResult = {
   path: string
 }
 
-export interface HarnessPlanOptions extends HarnessRunOptions {
+export type HarnessPlanOptions = HarnessRunOptions & {
   nextAction?: string
   summary?: string
   tasks?: string[]
 }
 
-export interface HarnessCheckpointOptions extends HarnessRunOptions {
+export type HarnessCheckpointOptions = HarnessRunOptions & {
   command: string
   nextAction?: string
   notes: string
@@ -182,7 +182,7 @@ export interface HarnessCheckpointOptions extends HarnessRunOptions {
   summary?: string
 }
 
-export interface HarnessEvaluateOptions extends HarnessRunOptions {
+export type HarnessEvaluateOptions = HarnessRunOptions & {
   nextAction?: string
   summary?: string
 }

--- a/src/lib/lazy-recharts.test.ts
+++ b/src/lib/lazy-recharts.test.ts
@@ -20,7 +20,7 @@ const componentNames = [
   'YAxis',
 ] as const
 
-interface LazyPayload {
+type LazyPayload = {
   _result: () => Promise<{ default: unknown }>
 }
 

--- a/src/lib/storage/analytics.ts
+++ b/src/lib/storage/analytics.ts
@@ -8,7 +8,7 @@ const HEX_RADIX_AS = 16
 
 const SAVED_ANALYTICS_VIEWS_KEY = 'savedAnalyticsViews'
 
-interface SavedAnalyticsView {
+type SavedAnalyticsView = {
   createdAt: number
   id: string
   name: string

--- a/src/lib/storage/categories.test.ts
+++ b/src/lib/storage/categories.test.ts
@@ -23,7 +23,7 @@ vi.mock('uuid', () => ({
   v4: mocks.uuid,
 }))
 
-interface StorageState {
+type StorageState = {
   domainCategoryMappings?: DomainParentCategoryMapping[]
   domainCategorySettings?: DomainCategorySettings[]
   parentCategories?: ParentCategory[]

--- a/src/lib/storage/migration.test.ts
+++ b/src/lib/storage/migration.test.ts
@@ -65,7 +65,7 @@ vi.mock('./urls', () => ({
   createOrUpdateUrlRecordsBatch: mocks.createOrUpdateUrlRecordsBatch,
 }))
 
-interface StorageState {
+type StorageState = {
   domainCategoryMappings?: DomainParentCategoryMapping[]
   domainCategorySettings?: DomainCategorySettings[]
   domainHostnameMigrationCompleted?: boolean

--- a/src/lib/storage/migration.ts
+++ b/src/lib/storage/migration.ts
@@ -172,7 +172,7 @@ const migrateParentCategoriesToDomainNames = async (): Promise<void> => {
     throw error
   }
 }
-interface DomainCategoryMatch {
+type DomainCategoryMatch = {
   category: ParentCategory
   method: 'mapping' | 'domainNames'
 }

--- a/src/lib/storage/project-keywords.ts
+++ b/src/lib/storage/project-keywords.ts
@@ -1,12 +1,12 @@
 import type { CustomProject, ProjectKeywordSettings } from '@/types/storage'
 import { toHostname } from '@/utils/domain-normalize'
 
-interface SavedTabKeywordMatchTarget {
+type SavedTabKeywordMatchTarget = {
   title: string
   url: string
 }
 
-interface FindMatchingProjectIdForSavedTabParams {
+type FindMatchingProjectIdForSavedTabParams = {
   projects: CustomProject[]
   savedTab: SavedTabKeywordMatchTarget
   projectOrder: string[]

--- a/src/lib/storage/projects.test.ts
+++ b/src/lib/storage/projects.test.ts
@@ -26,7 +26,7 @@ vi.mock('./url-migration', () => ({
   migrateToUrlsStorage: mocks.migrateToUrlsStorage,
 }))
 
-interface StorageState {
+type StorageState = {
   customProjectOrder?: string[]
   customProjects?: CustomProject[]
   savedTabs?: TabGroup[]

--- a/src/lib/storage/projects.ts
+++ b/src/lib/storage/projects.ts
@@ -27,7 +27,7 @@ const CUSTOM_UNCATEGORIZED_PROJECT_NAME = '未分類'
 
 let saveUrlsToCustomProjectsQueue: Promise<void> = Promise.resolve()
 
-interface SavedTabItem {
+type SavedTabItem = {
   url: string
   title: string
 }
@@ -726,7 +726,7 @@ const removeUrlsFromCustomProject = async (
   await syncDeleteToDomainMode(targetUrlsSet, urls.length)
 }
 
-interface DeleteSyncBehavior {
+type DeleteSyncBehavior = {
   throwOnError?: boolean
 }
 

--- a/src/lib/storage/tabs.ts
+++ b/src/lib/storage/tabs.ts
@@ -21,7 +21,7 @@ type ResolvedTabGroupUrl = UrlRecord & {
   subCategory?: string
 }
 
-interface DeleteSyncOptions {
+type DeleteSyncOptions = {
   throwOnSyncError?: boolean
 }
 

--- a/src/lib/storage/url-migration.test.ts
+++ b/src/lib/storage/url-migration.test.ts
@@ -25,7 +25,7 @@ vi.mock('./urls', () => ({
   invalidateUrlCache: mocks.invalidateUrlCache,
 }))
 
-interface StorageState {
+type StorageState = {
   customProjects?: CustomProject[]
   savedTabs?: TabGroup[]
   urls?: UrlRecord[]

--- a/src/lib/storage/url-migration.ts
+++ b/src/lib/storage/url-migration.ts
@@ -8,13 +8,13 @@ import { invalidateUrlCache } from './urls'
 /** モジュールスコープのメモ化フラグ（ページセッション中の重複ストレージアクセスを防ぐ） */
 let urlsMigrationDone = false
 
-interface UrlMapEntry {
+type UrlMapEntry = {
   id: string
   record: UrlRecord
 }
 
 type UrlMap = Map<string, UrlMapEntry>
-interface UrlMigrationData {
+type UrlMigrationData = {
   existingUrls: UrlRecord[]
   savedTabs: TabGroup[]
   customProjects: CustomProject[]

--- a/src/lib/storage/urls.test.ts
+++ b/src/lib/storage/urls.test.ts
@@ -20,14 +20,14 @@ vi.mock('uuid', () => ({
   v4: mocks.uuid,
 }))
 
-interface StorageState {
+type StorageState = {
   customProjects?: CustomProject[]
   savedTabs?: TabGroup[]
   // eslint-disable-next-line typescript/no-redundant-type-constituents
   urls?: UrlRecord[] | unknown
 }
 
-interface ChromeStorageLocalOptions {
+type ChromeStorageLocalOptions = {
   cloneReads?: boolean
   getSetDelayMs?: (value: Record<string, unknown>) => number
 }

--- a/src/lib/storage/urls.ts
+++ b/src/lib/storage/urls.ts
@@ -6,13 +6,13 @@ import type { CustomProject, TabGroup, UrlRecord } from '@/types/storage'
 let urlRecordsCache: UrlRecord[] | null = null
 let urlRecordMutationQueue: Promise<void> = Promise.resolve()
 
-interface UrlRecordInput {
+type UrlRecordInput = {
   url: string
   title: string
   favIconUrl?: string
 }
 
-interface CreateOrUpdateUrlRecordOptions {
+type CreateOrUpdateUrlRecordOptions = {
   preserveExistingOnDuplicate?: boolean
 }
 

--- a/src/lib/storybook/deferred-story.tsx
+++ b/src/lib/storybook/deferred-story.tsx
@@ -3,7 +3,7 @@ import type { LazyExoticComponent } from 'react'
 
 import { Button } from '@/components/ui/button'
 
-interface DeferredStoryLoaderProps {
+type DeferredStoryLoaderProps = {
   buttonLabel?: string
   component: LazyExoticComponent<() => React.JSX.Element>
   description: string

--- a/src/lib/storybook/preview.tsx
+++ b/src/lib/storybook/preview.tsx
@@ -13,7 +13,7 @@ import { storybookThemeStorage } from './fixtures'
 
 type StoryTheme = 'dark' | 'light' | 'system' | 'user'
 
-interface StorybookHarnessProps {
+type StorybookHarnessProps = {
   children: React.ReactNode
   storage?: Record<string, unknown>
   theme?: StoryTheme

--- a/src/types/ai-chat-protocol.ts
+++ b/src/types/ai-chat-protocol.ts
@@ -10,7 +10,7 @@ import type { DynamicToolUIPart } from 'ai'
 
 // --- Ollama error ---
 
-export interface OllamaErrorDetails {
+export type OllamaErrorDetails = {
   kind: 'forbidden' | 'notInstalledOrNotRunning'
   faqUrl: string
   downloadUrl: string
@@ -21,7 +21,7 @@ export interface OllamaErrorDetails {
 
 // --- AI chat attachment ---
 
-export interface AiChatAttachment {
+export type AiChatAttachment = {
   filename: string
   mediaType: string
   kind: 'text' | 'image'
@@ -34,7 +34,7 @@ export type AiChartType = 'area' | 'bar' | 'line' | 'pie' | 'radar'
 
 export type AiChartAxisFormat = 'count' | 'date' | 'label' | 'percent'
 
-export interface AiChartSeries {
+export type AiChartSeries = {
   colorToken: string
   dataKey: string
   label: string
@@ -42,7 +42,7 @@ export interface AiChartSeries {
 
 export type AiChartDatum = Record<string, number | string | null>
 
-export interface AiChartSpec {
+export type AiChartSpec = {
   type: AiChartType
   title: string
   data: AiChartDatum[]
@@ -58,7 +58,7 @@ export interface AiChartSpec {
 
 // --- AI chat tool trace ---
 
-export interface AiChatToolTrace {
+export type AiChatToolTrace = {
   toolCallId: string
   toolName: string
   title: string

--- a/src/types/background.ts
+++ b/src/types/background.ts
@@ -21,7 +21,7 @@ export type {
 /**
  * ドラッグされたURL情報
  */
-export interface DraggedUrlInfo {
+export type DraggedUrlInfo = {
   url: string
   timestamp: number
   processed: boolean
@@ -112,7 +112,7 @@ export const messageActionSchema = z.custom<MessageAction>(
 /**
  * メッセージ基底型
  */
-export interface BaseMessage {
+export type BaseMessage = {
   action: MessageAction
 }
 
@@ -198,7 +198,7 @@ export type RunAiChatMessage = Extract<
 /**
  * レスポンス型定義
  */
-export interface StatusResponse {
+export type StatusResponse = {
   status: string
   success?: boolean
   result?: unknown
@@ -206,18 +206,18 @@ export interface StatusResponse {
   error?: string
 }
 
-export interface TimeRemainingResponse {
+export type TimeRemainingResponse = {
   timeRemaining: number | null
   expirationTime?: number
   error?: string
 }
 
-export interface AlarmStatusResponse {
+export type AlarmStatusResponse = {
   exists: boolean
   scheduledTime?: number
 }
 
-export interface OllamaModelListResponse {
+export type OllamaModelListResponse = {
   status: 'ok' | 'error'
   models?: {
     name: string
@@ -228,7 +228,7 @@ export interface OllamaModelListResponse {
   ollamaError?: OllamaErrorDetails
 }
 
-export interface AiChatResponse {
+export type AiChatResponse = {
   status: 'ok' | 'error'
   answer?: string
   charts?: AiChartSpec[]
@@ -241,7 +241,7 @@ export interface AiChatResponse {
 
 export const AI_CHAT_STREAM_PORT_NAME = 'ai-chat-stream'
 
-export interface RunAiChatStreamPortMessage {
+export type RunAiChatStreamPortMessage = {
   type: 'run'
   prompt: string
   history: {
@@ -252,14 +252,14 @@ export interface RunAiChatStreamPortMessage {
   attachments?: AiChatAttachment[]
 }
 
-export interface AiChatStreamStepMessage {
+export type AiChatStreamStepMessage = {
   type: 'step'
   charts?: AiChartSpec[]
   reasoning: string
   toolTraces: AiChatToolTrace[]
 }
 
-export interface AiChatStreamCompleteMessage {
+export type AiChatStreamCompleteMessage = {
   type: 'complete'
   answer: string
   charts?: AiChartSpec[]
@@ -268,7 +268,7 @@ export interface AiChatStreamCompleteMessage {
   toolTraces: AiChatToolTrace[]
 }
 
-export interface AiChatStreamErrorMessage {
+export type AiChatStreamErrorMessage = {
   type: 'error'
   error: string
   ollamaError?: OllamaErrorDetails

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,5 +1,5 @@
 // URLレコードのインターフェース（共通URL管理用）
-export interface UrlRecord {
+export type UrlRecord = {
   id: string
   url: string
   title: string
@@ -8,7 +8,7 @@ export interface UrlRecord {
 }
 
 // 親カテゴリのインターフェース
-export interface ParentCategory {
+export type ParentCategory = {
   id: string
   name: string
   domains: string[] // このカテゴリに属するドメインIDのリスト
@@ -16,18 +16,18 @@ export interface ParentCategory {
 }
 
 // 子カテゴリのキーワード設定のインターフェース
-export interface SubCategoryKeyword {
+export type SubCategoryKeyword = {
   categoryName: string // カテゴリ名
   keywords: string[] // 関連キーワードリスト
 }
 
-export interface ProjectKeywordSettings {
+export type ProjectKeywordSettings = {
   titleKeywords: string[]
   urlKeywords: string[]
   domainKeywords: string[]
 }
 
-export interface TabGroup {
+export type TabGroup = {
   id: string
   domain: string
   parentCategoryId?: string // 親カテゴリのID
@@ -50,7 +50,7 @@ export interface TabGroup {
   savedAt?: number // グループ全体の保存時刻を追加
 }
 
-export interface UserSettings {
+export type UserSettings = {
   language?: 'system' | 'ja' | 'en'
   removeTabAfterOpen: boolean
   removeTabAfterExternalDrop: boolean
@@ -76,20 +76,20 @@ export interface UserSettings {
 }
 
 // ドメイン別のカテゴリ設定を保存するためのインターフェース
-export interface DomainCategorySettings {
+export type DomainCategorySettings = {
   domain: string // ドメイン
   subCategories: string[] // このドメインで設定された子カテゴリリスト
   categoryKeywords: SubCategoryKeyword[] // カテゴリキーワード設定
 }
 
 // ドメインと親カテゴリのマッピングを保存するインターフェース
-export interface DomainParentCategoryMapping {
+export type DomainParentCategoryMapping = {
   domain: string // ドメイン（URL）
   categoryId: string // 親カテゴリID
 }
 
 // カスタムプロジェクト（PJ単位）のデータ構造
-export interface CustomProject {
+export type CustomProject = {
   id: string
   name: string
   projectKeywords?: ProjectKeywordSettings
@@ -117,7 +117,7 @@ export interface CustomProject {
   updatedAt: number
 }
 
-export interface AiSystemPromptPreset {
+export type AiSystemPromptPreset = {
   id: string
   name: string
   template: string

--- a/src/utils/datetime.tsx
+++ b/src/utils/datetime.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-interface TimeRemainingResponse {
+type TimeRemainingResponse = {
   error?: string
   timeRemaining?: number
 }

--- a/src/utils/localDateTime.ts
+++ b/src/utils/localDateTime.ts
@@ -16,7 +16,7 @@ const WEEKDAY_INDEX: Record<string, number> = {
   Wed: 3,
 }
 
-interface DateParts {
+type DateParts = {
   day: number
   month: number
   year: number


### PR DESCRIPTION
## 変更内容

- `.oxlintrc.json` に `typescript/consistent-type-definitions: ["error", "type"]` を追加
- `src/**/*.d.ts` に override を設定し、declaration merging が必要な箇所を除外
- 既存の `interface` 宣言を `type` に変換（`extends` は intersection `&` に置換）
- `src/features/ai-chat/types.ts` の重複宣言（`AiChatConversation`, `AiChatHistoryItem`）を修正
- `oxlintConfig.test.ts` に新ルールのテストを追加し、fixture を `type` に更新
- `e2e/` 配下の `interface` も `type` に変換

### 例外

- `src/types/chrome-storage-compat.d.ts` の `StorageArea`（declaration merging で `interface` が必要）→ `.d.ts` override で対応
- `src/components/ai-elements/speech-input.tsx` の `declare global { interface Window }`（ambient declaration で `interface` が必要）→ `ignorePatterns` 対象のためそのまま

## ローカル検証

- [x] `bun run lint`
- [x] `bun run compile`
- [x] `bun run test`（3248 tests passed）
- [x] `bun run quality`

closes #632