### PR TITLE
domain/application 層の時刻・乱数・ID生成の直接利用を禁止し IdGeneratorPort を導入する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -807,6 +807,16 @@
             "object": "Date",
             "property": "now",
             "message": "domain 層は Date.now() を直接利用できません。ClockPort 経由で時刻を注入してください"
+          },
+          {
+            "object": "Math",
+            "property": "random",
+            "message": "domain 層は Math.random() を直接利用できません。RandomPort / IdGeneratorPort 経由で注入してください"
+          },
+          {
+            "object": "crypto",
+            "property": "randomUUID",
+            "message": "domain 層は crypto.randomUUID() を直接利用できません。IdGeneratorPort 経由で ID を生成してください"
           }
         ]
       }
@@ -840,6 +850,21 @@
             "object": "chrome",
             "property": "notifications",
             "message": "application 層は chrome.notifications を直接利用できません（NotificationPort 経由）"
+          },
+          {
+            "object": "Date",
+            "property": "now",
+            "message": "application 層は Date.now() を直接利用できません。ClockPort 経由で時刻を注入してください"
+          },
+          {
+            "object": "Math",
+            "property": "random",
+            "message": "application 層は Math.random() を直接利用できません。RandomPort / IdGeneratorPort 経由で注入してください"
+          },
+          {
+            "object": "crypto",
+            "property": "randomUUID",
+            "message": "application 層は crypto.randomUUID() を直接利用できません。IdGeneratorPort 経由で ID を生成してください"
           }
         ]
       }

--- a/src/contexts/saved-tabs/application/SavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/application/SavedTabsUseCasesDeps.ts
@@ -12,6 +12,7 @@ import type { CategoriesCommandService } from './ports/CategoriesCommandService'
 import type { CategoryAssignmentPort } from './ports/CategoryAssignmentPort'
 import type { ClockPort } from './ports/ClockPort'
 import type { CustomProjectsCommandService } from './ports/CustomProjectsCommandService'
+import type { IdGeneratorPort } from './ports/IdGeneratorPort'
 import type { MessagingPort } from './ports/MessagingPort'
 import type { MigrationPort } from './ports/MigrationPort'
 import type { NotificationPort } from './ports/NotificationPort'
@@ -28,6 +29,7 @@ export type SavedTabsUseCasesDeps = {
   readonly categoryAssignmentPort: CategoryAssignmentPort
   readonly clock: ClockPort
   readonly customProjectRepository: CustomProjectRepository
+  readonly idGenerator: IdGeneratorPort
   readonly customProjectsCommandService: CustomProjectsCommandService
   readonly domainCategoryMappingRepository: DomainCategoryMappingRepository
   readonly domainCategorySettingsRepository: DomainCategorySettingsRepository

--- a/src/contexts/saved-tabs/application/createSavedTabsUseCases.ts
+++ b/src/contexts/saved-tabs/application/createSavedTabsUseCases.ts
@@ -103,9 +103,10 @@ export const createSavedTabsUseCases = (
   createCustomProject: createCreateCustomProjectUseCase({
     clock: deps.clock,
     customProjectRepository: deps.customProjectRepository,
+    idGenerator: deps.idGenerator,
   }),
   createParentCategory: createCreateParentCategoryUseCase({
-    generateId: () => crypto.randomUUID(),
+    idGenerator: deps.idGenerator,
     parentCategoryRepository: deps.parentCategoryRepository,
   }),
   deleteCustomProject: createDeleteCustomProjectUseCase({

--- a/src/contexts/saved-tabs/application/ports/IdGeneratorPort.ts
+++ b/src/contexts/saved-tabs/application/ports/IdGeneratorPort.ts
@@ -1,0 +1,18 @@
+/**
+ * ID 生成を application / infrastructure から注入するための port。
+ *
+ * domain / application 層は ID 生成 API を直接利用してはならず
+ * (`.oxlintrc.json` の `no-restricted-properties` と
+ * `dddLayerGuard.test.ts` で検出)。ID 生成が必要な use-case は本 port
+ * 経由で `generate()` を呼び、テストでは固定 ID を返す stub に差し替える。
+ *
+ * 戻り値は UUID v4 形式の文字列とする。
+ *
+ * @example
+ * ```ts
+ * const id = idGenerator.generate()
+ * ```
+ */
+export type IdGeneratorPort = {
+  readonly generate: () => string
+}

--- a/src/contexts/saved-tabs/application/use-cases/CreateCustomProjectUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/CreateCustomProjectUseCase.ts
@@ -1,8 +1,7 @@
-import { v4 as uuidv4 } from 'uuid'
-
 import type { SavedTabsCustomProjectDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { toSavedTabsCustomProjectDto } from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
 import type { ClockPort } from '@/contexts/saved-tabs/application/ports/ClockPort'
+import type { IdGeneratorPort } from '@/contexts/saved-tabs/application/ports/IdGeneratorPort'
 import type { CustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import { createCustomProject } from '@/contexts/saved-tabs/domain/entities/CustomProject'
 import type { CustomProjectRepository } from '@/contexts/saved-tabs/domain/repositories/CustomProjectRepository'
@@ -26,17 +25,15 @@ export type CreateCustomProjectUseCase = (
 export type CreateCustomProjectUseCaseDeps = {
   readonly customProjectRepository: CustomProjectRepository
   readonly clock: ClockPort
-  readonly generateId?: () => string
+  readonly idGenerator: IdGeneratorPort
 }
-
-const defaultGenerateId = (): string => uuidv4()
 
 /**
  * `CreateCustomProjectUseCase` を生成する。
  *
  * 責務:
  * 1. 既存 `CustomProject` 一覧から同名 (大小無視) 重複を検出
- * 2. `generateId()` で `CustomProjectId` を採番
+ * 2. `idGenerator.generate()` で `CustomProjectId` を採番
  * 3. 空 `urlIds` / 空 `categories` の新規プロジェクトを repository に保存
  *
  * 旧 `src/lib/storage/projects.createCustomProject` の DDD use-case 化
@@ -59,7 +56,7 @@ export const createCreateCustomProjectUseCase = (
     ) {
       throw new Error(`DUPLICATE_PROJECT_NAME:${name}`)
     }
-    const id = (deps.generateId ?? defaultGenerateId)()
+    const id = deps.idGenerator.generate()
     const now = deps.clock.now()
     const newProject = createCustomProject({
       categories: [],

--- a/src/contexts/saved-tabs/application/use-cases/CreateParentCategoryUseCase.ts
+++ b/src/contexts/saved-tabs/application/use-cases/CreateParentCategoryUseCase.ts
@@ -1,5 +1,6 @@
 import type { SavedTabsParentCategoryDto } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDto'
 import { toSavedTabsParentCategoryDto } from '@/contexts/saved-tabs/application/mappers/SavedTabsPresentationMapper'
+import type { IdGeneratorPort } from '@/contexts/saved-tabs/application/ports/IdGeneratorPort'
 import type { ParentCategory } from '@/contexts/saved-tabs/domain/entities/ParentCategory'
 import type { ParentCategoryRepository } from '@/contexts/saved-tabs/domain/repositories/ParentCategoryRepository'
 import { createCategoryName } from '@/contexts/saved-tabs/domain/value-objects/CategoryName'
@@ -41,7 +42,7 @@ export type CreateParentCategoryUseCaseDeps = {
    * 旧 `src/lib/storage/categories.createParentCategory` の `uuidv4()`
    * 呼び出しを置換する。
    */
-  readonly generateId: () => string
+  readonly idGenerator: IdGeneratorPort
 }
 
 /**
@@ -51,7 +52,7 @@ export type CreateParentCategoryUseCaseDeps = {
  * 1. 既存カテゴリ一覧を `parentCategoryRepository.findAll` で取得する
  * 2. 同名 (`name.toLowerCase()`) のカテゴリが既にあれば
  *    `DUPLICATE_CATEGORY_NAME` 付き `Error` を投げる
- * 3. `generateId()` で採番した新規 `ParentCategory` を全カテゴリの
+ * 3. `idGenerator.generate()` で採番した新規 `ParentCategory` を全カテゴリの
  *    末尾に追加して `parentCategoryRepository.saveAll` で保存する
  * 4. 戻り値は `{ category, all: updatedCategories }`
  *
@@ -74,7 +75,7 @@ export const createCreateParentCategoryUseCase = (
     if (duplicate) {
       throw new Error(`DUPLICATE_CATEGORY_NAME:${name}`)
     }
-    const newId = createParentCategoryId(deps.generateId())
+    const newId = createParentCategoryId(deps.idGenerator.generate())
     const newCategory: ParentCategory = {
       domainNames: [],
       domains: [],

--- a/src/contexts/saved-tabs/application/use-cases/CustomProjectManagementUseCases.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/CustomProjectManagementUseCases.test.ts
@@ -41,7 +41,7 @@ describe('custom project management use-cases', () => {
     const customProjectRepository = createRepository([existingProject()])
     const createProject = createCreateCustomProjectUseCase({
       customProjectRepository,
-      generateId: () => 'project-2',
+      idGenerator: { generate: () => 'project-2' },
       clock: { now: () => 10 },
     })
 
@@ -59,19 +59,18 @@ describe('custom project management use-cases', () => {
     expect(customProjectRepository.saveAll).toHaveBeenCalledOnce()
   })
 
-  it('既定ID・時刻生成でもprojectを生成できる', async () => {
+  it('port 経由のID生成でprojectを生成できる', async () => {
     const customProjectRepository = createRepository()
     const createProject = createCreateCustomProjectUseCase({
       clock: { now: () => 1_700_000_000_000 },
       customProjectRepository,
+      idGenerator: { generate: () => 'generated-id' },
     })
 
     const result = await createProject({ name: 'Generated' })
 
-    expect(result.project.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
-    )
-    expect(result.project.createdAt).toBeGreaterThan(0)
+    expect(result.project.id).toBe('generated-id')
+    expect(result.project.createdAt).toBe(1_700_000_000_000)
   })
 
   it.each([
@@ -82,6 +81,7 @@ describe('custom project management use-cases', () => {
     const createProject = createCreateCustomProjectUseCase({
       clock: { now: () => 0 },
       customProjectRepository,
+      idGenerator: { generate: () => 'test-id' },
     })
 
     await expect(createProject({ name })).rejects.toThrow(message)

--- a/src/contexts/saved-tabs/application/use-cases/ParentCategoryManagementUseCases.test.ts
+++ b/src/contexts/saved-tabs/application/use-cases/ParentCategoryManagementUseCases.test.ts
@@ -31,7 +31,7 @@ describe('parent category management use-cases', () => {
       parentCategories: [],
     })
     const createCategory = createCreateParentCategoryUseCase({
-      generateId: () => 'category-1',
+      idGenerator: { generate: () => 'category-1' },
       parentCategoryRepository,
     })
 
@@ -66,7 +66,7 @@ describe('parent category management use-cases', () => {
       ],
     })
     const createCategory = createCreateParentCategoryUseCase({
-      generateId: () => 'category-2',
+      idGenerator: { generate: () => 'category-2' },
       parentCategoryRepository,
     })
 

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -368,6 +368,38 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       expect(names).toContain('Date.now')
     })
 
+    it('issue #642: Math.random() を no-restricted-properties で禁止している', () => {
+      const names = getRestrictedProperties(propertiesOverride)
+      expect(names).toContain('Math.random')
+    })
+
+    it('issue #642: crypto.randomUUID() を no-restricted-properties で禁止している', () => {
+      const names = getRestrictedProperties(propertiesOverride)
+      expect(names).toContain('crypto.randomUUID')
+    })
+
+    it('issue #642: domain 層のソースファイルが Math.random( / crypto.randomUUID( を直接使わない', () => {
+      const stripComments = (source: string): string =>
+        source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+      const domainRoot = resolve(repoRoot, 'src/contexts/saved-tabs/domain')
+      const domainSourceFiles = collectSourceFiles(domainRoot)
+      expect(domainSourceFiles.length).toBeGreaterThan(0)
+      for (const absolutePath of domainSourceFiles) {
+        const relativePath = relative(repoRoot, absolutePath)
+          .split(sep)
+          .join('/')
+        const source = stripComments(readFileSync(absolutePath, 'utf8'))
+        expect(
+          source,
+          `${relativePath} should not call Math.random() directly (use RandomPort / IdGeneratorPort)`,
+        ).not.toMatch(/\bMath\.random\s*\(/)
+        expect(
+          source,
+          `${relativePath} should not call crypto.randomUUID() directly (use IdGeneratorPort)`,
+        ).not.toMatch(/\bcrypto\.randomUUID\s*\(/)
+      }
+    })
+
     it('issue #582: domain 層のソースファイルが Date.now( / new Date( を直接使わない', () => {
       // JSDoc やコメント内の言及は対象外とする。
       // 検出したいのは「現在時刻の取得」という
@@ -425,6 +457,51 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       expect(names).toContain('chrome.contextMenus')
       expect(names).toContain('chrome.alarms')
       expect(names).toContain('chrome.notifications')
+    })
+
+    it('issue #642: Date.now() を no-restricted-properties で禁止している', () => {
+      const names = getRestrictedProperties(propertiesOverride)
+      expect(names).toContain('Date.now')
+    })
+
+    it('issue #642: Math.random() を no-restricted-properties で禁止している', () => {
+      const names = getRestrictedProperties(propertiesOverride)
+      expect(names).toContain('Math.random')
+    })
+
+    it('issue #642: crypto.randomUUID() を no-restricted-properties で禁止している', () => {
+      const names = getRestrictedProperties(propertiesOverride)
+      expect(names).toContain('crypto.randomUUID')
+    })
+
+    it('issue #642: application 層のソースファイルが Date.now( / new Date( / Math.random( / crypto.randomUUID( を直接使わない', () => {
+      const stripComments = (source: string): string =>
+        source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+      const appRoot = resolve(repoRoot, 'src/contexts/saved-tabs/application')
+      const appSourceFiles = collectSourceFiles(appRoot)
+      expect(appSourceFiles.length).toBeGreaterThan(0)
+      for (const absolutePath of appSourceFiles) {
+        const relativePath = relative(repoRoot, absolutePath)
+          .split(sep)
+          .join('/')
+        const source = stripComments(readFileSync(absolutePath, 'utf8'))
+        expect(
+          source,
+          `${relativePath} should not call Date.now() directly (use ClockPort)`,
+        ).not.toMatch(/\bDate\.now\s*\(/)
+        expect(
+          source,
+          `${relativePath} should not call new Date() directly (use ClockPort)`,
+        ).not.toMatch(/\bnew\s+Date\s*\(/)
+        expect(
+          source,
+          `${relativePath} should not call Math.random() directly (use RandomPort / IdGeneratorPort)`,
+        ).not.toMatch(/\bMath\.random\s*\(/)
+        expect(
+          source,
+          `${relativePath} should not call crypto.randomUUID() directly (use IdGeneratorPort)`,
+        ).not.toMatch(/\bcrypto\.randomUUID\s*\(/)
+      }
     })
   })
 
@@ -1404,6 +1481,96 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       )
       expect(source).toContain('clock: ClockPort')
       expect(source).toContain('import type { ClockPort }')
+    })
+  })
+
+  describe('issue #642: domain / application 層の直接 ID 生成依存を禁止する IdGeneratorPort 導入', () => {
+    it('IdGeneratorPort が定義されている', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/ports/IdGeneratorPort.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('type IdGeneratorPort')
+      expect(source).toContain('generate:')
+    })
+
+    it('IdGeneratorPort は chrome API を import / 利用しない', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/ports/IdGeneratorPort.ts',
+        ),
+        'utf8',
+      )
+      expect(source).not.toMatch(/from\s+['"]chrome['"]/)
+      expect(source).not.toMatch(/\bcrypto\.randomUUID\s*\(/)
+    })
+
+    it('SystemIdGeneratorAdapter が定義されている', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/infrastructure/browser/SystemIdGeneratorAdapter.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('IdGeneratorPort')
+      expect(source).toContain('createSystemIdGenerator')
+      // SystemIdGenerator は infrastructure 層なので crypto.randomUUID() 使用は OK
+      expect(source).toContain('crypto.randomUUID()')
+    })
+
+    it('createSavedTabsUseCasesDeps は idGenerator を組み立てる', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('idGenerator:')
+      expect(source).toContain('createSystemIdGenerator')
+    })
+
+    it('SavedTabsUseCasesDeps は idGenerator を含む', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/SavedTabsUseCasesDeps.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('idGenerator: IdGeneratorPort')
+      expect(source).toContain('import type { IdGeneratorPort }')
+    })
+
+    it('CreateParentCategoryUseCase は idGenerator を use-case 依存として受け取る', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/use-cases/CreateParentCategoryUseCase.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('idGenerator: IdGeneratorPort')
+      expect(source).toContain('deps.idGenerator.generate()')
+    })
+
+    it('CreateCustomProjectUseCase は idGenerator を use-case 依存として受け取る', () => {
+      const source = readFileSync(
+        resolve(
+          repoRoot,
+          'src/contexts/saved-tabs/application/use-cases/CreateCustomProjectUseCase.ts',
+        ),
+        'utf8',
+      )
+      expect(source).toContain('idGenerator: IdGeneratorPort')
+      expect(source).toContain('deps.idGenerator.generate()')
+      // uuid package の直接 import が残っていないことを確認
+      expect(source).not.toMatch(/from\s+['"]uuid['"]/)
     })
   })
 

--- a/src/contexts/saved-tabs/infrastructure/browser/SystemIdGeneratorAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/SystemIdGeneratorAdapter.test.ts
@@ -9,7 +9,9 @@ describe('SystemIdGeneratorAdapter', () => {
 
   it('crypto.randomUUID() を呼び出して ID 文字列を返す', () => {
     const idGenerator = createSystemIdGenerator()
-    const spy = vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000000')
+    const spy = vi
+      .spyOn(crypto, 'randomUUID')
+      .mockReturnValue('00000000-0000-4000-8000-000000000000')
     expect(idGenerator.generate()).toBe('00000000-0000-4000-8000-000000000000')
     expect(spy).toHaveBeenCalledOnce()
   })

--- a/src/contexts/saved-tabs/infrastructure/browser/SystemIdGeneratorAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/SystemIdGeneratorAdapter.test.ts
@@ -9,8 +9,8 @@ describe('SystemIdGeneratorAdapter', () => {
 
   it('crypto.randomUUID() を呼び出して ID 文字列を返す', () => {
     const idGenerator = createSystemIdGenerator()
-    const spy = vi.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid-1234')
-    expect(idGenerator.generate()).toBe('test-uuid-1234')
+    const spy = vi.spyOn(crypto, 'randomUUID').mockReturnValue('00000000-0000-4000-8000-000000000000')
+    expect(idGenerator.generate()).toBe('00000000-0000-4000-8000-000000000000')
     expect(spy).toHaveBeenCalledOnce()
   })
 

--- a/src/contexts/saved-tabs/infrastructure/browser/SystemIdGeneratorAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/SystemIdGeneratorAdapter.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createSystemIdGenerator } from './SystemIdGeneratorAdapter'
+
+describe('SystemIdGeneratorAdapter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('crypto.randomUUID() を呼び出して ID 文字列を返す', () => {
+    const idGenerator = createSystemIdGenerator()
+    const spy = vi.spyOn(crypto, 'randomUUID').mockReturnValue('test-uuid-1234')
+    expect(idGenerator.generate()).toBe('test-uuid-1234')
+    expect(spy).toHaveBeenCalledOnce()
+  })
+
+  it('IdGeneratorPort interface に適合する', () => {
+    const idGenerator = createSystemIdGenerator()
+    expect(idGenerator.generate).toBeTypeOf('function')
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/browser/SystemIdGeneratorAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/SystemIdGeneratorAdapter.ts
@@ -1,0 +1,12 @@
+import type { IdGeneratorPort } from '@/contexts/saved-tabs/application/ports/IdGeneratorPort'
+
+/**
+ * `crypto.randomUUID()` を `IdGeneratorPort` に適合させる adapter。
+ *
+ * ID 生成を `crypto.randomUUID()` に直接依存するのは infrastructure 層の
+ * 責務であり、application / domain 層は本 adapter 経由で注入された
+ * `IdGeneratorPort` を利用する。テストでは固定 ID を返す stub に差し替える。
+ */
+export const createSystemIdGenerator = (): IdGeneratorPort => ({
+  generate: () => crypto.randomUUID(),
+})

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
@@ -7,6 +7,7 @@ import type { ChromeApiLike as ChromeMessagingApiLike } from '@/contexts/saved-t
 import { createChromeStorageChangeAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter'
 import { createSonnerNotificationAdapter } from '@/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter'
 import { createSystemClock } from '@/contexts/saved-tabs/infrastructure/browser/SystemClockAdapter'
+import { createSystemIdGenerator } from '@/contexts/saved-tabs/infrastructure/browser/SystemIdGeneratorAdapter'
 import { createChromeCustomProjectRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeCustomProjectRepository'
 import { createChromeDomainCategoryMappingRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeDomainCategoryMappingRepository'
 import { createChromeDomainCategorySettingsRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeDomainCategorySettingsRepository'
@@ -127,6 +128,7 @@ export const createSavedTabsUseCasesDeps = (
     }),
     categoriesCommandService: createLibCategoriesCommandService(),
     clock: createSystemClock(),
+    idGenerator: createSystemIdGenerator(),
     categoryAssignmentPort: createLibCategoryAssignmentPort({
       parentCategoryRepository: createChromeParentCategoryRepository(port),
       tabGroupRepository: createChromeTabGroupRepository(port),

--- a/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/savedTabsFlowRegression.test.ts
@@ -121,6 +121,7 @@ const createBundle = (initial: StorageState = {}): Bundle => {
   const deps: SavedTabsUseCasesDeps = {
     browserTabPort: browserTabPort.port,
     clock: { now: () => 0 },
+    idGenerator: { generate: () => 'test-id' },
     browserWindowPort: browserWindowPort.port,
     categoriesCommandService: {
       updateDomainCategorySettings: vi.fn().mockResolvedValue(undefined),
@@ -465,6 +466,7 @@ describe('savedTabs DDD 移行 後 回帰テスト', () => {
       const deps: SavedTabsUseCasesDeps = {
         browserTabPort,
         clock: { now: () => 0 },
+        idGenerator: { generate: () => 'test-id' },
         browserWindowPort,
         categoriesCommandService: {
           updateDomainCategorySettings: vi.fn().mockResolvedValue(undefined),

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsPresentationLayout.test.tsx
@@ -91,6 +91,7 @@ const buildLayoutComposition = () => {
       open: async (input: { url: string }) => ({ url: input.url }),
     },
     clock: { now: () => 0 },
+    idGenerator: { generate: () => 'test-id' },
     browserWindowPort: {
       openWithUrls: async (input: { urls: readonly string[] }) => ({
         urls: [...input.urls],


### PR DESCRIPTION
## 変更内容

- `IdGeneratorPort` を新設し、`crypto.randomUUID()` の直接利用を application 層から排除した
- `SystemIdGeneratorAdapter` (infrastructure) を追加し、`crypto.randomUUID()` の呼び出しを infrastructure 層に閉じ込めた
- `CreateParentCategoryUseCase` の `generateId: () => string` を `idGenerator: IdGeneratorPort` に変更し、port 経由で ID 生成を行うようにした
- `CreateCustomProjectUseCase` から `uuid` package の直接 import を削除し、`idGenerator: IdGeneratorPort` 経由に統一した
- `SavedTabsUseCasesDeps` に `idGenerator` を追加し、`createSavedTabsUseCasesDeps` で `createSystemIdGenerator()` を組み立てるようにした
- `.oxlintrc.json` の domain 層 override に `Math.random` / `crypto.randomUUID` の `no-restricted-properties` 制限を追加した
- `.oxlintrc.json` の application 層 override に `Date.now` / `Math.random` / `crypto.randomUUID` の `no-restricted-properties` 制限を追加した
- `dddLayerGuard.test.ts` に新規制限のテストと `IdGeneratorPort` 導入のテストを追加した
- `dddLayerGuard.test.ts` の `new Date()` 検査を application 層にも拡張した（Oxlint が `no-restricted-syntax` 非対応のため、regex ベースで検出）
- `SystemIdGeneratorAdapter.test.ts` を追加した

## ローカル検証

- [x] `bun run lint`
- [x] `bun run compile`
- [x] `bun run test`（`test:node` 176 files / 2413 tests passed、`test:dom` 123 files / 849 tests passed）
- [ ] `bun run quality`（環境制限で実行できなかったが、lint / compile / test / Knip は個別に確認済み）

closes #642