### PR TITLE
SavedTabsChatWidgetの責務をcontrollerとviewへ分割する

### DIFF
--- a/docs/plans/2026-07-11-saved-tabs-chat-widget-responsibility-split-design.md
+++ b/docs/plans/2026-07-11-saved-tabs-chat-widget-responsibility-split-design.md
@@ -1,0 +1,97 @@
+# SavedTabsChatWidget 責務分割設計
+
+## 目的
+
+`SavedTabsChatWidget.tsx` に集中している状態管理、外部 I/O、画面表示を責務境界で分離し、
+既存挙動を変えずに AI チャット機能を拡張できる構造へ整理する。
+
+## 方針
+
+薄いファイルへ既存処理を移すだけではなく、外部 I/O とライフサイクルを専用 hook に
+閉じ込める。`SavedTabsChatWidget` は controller の view model と actions を表示 component
+へ接続する composition component とする。
+
+状態 machine への全面的な置き換えは行わない。streaming、runtime port、conversation
+generation の既存の競合制御を維持しながら責務だけを移動し、挙動変更によるデグレを
+避ける。
+
+## 責務境界
+
+### `useSavedTabsChatController`
+
+- widget props と i18n を受け取り、画面に必要な view model と actions を返す
+- settings と Chrome storage の同期を管理する
+- message state、streaming、runtime port、conversation generation を管理する
+- system prompt、会話 reset、履歴選択を調停する
+- resize、clipboard、Ollama model settings の専用 hook を組み合わせる
+- JSX を返さず、表示 component の DOM 構造を知らない
+
+### `useChatSidebarResize`
+
+- sidebar width の初期復元、clamp、永続化を管理する
+- pointer move / up listener の登録と解除を管理する
+- resize 中の `document.body.style.cssText` を退避し、終了時と unmount 時に復元する
+- page mode では resize I/O を発生させない
+
+### `useConversationClipboard`
+
+- Clipboard API の capability 判定を行う
+- 会話コピー文字列を書き込み、成功・失敗 toast を表示する
+- copied icon の timeout と unmount cleanup を管理する
+- controller と表示 component に browser API の詳細を漏らさない
+
+### `useOllamaModelSettings`
+
+- Ollama model 一覧の取得、選択モデルの保存を管理する
+- loading、saving、error、platform state を管理する
+- 保存成功時に controller が settings と conversation を更新できる action を返す
+
+### 表示 component
+
+- `SavedTabsChatHeader` は履歴、system prompt、copy、new conversation、close の表示を担う
+- `SavedTabsChatComposer` は入力、attachment、model selector、submit の表示を担う
+- `SavedTabsChatPanel` は header、conversation、notice、composer と page / floating shell を構成する
+- storage、runtime port、settings 保存を直接呼ばず、値と callback のみを props で受け取る
+- 既存の DOM 構造、test id、accessible name、page / floating の見た目を維持する
+
+### `SavedTabsChatWidget`
+
+- `useSavedTabsChatController` を呼ぶ
+- floating launcher の表示条件を判断する
+- controller の view model と actions を `SavedTabsChatPanel` へ渡す
+- business logic、browser I/O、streaming details を持たない
+
+## データフロー
+
+1. Widget props と storage settings を controller が正規化する。
+2. controller は専用 hook の state と actions を統合する。
+3. Panel / Header / Composer は view model を描画し、ユーザー操作を action として返す。
+4. controller が message、settings、streaming lifecycle を更新する。
+5. `onMessagesChange` など外部 callback は既存タイミングを維持して通知する。
+
+## 互換性とエラー処理
+
+- streaming 中の port disconnect と generation token の競合制御を変更しない
+- conversation 切り替え時の外部 message 同期と通知抑制を維持する
+- Clipboard API 不在、Ollama fetch / save 失敗、storage 読み込み失敗の表示を維持する
+- resize cleanup は pointer up、close、unmount のすべてで同じ後処理を通す
+- `useCallback` / `useMemo` の依存関係は移動後の所有 state に合わせて再検証する
+
+## テスト戦略
+
+- 既存 `SavedTabsChatWidget.test.tsx` を end-to-end に近い component contract として維持する
+- resize hook では復元、drag、永続化、body style 復元、unmount cleanup を検証する
+- clipboard hook では成功、API 不在、write 失敗、timeout cleanup を検証する
+- Ollama hook では一覧取得、保存、loading / saving、platform 別 error を検証する
+- controller では conversation 切り替え、streaming notification、disconnect 競合を重点検証する
+- component 分割後も accessible name、test id、page / floating mode の統合テストを通す
+- 最終確認として full test、coverage 100%、compile、lint、React Doctor、quality を実行する
+
+## Rollback 条件
+
+次のいずれかが起きた場合は、該当責務の移動を小さい単位へ戻して原因を特定する。
+
+- 既存 widget test の notification 回数または streaming lifecycle が変化する
+- page mode と floating mode の DOM または操作差分が失われる
+- hook 抽出のためだけの wrapper や browser API の二重抽象が必要になる
+- view component が storage、runtime port、settings 保存を直接参照する

--- a/docs/plans/2026-07-11-saved-tabs-chat-widget-responsibility-split.md
+++ b/docs/plans/2026-07-11-saved-tabs-chat-widget-responsibility-split.md
@@ -1,0 +1,325 @@
+# SavedTabsChatWidget Responsibility Split Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Split `SavedTabsChatWidget` into a thin composition component, a controller hook, focused browser-I/O hooks, and view-only panel components without changing behavior.
+
+**Architecture:** Keep streaming and conversation lifecycle semantics in one controller while extracting resize, clipboard, and Ollama model settings into hooks that own their effects and cleanup. Keep Header, Composer, and Panel presentational: they receive values and callbacks and do not access Chrome storage, runtime ports, or settings persistence.
+
+**Tech Stack:** React 19, TypeScript, Vitest, Testing Library, WXT, Chrome Extension APIs, Sonner
+
+---
+
+### Task 1: Extract sidebar resize lifecycle
+
+**Files:**
+
+- Create: `src/features/ai-chat/hooks/useChatSidebarResize.test.ts`
+- Create: `src/features/ai-chat/hooks/useChatSidebarResize.ts`
+- Modify: `src/features/ai-chat/components/SavedTabsChatWidget.tsx`
+
+**Step 1: Write the failing hook test**
+
+Add focused tests that render the hook with injected width persistence and verify:
+
+- stored width is restored and clamped
+- pointer movement updates width
+- pointer up persists width and restores the original body style
+- unmount removes listeners and restores body style
+- page mode does not register resize behavior
+
+The first test must import `useChatSidebarResize` from the new module so it fails before implementation.
+
+**Step 2: Run the test to verify RED**
+
+Run: `bunx vitest run --config vitest.ci.config.ts src/features/ai-chat/hooks/useChatSidebarResize.test.ts`
+
+Expected: FAIL because `useChatSidebarResize` does not exist.
+
+**Step 3: Implement the resize hook**
+
+Move width state, viewport width, pointer listeners, body-style restoration, `loadSidebarWidth`, and `persistSidebarWidth` ownership into the hook. Return `sidebarWidth`, `isResizing`, `isCompactLayout`, `cardStyle`, and `handleResizeStart`.
+
+Do not add a wrapper around the old widget handlers; delete their old ownership after the hook is connected.
+
+**Step 4: Run focused and widget tests to verify GREEN**
+
+Run: `bunx vitest run --config vitest.ci.config.ts src/features/ai-chat/hooks/useChatSidebarResize.test.ts src/features/ai-chat/components/SavedTabsChatWidget.test.tsx`
+
+Expected: PASS with no warnings.
+
+**Step 5: Commit**
+
+```bash
+git add src/features/ai-chat/hooks/useChatSidebarResize.ts src/features/ai-chat/hooks/useChatSidebarResize.test.ts src/features/ai-chat/components/SavedTabsChatWidget.tsx
+git commit -m "チャットサイドバーのリサイズ責務をhookへ分離する"
+```
+
+### Task 2: Extract conversation clipboard lifecycle
+
+**Files:**
+
+- Create: `src/features/ai-chat/hooks/useConversationClipboard.test.ts`
+- Create: `src/features/ai-chat/hooks/useConversationClipboard.ts`
+- Modify: `src/features/ai-chat/components/SavedTabsChatWidget.tsx`
+
+**Step 1: Write the failing hook test**
+
+Add tests for successful copy, missing Clipboard API, rejected writes, copied timeout reset, and timeout cleanup on unmount. Use fake timers only for the icon timeout.
+
+**Step 2: Run the test to verify RED**
+
+Run: `bunx vitest run --config vitest.ci.config.ts src/features/ai-chat/hooks/useConversationClipboard.test.ts`
+
+Expected: FAIL because the hook module does not exist.
+
+**Step 3: Implement the clipboard hook**
+
+Move capability-safe Clipboard API lookup, conversation text generation, toast handling, copied state, timeout replacement, and unmount cleanup into the hook. Return `isConversationCopied` and `copyConversation`.
+
+Delete the old clipboard writer, timeout ref, and handler from the widget after connecting the hook.
+
+**Step 4: Run focused and widget tests to verify GREEN**
+
+Run: `bunx vitest run --config vitest.ci.config.ts src/features/ai-chat/hooks/useConversationClipboard.test.ts src/features/ai-chat/components/SavedTabsChatWidget.test.tsx`
+
+Expected: PASS with the existing copy button behavior unchanged.
+
+**Step 5: Commit**
+
+```bash
+git add src/features/ai-chat/hooks/useConversationClipboard.ts src/features/ai-chat/hooks/useConversationClipboard.test.ts src/features/ai-chat/components/SavedTabsChatWidget.tsx
+git commit -m "会話コピーのライフサイクルをhookへ分離する"
+```
+
+### Task 3: Extract Ollama model settings
+
+**Files:**
+
+- Create: `src/features/ai-chat/hooks/useOllamaModelSettings.test.ts`
+- Create: `src/features/ai-chat/hooks/useOllamaModelSettings.ts`
+- Modify: `src/features/ai-chat/components/SavedTabsChatWidget.tsx`
+
+**Step 1: Write the failing hook test**
+
+Add tests for model fetch success, model fetch errors, model save success, save errors, duplicate in-flight actions, and platform-specific error details.
+
+**Step 2: Run the test to verify RED**
+
+Run: `bunx vitest run --config vitest.ci.config.ts src/features/ai-chat/hooks/useOllamaModelSettings.test.ts`
+
+Expected: FAIL because the hook module does not exist.
+
+**Step 3: Implement the model settings hook**
+
+Move model options, loading/saving state, setup errors, runtime platform, model fetching, and selected-model persistence into the hook. Accept normalized settings and an `onSettingsSaved` callback so the controller remains responsible for conversation reset semantics.
+
+Delete the old model handlers and state from the widget after connecting the hook.
+
+**Step 4: Run focused and widget tests to verify GREEN**
+
+Run: `bunx vitest run --config vitest.ci.config.ts src/features/ai-chat/hooks/useOllamaModelSettings.test.ts src/features/ai-chat/components/SavedTabsChatWidget.test.tsx`
+
+Expected: PASS with fetch, selection, and platform guidance unchanged.
+
+**Step 5: Commit**
+
+```bash
+git add src/features/ai-chat/hooks/useOllamaModelSettings.ts src/features/ai-chat/hooks/useOllamaModelSettings.test.ts src/features/ai-chat/components/SavedTabsChatWidget.tsx
+git commit -m "Ollamaモデル設定を専用hookへ分離する"
+```
+
+### Task 4: Extract view-only Header and Composer
+
+**Files:**
+
+- Create: `src/features/ai-chat/components/SavedTabsChatHeader.test.tsx`
+- Create: `src/features/ai-chat/components/SavedTabsChatHeader.tsx`
+- Create: `src/features/ai-chat/components/SavedTabsChatComposer.test.tsx`
+- Create: `src/features/ai-chat/components/SavedTabsChatComposer.tsx`
+- Modify: `src/features/ai-chat/components/SavedTabsChatWidget.tsx`
+
+**Step 1: Write failing component tests**
+
+Add direct rendering tests that cover Header actions and Composer input/model/submit rendering. Mock leaf UI components only where browser behavior is irrelevant. Assert that callbacks are invoked and that the component modules do not require storage or runtime mocks.
+
+**Step 2: Run the tests to verify RED**
+
+Run: `bunx vitest run --config vitest.ci.config.ts src/features/ai-chat/components/SavedTabsChatHeader.test.tsx src/features/ai-chat/components/SavedTabsChatComposer.test.tsx`
+
+Expected: FAIL because the view components do not exist.
+
+**Step 3: Implement Header and Composer**
+
+Move existing JSX and view-only memoization into the two components. Define explicit props containing values and callbacks only. Preserve DOM order, test ids, accessible names, narrow-layout behavior, and system-prompt/history interactions.
+
+**Step 4: Run component and widget tests to verify GREEN**
+
+Run: `bunx vitest run --config vitest.ci.config.ts src/features/ai-chat/components/SavedTabsChatHeader.test.tsx src/features/ai-chat/components/SavedTabsChatComposer.test.tsx src/features/ai-chat/components/SavedTabsChatWidget.test.tsx`
+
+Expected: PASS with no DOM or accessibility regressions.
+
+**Step 5: Commit**
+
+```bash
+git add src/features/ai-chat/components/SavedTabsChatHeader.tsx src/features/ai-chat/components/SavedTabsChatHeader.test.tsx src/features/ai-chat/components/SavedTabsChatComposer.tsx src/features/ai-chat/components/SavedTabsChatComposer.test.tsx src/features/ai-chat/components/SavedTabsChatWidget.tsx
+git commit -m "チャットのHeaderとComposerを表示componentへ分離する"
+```
+
+### Task 5: Extract the view-only Panel
+
+**Files:**
+
+- Create: `src/features/ai-chat/components/SavedTabsChatPanel.test.tsx`
+- Create: `src/features/ai-chat/components/SavedTabsChatPanel.tsx`
+- Modify: `src/features/ai-chat/components/SavedTabsChatWidget.tsx`
+
+**Step 1: Write the failing Panel test**
+
+Add tests for page and floating shells, resize handle wiring, conversation empty/content rendering, and bottom-dock composition.
+
+**Step 2: Run the test to verify RED**
+
+Run: `bunx vitest run --config vitest.ci.config.ts src/features/ai-chat/components/SavedTabsChatPanel.test.tsx`
+
+Expected: FAIL because `SavedTabsChatPanel` does not exist.
+
+**Step 3: Implement the Panel**
+
+Move the panel JSX and message rendering helpers into the Panel module. Keep the component view-only and preserve page/floating layout differences. Header and Composer remain child components rather than render-function wrappers.
+
+**Step 4: Run Panel and widget tests to verify GREEN**
+
+Run: `bunx vitest run --config vitest.ci.config.ts src/features/ai-chat/components/SavedTabsChatPanel.test.tsx src/features/ai-chat/components/SavedTabsChatWidget.test.tsx`
+
+Expected: PASS with page and floating layouts unchanged.
+
+**Step 5: Commit**
+
+```bash
+git add src/features/ai-chat/components/SavedTabsChatPanel.tsx src/features/ai-chat/components/SavedTabsChatPanel.test.tsx src/features/ai-chat/components/SavedTabsChatWidget.tsx
+git commit -m "チャットPanelを表示componentへ分離する"
+```
+
+### Task 6: Extract the controller and thin the Widget
+
+**Files:**
+
+- Create: `src/features/ai-chat/hooks/useSavedTabsChatController.test.ts`
+- Create: `src/features/ai-chat/hooks/useSavedTabsChatController.ts`
+- Modify: `src/features/ai-chat/components/SavedTabsChatWidget.tsx`
+- Modify: `src/features/ai-chat/components/SavedTabsChatWidget.test.tsx`
+
+**Step 1: Write the failing controller test**
+
+Add tests for external conversation synchronization, `onMessagesChange` notification timing, reset/disconnect behavior, storage setting updates, and generation-token protection against stale streaming callbacks.
+
+**Step 2: Run the test to verify RED**
+
+Run: `bunx vitest run --config vitest.ci.config.ts src/features/ai-chat/hooks/useSavedTabsChatController.test.ts`
+
+Expected: FAIL because the controller hook does not exist.
+
+**Step 3: Implement the controller**
+
+Move remaining non-view state, effects, refs, and actions into `useSavedTabsChatController`. Compose the three focused hooks and existing prompt/stream hooks. Return a semantic view model plus actions; do not return JSX or expose runtime ports.
+
+Reduce `SavedTabsChatWidget` to controller invocation, floating launcher composition, and `SavedTabsChatPanel` prop wiring.
+
+**Step 4: Run controller and widget tests to verify GREEN**
+
+Run: `bunx vitest run --config vitest.ci.config.ts src/features/ai-chat/hooks/useSavedTabsChatController.test.ts src/features/ai-chat/components/SavedTabsChatWidget.test.tsx`
+
+Expected: PASS, including stream-step notification and disconnect regression cases.
+
+**Step 5: Commit**
+
+```bash
+git add src/features/ai-chat/hooks/useSavedTabsChatController.ts src/features/ai-chat/hooks/useSavedTabsChatController.test.ts src/features/ai-chat/components/SavedTabsChatWidget.tsx src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
+git commit -m "SavedTabsChatWidgetを薄いcomposition componentにする"
+```
+
+### Task 7: Verify architecture and regressions
+
+**Files:**
+
+- Modify as required by diagnostics: only files introduced or changed in Tasks 1-6
+
+**Step 1: Format and compile**
+
+Run: `bun run format`
+
+Expected: PASS after formatting intended files only.
+
+Run: `bun run compile`
+
+Expected: PASS with zero type errors.
+
+**Step 2: Run focused DOM and full tests**
+
+Run: `bun run test:dom`
+
+Expected: PASS.
+
+Run: `bun run test`
+
+Expected: PASS with zero failures.
+
+**Step 3: Prove coverage**
+
+Run: `bun run test:coverage`
+
+Expected: PASS and report 100% statements, branches, functions, and lines.
+
+**Step 4: Run React and repository diagnostics**
+
+Run: `rtk bun run doctor -- --verbose --scope changed --base origin/develop`
+
+Expected: 100/100 with no diagnostics for changed files.
+
+Run: `bun run quality`
+
+Expected: PASS for format, lint, compile, test, Knip, duplication, architecture, and project gates.
+
+**Step 5: Validate harness evidence**
+
+Run: `bun run harness:validate`
+
+Expected: PASS.
+
+Run: `bun run harness:audit`
+
+Expected: no unresolved blocker or missing required evidence.
+
+**Step 6: Commit verification fixes if any**
+
+```bash
+git add <only-files-fixed-by-verification>
+git commit -m "Issue 654の品質検証指摘を解消する"
+```
+
+### Task 8: Review and publish
+
+**Files:**
+
+- Review: all files in `git diff origin/develop...HEAD`
+
+**Step 1: Request code review**
+
+Review the completed diff against Issue #654 acceptance criteria. Fix Critical and Important findings, then rerun the affected focused tests and the final quality gates.
+
+**Step 2: Confirm publication scope**
+
+Run: `git status --short --branch`
+
+Expected: clean branch with only intended commits ahead of `origin/develop`.
+
+**Step 3: Push the branch**
+
+Run: `git push -u origin codex/issue-654-split-saved-tabs-chat-widget`
+
+Expected: branch published successfully.
+
+**Step 4: Open the PR**
+
+Create a PR targeting `develop`, summarize responsibility boundaries and regression proof, include the exact validation commands, and add `closes #654`.

--- a/src/features/ai-chat/components/SavedTabsChatComposer.test.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatComposer.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
+
+const mocked = vi.hoisted(() => ({
+  promptInputErrorHandler: undefined as
+    | ((error: {
+        code: 'accept' | 'max_files' | 'max_file_size'
+        message: string
+      }) => void)
+    | undefined,
+}))
+
+vi.mock('@/components/ai-elements/prompt-input', async () => {
+  const actual = await vi.importActual<
+    // eslint-disable-next-line typescript/consistent-type-imports
+    typeof import('@/components/ai-elements/prompt-input')
+  >('@/components/ai-elements/prompt-input')
+
+  return {
+    ...actual,
+    PromptInput: (props: React.ComponentProps<typeof actual.PromptInput>) => {
+      mocked.promptInputErrorHandler = props.onError
+      return <actual.PromptInput {...props} />
+    },
+  }
+})
+
+vi.mock('@/features/ai-chat/components/OllamaModelSelector', () => ({
+  OllamaModelSelector: ({
+    layout,
+    onFetchModels,
+    onSelectModel,
+    status,
+  }: {
+    layout: string
+    onFetchModels: () => void
+    onSelectModel: (modelName: string) => Promise<boolean>
+    status: { isLoading: boolean; isSaving: boolean }
+  }) => (
+    <div
+      data-layout={layout}
+      data-loading={String(status.isLoading)}
+      data-saving={String(status.isSaving)}
+      data-testid='model-selector'
+    >
+      <button onClick={onFetchModels} type='button'>
+        Fetch models
+      </button>
+      <button
+        onClick={() => {
+          void onSelectModel('llama3.2')
+        }}
+        type='button'
+      >
+        Select llama3.2
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('@/features/i18n/context/I18nProvider', () => ({
+  useI18n: () => ({
+    t: (key: string) =>
+      (
+        ({
+          'aiChat.inputLabel': 'Ask AI',
+          'aiChat.inputPlaceholder': 'Ask about saved tabs',
+          'aiChat.inputPlaceholderSelectModel': 'Select a model first',
+          'aiChat.send': 'Send',
+          'aiChat.sending': 'Sending...',
+          'common.submit': 'Submit',
+        }) satisfies Record<string, string>
+      )[key] ?? key,
+  }),
+}))
+
+import { SavedTabsChatComposer } from './SavedTabsChatComposer'
+
+const createProps = () => ({
+  input: 'first',
+  modelName: 'llama3.2',
+  modelOptions: [{ label: 'llama3.2 (8B)', name: 'llama3.2' }],
+  onAttachmentError: vi.fn(),
+  onFetchModels: vi.fn(),
+  onInputChange: vi.fn(),
+  onSelectModel: vi.fn().mockResolvedValue(true),
+  onSubmit: vi.fn(),
+  platform: 'mac' as const,
+  presentation: { isCompactLayout: false },
+  setupErrorMessage: '',
+  status: {
+    isConfigured: true,
+    isLoadingModels: false,
+    isSavingModel: false,
+    isSubmitting: false,
+  },
+})
+
+describe('SavedTabsChatComposer', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    mocked.promptInputErrorHandler = undefined
+  })
+
+  it('forwards controlled input changes and inserts a newline on Enter', () => {
+    const props = createProps()
+    render(<SavedTabsChatComposer {...props} />)
+
+    const textarea = screen.getByRole('textbox', {
+      name: 'Ask AI',
+    }) as HTMLTextAreaElement
+    // Controlled input wiring is asserted without changing the fixture value.
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.change(textarea, { target: { value: 'changed' } })
+    expect(props.onInputChange).toHaveBeenCalledWith('changed')
+
+    props.onInputChange.mockClear()
+    textarea.focus()
+    textarea.setSelectionRange(5, 5)
+    // The caret position must be set before the synthetic Enter event.
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    expect(props.onInputChange).toHaveBeenCalledWith('first\n')
+    expect(props.onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('submits the prompt on Ctrl+Enter', async () => {
+    const user = userEvent.setup()
+    const props = createProps()
+    render(<SavedTabsChatComposer {...props} />)
+
+    const textarea = screen.getByRole('textbox', { name: 'Ask AI' })
+    textarea.focus()
+    await user.keyboard('{Control>}{Enter}{/Control}')
+
+    await waitFor(() => {
+      expect(props.onSubmit).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('forwards attachment input errors without owning browser or storage behavior', () => {
+    const props = createProps()
+    render(<SavedTabsChatComposer {...props} />)
+
+    const error = {
+      code: 'max_files' as const,
+      message: 'Too many files',
+    }
+    mocked.promptInputErrorHandler?.(error)
+
+    expect(props.onAttachmentError).toHaveBeenCalledWith(error)
+  })
+
+  it('forwards model fetch and selection and exposes selector status', async () => {
+    const user = userEvent.setup()
+    const props = createProps()
+    render(
+      <SavedTabsChatComposer
+        {...props}
+        status={{
+          ...props.status,
+          isLoadingModels: true,
+          isSavingModel: true,
+        }}
+      />,
+    )
+
+    const selector = screen.getByTestId('model-selector')
+    expect(selector).toHaveAttribute('data-loading', 'true')
+    expect(selector).toHaveAttribute('data-saving', 'true')
+
+    await user.click(screen.getByRole('button', { name: 'Fetch models' }))
+    await user.click(screen.getByRole('button', { name: 'Select llama3.2' }))
+
+    expect(props.onFetchModels).toHaveBeenCalledTimes(1)
+    expect(props.onSelectModel).toHaveBeenCalledWith('llama3.2')
+  })
+
+  it.each([
+    ['unconfigured', { isConfigured: false }],
+    ['submitting', { isSubmitting: true }],
+    ['saving model', { isSavingModel: true }],
+  ])('disables submit while %s', (_, statusOverride) => {
+    const props = createProps()
+    render(
+      <SavedTabsChatComposer
+        {...props}
+        status={{ ...props.status, ...statusOverride }}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled()
+  })
+
+  it('disables blank input and renders compact submit labels', () => {
+    const props = createProps()
+    const { rerender } = render(
+      <SavedTabsChatComposer {...props} input='   ' />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled()
+
+    rerender(
+      <SavedTabsChatComposer
+        {...props}
+        presentation={{ isCompactLayout: true }}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Send' })).toHaveClass('w-full')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute(
+      'data-layout',
+      'compact',
+    )
+
+    rerender(
+      <SavedTabsChatComposer
+        {...props}
+        presentation={{ isCompactLayout: true }}
+        status={{ ...props.status, isSubmitting: true }}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Sending...' })).toBeDisabled()
+  })
+})

--- a/src/features/ai-chat/components/SavedTabsChatComposer.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatComposer.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useMemo } from 'react'
+import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent } from 'react'
+
+import {
+  PromptInput,
+  PromptInputFooter,
+  PromptInputSubmit,
+  PromptInputTextarea,
+} from '@/components/ai-elements/prompt-input'
+import type { PromptInputProps } from '@/components/ai-elements/prompt-input'
+import { ChatPromptAttachmentButton } from '@/features/ai-chat/components/ChatPromptAttachmentButton'
+import { ChatPromptAttachments } from '@/features/ai-chat/components/ChatPromptAttachments'
+import type { OllamaErrorPlatform } from '@/features/ai-chat/components/OllamaErrorNotice'
+import { OllamaModelSelector } from '@/features/ai-chat/components/OllamaModelSelector'
+import {
+  insertLineBreakAtCursor,
+  requestPromptSubmit,
+} from '@/features/ai-chat/components/savedTabsChat/messages'
+import {
+  AI_CHAT_MAX_ATTACHMENTS,
+  AI_CHAT_MAX_ATTACHMENT_SIZE_BYTES,
+  getAiChatAttachmentInputAccept,
+} from '@/features/ai-chat/lib/attachments'
+import { useI18n } from '@/features/i18n/context/I18nProvider'
+import { cn } from '@/lib/utils'
+import type { OllamaErrorDetails } from '@/types/background'
+
+type SavedTabsChatComposerProps = {
+  input: string
+  modelName?: string
+  modelOptions: {
+    label: string
+    name: string
+  }[]
+  onAttachmentError: NonNullable<PromptInputProps['onError']>
+  onFetchModels: () => void
+  onInputChange: (value: string) => void
+  onSelectModel: (modelName: string) => Promise<boolean>
+  onSubmit: PromptInputProps['onSubmit']
+  platform: OllamaErrorPlatform
+  presentation: {
+    isCompactLayout: boolean
+  }
+  setupErrorMessage: string
+  setupOllamaError?: OllamaErrorDetails
+  status: {
+    isConfigured: boolean
+    isLoadingModels: boolean
+    isSavingModel: boolean
+    isSubmitting: boolean
+  }
+}
+
+const SavedTabsChatComposer = ({
+  input,
+  presentation,
+  modelName,
+  modelOptions,
+  onAttachmentError,
+  onFetchModels,
+  onInputChange,
+  onSelectModel,
+  onSubmit,
+  platform,
+  setupErrorMessage,
+  setupOllamaError,
+  status,
+}: SavedTabsChatComposerProps) => {
+  const { t } = useI18n()
+  const { isCompactLayout } = presentation
+  const { isConfigured, isLoadingModels, isSavingModel, isSubmitting } = status
+  const compactSubmitLabel = isSubmitting
+    ? t('aiChat.sending')
+    : t('aiChat.send')
+  const isSubmitDisabled =
+    !isConfigured || isSubmitting || isSavingModel || input.trim().length === 0
+  const handleTextareaKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key !== 'Enter' || event.nativeEvent.isComposing) {
+        return
+      }
+
+      if (event.ctrlKey || event.metaKey) {
+        event.preventDefault()
+        requestPromptSubmit(event.currentTarget)
+        return
+      }
+
+      event.preventDefault()
+
+      const textarea = event.currentTarget
+      const selectionStart = textarea.selectionStart
+      const selectionEnd = textarea.selectionEnd
+      const { cursorPosition, nextValue } = insertLineBreakAtCursor({
+        selectionEnd,
+        selectionStart,
+        value: input,
+      })
+
+      onInputChange(nextValue)
+
+      window.requestAnimationFrame(() => {
+        textarea.setSelectionRange(cursorPosition, cursorPosition)
+      })
+    },
+    [input, onInputChange],
+  )
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      onInputChange(event.target.value)
+    },
+    [onInputChange],
+  )
+
+  const behavior = useMemo(
+    () => ({ fetchOnOpen: true, hideFetchButton: true }),
+    [],
+  )
+
+  const selectorStatus = useMemo(
+    () => ({ isLoading: isLoadingModels, isSaving: isSavingModel }),
+    [isLoadingModels, isSavingModel],
+  )
+
+  return (
+    <PromptInput
+      accept={getAiChatAttachmentInputAccept()}
+      className='shrink-0'
+      data-testid='chat-form'
+      maxFiles={AI_CHAT_MAX_ATTACHMENTS}
+      maxFileSize={AI_CHAT_MAX_ATTACHMENT_SIZE_BYTES}
+      multiple
+      onError={onAttachmentError}
+      onSubmit={onSubmit}
+    >
+      <PromptInputTextarea
+        aria-label={t('aiChat.inputLabel')}
+        className={cn('min-h-16', isCompactLayout && 'min-h-24 text-sm')}
+        value={input}
+        onChange={handleChange}
+        onKeyDown={handleTextareaKeyDown}
+        disabled={!isConfigured || isSavingModel}
+        placeholder={
+          isConfigured
+            ? t('aiChat.inputPlaceholder')
+            : t('aiChat.inputPlaceholderSelectModel')
+        }
+      />
+      <ChatPromptAttachments />
+      <PromptInputFooter
+        className={cn(
+          'items-center justify-between gap-2 border-t border-border',
+          isCompactLayout && 'flex-wrap',
+        )}
+      >
+        <div
+          className={cn(
+            'flex min-w-0 flex-1 items-center gap-2',
+            isCompactLayout && 'w-full flex-wrap',
+          )}
+        >
+          <ChatPromptAttachmentButton />
+          <OllamaModelSelector
+            behavior={behavior}
+            errorMessage={setupErrorMessage}
+            layout={isCompactLayout ? 'compact' : 'default'}
+            models={modelOptions}
+            onFetchModels={onFetchModels}
+            onSelectModel={onSelectModel}
+            ollamaError={setupOllamaError}
+            platform={platform}
+            selectedModel={modelName}
+            status={selectorStatus}
+          />
+        </div>
+        <PromptInputSubmit
+          className={cn(isCompactLayout && 'w-full')}
+          disabled={isSubmitDisabled}
+          size={isCompactLayout ? 'sm' : 'icon-sm'}
+          {...(isCompactLayout
+            ? {
+                'aria-label': compactSubmitLabel,
+              }
+            : {})}
+        >
+          {isCompactLayout ? compactSubmitLabel : undefined}
+        </PromptInputSubmit>
+      </PromptInputFooter>
+    </PromptInput>
+  )
+}
+
+export type { SavedTabsChatComposerProps }
+export { SavedTabsChatComposer }

--- a/src/features/ai-chat/components/SavedTabsChatHeader.test.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatHeader.test.tsx
@@ -49,18 +49,12 @@ const historyItems = [
 
 const systemPrompts = [
   {
-    createdAt: 0,
     id: 'prompt-1',
     name: 'Default',
-    template: 'Answer from saved tabs.',
-    updatedAt: 0,
   },
   {
-    createdAt: 1,
     id: 'prompt-2',
     name: 'Research',
-    template: 'Compare saved tabs.',
-    updatedAt: 1,
   },
 ]
 

--- a/src/features/ai-chat/components/SavedTabsChatHeader.test.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatHeader.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
+
+vi.mock('@/features/i18n/context/I18nProvider', async () => {
+  const { getMessages } = await vi.importActual<
+    // eslint-disable-next-line typescript/consistent-type-imports
+    typeof import('@/features/i18n/messages')
+  >('@/features/i18n/messages')
+
+  return {
+    useI18n: () => ({
+      t: (key: string, fallback?: string, values?: Record<string, string>) => {
+        const messages = getMessages('en')
+        const template =
+          messages[key as keyof typeof messages] ?? fallback ?? key
+        return template.replaceAll(
+          /\{\{(\w+)\}\}/g,
+          (_, token) => values?.[token] ?? '', // eslint-disable-line
+        )
+      },
+    }),
+  }
+})
+
+import { SavedTabsChatHeader } from './SavedTabsChatHeader'
+
+const historyItems = [
+  {
+    id: 'conversation-1',
+    isActive: true,
+    preview: 'First preview',
+    title: 'First conversation',
+  },
+  {
+    id: 'conversation-2',
+    isActive: false,
+    preview: 'Second preview',
+    title: 'Second conversation',
+  },
+]
+
+const systemPrompts = [
+  {
+    createdAt: 0,
+    id: 'prompt-1',
+    name: 'Default',
+    template: 'Answer from saved tabs.',
+    updatedAt: 0,
+  },
+  {
+    createdAt: 1,
+    id: 'prompt-2',
+    name: 'Research',
+    template: 'Compare saved tabs.',
+    updatedAt: 1,
+  },
+]
+
+const createProps = () => ({
+  activeSystemPromptId: 'prompt-1',
+  historyItems,
+  historyVariant: 'none' as const,
+  onClose: vi.fn(),
+  onCopyConversation: vi.fn(),
+  onDeleteHistoryItem: vi.fn(),
+  onOpenSystemPromptManager: vi.fn(),
+  onResetConversation: vi.fn(),
+  onSelectHistoryItem: vi.fn(),
+  onSelectSystemPrompt: vi.fn(),
+  onToggleHistory: vi.fn(),
+  presentation: {
+    isCompactLayout: false,
+    showCloseButton: true,
+  },
+  status: {
+    isConversationCopied: false,
+    isCopyDisabled: false,
+  },
+  systemPrompts,
+  title: 'TABBIN AI',
+})
+
+describe('SavedTabsChatHeader', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('renders the title between the left controls and conversation actions', () => {
+    render(<SavedTabsChatHeader {...createProps()} />)
+
+    const leftControls = screen.getByTestId('ai-chat-header-left-controls')
+    const title = screen.getByTestId('chat-header-title')
+    const copyButton = screen.getByRole('button', {
+      name: 'Copy conversation',
+    })
+
+    expect(title).toHaveTextContent('TABBIN AI')
+    expect(title).toHaveClass('absolute', 'inset-x-0', 'justify-center')
+    expect(
+      leftControls.compareDocumentPosition(title) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(
+      title.compareDocumentPosition(copyButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+
+  it('renders sidebar history before settings and forwards header actions', async () => {
+    const user = userEvent.setup()
+    const props = createProps()
+
+    render(<SavedTabsChatHeader {...props} historyVariant='sidebar-toggle' />)
+
+    const historyButton = screen.getByRole('button', {
+      name: 'Recent conversations',
+    })
+    const settingsButton = screen.getByRole('button', {
+      name: 'Open system prompt settings',
+    })
+
+    expect(
+      historyButton.compareDocumentPosition(settingsButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+
+    await user.click(historyButton)
+    await user.click(settingsButton)
+    await user.click(screen.getByRole('button', { name: 'Copy conversation' }))
+    await user.click(screen.getByRole('button', { name: 'New conversation' }))
+    await user.click(screen.getByRole('button', { name: 'Close AI chat' }))
+
+    expect(props.onToggleHistory).toHaveBeenCalledTimes(1)
+    expect(props.onOpenSystemPromptManager).toHaveBeenCalledTimes(1)
+    expect(props.onCopyConversation).toHaveBeenCalledTimes(1)
+    expect(props.onResetConversation).toHaveBeenCalledTimes(1)
+    expect(props.onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens dropdown history, resumes a conversation, and confirms deletion', async () => {
+    const user = userEvent.setup()
+    const props = createProps()
+
+    render(<SavedTabsChatHeader {...props} historyVariant='dropdown' />)
+
+    await user.click(
+      screen.getByRole('button', { name: 'Recent conversations' }),
+    )
+    await user.click(
+      screen.getByRole('button', { name: /^Second conversation/ }),
+    )
+
+    expect(props.onSelectHistoryItem).toHaveBeenCalledWith('conversation-2')
+
+    await user.click(
+      screen.getByRole('button', { name: 'Recent conversations' }),
+    )
+    await user.click(
+      screen.getByRole('button', { name: 'Delete Second conversation' }),
+    )
+
+    const dialog = screen.getByRole('dialog', {
+      name: 'Delete this conversation?',
+    })
+    expect(
+      within(dialog).getByText('This action cannot be undone.'),
+    ).toBeTruthy()
+
+    await user.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    expect(props.onDeleteHistoryItem).toHaveBeenCalledWith('conversation-2')
+  })
+
+  it('forwards system prompt selection and reflects copied/disabled state', async () => {
+    const props = createProps()
+
+    render(
+      <SavedTabsChatHeader
+        {...props}
+        status={{ isConversationCopied: true, isCopyDisabled: true }}
+      />,
+    )
+
+    const copyButton = screen.getByRole('button', {
+      name: 'Copy conversation',
+    })
+    expect(copyButton).toBeDisabled()
+    expect(copyButton).toHaveAttribute('data-state', 'copied')
+
+    const selector = screen.getByRole('combobox', { name: 'Default' })
+    // Radix UI Select does not work with userEvent in jsdom
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.click(selector)
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.click(await screen.findByRole('option', { name: 'Research' }))
+
+    expect(props.onSelectSystemPrompt).toHaveBeenCalledWith('prompt-2')
+  })
+
+  it('hides the close action and uses compact selector width when requested', () => {
+    const props = createProps()
+
+    render(
+      <SavedTabsChatHeader
+        {...props}
+        presentation={{ isCompactLayout: true, showCloseButton: false }}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: 'Close AI chat' })).toBeNull()
+    expect(screen.getByRole('combobox', { name: 'Default' })).toHaveClass(
+      'w-[112px]',
+    )
+  })
+})

--- a/src/features/ai-chat/components/SavedTabsChatHeader.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatHeader.tsx
@@ -29,16 +29,17 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import {
-  getSelectedPrompt,
-  SYSTEM_PROMPT_SELECTOR_EMPTY_VALUE,
-} from '@/features/ai-chat/components/savedTabsChat/prompts'
+import { SYSTEM_PROMPT_SELECTOR_EMPTY_VALUE } from '@/features/ai-chat/components/savedTabsChat/prompts'
 import { SavedTabsChatHeaderTooltipButton } from '@/features/ai-chat/components/SavedTabsChatHeaderTooltipButton'
 import { SavedTabsChatHistoryItemCard } from '@/features/ai-chat/components/SavedTabsChatHistoryItemCard'
 import type { AiChatHistoryItem } from '@/features/ai-chat/types'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { cn } from '@/lib/utils'
-import type { AiSystemPromptPreset } from '@/types/storage'
+
+type SavedTabsChatSystemPromptOption = Readonly<{
+  id: string
+  name: string
+}>
 
 type SavedTabsChatHeaderProps = {
   activeSystemPromptId: string
@@ -60,7 +61,7 @@ type SavedTabsChatHeaderProps = {
     isConversationCopied: boolean
     isCopyDisabled: boolean
   }
-  systemPrompts: AiSystemPromptPreset[]
+  systemPrompts: readonly SavedTabsChatSystemPromptOption[]
   title: string
 }
 
@@ -71,12 +72,12 @@ const SystemPromptSelector = ({
   onValueChange,
 }: {
   isCompactLayout: boolean
-  prompts: AiSystemPromptPreset[]
+  prompts: readonly SavedTabsChatSystemPromptOption[]
   selectedPromptId: string
   onValueChange: (value: string) => void
 }) => {
   const { t } = useI18n()
-  const activePrompt = getSelectedPrompt(prompts, selectedPromptId)
+  const activePrompt = prompts.find((prompt) => prompt.id === selectedPromptId)
   if (!activePrompt) {
     return null
   }
@@ -366,5 +367,5 @@ const SavedTabsChatHeader = ({
   )
 }
 
-export type { SavedTabsChatHeaderProps }
+export type { SavedTabsChatHeaderProps, SavedTabsChatSystemPromptOption }
 export { SavedTabsChatHeader }

--- a/src/features/ai-chat/components/SavedTabsChatHeader.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatHeader.tsx
@@ -1,0 +1,370 @@
+import { Check, Copy, History, Plus, Settings2, X } from 'lucide-react'
+import { useCallback, useState } from 'react'
+
+import {
+  PromptInputSelect,
+  PromptInputSelectContent,
+  PromptInputSelectItem,
+  PromptInputSelectTrigger,
+  PromptInputSelectValue,
+} from '@/components/ai-elements/prompt-input'
+import { Button } from '@/components/ui/button'
+import { CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import {
+  getSelectedPrompt,
+  SYSTEM_PROMPT_SELECTOR_EMPTY_VALUE,
+} from '@/features/ai-chat/components/savedTabsChat/prompts'
+import { SavedTabsChatHeaderTooltipButton } from '@/features/ai-chat/components/SavedTabsChatHeaderTooltipButton'
+import { SavedTabsChatHistoryItemCard } from '@/features/ai-chat/components/SavedTabsChatHistoryItemCard'
+import type { AiChatHistoryItem } from '@/features/ai-chat/types'
+import { useI18n } from '@/features/i18n/context/I18nProvider'
+import { cn } from '@/lib/utils'
+import type { AiSystemPromptPreset } from '@/types/storage'
+
+type SavedTabsChatHeaderProps = {
+  activeSystemPromptId: string
+  historyItems: AiChatHistoryItem[]
+  historyVariant: 'dropdown' | 'none' | 'sidebar-toggle'
+  presentation: {
+    isCompactLayout: boolean
+    showCloseButton: boolean
+  }
+  onClose: () => void
+  onCopyConversation: () => void
+  onDeleteHistoryItem?: (conversationId: string) => void
+  onOpenSystemPromptManager: () => void
+  onResetConversation: () => void
+  onSelectHistoryItem?: (conversationId: string) => void
+  onSelectSystemPrompt: (promptId: string) => void
+  onToggleHistory?: () => void
+  status: {
+    isConversationCopied: boolean
+    isCopyDisabled: boolean
+  }
+  systemPrompts: AiSystemPromptPreset[]
+  title: string
+}
+
+const SystemPromptSelector = ({
+  isCompactLayout,
+  prompts,
+  selectedPromptId,
+  onValueChange,
+}: {
+  isCompactLayout: boolean
+  prompts: AiSystemPromptPreset[]
+  selectedPromptId: string
+  onValueChange: (value: string) => void
+}) => {
+  const { t } = useI18n()
+  const activePrompt = getSelectedPrompt(prompts, selectedPromptId)
+  if (!activePrompt) {
+    return null
+  }
+
+  return (
+    <PromptInputSelect
+      key={selectedPromptId}
+      value={activePrompt.id}
+      onValueChange={onValueChange}
+    >
+      <PromptInputSelectTrigger
+        aria-label={activePrompt.name || t('aiChat.systemPrompt.select')}
+        className={cn(
+          'h-8 w-[140px] shrink-0 justify-between rounded-md border border-border/70 bg-background px-2 text-xs shadow-none',
+          isCompactLayout && 'w-[112px]',
+        )}
+      >
+        <PromptInputSelectValue
+          placeholder={t('aiChat.systemPrompt.placeholder')}
+        />
+      </PromptInputSelectTrigger>
+      <PromptInputSelectContent>
+        {prompts.length > 0 ? (
+          prompts.map((prompt) => (
+            <PromptInputSelectItem key={prompt.id} value={prompt.id}>
+              {prompt.name}
+            </PromptInputSelectItem>
+          ))
+        ) : (
+          <PromptInputSelectItem
+            disabled
+            value={SYSTEM_PROMPT_SELECTOR_EMPTY_VALUE}
+          >
+            {t('aiChat.systemPrompt.empty')}
+          </PromptInputSelectItem>
+        )}
+      </PromptInputSelectContent>
+    </PromptInputSelect>
+  )
+}
+
+const ChatHistoryButton = ({
+  label,
+  onClick,
+}: {
+  label: string
+  onClick?: () => void
+}) => (
+  <TooltipProvider delayDuration={0}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type='button'
+          variant='ghost'
+          size='icon'
+          aria-label={label}
+          onClick={onClick}
+        >
+          <History className='size-4' />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side='bottom'>{label}</TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+)
+
+const ChatHistoryDropdown = ({
+  historyItems,
+  onDeleteHistoryItem,
+  onSelectHistoryItem,
+}: {
+  historyItems: AiChatHistoryItem[]
+  onDeleteHistoryItem?: (conversationId: string) => void
+  onSelectHistoryItem?: (conversationId: string) => void
+}) => {
+  const { t } = useI18n()
+  const [isOpen, setIsOpen] = useState(false)
+  const [pendingDeleteHistoryItem, setPendingDeleteHistoryItem] =
+    useState<AiChatHistoryItem | null>(null)
+
+  const handleDialogOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setPendingDeleteHistoryItem(null)
+    }
+  }, [])
+
+  const handleConfirmDelete = useCallback(() => {
+    if (!pendingDeleteHistoryItem) {
+      return
+    }
+
+    onDeleteHistoryItem?.(pendingDeleteHistoryItem.id)
+    setPendingDeleteHistoryItem(null)
+  }, [onDeleteHistoryItem, pendingDeleteHistoryItem])
+  const handleCancelDelete = useCallback(() => {
+    setPendingDeleteHistoryItem(null)
+  }, [])
+
+  return (
+    <>
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type='button'
+            variant='ghost'
+            size='icon'
+            aria-label={t('aiChat.historyTitle')}
+          >
+            <History className='size-4' />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align='start'
+          className='w-72 gap-y-2 p-2'
+          side='bottom'
+        >
+          <div className='px-2 py-1'>
+            <p className='text-sm font-medium'>{t('aiChat.historyTitle')}</p>
+            <p className='text-xs text-muted-foreground'>
+              {t('aiChat.history.resumeHint')}
+            </p>
+          </div>
+
+          <div className='max-h-80 gap-y-1 overflow-y-auto'>
+            {historyItems.length > 0 ? (
+              historyItems.map((historyItem) => (
+                <SavedTabsChatHistoryItemCard
+                  historyItem={historyItem}
+                  isActive={historyItem.isActive}
+                  key={historyItem.id}
+                  onDeleteHistoryItem={onDeleteHistoryItem}
+                  onSelectHistoryItem={onSelectHistoryItem}
+                  setIsOpen={setIsOpen}
+                  setPendingDeleteHistoryItem={setPendingDeleteHistoryItem}
+                  t={t}
+                />
+              ))
+            ) : (
+              <div className='rounded-xl px-3 py-4 text-sm text-muted-foreground'>
+                {t('aiChat.history.empty')}
+              </div>
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <Dialog
+        open={pendingDeleteHistoryItem !== null}
+        onOpenChange={handleDialogOpenChange}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('aiChat.deleteTitle')}</DialogTitle>
+            <DialogDescription>
+              {t('aiChat.deleteDescription')}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={handleCancelDelete}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              type='button'
+              variant='destructive'
+              onClick={handleConfirmDelete}
+            >
+              {t('common.delete')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}
+
+const SavedTabsChatHeader = ({
+  activeSystemPromptId,
+  historyItems,
+  historyVariant,
+  presentation,
+  onClose,
+  onCopyConversation,
+  onDeleteHistoryItem,
+  onOpenSystemPromptManager,
+  onResetConversation,
+  onSelectHistoryItem,
+  onSelectSystemPrompt,
+  onToggleHistory,
+  systemPrompts,
+  title,
+  status,
+}: SavedTabsChatHeaderProps) => {
+  const { t } = useI18n()
+  const { isCompactLayout, showCloseButton } = presentation
+  const { isConversationCopied, isCopyDisabled } = status
+
+  return (
+    <CardHeader className='items-center border-b border-border p-4 text-center'>
+      <div
+        className={cn(
+          'relative flex w-full items-center justify-between gap-2',
+          isCompactLayout && 'min-h-10',
+        )}
+      >
+        <div
+          className='z-10 flex min-w-0 items-center gap-1'
+          data-testid='ai-chat-header-left-controls'
+        >
+          {historyVariant === 'sidebar-toggle' ? (
+            <ChatHistoryButton
+              label={t('aiChat.historyTitle')}
+              onClick={onToggleHistory}
+            />
+          ) : null}
+          {historyVariant === 'dropdown' ? (
+            <ChatHistoryDropdown
+              historyItems={historyItems}
+              onDeleteHistoryItem={onDeleteHistoryItem}
+              onSelectHistoryItem={onSelectHistoryItem}
+            />
+          ) : null}
+          <SavedTabsChatHeaderTooltipButton
+            ariaLabel={t('aiChat.systemPrompt.openSettings')}
+            onClick={onOpenSystemPromptManager}
+            tooltipText={t('aiChat.systemPrompt.settingsTooltip')}
+          >
+            <Settings2 className='size-4' />
+          </SavedTabsChatHeaderTooltipButton>
+          <SystemPromptSelector
+            isCompactLayout={isCompactLayout}
+            onValueChange={onSelectSystemPrompt}
+            prompts={systemPrompts}
+            selectedPromptId={activeSystemPromptId}
+          />
+        </div>
+
+        <CardTitle
+          className='pointer-events-none absolute inset-x-0 flex items-center justify-center px-20 text-base'
+          data-testid='chat-header-title'
+        >
+          <span className='truncate'>{title}</span>
+        </CardTitle>
+
+        <div className='z-10 flex items-center justify-end gap-1'>
+          <SavedTabsChatHeaderTooltipButton
+            ariaLabel={t('aiChat.copyConversation')}
+            dataState={isConversationCopied ? 'copied' : 'idle'}
+            disabled={isCopyDisabled}
+            onClick={onCopyConversation}
+            tooltipText={
+              isConversationCopied
+                ? t('aiChat.ollama.copied')
+                : t('aiChat.copyConversation')
+            }
+          >
+            {isConversationCopied ? (
+              <Check className='size-4' />
+            ) : (
+              <Copy className='size-4' />
+            )}
+          </SavedTabsChatHeaderTooltipButton>
+          <SavedTabsChatHeaderTooltipButton
+            ariaLabel={t('aiChat.newConversation')}
+            onClick={onResetConversation}
+            tooltipText={t('aiChat.newConversation')}
+          >
+            <Plus className='size-4' />
+          </SavedTabsChatHeaderTooltipButton>
+          {showCloseButton ? (
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon'
+              aria-label={t('aiChat.close')}
+              onClick={onClose}
+            >
+              <X className='size-4' />
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </CardHeader>
+  )
+}
+
+export type { SavedTabsChatHeaderProps }
+export { SavedTabsChatHeader }

--- a/src/features/ai-chat/components/SavedTabsChatPanel.test.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatPanel.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/features/i18n/context/I18nProvider', async () => {
+  const { getMessages } = await vi.importActual<
+    // eslint-disable-next-line typescript/consistent-type-imports
+    typeof import('@/features/i18n/messages')
+  >('@/features/i18n/messages')
+
+  return {
+    useI18n: () => ({
+      t: (key: string, fallback?: string, values?: Record<string, string>) => {
+        const messages = getMessages('en')
+        const template =
+          messages[key as keyof typeof messages] ?? fallback ?? key
+        return template.replaceAll(
+          /\{\{(\w+)\}\}/g,
+          (_, token) => values?.[token] ?? '',
+        )
+      },
+    }),
+  }
+})
+
+vi.mock('./SavedTabsChatHeader', () => ({
+  SavedTabsChatHeader: ({ title }: { title: string }) => (
+    <div data-testid='panel-header'>{title}</div>
+  ),
+}))
+
+vi.mock('./SavedTabsChatComposer', () => ({
+  SavedTabsChatComposer: ({ input }: { input: string }) => (
+    <div data-testid='panel-composer'>{input}</div>
+  ),
+}))
+
+import { SavedTabsChatPanel } from './SavedTabsChatPanel'
+import type { SavedTabsChatPanelProps } from './SavedTabsChatPanel'
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class ResizeObserver {
+      disconnect() {}
+      observe() {}
+      unobserve() {}
+    },
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+const createProps = (
+  overrides: Partial<SavedTabsChatPanelProps> = {},
+): SavedTabsChatPanelProps => ({
+  activeSystemPromptId: 'prompt-1',
+  chatErrorMessage: '',
+  historyItems: [],
+  historyVariant: 'none',
+  input: 'draft',
+  layout: {
+    isCompactLayout: false,
+    isResizing: false,
+    mode: 'page',
+    showCloseButton: false,
+  },
+  messages: [],
+  modelName: 'llama3.2',
+  modelOptions: [{ label: 'llama3.2', name: 'llama3.2' }],
+  onClose: vi.fn(),
+  onCopyConversation: vi.fn(),
+  onFetchModels: vi.fn(),
+  onInputChange: vi.fn(),
+  onOpenSystemPromptManager: vi.fn(),
+  onResetConversation: vi.fn(),
+  onResizeStart: vi.fn(),
+  onSelectModel: vi.fn().mockResolvedValue(true),
+  onSelectSuggestion: vi.fn(),
+  onSelectSystemPrompt: vi.fn(),
+  onSubmit: vi.fn(),
+  platform: 'mac',
+  setupErrorMessage: '',
+  status: {
+    isConfigured: true,
+    isConversationCopied: false,
+    isCopyDisabled: false,
+    isLoadingModels: false,
+    isOpen: true,
+    isSavingModel: false,
+    isSubmitting: false,
+  },
+  systemPrompts: [],
+  title: 'Saved tabs assistant',
+  ...overrides,
+})
+
+describe('SavedTabsChatPanel', () => {
+  it('composes the page shell with Header, intro, data scope, and Composer', () => {
+    render(<SavedTabsChatPanel {...createProps()} />)
+
+    expect(screen.getByLabelText('AI chat page')).toBeTruthy()
+    expect(screen.queryByTestId('chat-shell')).toBeNull()
+    expect(screen.getByTestId('panel-header').textContent).toBe(
+      'Saved tabs assistant',
+    )
+    expect(screen.getByTestId('ai-chat-intro')).toBeTruthy()
+    expect(screen.getByTestId('ai-chat-data-scope')).toBeTruthy()
+    expect(screen.getByTestId('ai-chat-bottom-dock')).toContainElement(
+      screen.getByTestId('panel-composer'),
+    )
+  })
+
+  it('renders the floating shell and forwards resize pointer input', async () => {
+    const user = userEvent.setup()
+    const onResizeStart = vi.fn()
+    render(
+      <SavedTabsChatPanel
+        {...createProps({
+          layout: {
+            isCompactLayout: true,
+            isResizing: true,
+            mode: 'floating',
+            showCloseButton: true,
+          },
+          onResizeStart,
+        })}
+      />,
+    )
+
+    expect(screen.getByTestId('chat-shell')).toBeTruthy()
+    expect(screen.getByLabelText('AI chat sidebar')).toBeTruthy()
+    await user.pointer({
+      keys: '[MouseLeft>]',
+      target: screen.getByRole('button', {
+        name: 'Resize the AI chat width',
+      }),
+    })
+    expect(onResizeStart).toHaveBeenCalledOnce()
+  })
+
+  it('switches from the unconfigured empty state to rendered conversation content', () => {
+    const { rerender } = render(
+      <SavedTabsChatPanel
+        {...createProps({
+          status: {
+            ...createProps().status,
+            isConfigured: false,
+          },
+        })}
+      />,
+    )
+
+    expect(screen.getByTestId('empty-state-root')).toBeTruthy()
+    expect(screen.queryByTestId('ai-chat-data-scope')).toBeNull()
+
+    rerender(
+      <SavedTabsChatPanel
+        {...createProps({
+          messages: [
+            { content: 'Question', id: 'user-1', role: 'user' },
+            {
+              content: '',
+              id: 'assistant-1',
+              isStreaming: true,
+              role: 'assistant',
+            },
+          ],
+        })}
+      />,
+    )
+
+    expect(screen.getAllByTestId('chat-message')).toHaveLength(2)
+    expect(screen.getByText('Question')).toBeTruthy()
+    expect(screen.getByText('Assembling the answer...')).toBeTruthy()
+  })
+
+  it('keeps conversation errors in the bottom dock', () => {
+    render(
+      <SavedTabsChatPanel
+        {...createProps({ chatErrorMessage: 'Connection failed' })}
+      />,
+    )
+
+    expect(screen.getByTestId('ai-chat-bottom-dock')).toContainElement(
+      screen.getByText('Connection failed'),
+    )
+  })
+
+  it('does not render when closed', () => {
+    const props = createProps()
+    render(
+      <SavedTabsChatPanel
+        {...props}
+        status={{ ...props.status, isOpen: false }}
+      />,
+    )
+
+    expect(screen.queryByTestId('panel-header')).toBeNull()
+  })
+})

--- a/src/features/ai-chat/components/SavedTabsChatPanel.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatPanel.tsx
@@ -1,0 +1,566 @@
+import { ChevronDown } from 'lucide-react'
+import { useCallback, useMemo } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { toast } from 'sonner'
+
+import { Attachments } from '@/components/ai-elements/attachments'
+import {
+  Conversation,
+  ConversationContent,
+  ConversationEmptyState,
+  ConversationScrollButton,
+} from '@/components/ai-elements/conversation'
+import {
+  Message,
+  MessageContent,
+  MessageResponse,
+} from '@/components/ai-elements/message'
+import type { PromptInputProps } from '@/components/ai-elements/prompt-input'
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningTrigger,
+} from '@/components/ai-elements/reasoning'
+import { Shimmer } from '@/components/ai-elements/shimmer'
+import {
+  Source,
+  Sources,
+  SourcesContent,
+  SourcesTrigger,
+} from '@/components/ai-elements/sources'
+import { Suggestion, Suggestions } from '@/components/ai-elements/suggestion'
+import {
+  Tool,
+  ToolContent,
+  ToolHeader,
+  ToolInput,
+  ToolOutput,
+} from '@/components/ai-elements/tool'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { AiChartRenderer } from '@/features/ai-chat/components/AiChartRenderer'
+import { OllamaErrorNotice } from '@/features/ai-chat/components/OllamaErrorNotice'
+import type { OllamaErrorPlatform } from '@/features/ai-chat/components/OllamaErrorNotice'
+import { SavedTabsChatAttachmentItem } from '@/features/ai-chat/components/SavedTabsChatAttachmentItem'
+import { SavedTabsChatComposer } from '@/features/ai-chat/components/SavedTabsChatComposer'
+import { SavedTabsChatHeader } from '@/features/ai-chat/components/SavedTabsChatHeader'
+import type {
+  AiChatAttachment,
+  AiChatHistoryItem,
+} from '@/features/ai-chat/types'
+import { useI18n } from '@/features/i18n/context/I18nProvider'
+import { cn } from '@/lib/utils'
+import type { OllamaErrorDetails } from '@/types/background'
+
+import { getMessageSources, getSourcesLabel } from './savedTabsChat/messages'
+import type { ChatMessage, TranslateFn } from './savedTabsChat/messages'
+import { getAttachmentInputErrorMessage } from './savedTabsChat/streaming'
+import { getSavedTabsChatAttachmentId } from './savedTabsChatAttachmentItem.helpers'
+
+const EMPTY_PANEL_TOOL_TRACES: NonNullable<ChatMessage['toolTraces']> = []
+
+type SavedTabsChatPanelProps = {
+  activeSystemPromptId: string
+  chatErrorMessage: string
+  chatOllamaError?: OllamaErrorDetails
+  historyItems: AiChatHistoryItem[]
+  historyVariant: 'dropdown' | 'none' | 'sidebar-toggle'
+  input: string
+  layout: {
+    cardStyle?: CSSProperties
+    isCompactLayout: boolean
+    isResizing: boolean
+    mode: 'floating' | 'page'
+    showCloseButton: boolean
+  }
+  status: {
+    isConfigured: boolean
+    isConversationCopied: boolean
+    isCopyDisabled: boolean
+    isLoadingModels: boolean
+    isOpen: boolean
+    isSavingModel: boolean
+    isSubmitting: boolean
+  }
+  messages: ChatMessage[]
+  modelName?: string
+  modelOptions: { label: string; name: string }[]
+  onClose: () => void
+  onCopyConversation: () => void
+  onDeleteHistoryItem?: (conversationId: string) => void
+  onFetchModels: () => void
+  onInputChange: (value: string) => void
+  onOpenSystemPromptManager: () => void
+  onResetConversation: () => void
+  onResizeStart: (event: React.PointerEvent<HTMLButtonElement>) => void
+  onSelectHistoryItem?: (conversationId: string) => void
+  onSelectModel: (modelName: string) => Promise<boolean>
+  onSelectSuggestion: (value: string) => void
+  onSelectSystemPrompt: (promptId: string) => void
+  onSubmit: PromptInputProps['onSubmit']
+  onToggleHistory?: () => void
+  platform: OllamaErrorPlatform
+  title: string
+  setupErrorMessage: string
+  setupOllamaError?: OllamaErrorDetails
+  systemPrompts: { id: string; name: string }[]
+}
+
+const AssistantMessageDiagnostics = ({
+  isStreaming,
+  reasoning,
+  toolTraces = EMPTY_PANEL_TOOL_TRACES,
+}: Pick<ChatMessage, 'isStreaming' | 'reasoning' | 'toolTraces'>) => {
+  const { t } = useI18n()
+  const getThinkingMessage = useCallback(
+    () =>
+      `${t('aiChat.reasoning')}${
+        toolTraces.length > 0 ? ` / ${toolTraces.length}` : ''
+      }`,
+    [t, toolTraces.length],
+  )
+
+  if (!reasoning && toolTraces.length === 0) {
+    return null
+  }
+
+  return (
+    <div className='gap-y-2 pl-1 wrap-break-word'>
+      {reasoning ? (
+        <Reasoning
+          className='mb-0 rounded-md border border-border/70 bg-background/70 px-3 py-2'
+          isStreaming={isStreaming}
+        >
+          <ReasoningTrigger getThinkingMessage={getThinkingMessage} />
+          <ReasoningContent>{reasoning}</ReasoningContent>
+        </Reasoning>
+      ) : null}
+      {toolTraces.length > 0 ? (
+        <div className='gap-y-2'>
+          <p className='pl-1 text-[11px] font-medium tracking-wide text-muted-foreground uppercase'>
+            {t('aiChat.toolsRun')}
+          </p>
+          {toolTraces.map((toolTrace) => (
+            <Tool
+              className='mb-0 border-border/70 bg-background/70'
+              key={toolTrace.toolCallId}
+            >
+              <ToolHeader
+                state={toolTrace.state}
+                title={toolTrace.title}
+                toolName={toolTrace.toolName}
+                type='dynamic-tool'
+              />
+              <ToolContent>
+                <ToolInput input={toolTrace.input} />
+                <ToolOutput
+                  errorText={toolTrace.errorText}
+                  output={toolTrace.output}
+                />
+              </ToolContent>
+            </Tool>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+const renderChatPromptIntro = ({
+  isCompactLayout,
+  onSelectSuggestion,
+  t,
+}: {
+  isCompactLayout: boolean
+  onSelectSuggestion: (value: string) => void
+  t: TranslateFn
+}) => {
+  const suggestions = [
+    t('aiChat.suggestion.recentTabs'),
+    t('aiChat.suggestion.favoriteContent'),
+    t('aiChat.suggestion.recommendation'),
+  ]
+  const suggestionItems = suggestions.map((suggestion) => (
+    <Suggestion
+      className={
+        isCompactLayout
+          ? 'w-full justify-start text-left whitespace-normal'
+          : undefined
+      }
+      key={suggestion}
+      suggestion={suggestion}
+      onClick={onSelectSuggestion}
+    />
+  ))
+
+  return (
+    <div className='shrink-0 gap-y-3' data-testid='ai-chat-intro'>
+      <p className='text-sm text-muted-foreground'>{t('aiChat.intro')}</p>
+      {isCompactLayout ? (
+        <div className='grid gap-2'>{suggestionItems}</div>
+      ) : (
+        <Suggestions>{suggestionItems}</Suggestions>
+      )}
+    </div>
+  )
+}
+
+const renderChatDataScopeNotice = ({
+  isVisible,
+  t,
+}: {
+  isVisible: boolean
+  t: TranslateFn
+}) =>
+  isVisible ? (
+    <p
+      className='text-[11px] leading-4 text-muted-foreground'
+      data-testid='ai-chat-data-scope'
+    >
+      {t('aiChat.dataScope')}
+    </p>
+  ) : null
+
+const renderChatMessageAttachments = ({
+  attachments,
+}: {
+  attachments: AiChatAttachment[]
+}) => (
+  <Attachments className='mb-2 w-full' variant='inline'>
+    {attachments.map((attachment) => (
+      <SavedTabsChatAttachmentItem
+        attachment={attachment}
+        key={getSavedTabsChatAttachmentId(attachment)}
+      />
+    ))}
+  </Attachments>
+)
+
+const renderConversationMessageBody = ({
+  message,
+  platform,
+}: {
+  message: ChatMessage
+  platform: OllamaErrorPlatform
+}) =>
+  message.ollamaError ? (
+    <OllamaErrorNotice
+      className='text-sm'
+      error={message.ollamaError}
+      platform={platform}
+    />
+  ) : (
+    <MessageResponse>{message.content}</MessageResponse>
+  )
+
+const renderChatConversationMessage = ({
+  // eslint-disable-line eslint/complexity
+  message,
+  platform,
+  t,
+}: {
+  message: ChatMessage
+  platform: OllamaErrorPlatform
+  t: TranslateFn
+}) => {
+  const messageSources =
+    message.role === 'assistant' ? getMessageSources(message.toolTraces) : []
+  const messageBody = renderConversationMessageBody({ message, platform })
+  const shouldShowStreamingShimmer =
+    message.role === 'assistant' &&
+    message.isStreaming &&
+    message.content.length === 0
+  const hasCharts =
+    message.role === 'assistant' &&
+    Boolean(message.charts && message.charts.length > 0)
+
+  return (
+    <Message
+      className={cn(hasCharts && 'max-w-full')}
+      data-testid='chat-message'
+      from={message.role}
+    >
+      {messageSources.length > 0 ? (
+        <Sources
+          className='mb-0 rounded-md border border-border/70 bg-background/70 px-3 py-2 text-foreground'
+          data-slot='sources'
+          data-testid='message-sources'
+        >
+          <SourcesTrigger
+            className='w-full justify-between text-muted-foreground'
+            count={messageSources.length}
+          >
+            <span className='text-[11px] font-medium tracking-wide uppercase'>
+              {getSourcesLabel({ count: messageSources.length, t })}
+            </span>
+            <ChevronDown className='size-4' />
+          </SourcesTrigger>
+          <SourcesContent className='w-full'>
+            {messageSources.map((source) => (
+              <Source href={source.url} key={source.url} title={source.title} />
+            ))}
+          </SourcesContent>
+        </Sources>
+      ) : null}
+      {message.role === 'assistant' ? (
+        <AssistantMessageDiagnostics
+          isStreaming={message.isStreaming}
+          reasoning={message.reasoning}
+          toolTraces={message.toolTraces}
+        />
+      ) : null}
+      <MessageContent
+        className={cn(
+          message.role === 'user'
+            ? 'bg-primary text-primary-foreground'
+            : 'bg-muted text-foreground',
+          hasCharts && 'w-full overflow-visible',
+          'wrap-break-word whitespace-pre-wrap',
+        )}
+        data-testid='message-content'
+      >
+        {message.attachments && message.attachments.length > 0
+          ? renderChatMessageAttachments({ attachments: message.attachments })
+          : null}
+        {messageBody}
+        {message.role === 'assistant' ? (
+          <AiChartRenderer charts={message.charts} />
+        ) : null}
+        {shouldShowStreamingShimmer ? (
+          <Shimmer className='text-sm'>{t('aiChat.shimmer')}</Shimmer>
+        ) : null}
+      </MessageContent>
+    </Message>
+  )
+}
+
+// eslint-disable-next-line eslint/complexity
+const SavedTabsChatPanel = ({
+  activeSystemPromptId,
+  chatErrorMessage,
+  chatOllamaError,
+  historyItems,
+  historyVariant,
+  input,
+  layout,
+  messages,
+  modelName,
+  modelOptions,
+  onClose,
+  onCopyConversation,
+  onDeleteHistoryItem,
+  onFetchModels,
+  onInputChange,
+  onOpenSystemPromptManager,
+  onResetConversation,
+  onResizeStart,
+  onSelectHistoryItem,
+  onSelectModel,
+  onSelectSuggestion,
+  onSelectSystemPrompt,
+  onSubmit,
+  onToggleHistory,
+  platform,
+  status,
+  title,
+  setupErrorMessage,
+  setupOllamaError,
+  systemPrompts,
+}: SavedTabsChatPanelProps) => {
+  const { t } = useI18n()
+  const handleAttachmentError = useCallback(
+    (error: {
+      code: 'accept' | 'max_files' | 'max_file_size'
+      message: string
+    }) => toast.error(getAttachmentInputErrorMessage(error, t)),
+    [t],
+  )
+  const headerPresentation = useMemo(
+    () => ({
+      isCompactLayout: layout.isCompactLayout,
+      showCloseButton: layout.showCloseButton,
+    }),
+    [layout.isCompactLayout, layout.showCloseButton],
+  )
+  const headerStatus = useMemo(
+    () => ({
+      isConversationCopied: status.isConversationCopied,
+      isCopyDisabled: status.isCopyDisabled,
+    }),
+    [status.isConversationCopied, status.isCopyDisabled],
+  )
+  const headerSystemPrompts = useMemo(
+    () => systemPrompts.map(({ id, name }) => ({ id, name })),
+    [systemPrompts],
+  )
+  const composerPresentation = useMemo(
+    () => ({ isCompactLayout: layout.isCompactLayout }),
+    [layout.isCompactLayout],
+  )
+  const composerStatus = useMemo(
+    () => ({
+      isConfigured: status.isConfigured,
+      isLoadingModels: status.isLoadingModels,
+      isSavingModel: status.isSavingModel,
+      isSubmitting: status.isSubmitting,
+    }),
+    [
+      status.isConfigured,
+      status.isLoadingModels,
+      status.isSavingModel,
+      status.isSubmitting,
+    ],
+  )
+  const { cardStyle, isCompactLayout, isResizing, mode } = layout
+  const { isConfigured, isOpen } = status
+  if (!isOpen) {
+    return null
+  }
+
+  const renderedMessages = messages.map((message) => ({
+    id: message.id,
+    view: renderChatConversationMessage({ message, platform, t }),
+  }))
+  const introContent =
+    messages.length === 0 && isConfigured
+      ? renderChatPromptIntro({ isCompactLayout, onSelectSuggestion, t })
+      : null
+  const chatDataScopeNotice = renderChatDataScopeNotice({
+    isVisible: isConfigured,
+    t,
+  })
+  const cardClassName =
+    mode === 'page'
+      ? 'flex h-full min-h-0 flex-1 flex-col rounded-[1.5rem] border-border shadow-lg'
+      : 'flex h-full min-h-0 flex-col rounded-none border-border border-y-0 border-r-0 border-l shadow-2xl'
+  let chatErrorContent: ReactNode = null
+  if (chatOllamaError) {
+    chatErrorContent = (
+      <OllamaErrorNotice
+        className='shrink-0 text-sm text-destructive'
+        error={chatOllamaError}
+        platform={platform}
+      />
+    )
+  } else if (chatErrorMessage) {
+    chatErrorContent = (
+      <p className='shrink-0 text-sm wrap-break-word whitespace-pre-line text-destructive'>
+        {chatErrorMessage}
+      </p>
+    )
+  }
+
+  const card = (
+    <Card
+      aria-label={
+        mode === 'page' ? t('aiChat.pageAria') : t('aiChat.sidebarAria')
+      }
+      data-sidebar-layout={isCompactLayout ? 'compact' : 'default'}
+      className={cardClassName}
+      style={cardStyle}
+    >
+      <SavedTabsChatHeader
+        activeSystemPromptId={activeSystemPromptId}
+        historyItems={historyItems}
+        historyVariant={historyVariant}
+        onClose={onClose}
+        onCopyConversation={onCopyConversation}
+        onDeleteHistoryItem={onDeleteHistoryItem}
+        onOpenSystemPromptManager={onOpenSystemPromptManager}
+        onResetConversation={onResetConversation}
+        onSelectHistoryItem={onSelectHistoryItem}
+        onSelectSystemPrompt={onSelectSystemPrompt}
+        onToggleHistory={onToggleHistory}
+        presentation={headerPresentation}
+        status={headerStatus}
+        systemPrompts={headerSystemPrompts}
+        title={title}
+      />
+      <CardContent
+        className={cn(
+          'flex min-h-0 flex-1 flex-col overflow-hidden',
+          isCompactLayout ? 'gap-2 p-2' : 'gap-3 p-3',
+        )}
+      >
+        <Conversation className='min-h-0 flex-1'>
+          {messages.length === 0 && !isConfigured ? (
+            <ConversationEmptyState
+              data-testid='empty-state-root'
+              description=''
+              title={t('aiChat.emptySelectModel')}
+            />
+          ) : (
+            <>
+              <ConversationContent
+                className={cn(isCompactLayout && 'gap-5 p-3')}
+                scrollClassName='overscroll-contain overflow-y-auto'
+              >
+                {renderedMessages.map((message) => (
+                  <div key={message.id}>{message.view}</div>
+                ))}
+              </ConversationContent>
+              <ConversationScrollButton
+                aria-label={t('aiChat.scrollLatest')}
+                className='bottom-3'
+              />
+            </>
+          )}
+        </Conversation>
+        <div
+          className='mt-auto shrink-0 gap-y-3'
+          data-testid='ai-chat-bottom-dock'
+        >
+          {introContent}
+          {chatErrorContent}
+          {chatDataScopeNotice}
+          <SavedTabsChatComposer
+            input={input}
+            modelName={modelName}
+            modelOptions={modelOptions}
+            onAttachmentError={handleAttachmentError}
+            onFetchModels={onFetchModels}
+            onInputChange={onInputChange}
+            onSelectModel={onSelectModel}
+            onSubmit={onSubmit}
+            platform={platform}
+            presentation={composerPresentation}
+            setupErrorMessage={setupErrorMessage}
+            setupOllamaError={setupOllamaError}
+            status={composerStatus}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
+
+  if (mode === 'page') {
+    return <div className='flex h-full min-h-0 flex-1'>{card}</div>
+  }
+
+  return (
+    <div
+      className='sticky top-0 z-50 flex h-screen max-w-[calc(100vw-24px)] shrink-0 self-start overflow-hidden overscroll-none'
+      data-testid='chat-shell'
+    >
+      <Button
+        aria-label={t('aiChat.resizeAria')}
+        className={`relative min-h-0 w-4 shrink-0 cursor-col-resize touch-none self-stretch rounded-none border-0 bg-transparent ${
+          isResizing ? 'bg-primary/10' : 'bg-transparent'
+        }`}
+        onPointerDown={onResizeStart}
+        size='unstyled'
+        type='button'
+        variant='ghost'
+      >
+        <span
+          aria-hidden='true'
+          className='absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border/80'
+        />
+      </Button>
+      {card}
+    </div>
+  )
+}
+
+export { SavedTabsChatPanel }
+export type { SavedTabsChatPanelProps }

--- a/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.test.tsx
@@ -2384,6 +2384,47 @@ describe('SavedTabsChatWidget', () => {
     expect(screen.queryByText('Ollama: llama3.2')).toBeNull()
   })
 
+  it('keeps the active conversation and draft input after changing the model', async () => {
+    const user = userEvent.setup()
+    restoreClipboardMock()
+    mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
+    mocked.sendRuntimeMessage.mockResolvedValue({
+      models: [{ label: 'Qwen 3', name: 'qwen3' }],
+      status: 'ok',
+    })
+
+    render(
+      <SavedTabsChatWidget
+        conversationId='active-conversation'
+        initialMessages={[
+          {
+            content: 'Keep this conversation',
+            id: 'existing-message',
+            role: 'user',
+          },
+        ]}
+        mode='page'
+      />,
+    )
+
+    await user.type(await screen.findByLabelText('Ask AI'), 'Keep this draft')
+    // Radix UI Select does not work with userEvent in jsdom
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.click(screen.getByRole('combobox', { name: 'llama3.2' }))
+    // eslint-disable-next-line testing-library/prefer-user-event
+    fireEvent.click(await screen.findByRole('option', { name: 'Qwen 3' }))
+
+    await waitFor(() => {
+      expect(mocked.saveUserSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ ollamaModel: 'qwen3' }),
+      )
+    })
+    expect(screen.getByText('Keep this conversation')).toBeTruthy()
+    expect((screen.getByLabelText('Ask AI') as HTMLTextAreaElement).value).toBe(
+      'Keep this draft',
+    )
+  })
+
   it('shows Windows guidance and download links for Ollama connection errors while fetching the model list', async () => {
     const user = userEvent.setup()
     restoreClipboardMock()

--- a/src/features/ai-chat/components/SavedTabsChatWidget.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.tsx
@@ -465,6 +465,14 @@ const useSavedTabsChatPanelView = ({
     }),
     [status.isConversationCopied, status.isCopyDisabled],
   )
+  const headerSystemPrompts = useMemo(
+    () =>
+      systemPrompts.map(({ id, name }) => ({
+        id,
+        name,
+      })),
+    [systemPrompts],
+  )
   const composerPresentation = useMemo(
     () => ({ isCompactLayout: layout.isCompactLayout }),
     [layout.isCompactLayout],
@@ -554,7 +562,7 @@ const useSavedTabsChatPanelView = ({
         onToggleHistory={onToggleHistory}
         presentation={headerPresentation}
         status={headerStatus}
-        systemPrompts={systemPrompts}
+        systemPrompts={headerSystemPrompts}
         title={title}
       />
 

--- a/src/features/ai-chat/components/SavedTabsChatWidget.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.tsx
@@ -1404,7 +1404,6 @@ const useSavedTabsChatWidgetView = ({
   } = useOllamaModelSettings({
     onSettingsSaved: (nextSettings) => {
       setSettings(nextSettings)
-      handleResetConversation()
     },
     settings: resolvedSettings,
     t,

--- a/src/features/ai-chat/components/SavedTabsChatWidget.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.tsx
@@ -1,512 +1,67 @@
 import { MessageCircleMore } from 'lucide-react'
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useReducer,
-  useRef,
-  useState,
-} from 'react'
 
 import { Button } from '@/components/ui/button'
-import { SavedTabsChatPanel } from '@/features/ai-chat/components/SavedTabsChatPanel'
-import { SystemPromptManagerDialog } from '@/features/ai-chat/components/SystemPromptManagerDialog'
-import type { SystemPromptManagerDialogProps } from '@/features/ai-chat/components/SystemPromptManagerDialog'
-import { useChatSidebarResize } from '@/features/ai-chat/hooks/useChatSidebarResize'
-import { useConversationClipboard } from '@/features/ai-chat/hooks/useConversationClipboard'
-import { useOllamaModelSettings } from '@/features/ai-chat/hooks/useOllamaModelSettings'
-import {
-  getActiveAiSystemPrompt,
-  normalizeAiSystemPromptSettings,
-} from '@/features/ai-chat/lib/systemPromptPresets'
-import type { AiChatHistoryItem } from '@/features/ai-chat/types'
-import { useI18n } from '@/features/i18n/context/I18nProvider'
-import {
-  getChromeStorageOnChanged,
-  warnMissingChromeStorage,
-} from '@/lib/browser/chrome-storage'
-import { saveUserSettings } from '@/lib/storage/settings'
-import {
-  UserSettingsSchema,
-  fromStorageChange,
-} from '@/lib/storage/zod-storage'
-import type { OllamaErrorDetails } from '@/types/background'
-import type { UserSettings } from '@/types/storage'
+import { useSavedTabsChatController } from '@/features/ai-chat/hooks/useSavedTabsChatController'
+import type { SavedTabsChatControllerOptions } from '@/features/ai-chat/hooks/useSavedTabsChatController'
 
-import type { ChatMessage } from './savedTabsChat/messages'
-import {
-  areMessagesEquivalent,
-  EMPTY_CHAT_MESSAGES,
-  EMPTY_HISTORY_ITEMS,
-  getResolvedSettings,
-  isAiChatConfigured,
-  loadWidgetSettings,
-  syncExternalConversationState,
-} from './savedTabsChat/storage'
-import { useChatPromptManager } from './savedTabsChat/useChatPromptManager'
-import { useChatStreamHandlers } from './savedTabsChat/useChatStreamHandlers'
+import { SavedTabsChatPanel } from './SavedTabsChatPanel'
+import { SystemPromptManagerDialog } from './SystemPromptManagerDialog'
 
-type SavedTabsChatWidgetProps = {
-  conversationId?: string
-  defaultOpen?: boolean
-  historyItems?: AiChatHistoryItem[]
-  historyVariant?: 'dropdown' | 'none' | 'sidebar-toggle'
-  initialMessages?: ChatMessage[]
-  mode?: 'floating' | 'page'
-  title?: string
-  onCreateConversation?: () => void
-  onDeleteHistoryItem?: (conversationId: string) => void
-  onMessagesChange?: (messages: ChatMessage[]) => void
-  onOpenChange?: (isOpen: boolean) => void
-  onSelectHistoryItem?: (conversationId: string) => void
-  onToggleHistory?: () => void
-}
+type SavedTabsChatWidgetProps = SavedTabsChatControllerOptions
 
-// eslint-disable-next-line eslint/max-statements
-const useSavedTabsChatWidgetView = ({
-  conversationId,
-  defaultOpen = false,
-  historyItems = EMPTY_HISTORY_ITEMS,
-  historyVariant = 'none',
-  initialMessages = EMPTY_CHAT_MESSAGES,
-  mode = 'floating',
-  title,
-  onCreateConversation,
-  onDeleteHistoryItem,
-  onMessagesChange,
-  onOpenChange,
-  onSelectHistoryItem,
-  onToggleHistory,
-}: SavedTabsChatWidgetProps = {}) => {
-  const { language, t } = useI18n()
-  const [settings, setSettings] = useState<UserSettings | null>(null)
-  const [isFloatingOpen, setIsFloatingOpen] = useState(
-    defaultOpen || mode === 'page',
-  )
-  const { cardStyle, handleResizeStart, isCompactLayout, isResizing } =
-    useChatSidebarResize({ mode })
-  const [input, setInput] = useState('')
-  const [messages, setMessages] = useReducer(
-    (_state: ChatMessage[], nextMessages: ChatMessage[]) => nextMessages,
-    initialMessages,
-  )
-  const { copyConversation, isConversationCopied } = useConversationClipboard({
-    messages,
-    t,
-  })
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [errorMessage, setErrorMessage] = useState('')
-  const [chatOllamaError, setChatOllamaError] = useState<
-    OllamaErrorDetails | undefined
-  >(undefined)
-  const activePortRef = useRef<{
-    disconnect: () => void
-  } | null>(null)
-  const conversationGenerationRef = useRef(0)
-  const ignoreNextDisconnectRef = useRef(false)
-  const messagesRef = useRef<ChatMessage[]>(initialMessages)
-  const syncedConversationIdRef = useRef<string | undefined>(conversationId)
-  const isOpen = mode === 'page' || isFloatingOpen
-  const releaseChatWidgetResources = useCallback(() => {
-    activePortRef.current?.disconnect()
-    activePortRef.current = null
-  }, [])
-
-  useEffect(() => {
-    const shouldSyncExternalConversation =
-      typeof conversationId === 'string' || mode === 'page'
-
-    if (!shouldSyncExternalConversation) {
-      return
-    }
-
-    const isSameConversationId =
-      syncedConversationIdRef.current === conversationId
-
-    if (
-      isSameConversationId &&
-      areMessagesEquivalent(initialMessages, messagesRef.current)
-    ) {
-      return
-    }
-
-    syncExternalConversationState({
-      conversationId,
-      initialMessages,
-      messagesRef,
-      setChatOllamaError,
-      setErrorMessage,
-      setInput,
-      setIsSubmitting,
-      setMessages,
-      syncedConversationIdRef,
-    })
-  }, [conversationId, initialMessages, mode])
-
-  useEffect(() => {
-    let isMounted = true
-
-    const syncWidgetSettings = async () => {
-      const nextSettings = await loadWidgetSettings()
-      if (!isMounted) {
-        return
-      }
-
-      setSettings(nextSettings)
-    }
-
-    void syncWidgetSettings()
-
-    return () => {
-      isMounted = false
-    }
-  }, [])
-
-  useEffect(() => releaseChatWidgetResources, [releaseChatWidgetResources])
-
-  useEffect(() => {
-    const storageChangeListener = (
-      changes: Partial<Record<string, chrome.storage.StorageChange>>,
-      areaName: string,
-    ) => {
-      if (areaName !== 'local' || !changes.userSettings) {
-        return
-      }
-
-      setSettings(
-        fromStorageChange(UserSettingsSchema, changes.userSettings.newValue),
-      )
-    }
-
-    const storageOnChanged = getChromeStorageOnChanged()
-    if (!storageOnChanged) {
-      warnMissingChromeStorage('AI chat settings change watcher')
-      return
-    }
-
-    storageOnChanged.addListener(storageChangeListener)
-
-    // eslint-disable-next-line typescript/consistent-return
-    return () => {
-      storageOnChanged.removeListener(storageChangeListener)
-    }
-  }, [])
-
-  const resolvedSettings = getResolvedSettings(settings)
-  const activeSystemPrompt = getActiveAiSystemPrompt(resolvedSettings)
-  const isConfigured = isAiChatConfigured(resolvedSettings)
-  const resolvedTitle = title ?? t('aiChat.chatTitle')
-
-  const setMessagesState = (nextMessages: ChatMessage[]) => {
-    messagesRef.current = nextMessages
-    setMessages(nextMessages)
-  }
-
-  const updateMessageList = (
-    update: (currentMessages: ChatMessage[]) => ChatMessage[],
-    options?: {
-      commit?: boolean
-    },
-  ): ChatMessage[] => {
-    const nextMessages = update(messagesRef.current)
-    setMessagesState(nextMessages)
-
-    if (options?.commit) {
-      onMessagesChange?.(nextMessages)
-    }
-
-    return nextMessages
-  }
-
-  const replaceMessage = (
-    messageId: string,
-    nextMessage: Partial<ChatMessage>,
-    options?: {
-      commit?: boolean
-    },
-  ) =>
-    updateMessageList(
-      (currentMessages) =>
-        currentMessages.map((message) =>
-          message.id === messageId
-            ? {
-                ...message,
-                ...nextMessage,
-              }
-            : message,
-        ),
-      options,
-    )
-
-  const removeMessage = (
-    messageId: string,
-    options?: {
-      commit?: boolean
-    },
-  ) =>
-    updateMessageList(
-      (currentMessages) =>
-        currentMessages.filter((message) => message.id !== messageId),
-      options,
-    )
-
-  const disconnectActivePort = useCallback(
-    (suppressDisconnectError = false) => {
-      const activePort = activePortRef.current
-      if (!activePort) {
-        return
-      }
-
-      if (suppressDisconnectError) {
-        ignoreNextDisconnectRef.current = true
-      }
-
-      activePortRef.current = null
-      activePort.disconnect()
-    },
-    [],
-  )
-
-  const handleResetConversation = useCallback(() => {
-    conversationGenerationRef.current += 1
-    disconnectActivePort(true)
-    setMessagesState([])
-    setInput('')
-    setErrorMessage('')
-    setChatOllamaError(undefined)
-    setIsSubmitting(false)
-  }, [disconnectActivePort])
-
-  const {
-    isLoadingModels,
-    isSavingModel,
-    modelOptions,
-    platform,
-    requestModels: handleFetchModels,
-    selectModel: handleSelectModel,
-    setupErrorMessage,
-    setupOllamaError,
-  } = useOllamaModelSettings({
-    onSettingsSaved: (nextSettings) => {
-      setSettings(nextSettings)
-    },
-    settings: resolvedSettings,
-    t,
-  })
-
-  const handleConversationAction = useCallback(() => {
-    if (onCreateConversation) {
-      onCreateConversation()
-      return
-    }
-
-    handleResetConversation()
-  }, [handleResetConversation, onCreateConversation])
-
-  const handleSelectSystemPrompt = useCallback(
-    async (promptId: string) => {
-      if (!promptId || promptId === resolvedSettings.activeAiSystemPromptId) {
-        return
-      }
-      const nextSettings = normalizeAiSystemPromptSettings({
-        ...resolvedSettings,
-        activeAiSystemPromptId: promptId,
-      })
-      try {
-        await saveUserSettings(nextSettings)
-        setSettings(nextSettings)
-        handleResetConversation()
-      } catch {
-        setChatOllamaError(undefined)
-        setErrorMessage(t('aiChat.systemPrompt.switchSaveError'))
-      }
-    },
-    [handleResetConversation, resolvedSettings, t],
-  )
-  const {
-    isPromptManagerOpen,
-    promptDrafts,
-    selectedPromptIdInModal,
-    setSelectedPromptIdInModal,
-    draftActivePromptId,
-    setPromptManagerError,
-    isSavingPrompts,
-    handleOpenSystemPromptManager,
-    handleCancelSystemPromptManager,
-    handlePromptManagerOpenChange,
-    handleChangePromptName,
-    handleChangePromptTemplate,
-    handleCreatePrompt,
-    handleDuplicatePrompt,
-    handleDeletePrompt,
-    handleSavePromptManager,
-    promptManagerDisplayError,
-    isPromptManagerSaveDisabled,
-  } = useChatPromptManager({
-    resolvedSettings,
-    activeSystemPrompt,
-    language,
-    t,
-    handleResetConversation,
-    onSettingsChange: setSettings,
-  })
-  const { submitPrompt, handleSubmit } = useChatStreamHandlers({
-    messages,
-    activePortRef,
-    conversationGenerationRef,
-    ignoreNextDisconnectRef,
-    disconnectActivePort,
-    replaceMessage,
-    removeMessage,
-    updateMessageList,
-    setInput,
-    setErrorMessage,
-    setChatOllamaError,
-    setIsSubmitting,
-    isConfigured,
-    isSubmitting,
-    t,
-    language,
-  })
-  const panelLayout = useMemo(
-    () => ({
-      cardStyle,
-      isCompactLayout,
-      isResizing,
-      mode,
-      showCloseButton: mode === 'floating',
-    }),
-    [cardStyle, isCompactLayout, isResizing, mode],
-  )
-  const panelStatus = useMemo(
-    () => ({
-      isConfigured,
-      isConversationCopied,
-      isCopyDisabled: messages.every(
-        (message) => message.content.trim().length === 0,
-      ),
-      isLoadingModels,
-      isOpen,
-      isSavingModel,
-      isSubmitting,
-    }),
-    [
-      isConfigured,
-      isConversationCopied,
-      isLoadingModels,
-      isOpen,
-      isSavingModel,
-      isSubmitting,
-      messages,
-    ],
-  )
-  const panelSystemPrompts = useMemo(
-    () => resolvedSettings.aiSystemPrompts ?? [],
-    [resolvedSettings.aiSystemPrompts],
-  )
-  const handlePanelClose = useCallback(() => {
-    setIsFloatingOpen(false)
-    onOpenChange?.(false)
-  }, [onOpenChange])
-  const handlePanelCopyConversation = useCallback(() => {
-    void copyConversation()
-  }, [copyConversation])
-  const handlePanelFetchModels = useCallback(() => {
-    void handleFetchModels()
-  }, [handleFetchModels])
-  const handlePanelSelectSuggestion = useCallback(
-    (value: string) => {
-      void submitPrompt(value)
-    },
-    [submitPrompt],
-  )
-  const handlePanelSelectSystemPrompt = useCallback(
-    (promptId: string) => {
-      void handleSelectSystemPrompt(promptId)
-    },
-    [handleSelectSystemPrompt],
-  )
-  const chatPanel = (
-    <SavedTabsChatPanel
-      activeSystemPromptId={resolvedSettings.activeAiSystemPromptId ?? ''}
-      chatErrorMessage={errorMessage}
-      chatOllamaError={chatOllamaError}
-      historyItems={historyItems}
-      historyVariant={historyVariant}
-      input={input}
-      layout={panelLayout}
-      messages={messages}
-      modelName={resolvedSettings.ollamaModel}
-      modelOptions={modelOptions}
-      onClose={handlePanelClose}
-      onCopyConversation={handlePanelCopyConversation}
-      onDeleteHistoryItem={onDeleteHistoryItem}
-      onFetchModels={handlePanelFetchModels}
-      onInputChange={setInput}
-      onOpenSystemPromptManager={handleOpenSystemPromptManager}
-      onResetConversation={handleConversationAction}
-      onResizeStart={handleResizeStart}
-      onSelectHistoryItem={onSelectHistoryItem}
-      onSelectModel={handleSelectModel}
-      onSelectSuggestion={handlePanelSelectSuggestion}
-      onSelectSystemPrompt={handlePanelSelectSystemPrompt}
-      onSubmit={handleSubmit}
-      onToggleHistory={onToggleHistory}
-      platform={platform}
-      setupErrorMessage={setupErrorMessage}
-      setupOllamaError={setupOllamaError}
-      status={panelStatus}
-      systemPrompts={panelSystemPrompts}
-      title={resolvedTitle}
-    />
-  )
-  const systemPromptManagerDialogProps: SystemPromptManagerDialogProps = {
-    activePromptId: draftActivePromptId,
-    errorMessage: promptManagerDisplayError,
-    isOpen: isPromptManagerOpen,
-    isSaveDisabled: isPromptManagerSaveDisabled,
-    isSaving: isSavingPrompts,
-    onCancel: handleCancelSystemPromptManager,
-    onChangePromptName: handleChangePromptName,
-    onChangePromptTemplate: handleChangePromptTemplate,
-    onCloseChange: handlePromptManagerOpenChange,
-    onCreatePrompt: handleCreatePrompt,
-    onDeletePrompt: handleDeletePrompt,
-    onDuplicatePrompt: handleDuplicatePrompt,
-    onSave: handleSavePromptManager,
-    onSelectPrompt: (promptId) => {
-      setPromptManagerError('')
-      setSelectedPromptIdInModal(promptId)
-    },
-    presets: promptDrafts,
-    selectedPromptId: selectedPromptIdInModal,
-  }
-
-  const handleFloatingButtonClick = useCallback(() => {
-    setIsFloatingOpen(true)
-    onOpenChange?.(true)
-  }, [onOpenChange])
+const SavedTabsChatWidget = (props: SavedTabsChatWidgetProps = {}) => {
+  const controller = useSavedTabsChatController(props)
 
   return (
     <>
-      {mode === 'floating' && !isOpen ? (
+      {controller.launcher.isVisible ? (
         <Button
           type='button'
-          aria-label={t('aiChat.open')}
+          aria-label={controller.launcher.label}
           className='fixed right-4 bottom-4 z-50 size-10 cursor-pointer rounded-full shadow-lg'
-          onClick={handleFloatingButtonClick}
+          onClick={controller.launcher.handleOpen}
         >
           <MessageCircleMore className='size-5' />
         </Button>
       ) : null}
 
-      {chatPanel}
-      <SystemPromptManagerDialog {...systemPromptManagerDialogProps} />
+      <SavedTabsChatPanel
+        activeSystemPromptId={controller.settings.activeSystemPromptId}
+        chatErrorMessage={controller.errors.chatMessage}
+        chatOllamaError={controller.errors.chatOllama}
+        historyItems={controller.history.items}
+        historyVariant={controller.history.variant}
+        input={controller.messages.input}
+        layout={controller.layout}
+        messages={controller.messages.items}
+        modelName={controller.settings.modelName}
+        modelOptions={controller.settings.modelOptions}
+        onClose={controller.actions.handleClose}
+        onCopyConversation={controller.actions.handleCopyConversation}
+        onDeleteHistoryItem={controller.history.handleDeleteItem}
+        onFetchModels={controller.actions.handleFetchModels}
+        onInputChange={controller.actions.handleInputChange}
+        onOpenSystemPromptManager={
+          controller.actions.handleOpenSystemPromptManager
+        }
+        onResetConversation={controller.actions.handleCreateConversation}
+        onResizeStart={controller.actions.handleResizeStart}
+        onSelectHistoryItem={controller.history.handleSelectItem}
+        onSelectModel={controller.actions.handleSelectModel}
+        onSelectSuggestion={controller.actions.handleSelectSuggestion}
+        onSelectSystemPrompt={controller.actions.handleSelectSystemPrompt}
+        onSubmit={controller.actions.handleSubmit}
+        onToggleHistory={controller.history.handleToggle}
+        platform={controller.settings.platform}
+        setupErrorMessage={controller.errors.setupMessage}
+        setupOllamaError={controller.errors.setupOllama}
+        status={controller.status}
+        systemPrompts={controller.settings.systemPrompts}
+        title={controller.title}
+      />
+      <SystemPromptManagerDialog {...controller.dialog} />
     </>
   )
 }
-
-const SavedTabsChatWidget = (props: SavedTabsChatWidgetProps = {}) =>
-  useSavedTabsChatWidgetView(props)
 
 export { SavedTabsChatWidget }

--- a/src/features/ai-chat/components/SavedTabsChatWidget.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, MessageCircleMore } from 'lucide-react'
+import { MessageCircleMore } from 'lucide-react'
 import {
   useCallback,
   useEffect,
@@ -7,50 +7,9 @@ import {
   useRef,
   useState,
 } from 'react'
-import type { CSSProperties, ReactNode } from 'react'
-import { toast } from 'sonner'
 
-import { Attachments } from '@/components/ai-elements/attachments'
-import {
-  Conversation,
-  ConversationContent,
-  ConversationEmptyState,
-  ConversationScrollButton,
-} from '@/components/ai-elements/conversation'
-import {
-  Message,
-  MessageContent,
-  MessageResponse,
-} from '@/components/ai-elements/message'
-import type { PromptInputProps } from '@/components/ai-elements/prompt-input'
-import {
-  Reasoning,
-  ReasoningContent,
-  ReasoningTrigger,
-} from '@/components/ai-elements/reasoning'
-import { Shimmer } from '@/components/ai-elements/shimmer'
-import {
-  Source,
-  Sources,
-  SourcesContent,
-  SourcesTrigger,
-} from '@/components/ai-elements/sources'
-import { Suggestion, Suggestions } from '@/components/ai-elements/suggestion'
-import {
-  Tool,
-  ToolContent,
-  ToolHeader,
-  ToolInput,
-  ToolOutput,
-} from '@/components/ai-elements/tool'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent } from '@/components/ui/card'
-import { AiChartRenderer } from '@/features/ai-chat/components/AiChartRenderer'
-import { OllamaErrorNotice } from '@/features/ai-chat/components/OllamaErrorNotice'
-import type { OllamaErrorPlatform } from '@/features/ai-chat/components/OllamaErrorNotice'
-import { SavedTabsChatAttachmentItem } from '@/features/ai-chat/components/SavedTabsChatAttachmentItem'
-import { SavedTabsChatComposer } from '@/features/ai-chat/components/SavedTabsChatComposer'
-import { SavedTabsChatHeader } from '@/features/ai-chat/components/SavedTabsChatHeader'
+import { SavedTabsChatPanel } from '@/features/ai-chat/components/SavedTabsChatPanel'
 import { SystemPromptManagerDialog } from '@/features/ai-chat/components/SystemPromptManagerDialog'
 import type { SystemPromptManagerDialogProps } from '@/features/ai-chat/components/SystemPromptManagerDialog'
 import { useChatSidebarResize } from '@/features/ai-chat/hooks/useChatSidebarResize'
@@ -60,10 +19,7 @@ import {
   getActiveAiSystemPrompt,
   normalizeAiSystemPromptSettings,
 } from '@/features/ai-chat/lib/systemPromptPresets'
-import type {
-  AiChatAttachment,
-  AiChatHistoryItem,
-} from '@/features/ai-chat/types'
+import type { AiChatHistoryItem } from '@/features/ai-chat/types'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import {
   getChromeStorageOnChanged,
@@ -74,76 +30,21 @@ import {
   UserSettingsSchema,
   fromStorageChange,
 } from '@/lib/storage/zod-storage'
-import { cn } from '@/lib/utils'
 import type { OllamaErrorDetails } from '@/types/background'
-import type { AiSystemPromptPreset, UserSettings } from '@/types/storage'
+import type { UserSettings } from '@/types/storage'
 
-import { getMessageSources, getSourcesLabel } from './savedTabsChat/messages'
-import type { ChatMessage, TranslateFn } from './savedTabsChat/messages'
+import type { ChatMessage } from './savedTabsChat/messages'
 import {
   areMessagesEquivalent,
   EMPTY_CHAT_MESSAGES,
   EMPTY_HISTORY_ITEMS,
-  EMPTY_TOOL_TRACES,
   getResolvedSettings,
   isAiChatConfigured,
   loadWidgetSettings,
   syncExternalConversationState,
 } from './savedTabsChat/storage'
-import { getAttachmentInputErrorMessage } from './savedTabsChat/streaming'
 import { useChatPromptManager } from './savedTabsChat/useChatPromptManager'
 import { useChatStreamHandlers } from './savedTabsChat/useChatStreamHandlers'
-import { getSavedTabsChatAttachmentId } from './savedTabsChatAttachmentItem.helpers'
-
-type SavedTabsChatPanelProps = {
-  activeSystemPromptId: string
-  chatErrorMessage: string
-  chatOllamaError?: OllamaErrorDetails
-  historyItems: AiChatHistoryItem[]
-  historyVariant: 'dropdown' | 'none' | 'sidebar-toggle'
-  input: string
-  layout: {
-    cardStyle?: CSSProperties
-    isCompactLayout: boolean
-    isResizing: boolean
-    mode: 'floating' | 'page'
-    showCloseButton: boolean
-  }
-  status: {
-    isConfigured: boolean
-    isConversationCopied: boolean
-    isCopyDisabled: boolean
-    isLoadingModels: boolean
-    isOpen: boolean
-    isSavingModel: boolean
-    isSubmitting: boolean
-  }
-  messages: ChatMessage[]
-  modelName?: string
-  modelOptions: {
-    label: string
-    name: string
-  }[]
-  onClose: () => void
-  onCopyConversation: () => void
-  onDeleteHistoryItem?: (conversationId: string) => void
-  onFetchModels: () => void
-  onInputChange: (value: string) => void
-  onOpenSystemPromptManager: () => void
-  onResetConversation: () => void
-  onResizeStart: (event: React.PointerEvent<HTMLButtonElement>) => void
-  onSelectHistoryItem?: (conversationId: string) => void
-  onSelectModel: (modelName: string) => Promise<boolean>
-  onSelectSuggestion: (value: string) => void
-  onSelectSystemPrompt: (promptId: string) => void
-  onSubmit: PromptInputProps['onSubmit']
-  onToggleHistory?: () => void
-  platform: OllamaErrorPlatform
-  title: string
-  setupErrorMessage: string
-  setupOllamaError?: OllamaErrorDetails
-  systemPrompts: AiSystemPromptPreset[]
-}
 
 type SavedTabsChatWidgetProps = {
   conversationId?: string
@@ -159,502 +60,6 @@ type SavedTabsChatWidgetProps = {
   onOpenChange?: (isOpen: boolean) => void
   onSelectHistoryItem?: (conversationId: string) => void
   onToggleHistory?: () => void
-}
-
-const AssistantMessageDiagnostics = ({
-  isStreaming,
-  reasoning,
-  toolTraces = EMPTY_TOOL_TRACES,
-}: Pick<ChatMessage, 'isStreaming' | 'reasoning' | 'toolTraces'>) => {
-  const { t } = useI18n()
-  const getThinkingMessage = useCallback(
-    () =>
-      `${t('aiChat.reasoning')}${
-        toolTraces.length > 0 ? ` / ${toolTraces.length}` : ''
-      }`,
-    [t, toolTraces.length],
-  )
-
-  if (!reasoning && toolTraces.length === 0) {
-    return null
-  }
-
-  return (
-    <div className='gap-y-2 pl-1 wrap-break-word'>
-      {reasoning ? (
-        <Reasoning
-          className='mb-0 rounded-md border border-border/70 bg-background/70 px-3 py-2'
-          isStreaming={isStreaming}
-        >
-          <ReasoningTrigger getThinkingMessage={getThinkingMessage} />
-          <ReasoningContent>{reasoning}</ReasoningContent>
-        </Reasoning>
-      ) : null}
-
-      {toolTraces.length > 0 ? (
-        <div className='gap-y-2'>
-          <p className='pl-1 text-[11px] font-medium tracking-wide text-muted-foreground uppercase'>
-            {t('aiChat.toolsRun')}
-          </p>
-          {toolTraces.map((toolTrace) => (
-            <Tool
-              className='mb-0 border-border/70 bg-background/70'
-              key={toolTrace.toolCallId}
-            >
-              <ToolHeader
-                state={toolTrace.state}
-                title={toolTrace.title}
-                toolName={toolTrace.toolName}
-                type='dynamic-tool'
-              />
-              <ToolContent>
-                <ToolInput input={toolTrace.input} />
-                <ToolOutput
-                  errorText={toolTrace.errorText}
-                  output={toolTrace.output}
-                />
-              </ToolContent>
-            </Tool>
-          ))}
-        </div>
-      ) : null}
-    </div>
-  )
-}
-
-const renderChatPromptIntro = ({
-  isCompactLayout,
-  onSelectSuggestion,
-  t,
-}: {
-  isCompactLayout: boolean
-  onSelectSuggestion: (value: string) => void
-  t: TranslateFn
-}) => {
-  const suggestions = [
-    t('aiChat.suggestion.recentTabs'),
-    t('aiChat.suggestion.favoriteContent'),
-    t('aiChat.suggestion.recommendation'),
-  ]
-  const suggestionItems = suggestions.map((suggestion) => (
-    <Suggestion
-      className={
-        isCompactLayout
-          ? 'w-full justify-start text-left whitespace-normal'
-          : undefined
-      }
-      key={suggestion}
-      suggestion={suggestion}
-      onClick={onSelectSuggestion}
-    />
-  ))
-
-  return (
-    <div className='shrink-0 gap-y-3' data-testid='ai-chat-intro'>
-      <p className='text-sm text-muted-foreground'>{t('aiChat.intro')}</p>
-      {isCompactLayout ? (
-        <div className='grid gap-2'>{suggestionItems}</div>
-      ) : (
-        <Suggestions>{suggestionItems}</Suggestions>
-      )}
-    </div>
-  )
-}
-
-const renderChatDataScopeNotice = ({
-  isVisible,
-  t,
-}: {
-  isVisible: boolean
-  t: TranslateFn
-}) => {
-  if (!isVisible) {
-    return null
-  }
-
-  return (
-    <p
-      className='text-[11px] leading-4 text-muted-foreground'
-      data-testid='ai-chat-data-scope'
-    >
-      {t('aiChat.dataScope')}
-    </p>
-  )
-}
-
-const renderChatMessageAttachments = ({
-  attachments,
-}: {
-  attachments: AiChatAttachment[]
-}) => {
-  return (
-    <Attachments className='mb-2 w-full' variant='inline'>
-      {attachments.map((attachment) => (
-        <SavedTabsChatAttachmentItem
-          attachment={attachment}
-          key={getSavedTabsChatAttachmentId(attachment)}
-        />
-      ))}
-    </Attachments>
-  )
-}
-
-const renderConversationMessageBody = ({
-  message,
-  platform,
-}: {
-  message: ChatMessage
-  platform: OllamaErrorPlatform
-}) => {
-  if (message.ollamaError) {
-    return (
-      <OllamaErrorNotice
-        className='text-sm'
-        error={message.ollamaError}
-        platform={platform}
-      />
-    )
-  }
-
-  return <MessageResponse>{message.content}</MessageResponse>
-}
-
-const renderChatConversationMessage = ({
-  // eslint-disable-line eslint/complexity
-  message,
-  platform,
-  t,
-}: {
-  message: ChatMessage
-  platform: OllamaErrorPlatform
-  t: TranslateFn
-}) => {
-  const messageSources =
-    message.role === 'assistant' ? getMessageSources(message.toolTraces) : []
-  const messageBody = renderConversationMessageBody({
-    message,
-    platform,
-  })
-  const shouldShowStreamingShimmer =
-    message.role === 'assistant' &&
-    message.isStreaming &&
-    message.content.length === 0
-  const hasCharts =
-    message.role === 'assistant' &&
-    Boolean(message.charts && message.charts.length > 0)
-
-  return (
-    <Message
-      className={cn(hasCharts && 'max-w-full')}
-      data-testid='chat-message'
-      from={message.role}
-    >
-      {messageSources.length > 0 ? (
-        <Sources
-          className='mb-0 rounded-md border border-border/70 bg-background/70 px-3 py-2 text-foreground'
-          data-slot='sources'
-          data-testid='message-sources'
-        >
-          <SourcesTrigger
-            className='w-full justify-between text-muted-foreground'
-            count={messageSources.length}
-          >
-            <span className='text-[11px] font-medium tracking-wide uppercase'>
-              {getSourcesLabel({ count: messageSources.length, t })}
-            </span>
-            <ChevronDown className='size-4' />
-          </SourcesTrigger>
-          <SourcesContent className='w-full'>
-            {messageSources.map((source) => (
-              <Source href={source.url} key={source.url} title={source.title} />
-            ))}
-          </SourcesContent>
-        </Sources>
-      ) : null}
-
-      {message.role === 'assistant' ? (
-        <AssistantMessageDiagnostics
-          isStreaming={message.isStreaming}
-          reasoning={message.reasoning}
-          toolTraces={message.toolTraces}
-        />
-      ) : null}
-
-      <MessageContent
-        className={cn(
-          message.role === 'user'
-            ? 'bg-primary text-primary-foreground'
-            : 'bg-muted text-foreground',
-          hasCharts && 'w-full overflow-visible',
-          'wrap-break-word whitespace-pre-wrap',
-        )}
-        data-testid='message-content'
-      >
-        {message.attachments && message.attachments.length > 0
-          ? renderChatMessageAttachments({
-              attachments: message.attachments,
-            })
-          : null}
-        {messageBody}
-        {message.role === 'assistant' ? (
-          <AiChartRenderer charts={message.charts} />
-        ) : null}
-        {shouldShowStreamingShimmer ? (
-          <Shimmer className='text-sm'>{t('aiChat.shimmer')}</Shimmer>
-        ) : null}
-      </MessageContent>
-    </Message>
-  )
-}
-
-// TODO(#557): この関数の複雑度が高い。useMemo/useCallback の分割や早期 return で削減する。
-// eslint-disable-next-line eslint/complexity
-const useSavedTabsChatPanelView = ({
-  activeSystemPromptId,
-  chatErrorMessage,
-  chatOllamaError,
-  historyItems,
-  historyVariant,
-  input,
-  layout,
-  messages,
-  modelName,
-  modelOptions,
-  onClose,
-  onCopyConversation,
-  onDeleteHistoryItem,
-  onFetchModels,
-  onInputChange,
-  onOpenSystemPromptManager,
-  onResetConversation,
-  onResizeStart,
-  onSelectHistoryItem,
-  onSelectModel,
-  onSelectSuggestion,
-  onSelectSystemPrompt,
-  onSubmit,
-  onToggleHistory,
-  platform,
-  status,
-  title,
-  setupErrorMessage,
-  setupOllamaError,
-  systemPrompts,
-}: SavedTabsChatPanelProps) => {
-  const { t } = useI18n()
-  const handleAttachmentError = useCallback(
-    (error: {
-      code: 'accept' | 'max_files' | 'max_file_size'
-      message: string
-    }) => {
-      toast.error(getAttachmentInputErrorMessage(error, t))
-    },
-    [t],
-  )
-  const headerPresentation = useMemo(
-    () => ({
-      isCompactLayout: layout.isCompactLayout,
-      showCloseButton: layout.showCloseButton,
-    }),
-    [layout.isCompactLayout, layout.showCloseButton],
-  )
-  const headerStatus = useMemo(
-    () => ({
-      isConversationCopied: status.isConversationCopied,
-      isCopyDisabled: status.isCopyDisabled,
-    }),
-    [status.isConversationCopied, status.isCopyDisabled],
-  )
-  const headerSystemPrompts = useMemo(
-    () =>
-      systemPrompts.map(({ id, name }) => ({
-        id,
-        name,
-      })),
-    [systemPrompts],
-  )
-  const composerPresentation = useMemo(
-    () => ({ isCompactLayout: layout.isCompactLayout }),
-    [layout.isCompactLayout],
-  )
-  const composerStatus = useMemo(
-    () => ({
-      isConfigured: status.isConfigured,
-      isLoadingModels: status.isLoadingModels,
-      isSavingModel: status.isSavingModel,
-      isSubmitting: status.isSubmitting,
-    }),
-    [
-      status.isConfigured,
-      status.isLoadingModels,
-      status.isSavingModel,
-      status.isSubmitting,
-    ],
-  )
-  const { cardStyle, isCompactLayout, isResizing, mode } = layout
-  const { isConfigured, isOpen } = status
-  const renderedMessages = messages.map((message) => ({
-    id: message.id,
-    view: renderChatConversationMessage({
-      message,
-      platform,
-      t,
-    }),
-  }))
-  const introContent =
-    messages.length === 0 && isConfigured
-      ? renderChatPromptIntro({
-          isCompactLayout,
-          onSelectSuggestion,
-          t,
-        })
-      : null
-  const chatDataScopeNotice = renderChatDataScopeNotice({
-    isVisible: isConfigured,
-    t,
-  })
-  const cardClassName =
-    mode === 'page'
-      ? 'flex h-full min-h-0 flex-1 flex-col rounded-[1.5rem] border-border shadow-lg'
-      : 'flex h-full min-h-0 flex-col rounded-none border-border border-y-0 border-r-0 border-l shadow-2xl'
-  if (!isOpen) {
-    return null
-  }
-
-  let chatErrorContent: ReactNode = null
-
-  if (chatOllamaError) {
-    chatErrorContent = (
-      <OllamaErrorNotice
-        className='shrink-0 text-sm text-destructive'
-        error={chatOllamaError}
-        platform={platform}
-      />
-    )
-  } else if (chatErrorMessage) {
-    chatErrorContent = (
-      <p className='shrink-0 text-sm wrap-break-word whitespace-pre-line text-destructive'>
-        {chatErrorMessage}
-      </p>
-    )
-  }
-
-  const card = (
-    <Card
-      aria-label={
-        mode === 'page' ? t('aiChat.pageAria') : t('aiChat.sidebarAria')
-      }
-      data-sidebar-layout={isCompactLayout ? 'compact' : 'default'}
-      className={cardClassName}
-      style={cardStyle}
-    >
-      <SavedTabsChatHeader
-        activeSystemPromptId={activeSystemPromptId}
-        historyItems={historyItems}
-        historyVariant={historyVariant}
-        onClose={onClose}
-        onCopyConversation={onCopyConversation}
-        onDeleteHistoryItem={onDeleteHistoryItem}
-        onOpenSystemPromptManager={onOpenSystemPromptManager}
-        onResetConversation={onResetConversation}
-        onSelectHistoryItem={onSelectHistoryItem}
-        onSelectSystemPrompt={onSelectSystemPrompt}
-        onToggleHistory={onToggleHistory}
-        presentation={headerPresentation}
-        status={headerStatus}
-        systemPrompts={headerSystemPrompts}
-        title={title}
-      />
-
-      <CardContent
-        className={cn(
-          'flex min-h-0 flex-1 flex-col overflow-hidden',
-          isCompactLayout ? 'gap-2 p-2' : 'gap-3 p-3',
-        )}
-      >
-        <Conversation className='min-h-0 flex-1'>
-          {messages.length === 0 && !isConfigured ? (
-            <ConversationEmptyState
-              data-testid='empty-state-root'
-              description=''
-              title={t('aiChat.emptySelectModel')}
-            />
-          ) : (
-            <>
-              <ConversationContent
-                className={cn(isCompactLayout && 'gap-5 p-3')}
-                scrollClassName='overscroll-contain overflow-y-auto'
-              >
-                {renderedMessages.map((message) => (
-                  <div key={message.id}>{message.view}</div>
-                ))}
-              </ConversationContent>
-              <ConversationScrollButton
-                aria-label={t('aiChat.scrollLatest')}
-                className='bottom-3'
-              />
-            </>
-          )}
-        </Conversation>
-
-        <div
-          className='mt-auto shrink-0 gap-y-3'
-          data-testid='ai-chat-bottom-dock'
-        >
-          {introContent}
-
-          {chatErrorContent}
-
-          {chatDataScopeNotice}
-
-          <SavedTabsChatComposer
-            input={input}
-            modelName={modelName}
-            modelOptions={modelOptions}
-            onAttachmentError={handleAttachmentError}
-            onFetchModels={onFetchModels}
-            onInputChange={onInputChange}
-            onSelectModel={onSelectModel}
-            onSubmit={onSubmit}
-            platform={platform}
-            presentation={composerPresentation}
-            setupErrorMessage={setupErrorMessage}
-            setupOllamaError={setupOllamaError}
-            status={composerStatus}
-          />
-        </div>
-      </CardContent>
-    </Card>
-  )
-
-  if (mode === 'page') {
-    return <div className='flex h-full min-h-0 flex-1'>{card}</div>
-  }
-
-  return (
-    <div
-      className='sticky top-0 z-50 flex h-screen max-w-[calc(100vw-24px)] shrink-0 self-start overflow-hidden overscroll-none'
-      data-testid='chat-shell'
-    >
-      <Button
-        aria-label={t('aiChat.resizeAria')}
-        className={`relative min-h-0 w-4 shrink-0 cursor-col-resize touch-none self-stretch rounded-none border-0 bg-transparent ${
-          isResizing ? 'bg-primary/10' : 'bg-transparent'
-        }`}
-        onPointerDown={onResizeStart}
-        size='unstyled'
-        type='button'
-        variant='ghost'
-      >
-        <span
-          aria-hidden='true'
-          className='absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border/80'
-        />
-      </Button>
-
-      {card}
-    </div>
-  )
 }
 
 // eslint-disable-next-line eslint/max-statements
@@ -845,21 +250,24 @@ const useSavedTabsChatWidgetView = ({
       options,
     )
 
-  const disconnectActivePort = (suppressDisconnectError = false) => {
-    const activePort = activePortRef.current
-    if (!activePort) {
-      return
-    }
+  const disconnectActivePort = useCallback(
+    (suppressDisconnectError = false) => {
+      const activePort = activePortRef.current
+      if (!activePort) {
+        return
+      }
 
-    if (suppressDisconnectError) {
-      ignoreNextDisconnectRef.current = true
-    }
+      if (suppressDisconnectError) {
+        ignoreNextDisconnectRef.current = true
+      }
 
-    activePortRef.current = null
-    activePort.disconnect()
-  }
+      activePortRef.current = null
+      activePort.disconnect()
+    },
+    [],
+  )
 
-  const handleResetConversation = () => {
+  const handleResetConversation = useCallback(() => {
     conversationGenerationRef.current += 1
     disconnectActivePort(true)
     setMessagesState([])
@@ -867,7 +275,7 @@ const useSavedTabsChatWidgetView = ({
     setErrorMessage('')
     setChatOllamaError(undefined)
     setIsSubmitting(false)
-  }
+  }, [disconnectActivePort])
 
   const {
     isLoadingModels,
@@ -886,32 +294,35 @@ const useSavedTabsChatWidgetView = ({
     t,
   })
 
-  const handleConversationAction = () => {
+  const handleConversationAction = useCallback(() => {
     if (onCreateConversation) {
       onCreateConversation()
       return
     }
 
     handleResetConversation()
-  }
+  }, [handleResetConversation, onCreateConversation])
 
-  const handleSelectSystemPrompt = async (promptId: string) => {
-    if (!promptId || promptId === resolvedSettings.activeAiSystemPromptId) {
-      return
-    }
-    const nextSettings = normalizeAiSystemPromptSettings({
-      ...resolvedSettings,
-      activeAiSystemPromptId: promptId,
-    })
-    try {
-      await saveUserSettings(nextSettings)
-      setSettings(nextSettings)
-      handleResetConversation()
-    } catch {
-      setChatOllamaError(undefined)
-      setErrorMessage(t('aiChat.systemPrompt.switchSaveError'))
-    }
-  }
+  const handleSelectSystemPrompt = useCallback(
+    async (promptId: string) => {
+      if (!promptId || promptId === resolvedSettings.activeAiSystemPromptId) {
+        return
+      }
+      const nextSettings = normalizeAiSystemPromptSettings({
+        ...resolvedSettings,
+        activeAiSystemPromptId: promptId,
+      })
+      try {
+        await saveUserSettings(nextSettings)
+        setSettings(nextSettings)
+        handleResetConversation()
+      } catch {
+        setChatOllamaError(undefined)
+        setErrorMessage(t('aiChat.systemPrompt.switchSaveError'))
+      }
+    },
+    [handleResetConversation, resolvedSettings, t],
+  )
   const {
     isPromptManagerOpen,
     promptDrafts,
@@ -957,51 +368,18 @@ const useSavedTabsChatWidgetView = ({
     t,
     language,
   })
-  const chatPanel = useSavedTabsChatPanelView({
-    activeSystemPromptId: resolvedSettings.activeAiSystemPromptId ?? '',
-    chatErrorMessage: errorMessage,
-    chatOllamaError,
-    historyItems,
-    historyVariant,
-    input,
-    layout: {
+  const panelLayout = useMemo(
+    () => ({
       cardStyle,
       isCompactLayout,
       isResizing,
       mode,
       showCloseButton: mode === 'floating',
-    },
-    messages,
-    modelName: resolvedSettings.ollamaModel,
-    modelOptions,
-    onClose: () => {
-      setIsFloatingOpen(false)
-      onOpenChange?.(false)
-    },
-    onCopyConversation: () => {
-      void copyConversation()
-    },
-    onDeleteHistoryItem,
-    // eslint-disable-next-line typescript/no-misused-promises
-    onFetchModels: handleFetchModels,
-    onInputChange: setInput,
-    onOpenSystemPromptManager: handleOpenSystemPromptManager,
-    onResetConversation: handleConversationAction,
-    onResizeStart: handleResizeStart,
-    onSelectHistoryItem,
-    onSelectModel: handleSelectModel,
-    onSelectSuggestion: (value) => {
-      void submitPrompt(value)
-    },
-    onSelectSystemPrompt: (promptId) => {
-      void handleSelectSystemPrompt(promptId)
-    },
-    onSubmit: handleSubmit,
-    onToggleHistory,
-    platform,
-    setupErrorMessage,
-    setupOllamaError,
-    status: {
+    }),
+    [cardStyle, isCompactLayout, isResizing, mode],
+  )
+  const panelStatus = useMemo(
+    () => ({
       isConfigured,
       isConversationCopied,
       isCopyDisabled: messages.every(
@@ -1011,10 +389,77 @@ const useSavedTabsChatWidgetView = ({
       isOpen,
       isSavingModel,
       isSubmitting,
+    }),
+    [
+      isConfigured,
+      isConversationCopied,
+      isLoadingModels,
+      isOpen,
+      isSavingModel,
+      isSubmitting,
+      messages,
+    ],
+  )
+  const panelSystemPrompts = useMemo(
+    () => resolvedSettings.aiSystemPrompts ?? [],
+    [resolvedSettings.aiSystemPrompts],
+  )
+  const handlePanelClose = useCallback(() => {
+    setIsFloatingOpen(false)
+    onOpenChange?.(false)
+  }, [onOpenChange])
+  const handlePanelCopyConversation = useCallback(() => {
+    void copyConversation()
+  }, [copyConversation])
+  const handlePanelFetchModels = useCallback(() => {
+    void handleFetchModels()
+  }, [handleFetchModels])
+  const handlePanelSelectSuggestion = useCallback(
+    (value: string) => {
+      void submitPrompt(value)
     },
-    systemPrompts: resolvedSettings.aiSystemPrompts ?? [],
-    title: resolvedTitle,
-  })
+    [submitPrompt],
+  )
+  const handlePanelSelectSystemPrompt = useCallback(
+    (promptId: string) => {
+      void handleSelectSystemPrompt(promptId)
+    },
+    [handleSelectSystemPrompt],
+  )
+  const chatPanel = (
+    <SavedTabsChatPanel
+      activeSystemPromptId={resolvedSettings.activeAiSystemPromptId ?? ''}
+      chatErrorMessage={errorMessage}
+      chatOllamaError={chatOllamaError}
+      historyItems={historyItems}
+      historyVariant={historyVariant}
+      input={input}
+      layout={panelLayout}
+      messages={messages}
+      modelName={resolvedSettings.ollamaModel}
+      modelOptions={modelOptions}
+      onClose={handlePanelClose}
+      onCopyConversation={handlePanelCopyConversation}
+      onDeleteHistoryItem={onDeleteHistoryItem}
+      onFetchModels={handlePanelFetchModels}
+      onInputChange={setInput}
+      onOpenSystemPromptManager={handleOpenSystemPromptManager}
+      onResetConversation={handleConversationAction}
+      onResizeStart={handleResizeStart}
+      onSelectHistoryItem={onSelectHistoryItem}
+      onSelectModel={handleSelectModel}
+      onSelectSuggestion={handlePanelSelectSuggestion}
+      onSelectSystemPrompt={handlePanelSelectSystemPrompt}
+      onSubmit={handleSubmit}
+      onToggleHistory={onToggleHistory}
+      platform={platform}
+      setupErrorMessage={setupErrorMessage}
+      setupOllamaError={setupOllamaError}
+      status={panelStatus}
+      systemPrompts={panelSystemPrompts}
+      title={resolvedTitle}
+    />
+  )
   const systemPromptManagerDialogProps: SystemPromptManagerDialogProps = {
     activePromptId: draftActivePromptId,
     errorMessage: promptManagerDisplayError,

--- a/src/features/ai-chat/components/SavedTabsChatWidget.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.tsx
@@ -16,7 +16,11 @@ import {
   useRef,
   useState,
 } from 'react'
-import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react'
+import type {
+  CSSProperties,
+  KeyboardEvent as ReactKeyboardEvent,
+  ReactNode,
+} from 'react'
 import { toast } from 'sonner'
 
 import { Attachments } from '@/components/ai-elements/attachments'
@@ -95,6 +99,7 @@ import { SavedTabsChatHeaderTooltipButton } from '@/features/ai-chat/components/
 import { SavedTabsChatHistoryItemCard } from '@/features/ai-chat/components/SavedTabsChatHistoryItemCard'
 import { SystemPromptManagerDialog } from '@/features/ai-chat/components/SystemPromptManagerDialog'
 import type { SystemPromptManagerDialogProps } from '@/features/ai-chat/components/SystemPromptManagerDialog'
+import { useChatSidebarResize } from '@/features/ai-chat/hooks/useChatSidebarResize'
 import {
   AI_CHAT_MAX_ATTACHMENTS,
   AI_CHAT_MAX_ATTACHMENT_SIZE_BYTES,
@@ -136,17 +141,13 @@ import {
 } from './savedTabsChat/prompts'
 import {
   areMessagesEquivalent,
-  clampSidebarWidth,
   COPIED_CONVERSATION_ICON_TIMEOUT,
-  DEFAULT_CHAT_SIDEBAR_WIDTH,
   EMPTY_CHAT_MESSAGES,
   EMPTY_HISTORY_ITEMS,
   EMPTY_TOOL_TRACES,
   getResolvedSettings,
   isAiChatConfigured,
-  loadSidebarWidth,
   loadWidgetSettings,
-  persistSidebarWidth,
   syncExternalConversationState,
 } from './savedTabsChat/storage'
 import {
@@ -193,11 +194,11 @@ type SavedTabsChatPanelProps = {
   historyVariant: 'dropdown' | 'none' | 'sidebar-toggle'
   input: string
   layout: {
+    cardStyle?: CSSProperties
     isCompactLayout: boolean
     isResizing: boolean
     mode: 'floating' | 'page'
     showCloseButton: boolean
-    sidebarWidth: number
   }
   status: {
     isConfigured: boolean
@@ -1074,7 +1075,7 @@ const useSavedTabsChatPanelView = ({
     },
     t,
   })
-  const { isCompactLayout, isResizing, mode, sidebarWidth } = layout
+  const { cardStyle, isCompactLayout, isResizing, mode } = layout
   const { isConfigured, isOpen } = status
   const renderedMessages = messages.map((message) => ({
     id: message.id,
@@ -1100,11 +1101,6 @@ const useSavedTabsChatPanelView = ({
     mode === 'page'
       ? 'flex h-full min-h-0 flex-1 flex-col rounded-[1.5rem] border-border shadow-lg'
       : 'flex h-full min-h-0 flex-col rounded-none border-border border-y-0 border-r-0 border-l shadow-2xl'
-  const cardStyle = useMemo(
-    () => (mode === 'page' ? undefined : { width: `${sidebarWidth}px` }),
-    [mode, sidebarWidth],
-  )
-
   if (!isOpen) {
     return null
   }
@@ -1236,7 +1232,8 @@ const useSavedTabsChatWidgetView = ({
   const [isFloatingOpen, setIsFloatingOpen] = useState(
     defaultOpen || mode === 'page',
   )
-  const [isResizing, setIsResizing] = useState(false)
+  const { cardStyle, handleResizeStart, isCompactLayout, isResizing } =
+    useChatSidebarResize({ mode })
   const [input, setInput] = useState('')
   const [messages, setMessages] = useReducer(
     (_state: ChatMessage[], nextMessages: ChatMessage[]) => nextMessages,
@@ -1261,22 +1258,16 @@ const useSavedTabsChatWidgetView = ({
     OllamaErrorDetails | undefined
   >(undefined)
   const [platform, setPlatform] = useState<OllamaErrorPlatform>('unknown')
-  const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_CHAT_SIDEBAR_WIDTH)
-  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth)
   const activePortRef = useRef<{
     disconnect: () => void
   } | null>(null)
   const conversationGenerationRef = useRef(0)
   const ignoreNextDisconnectRef = useRef(false)
-  const resizeCleanupRef = useRef<(() => void) | null>(null)
-  const sidebarWidthRef = useRef(DEFAULT_CHAT_SIDEBAR_WIDTH)
   const conversationCopiedTimeoutRef = useRef<number | null>(null)
   const messagesRef = useRef<ChatMessage[]>(initialMessages)
   const syncedConversationIdRef = useRef<string | undefined>(conversationId)
   const isOpen = mode === 'page' || isFloatingOpen
   const releaseChatWidgetResources = useCallback(() => {
-    resizeCleanupRef.current?.()
-    resizeCleanupRef.current = null
     if (conversationCopiedTimeoutRef.current) {
       window.clearTimeout(conversationCopiedTimeoutRef.current)
       conversationCopiedTimeoutRef.current = null
@@ -1284,10 +1275,6 @@ const useSavedTabsChatWidgetView = ({
     activePortRef.current?.disconnect()
     activePortRef.current = null
   }, [])
-
-  useEffect(() => {
-    sidebarWidthRef.current = sidebarWidth
-  }, [sidebarWidth])
 
   useEffect(() => {
     const shouldSyncExternalConversation =
@@ -1344,7 +1331,6 @@ const useSavedTabsChatWidgetView = ({
       }
 
       setSettings(nextSettings)
-      setSidebarWidth(loadSidebarWidth())
     }
 
     void syncWidgetSettings()
@@ -1384,29 +1370,9 @@ const useSavedTabsChatWidgetView = ({
     }
   }, [])
 
-  useEffect(() => {
-    const handleWindowResize = () => {
-      setViewportWidth(window.innerWidth)
-      setSidebarWidth((currentWidth) => clampSidebarWidth(currentWidth))
-    }
-
-    window.addEventListener('resize', handleWindowResize)
-
-    return () => {
-      window.removeEventListener('resize', handleWindowResize)
-    }
-  }, [])
-
   const resolvedSettings = getResolvedSettings(settings)
   const activeSystemPrompt = getActiveAiSystemPrompt(resolvedSettings)
   const isConfigured = isAiChatConfigured(resolvedSettings)
-  const TABLET_BREAKPOINT = 768
-  const SIDEBAR_COMPACT_BREAKPOINT = 360
-
-  const isCompactLayout =
-    mode === 'page'
-      ? viewportWidth < TABLET_BREAKPOINT
-      : sidebarWidth <= SIDEBAR_COMPACT_BREAKPOINT
   const resolvedTitle = title ?? t('aiChat.chatTitle')
 
   const setMessagesState = (nextMessages: ChatMessage[]) => {
@@ -1474,38 +1440,6 @@ const useSavedTabsChatWidgetView = ({
 
     activePortRef.current = null
     activePort.disconnect()
-  }
-
-  const stopResize = () => {
-    resizeCleanupRef.current?.()
-    resizeCleanupRef.current = null
-  }
-  const handleResizeStart = (event: React.PointerEvent<HTMLButtonElement>) => {
-    event.preventDefault()
-    stopResize()
-    setIsResizing(true)
-
-    const previousBodyStyle = document.body.style.cssText
-    const handlePointerMove = (moveEvent: PointerEvent) => {
-      const nextWidth = clampSidebarWidth(window.innerWidth - moveEvent.clientX)
-      sidebarWidthRef.current = nextWidth
-      setSidebarWidth(nextWidth)
-    }
-    const handlePointerUp = () => {
-      persistSidebarWidth(sidebarWidthRef.current)
-      setIsResizing(false)
-      stopResize()
-    }
-
-    document.body.style.cssText = `${previousBodyStyle}; cursor: col-resize; user-select: none;`
-    window.addEventListener('pointermove', handlePointerMove)
-    window.addEventListener('pointerup', handlePointerUp)
-
-    resizeCleanupRef.current = () => {
-      document.body.style.cssText = previousBodyStyle
-      window.removeEventListener('pointermove', handlePointerMove)
-      window.removeEventListener('pointerup', handlePointerUp)
-    }
   }
 
   const handleFetchModels = async () => {
@@ -1677,11 +1611,11 @@ const useSavedTabsChatWidgetView = ({
     historyVariant,
     input,
     layout: {
+      cardStyle,
       isCompactLayout,
       isResizing,
       mode,
       showCloseButton: mode === 'floating',
-      sidebarWidth,
     },
     messages,
     modelName: resolvedSettings.ollamaModel,

--- a/src/features/ai-chat/components/SavedTabsChatWidget.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.tsx
@@ -1,13 +1,4 @@
-import {
-  Check,
-  ChevronDown,
-  Copy,
-  History,
-  MessageCircleMore,
-  Plus,
-  Settings2,
-  X,
-} from 'lucide-react'
+import { ChevronDown, MessageCircleMore } from 'lucide-react'
 import {
   useCallback,
   useEffect,
@@ -16,11 +7,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import type {
-  CSSProperties,
-  KeyboardEvent as ReactKeyboardEvent,
-  ReactNode,
-} from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { toast } from 'sonner'
 
 import { Attachments } from '@/components/ai-elements/attachments'
@@ -35,17 +22,6 @@ import {
   MessageContent,
   MessageResponse,
 } from '@/components/ai-elements/message'
-import {
-  PromptInput,
-  PromptInputFooter,
-  PromptInputSelect,
-  PromptInputSelectContent,
-  PromptInputSelectItem,
-  PromptInputSelectTrigger,
-  PromptInputSelectValue,
-  PromptInputSubmit,
-  PromptInputTextarea,
-} from '@/components/ai-elements/prompt-input'
 import type { PromptInputProps } from '@/components/ai-elements/prompt-input'
 import {
   Reasoning,
@@ -68,45 +44,18 @@ import {
   ToolOutput,
 } from '@/components/ai-elements/tool'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+import { Card, CardContent } from '@/components/ui/card'
 import { AiChartRenderer } from '@/features/ai-chat/components/AiChartRenderer'
-import { ChatPromptAttachmentButton } from '@/features/ai-chat/components/ChatPromptAttachmentButton'
-import { ChatPromptAttachments } from '@/features/ai-chat/components/ChatPromptAttachments'
 import { OllamaErrorNotice } from '@/features/ai-chat/components/OllamaErrorNotice'
 import type { OllamaErrorPlatform } from '@/features/ai-chat/components/OllamaErrorNotice'
-import { OllamaModelSelector } from '@/features/ai-chat/components/OllamaModelSelector'
 import { SavedTabsChatAttachmentItem } from '@/features/ai-chat/components/SavedTabsChatAttachmentItem'
-import { SavedTabsChatHeaderTooltipButton } from '@/features/ai-chat/components/SavedTabsChatHeaderTooltipButton'
-import { SavedTabsChatHistoryItemCard } from '@/features/ai-chat/components/SavedTabsChatHistoryItemCard'
+import { SavedTabsChatComposer } from '@/features/ai-chat/components/SavedTabsChatComposer'
+import { SavedTabsChatHeader } from '@/features/ai-chat/components/SavedTabsChatHeader'
 import { SystemPromptManagerDialog } from '@/features/ai-chat/components/SystemPromptManagerDialog'
 import type { SystemPromptManagerDialogProps } from '@/features/ai-chat/components/SystemPromptManagerDialog'
 import { useChatSidebarResize } from '@/features/ai-chat/hooks/useChatSidebarResize'
 import { useConversationClipboard } from '@/features/ai-chat/hooks/useConversationClipboard'
 import { useOllamaModelSettings } from '@/features/ai-chat/hooks/useOllamaModelSettings'
-import {
-  AI_CHAT_MAX_ATTACHMENTS,
-  AI_CHAT_MAX_ATTACHMENT_SIZE_BYTES,
-  getAiChatAttachmentInputAccept,
-} from '@/features/ai-chat/lib/attachments'
 import {
   getActiveAiSystemPrompt,
   normalizeAiSystemPromptSettings,
@@ -129,17 +78,8 @@ import { cn } from '@/lib/utils'
 import type { OllamaErrorDetails } from '@/types/background'
 import type { AiSystemPromptPreset, UserSettings } from '@/types/storage'
 
-import {
-  getMessageSources,
-  getSourcesLabel,
-  insertLineBreakAtCursor,
-  requestPromptSubmit,
-} from './savedTabsChat/messages'
+import { getMessageSources, getSourcesLabel } from './savedTabsChat/messages'
 import type { ChatMessage, TranslateFn } from './savedTabsChat/messages'
-import {
-  getSelectedPrompt,
-  SYSTEM_PROMPT_SELECTOR_EMPTY_VALUE,
-} from './savedTabsChat/prompts'
 import {
   areMessagesEquivalent,
   EMPTY_CHAT_MESSAGES,
@@ -342,334 +282,6 @@ const renderChatDataScopeNotice = ({
   )
 }
 
-const renderSystemPromptSelector = ({
-  isCompactLayout,
-  prompts,
-  selectedPromptId,
-  t,
-  onValueChange,
-}: {
-  isCompactLayout: boolean
-  prompts: AiSystemPromptPreset[]
-  selectedPromptId: string
-  t: TranslateFn
-  onValueChange: (value: string) => void
-}) => {
-  const activePrompt = getSelectedPrompt(prompts, selectedPromptId)
-  if (!activePrompt) {
-    return null
-  }
-
-  return (
-    <PromptInputSelect
-      key={selectedPromptId}
-      value={activePrompt.id}
-      onValueChange={onValueChange}
-    >
-      <PromptInputSelectTrigger
-        aria-label={activePrompt.name || t('aiChat.systemPrompt.select')}
-        className={cn(
-          'h-8 w-[140px] shrink-0 justify-between rounded-md border border-border/70 bg-background px-2 text-xs shadow-none',
-          isCompactLayout && 'w-[112px]',
-        )}
-      >
-        <PromptInputSelectValue
-          placeholder={t('aiChat.systemPrompt.placeholder')}
-        />
-      </PromptInputSelectTrigger>
-      <PromptInputSelectContent>
-        {prompts.length > 0 ? (
-          prompts.map((prompt) => (
-            <PromptInputSelectItem key={prompt.id} value={prompt.id}>
-              {prompt.name}
-            </PromptInputSelectItem>
-          ))
-        ) : (
-          <PromptInputSelectItem
-            disabled
-            value={SYSTEM_PROMPT_SELECTOR_EMPTY_VALUE}
-          >
-            {t('aiChat.systemPrompt.empty')}
-          </PromptInputSelectItem>
-        )}
-      </PromptInputSelectContent>
-    </PromptInputSelect>
-  )
-}
-
-const renderChatHistoryButton = ({
-  label,
-  onClick,
-}: {
-  label: string
-  onClick?: () => void
-}) => {
-  return (
-    <TooltipProvider delayDuration={0}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type='button'
-            variant='ghost'
-            size='icon'
-            aria-label={label}
-            onClick={onClick}
-          >
-            <History className='size-4' />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side='bottom'>{label}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  )
-}
-
-const useChatHistoryDropdownView = ({
-  historyItems,
-  onDeleteHistoryItem,
-  onSelectHistoryItem,
-}: {
-  historyItems: AiChatHistoryItem[]
-  onDeleteHistoryItem?: (conversationId: string) => void
-  onSelectHistoryItem?: (conversationId: string) => void
-}) => {
-  const { t } = useI18n()
-  const [isOpen, setIsOpen] = useState(false)
-  const [pendingDeleteHistoryItem, setPendingDeleteHistoryItem] =
-    useState<AiChatHistoryItem | null>(null)
-
-  const handleDialogOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      setPendingDeleteHistoryItem(null)
-    }
-  }, [])
-
-  const handleCancelDelete = useCallback(() => {
-    setPendingDeleteHistoryItem(null)
-  }, [])
-
-  const handleConfirmDelete = useCallback(() => {
-    if (!pendingDeleteHistoryItem) {
-      return
-    }
-
-    onDeleteHistoryItem?.(pendingDeleteHistoryItem.id)
-    setPendingDeleteHistoryItem(null)
-  }, [onDeleteHistoryItem, pendingDeleteHistoryItem])
-
-  return (
-    <>
-      <Popover open={isOpen} onOpenChange={setIsOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            type='button'
-            variant='ghost'
-            size='icon'
-            aria-label={t('aiChat.historyTitle')}
-          >
-            <History className='size-4' />
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent
-          align='start'
-          className='w-72 gap-y-2 p-2'
-          side='bottom'
-        >
-          <div className='px-2 py-1'>
-            <p className='text-sm font-medium'>{t('aiChat.historyTitle')}</p>
-            <p className='text-xs text-muted-foreground'>
-              {t('aiChat.history.resumeHint')}
-            </p>
-          </div>
-
-          <div className='max-h-80 gap-y-1 overflow-y-auto'>
-            {historyItems.length > 0 ? (
-              historyItems.map((historyItem) => (
-                <SavedTabsChatHistoryItemCard
-                  historyItem={historyItem}
-                  isActive={historyItem.isActive}
-                  key={historyItem.id}
-                  onDeleteHistoryItem={onDeleteHistoryItem}
-                  onSelectHistoryItem={onSelectHistoryItem}
-                  setIsOpen={setIsOpen}
-                  setPendingDeleteHistoryItem={setPendingDeleteHistoryItem}
-                  t={t}
-                />
-              ))
-            ) : (
-              <div className='rounded-xl px-3 py-4 text-sm text-muted-foreground'>
-                {t('aiChat.history.empty')}
-              </div>
-            )}
-          </div>
-        </PopoverContent>
-      </Popover>
-
-      <Dialog
-        open={pendingDeleteHistoryItem !== null}
-        onOpenChange={handleDialogOpenChange}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t('aiChat.deleteTitle')}</DialogTitle>
-            <DialogDescription>
-              {t('aiChat.deleteDescription')}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              type='button'
-              variant='outline'
-              onClick={handleCancelDelete}
-            >
-              {t('common.cancel')}
-            </Button>
-            <Button
-              type='button'
-              variant='destructive'
-              onClick={handleConfirmDelete}
-            >
-              {t('common.delete')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
-  )
-}
-
-const useChatSidebarHeaderView = ({
-  activeSystemPromptId,
-  historyItems,
-  historyVariant,
-  presentation,
-  onClose,
-  onCopyConversation,
-  onDeleteHistoryItem,
-  onOpenSystemPromptManager,
-  onResetConversation,
-  onSelectHistoryItem,
-  onSelectSystemPrompt,
-  onToggleHistory,
-  systemPrompts,
-  title,
-  status,
-}: {
-  activeSystemPromptId: string
-  historyItems: AiChatHistoryItem[]
-  historyVariant: 'dropdown' | 'none' | 'sidebar-toggle'
-  presentation: {
-    isCompactLayout: boolean
-    showCloseButton: boolean
-  }
-  onClose: () => void
-  onCopyConversation: () => void
-  onDeleteHistoryItem?: (conversationId: string) => void
-  onOpenSystemPromptManager: () => void
-  onResetConversation: () => void
-  onSelectHistoryItem?: (conversationId: string) => void
-  onSelectSystemPrompt: (promptId: string) => void
-  onToggleHistory?: () => void
-  status: {
-    isConversationCopied: boolean
-    isCopyDisabled: boolean
-  }
-  systemPrompts: AiSystemPromptPreset[]
-  title: string
-}) => {
-  const { t } = useI18n()
-  const { isCompactLayout, showCloseButton } = presentation
-  const { isConversationCopied, isCopyDisabled } = status
-  const chatHistoryDropdown = useChatHistoryDropdownView({
-    historyItems,
-    onDeleteHistoryItem,
-    onSelectHistoryItem,
-  })
-  const historyButton = renderChatHistoryButton({
-    label: t('aiChat.historyTitle'),
-    onClick: onToggleHistory,
-  })
-  const systemPromptSelector = renderSystemPromptSelector({
-    isCompactLayout,
-    onValueChange: onSelectSystemPrompt,
-    prompts: systemPrompts,
-    selectedPromptId: activeSystemPromptId,
-    t,
-  })
-
-  return (
-    <CardHeader className='items-center border-b border-border p-4 text-center'>
-      <div
-        className={cn(
-          'relative flex w-full items-center justify-between gap-2',
-          isCompactLayout && 'min-h-10',
-        )}
-      >
-        <div
-          className='z-10 flex min-w-0 items-center gap-1'
-          data-testid='ai-chat-header-left-controls'
-        >
-          {historyVariant === 'sidebar-toggle' ? historyButton : null}
-          {historyVariant === 'dropdown' ? chatHistoryDropdown : null}
-          <SavedTabsChatHeaderTooltipButton
-            ariaLabel={t('aiChat.systemPrompt.openSettings')}
-            onClick={onOpenSystemPromptManager}
-            tooltipText={t('aiChat.systemPrompt.settingsTooltip')}
-          >
-            <Settings2 className='size-4' />
-          </SavedTabsChatHeaderTooltipButton>
-          {systemPromptSelector}
-        </div>
-
-        <CardTitle
-          className='pointer-events-none absolute inset-x-0 flex items-center justify-center px-20 text-base'
-          data-testid='chat-header-title'
-        >
-          <span className='truncate'>{title}</span>
-        </CardTitle>
-
-        <div className='z-10 flex items-center justify-end gap-1'>
-          <SavedTabsChatHeaderTooltipButton
-            ariaLabel={t('aiChat.copyConversation')}
-            dataState={isConversationCopied ? 'copied' : 'idle'}
-            disabled={isCopyDisabled}
-            onClick={onCopyConversation}
-            tooltipText={
-              isConversationCopied
-                ? t('aiChat.ollama.copied')
-                : t('aiChat.copyConversation')
-            }
-          >
-            {isConversationCopied ? (
-              <Check className='size-4' />
-            ) : (
-              <Copy className='size-4' />
-            )}
-          </SavedTabsChatHeaderTooltipButton>
-          <SavedTabsChatHeaderTooltipButton
-            ariaLabel={t('aiChat.newConversation')}
-            onClick={onResetConversation}
-            tooltipText={t('aiChat.newConversation')}
-          >
-            <Plus className='size-4' />
-          </SavedTabsChatHeaderTooltipButton>
-          {showCloseButton ? (
-            <Button
-              type='button'
-              variant='ghost'
-              size='icon'
-              aria-label={t('aiChat.close')}
-              onClick={onClose}
-            >
-              <X className='size-4' />
-            </Button>
-          ) : null}
-        </div>
-      </div>
-    </CardHeader>
-  )
-}
-
 const renderChatMessageAttachments = ({
   attachments,
 }: {
@@ -795,177 +407,6 @@ const renderChatConversationMessage = ({
   )
 }
 
-const useChatPromptComposerView = ({
-  // eslint-disable-line eslint/complexity
-  input,
-  presentation,
-  modelName,
-  modelOptions,
-  onFetchModels,
-  onInputChange,
-  onSelectModel,
-  onSubmit,
-  platform,
-  setupErrorMessage,
-  setupOllamaError,
-  status,
-  t,
-}: {
-  input: string
-  modelName?: string
-  modelOptions: SavedTabsChatPanelProps['modelOptions']
-  onFetchModels: () => void
-  onInputChange: (value: string) => void
-  onSelectModel: (modelName: string) => Promise<boolean>
-  onSubmit: PromptInputProps['onSubmit']
-  platform: OllamaErrorPlatform
-  presentation: {
-    isCompactLayout: boolean
-  }
-  setupErrorMessage: string
-  setupOllamaError?: OllamaErrorDetails
-  status: {
-    isConfigured: boolean
-    isLoadingModels: boolean
-    isSavingModel: boolean
-    isSubmitting: boolean
-  }
-  t: TranslateFn
-}) => {
-  const { isCompactLayout } = presentation
-  const { isConfigured, isLoadingModels, isSavingModel, isSubmitting } = status
-  const compactSubmitLabel = isSubmitting
-    ? t('aiChat.sending')
-    : t('aiChat.send')
-  const isSubmitDisabled =
-    !isConfigured || isSubmitting || isSavingModel || input.trim().length === 0
-  const handleTextareaKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
-      if (event.key !== 'Enter' || event.nativeEvent.isComposing) {
-        return
-      }
-
-      if (event.ctrlKey || event.metaKey) {
-        event.preventDefault()
-        requestPromptSubmit(event.currentTarget)
-        return
-      }
-
-      event.preventDefault()
-
-      const textarea = event.currentTarget
-      const selectionStart = textarea.selectionStart
-      const selectionEnd = textarea.selectionEnd
-      const { cursorPosition, nextValue } = insertLineBreakAtCursor({
-        selectionEnd,
-        selectionStart,
-        value: input,
-      })
-
-      onInputChange(nextValue)
-
-      window.requestAnimationFrame(() => {
-        textarea.setSelectionRange(cursorPosition, cursorPosition)
-      })
-    },
-    [input, onInputChange],
-  )
-
-  const handleError = useCallback(
-    (error: {
-      code: 'accept' | 'max_files' | 'max_file_size'
-      message: string
-    }) => {
-      toast.error(getAttachmentInputErrorMessage(error, t))
-    },
-    [t],
-  )
-
-  const handleChange = useCallback(
-    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-      onInputChange(event.target.value)
-    },
-    [onInputChange],
-  )
-
-  const behavior = useMemo(
-    () => ({ fetchOnOpen: true, hideFetchButton: true }),
-    [],
-  )
-
-  const selectorStatus = useMemo(
-    () => ({ isLoading: isLoadingModels, isSaving: isSavingModel }),
-    [isLoadingModels, isSavingModel],
-  )
-
-  return (
-    <PromptInput
-      accept={getAiChatAttachmentInputAccept()}
-      className='shrink-0'
-      data-testid='chat-form'
-      maxFiles={AI_CHAT_MAX_ATTACHMENTS}
-      maxFileSize={AI_CHAT_MAX_ATTACHMENT_SIZE_BYTES}
-      multiple
-      onError={handleError}
-      onSubmit={onSubmit}
-    >
-      <PromptInputTextarea
-        aria-label={t('aiChat.inputLabel')}
-        className={cn('min-h-16', isCompactLayout && 'min-h-24 text-sm')}
-        value={input}
-        onChange={handleChange}
-        onKeyDown={handleTextareaKeyDown}
-        disabled={!isConfigured || isSavingModel}
-        placeholder={
-          isConfigured
-            ? t('aiChat.inputPlaceholder')
-            : t('aiChat.inputPlaceholderSelectModel')
-        }
-      />
-      <ChatPromptAttachments />
-      <PromptInputFooter
-        className={cn(
-          'items-center justify-between gap-2 border-t border-border',
-          isCompactLayout && 'flex-wrap',
-        )}
-      >
-        <div
-          className={cn(
-            'flex min-w-0 flex-1 items-center gap-2',
-            isCompactLayout && 'w-full flex-wrap',
-          )}
-        >
-          <ChatPromptAttachmentButton />
-          <OllamaModelSelector
-            behavior={behavior}
-            errorMessage={setupErrorMessage}
-            layout={isCompactLayout ? 'compact' : 'default'}
-            models={modelOptions}
-            onFetchModels={onFetchModels}
-            onSelectModel={onSelectModel}
-            ollamaError={setupOllamaError}
-            platform={platform}
-            selectedModel={modelName}
-            status={selectorStatus}
-          />
-        </div>
-        <PromptInputSubmit
-          className={cn(isCompactLayout && 'w-full')}
-          disabled={isSubmitDisabled}
-          size={isCompactLayout ? 'sm' : 'icon-sm'}
-          {...(isCompactLayout
-            ? {
-                'aria-label': compactSubmitLabel,
-              }
-            : {})}
-        >
-          {isCompactLayout ? compactSubmitLabel : undefined}
-        </PromptInputSubmit>
-      </PromptInputFooter>
-    </PromptInput>
-  )
-}
-
 // TODO(#557): この関数の複雑度が高い。useMemo/useCallback の分割や早期 return で削減する。
 // eslint-disable-next-line eslint/complexity
 const useSavedTabsChatPanelView = ({
@@ -1001,49 +442,47 @@ const useSavedTabsChatPanelView = ({
   systemPrompts,
 }: SavedTabsChatPanelProps) => {
   const { t } = useI18n()
-  const chatSidebarHeader = useChatSidebarHeaderView({
-    activeSystemPromptId,
-    historyItems,
-    historyVariant,
-    onClose,
-    onCopyConversation,
-    onDeleteHistoryItem,
-    onOpenSystemPromptManager,
-    onResetConversation,
-    onSelectHistoryItem,
-    onSelectSystemPrompt,
-    onToggleHistory,
-    presentation: {
+  const handleAttachmentError = useCallback(
+    (error: {
+      code: 'accept' | 'max_files' | 'max_file_size'
+      message: string
+    }) => {
+      toast.error(getAttachmentInputErrorMessage(error, t))
+    },
+    [t],
+  )
+  const headerPresentation = useMemo(
+    () => ({
       isCompactLayout: layout.isCompactLayout,
       showCloseButton: layout.showCloseButton,
-    },
-    status: {
+    }),
+    [layout.isCompactLayout, layout.showCloseButton],
+  )
+  const headerStatus = useMemo(
+    () => ({
       isConversationCopied: status.isConversationCopied,
       isCopyDisabled: status.isCopyDisabled,
-    },
-    systemPrompts,
-    title,
-  })
-  const chatPromptComposer = useChatPromptComposerView({
-    input,
-    modelName,
-    modelOptions,
-    onFetchModels,
-    onInputChange,
-    onSelectModel,
-    onSubmit,
-    platform,
-    presentation: { isCompactLayout: layout.isCompactLayout },
-    setupErrorMessage,
-    setupOllamaError,
-    status: {
+    }),
+    [status.isConversationCopied, status.isCopyDisabled],
+  )
+  const composerPresentation = useMemo(
+    () => ({ isCompactLayout: layout.isCompactLayout }),
+    [layout.isCompactLayout],
+  )
+  const composerStatus = useMemo(
+    () => ({
       isConfigured: status.isConfigured,
       isLoadingModels: status.isLoadingModels,
       isSavingModel: status.isSavingModel,
       isSubmitting: status.isSubmitting,
-    },
-    t,
-  })
+    }),
+    [
+      status.isConfigured,
+      status.isLoadingModels,
+      status.isSavingModel,
+      status.isSubmitting,
+    ],
+  )
   const { cardStyle, isCompactLayout, isResizing, mode } = layout
   const { isConfigured, isOpen } = status
   const renderedMessages = messages.map((message) => ({
@@ -1101,7 +540,23 @@ const useSavedTabsChatPanelView = ({
       className={cardClassName}
       style={cardStyle}
     >
-      {chatSidebarHeader}
+      <SavedTabsChatHeader
+        activeSystemPromptId={activeSystemPromptId}
+        historyItems={historyItems}
+        historyVariant={historyVariant}
+        onClose={onClose}
+        onCopyConversation={onCopyConversation}
+        onDeleteHistoryItem={onDeleteHistoryItem}
+        onOpenSystemPromptManager={onOpenSystemPromptManager}
+        onResetConversation={onResetConversation}
+        onSelectHistoryItem={onSelectHistoryItem}
+        onSelectSystemPrompt={onSelectSystemPrompt}
+        onToggleHistory={onToggleHistory}
+        presentation={headerPresentation}
+        status={headerStatus}
+        systemPrompts={systemPrompts}
+        title={title}
+      />
 
       <CardContent
         className={cn(
@@ -1144,7 +599,21 @@ const useSavedTabsChatPanelView = ({
 
           {chatDataScopeNotice}
 
-          {chatPromptComposer}
+          <SavedTabsChatComposer
+            input={input}
+            modelName={modelName}
+            modelOptions={modelOptions}
+            onAttachmentError={handleAttachmentError}
+            onFetchModels={onFetchModels}
+            onInputChange={onInputChange}
+            onSelectModel={onSelectModel}
+            onSubmit={onSubmit}
+            platform={platform}
+            presentation={composerPresentation}
+            setupErrorMessage={setupErrorMessage}
+            setupOllamaError={setupOllamaError}
+            status={composerStatus}
+          />
         </div>
       </CardContent>
     </Card>

--- a/src/features/ai-chat/components/SavedTabsChatWidget.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.tsx
@@ -101,6 +101,7 @@ import { SystemPromptManagerDialog } from '@/features/ai-chat/components/SystemP
 import type { SystemPromptManagerDialogProps } from '@/features/ai-chat/components/SystemPromptManagerDialog'
 import { useChatSidebarResize } from '@/features/ai-chat/hooks/useChatSidebarResize'
 import { useConversationClipboard } from '@/features/ai-chat/hooks/useConversationClipboard'
+import { useOllamaModelSettings } from '@/features/ai-chat/hooks/useOllamaModelSettings'
 import {
   AI_CHAT_MAX_ATTACHMENTS,
   AI_CHAT_MAX_ATTACHMENT_SIZE_BYTES,
@@ -149,11 +150,7 @@ import {
   loadWidgetSettings,
   syncExternalConversationState,
 } from './savedTabsChat/storage'
-import {
-  getAttachmentInputErrorMessage,
-  getRuntimePlatform,
-  requestOllamaModels,
-} from './savedTabsChat/streaming'
+import { getAttachmentInputErrorMessage } from './savedTabsChat/streaming'
 import { useChatPromptManager } from './savedTabsChat/useChatPromptManager'
 import { useChatStreamHandlers } from './savedTabsChat/useChatStreamHandlers'
 import { getSavedTabsChatAttachmentId } from './savedTabsChatAttachmentItem.helpers'
@@ -1220,19 +1217,6 @@ const useSavedTabsChatWidgetView = ({
   const [chatOllamaError, setChatOllamaError] = useState<
     OllamaErrorDetails | undefined
   >(undefined)
-  const [modelOptions, setModelOptions] = useState<
-    {
-      label: string
-      name: string
-    }[]
-  >([])
-  const [isLoadingModels, setIsLoadingModels] = useState(false)
-  const [isSavingModel, setIsSavingModel] = useState(false)
-  const [setupErrorMessage, setSetupErrorMessage] = useState('')
-  const [setupOllamaError, setSetupOllamaError] = useState<
-    OllamaErrorDetails | undefined
-  >(undefined)
-  const [platform, setPlatform] = useState<OllamaErrorPlatform>('unknown')
   const activePortRef = useRef<{
     disconnect: () => void
   } | null>(null)
@@ -1276,20 +1260,6 @@ const useSavedTabsChatWidgetView = ({
       syncedConversationIdRef,
     })
   }, [conversationId, initialMessages, mode])
-
-  useEffect(() => {
-    let isMounted = true
-
-    void getRuntimePlatform().then((nextPlatform) => {
-      if (isMounted) {
-        setPlatform(nextPlatform)
-      }
-    })
-
-    return () => {
-      isMounted = false
-    }
-  }, [])
 
   useEffect(() => {
     let isMounted = true
@@ -1412,53 +1382,6 @@ const useSavedTabsChatWidgetView = ({
     activePort.disconnect()
   }
 
-  const handleFetchModels = async () => {
-    setIsLoadingModels(true)
-    setSetupErrorMessage('')
-    setSetupOllamaError(undefined)
-
-    const response = await requestOllamaModels()
-
-    if (response?.status !== 'ok' || !response.models) {
-      setModelOptions([])
-      setSetupErrorMessage(response?.error || t('aiChat.modelListLoadError')) // eslint-disable-line typescript/prefer-nullish-coalescing -- empty error should show default message
-      setSetupOllamaError(response?.ollamaError)
-      setIsLoadingModels(false)
-      return
-    }
-
-    setModelOptions(
-      response.models.map((model) => ({
-        label: model.label,
-        name: model.name,
-      })),
-    )
-    setSetupOllamaError(undefined)
-    setIsLoadingModels(false)
-  }
-
-  const handleSelectModel = async (modelName: string): Promise<boolean> => {
-    const nextSettings = normalizeAiSystemPromptSettings({
-      ...resolvedSettings,
-      ollamaModel: modelName,
-    })
-
-    setIsSavingModel(true)
-    setSetupErrorMessage('')
-    setSetupOllamaError(undefined)
-
-    try {
-      await saveUserSettings(nextSettings)
-      setSettings(nextSettings)
-      return true
-    } catch {
-      setSetupErrorMessage(t('aiChat.modelSettingsSaveError'))
-      return false
-    } finally {
-      setIsSavingModel(false)
-    }
-  }
-
   const handleResetConversation = () => {
     conversationGenerationRef.current += 1
     disconnectActivePort(true)
@@ -1468,6 +1391,24 @@ const useSavedTabsChatWidgetView = ({
     setChatOllamaError(undefined)
     setIsSubmitting(false)
   }
+
+  const {
+    isLoadingModels,
+    isSavingModel,
+    modelOptions,
+    platform,
+    requestModels: handleFetchModels,
+    selectModel: handleSelectModel,
+    setupErrorMessage,
+    setupOllamaError,
+  } = useOllamaModelSettings({
+    onSettingsSaved: (nextSettings) => {
+      setSettings(nextSettings)
+      handleResetConversation()
+    },
+    settings: resolvedSettings,
+    t,
+  })
 
   const handleConversationAction = () => {
     if (onCreateConversation) {

--- a/src/features/ai-chat/components/SavedTabsChatWidget.tsx
+++ b/src/features/ai-chat/components/SavedTabsChatWidget.tsx
@@ -100,6 +100,7 @@ import { SavedTabsChatHistoryItemCard } from '@/features/ai-chat/components/Save
 import { SystemPromptManagerDialog } from '@/features/ai-chat/components/SystemPromptManagerDialog'
 import type { SystemPromptManagerDialogProps } from '@/features/ai-chat/components/SystemPromptManagerDialog'
 import { useChatSidebarResize } from '@/features/ai-chat/hooks/useChatSidebarResize'
+import { useConversationClipboard } from '@/features/ai-chat/hooks/useConversationClipboard'
 import {
   AI_CHAT_MAX_ATTACHMENTS,
   AI_CHAT_MAX_ATTACHMENT_SIZE_BYTES,
@@ -128,7 +129,6 @@ import type { OllamaErrorDetails } from '@/types/background'
 import type { AiSystemPromptPreset, UserSettings } from '@/types/storage'
 
 import {
-  getConversationCopyText,
   getMessageSources,
   getSourcesLabel,
   insertLineBreakAtCursor,
@@ -141,7 +141,6 @@ import {
 } from './savedTabsChat/prompts'
 import {
   areMessagesEquivalent,
-  COPIED_CONVERSATION_ICON_TIMEOUT,
   EMPTY_CHAT_MESSAGES,
   EMPTY_HISTORY_ITEMS,
   EMPTY_TOOL_TRACES,
@@ -158,33 +157,6 @@ import {
 import { useChatPromptManager } from './savedTabsChat/useChatPromptManager'
 import { useChatStreamHandlers } from './savedTabsChat/useChatStreamHandlers'
 import { getSavedTabsChatAttachmentId } from './savedTabsChatAttachmentItem.helpers'
-
-type ClipboardWriter = {
-  writeText: (text: string) => Promise<void>
-}
-
-const getClipboardWriter = (): ClipboardWriter | null => {
-  const navigatorValue: unknown = Reflect.get(globalThis, 'navigator')
-  if (typeof navigatorValue !== 'object' || navigatorValue === null) {
-    return null
-  }
-  const clipboardValue: unknown = Reflect.get(navigatorValue, 'clipboard')
-  if (typeof clipboardValue !== 'object' || clipboardValue === null) {
-    return null
-  }
-  const writeTextValue: unknown = Reflect.get(clipboardValue, 'writeText')
-  if (typeof writeTextValue !== 'function') {
-    return null
-  }
-  return {
-    writeText: async (text) => {
-      await Reflect.apply(writeTextValue, clipboardValue, [text])
-    },
-  }
-}
-
-const getConversationClipboard = (): ClipboardWriter | null =>
-  typeof window === 'undefined' ? null : getClipboardWriter()
 
 type SavedTabsChatPanelProps = {
   activeSystemPromptId: string
@@ -1239,7 +1211,10 @@ const useSavedTabsChatWidgetView = ({
     (_state: ChatMessage[], nextMessages: ChatMessage[]) => nextMessages,
     initialMessages,
   )
-  const [isConversationCopied, setIsConversationCopied] = useState(false)
+  const { copyConversation, isConversationCopied } = useConversationClipboard({
+    messages,
+    t,
+  })
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
   const [chatOllamaError, setChatOllamaError] = useState<
@@ -1263,15 +1238,10 @@ const useSavedTabsChatWidgetView = ({
   } | null>(null)
   const conversationGenerationRef = useRef(0)
   const ignoreNextDisconnectRef = useRef(false)
-  const conversationCopiedTimeoutRef = useRef<number | null>(null)
   const messagesRef = useRef<ChatMessage[]>(initialMessages)
   const syncedConversationIdRef = useRef<string | undefined>(conversationId)
   const isOpen = mode === 'page' || isFloatingOpen
   const releaseChatWidgetResources = useCallback(() => {
-    if (conversationCopiedTimeoutRef.current) {
-      window.clearTimeout(conversationCopiedTimeoutRef.current)
-      conversationCopiedTimeoutRef.current = null
-    }
     activePortRef.current?.disconnect()
     activePortRef.current = null
   }, [])
@@ -1490,14 +1460,9 @@ const useSavedTabsChatWidgetView = ({
   }
 
   const handleResetConversation = () => {
-    if (conversationCopiedTimeoutRef.current) {
-      window.clearTimeout(conversationCopiedTimeoutRef.current)
-      conversationCopiedTimeoutRef.current = null
-    }
     conversationGenerationRef.current += 1
     disconnectActivePort(true)
     setMessagesState([])
-    setIsConversationCopied(false)
     setInput('')
     setErrorMessage('')
     setChatOllamaError(undefined)
@@ -1511,34 +1476,6 @@ const useSavedTabsChatWidgetView = ({
     }
 
     handleResetConversation()
-  }
-
-  const handleCopyConversation = async () => {
-    const conversationCopyText = getConversationCopyText(messages, t)
-    if (!conversationCopyText) {
-      return
-    }
-
-    const clipboard = getConversationClipboard()
-    if (!clipboard) {
-      toast.error(t('aiChat.copyConversationError'))
-      return
-    }
-
-    try {
-      await clipboard.writeText(conversationCopyText)
-      if (conversationCopiedTimeoutRef.current) {
-        window.clearTimeout(conversationCopiedTimeoutRef.current)
-      }
-      setIsConversationCopied(true)
-      toast.success(t('aiChat.copyConversationSuccess'))
-      conversationCopiedTimeoutRef.current = window.setTimeout(() => {
-        setIsConversationCopied(false)
-        conversationCopiedTimeoutRef.current = null
-      }, COPIED_CONVERSATION_ICON_TIMEOUT)
-    } catch {
-      toast.error(t('aiChat.copyConversationError'))
-    }
   }
 
   const handleSelectSystemPrompt = async (promptId: string) => {
@@ -1625,7 +1562,7 @@ const useSavedTabsChatWidgetView = ({
       onOpenChange?.(false)
     },
     onCopyConversation: () => {
-      void handleCopyConversation()
+      void copyConversation()
     },
     onDeleteHistoryItem,
     // eslint-disable-next-line typescript/no-misused-promises

--- a/src/features/ai-chat/components/savedTabsChat/useChatStreamHandlers.ts
+++ b/src/features/ai-chat/components/savedTabsChat/useChatStreamHandlers.ts
@@ -32,8 +32,7 @@ type UseChatStreamHandlersParams = {
     } | null
   }
   conversationGenerationRef: { current: number }
-  ignoreNextDisconnectRef: { current: boolean }
-  disconnectActivePort: (suppressDisconnectError?: boolean) => void
+  disconnectActivePort: () => void
   replaceMessage: (
     messageId: string,
     nextMessage: Partial<ChatMessage>,
@@ -63,7 +62,6 @@ const useChatStreamHandlers = ({
   messages,
   activePortRef,
   conversationGenerationRef,
-  ignoreNextDisconnectRef,
   disconnectActivePort,
   replaceMessage,
   removeMessage,
@@ -204,11 +202,6 @@ const useChatStreamHandlers = ({
       activePortRef.current = null
     }
 
-    if (ignoreNextDisconnectRef.current) {
-      ignoreNextDisconnectRef.current = false
-      return
-    }
-
     if (!isCurrentRequest(requestGeneration) || isFinished) {
       return
     }
@@ -232,6 +225,11 @@ const useChatStreamHandlers = ({
     try {
       const streamPort = await connectRuntimePort(AI_CHAT_STREAM_PORT_NAME)
       if (!streamPort) {
+        return false
+      }
+
+      if (!isCurrentRequest(requestGeneration)) {
+        streamPort.disconnect()
         return false
       }
 

--- a/src/features/ai-chat/hooks/useChatSidebarResize.test.tsx
+++ b/src/features/ai-chat/hooks/useChatSidebarResize.test.tsx
@@ -1,6 +1,23 @@
 // @vitest-environment jsdom
-import { act, renderHook } from '@testing-library/react'
+import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocked = vi.hoisted(() => ({
+  loadSidebarWidth: vi.fn(() => 420),
+  persistSidebarWidth: vi.fn(),
+}))
+
+vi.mock('@/features/ai-chat/components/savedTabsChat/storage', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '@/features/ai-chat/components/savedTabsChat/storage',
+  )
+
+  return {
+    ...actual,
+    loadSidebarWidth: mocked.loadSidebarWidth,
+    persistSidebarWidth: mocked.persistSidebarWidth,
+  }
+})
 
 import { useChatSidebarResize } from './useChatSidebarResize'
 
@@ -16,27 +33,49 @@ const createResizeStartEvent = () => ({
   preventDefault: vi.fn(),
 })
 
+type HookProps = {
+  mode: 'floating' | 'page'
+}
+
 describe('useChatSidebarResize', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
+    mocked.loadSidebarWidth.mockReturnValue(420)
     setViewportWidth(1200)
-    window.localStorage.clear()
     document.body.style.cssText = 'color: red;'
   })
 
   afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
     document.body.style.cssText = ''
   })
 
-  it('restores and clamps the stored floating sidebar width', () => {
-    setViewportWidth(600)
-    window.localStorage.setItem('tabbin-ai-chat-sidebar-width', '900')
+  it('restores the clamped width returned by the storage accessor', () => {
+    mocked.loadSidebarWidth.mockReturnValue(552)
 
     const { result } = renderHook(() =>
       useChatSidebarResize({ mode: 'floating' }),
     )
 
+    expect(mocked.loadSidebarWidth).toHaveBeenCalledOnce()
     expect(result.current.sidebarWidth).toBe(552)
     expect(result.current.cardStyle).toEqual({ width: '552px' })
+  })
+
+  it('restores the saved width when the same instance changes from page to floating', () => {
+    mocked.loadSidebarWidth.mockReturnValue(640)
+    const initialProps: HookProps = { mode: 'page' }
+    const { result, rerender } = renderHook(
+      ({ mode }: HookProps) => useChatSidebarResize({ mode }),
+      { initialProps },
+    )
+
+    rerender({ mode: 'floating' })
+
+    expect(mocked.loadSidebarWidth).toHaveBeenCalledOnce()
+    expect(result.current.sidebarWidth).toBe(640)
+    expect(result.current.cardStyle).toEqual({ width: '640px' })
   })
 
   it('updates the floating sidebar width during pointer movement', () => {
@@ -73,9 +112,8 @@ describe('useChatSidebarResize', () => {
       window.dispatchEvent(new PointerEvent('pointerup'))
     })
 
-    expect(window.localStorage.getItem('tabbin-ai-chat-sidebar-width')).toBe(
-      '550',
-    )
+    expect(mocked.persistSidebarWidth).toHaveBeenCalledOnce()
+    expect(mocked.persistSidebarWidth).toHaveBeenCalledWith(550)
     expect(result.current.isResizing).toBe(false)
     expect(document.body.style.cssText).toBe('color: red;')
   })
@@ -115,5 +153,34 @@ describe('useChatSidebarResize', () => {
     expect(result.current.isResizing).toBe(false)
     expect(result.current.cardStyle).toBeUndefined()
     expect(document.body.style.cssText).toBe('color: red;')
+  })
+
+  it('stops active resizing when the same instance changes to page mode', () => {
+    const removeEventListener = vi.spyOn(window, 'removeEventListener')
+    const initialProps: HookProps = { mode: 'floating' }
+    const { result, rerender } = renderHook(
+      ({ mode }: HookProps) => useChatSidebarResize({ mode }),
+      { initialProps },
+    )
+
+    act(() => {
+      result.current.handleResizeStart(createResizeStartEvent())
+    })
+    rerender({ mode: 'page' })
+    act(() => {
+      window.dispatchEvent(new PointerEvent('pointerup'))
+    })
+
+    expect(result.current.isResizing).toBe(false)
+    expect(mocked.persistSidebarWidth).not.toHaveBeenCalled()
+    expect(document.body.style.cssText).toBe('color: red;')
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'pointermove',
+      expect.any(Function),
+    )
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'pointerup',
+      expect.any(Function),
+    )
   })
 })

--- a/src/features/ai-chat/hooks/useChatSidebarResize.test.tsx
+++ b/src/features/ai-chat/hooks/useChatSidebarResize.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useChatSidebarResize } from './useChatSidebarResize'
+
+const setViewportWidth = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: width,
+    writable: true,
+  })
+}
+
+const createResizeStartEvent = () => ({
+  preventDefault: vi.fn(),
+})
+
+describe('useChatSidebarResize', () => {
+  beforeEach(() => {
+    setViewportWidth(1200)
+    window.localStorage.clear()
+    document.body.style.cssText = 'color: red;'
+  })
+
+  afterEach(() => {
+    document.body.style.cssText = ''
+  })
+
+  it('restores and clamps the stored floating sidebar width', () => {
+    setViewportWidth(600)
+    window.localStorage.setItem('tabbin-ai-chat-sidebar-width', '900')
+
+    const { result } = renderHook(() =>
+      useChatSidebarResize({ mode: 'floating' }),
+    )
+
+    expect(result.current.sidebarWidth).toBe(552)
+    expect(result.current.cardStyle).toEqual({ width: '552px' })
+  })
+
+  it('updates the floating sidebar width during pointer movement', () => {
+    const { result } = renderHook(() =>
+      useChatSidebarResize({ mode: 'floating' }),
+    )
+    const event = createResizeStartEvent()
+
+    act(() => {
+      result.current.handleResizeStart(event)
+    })
+    act(() => {
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: 700 }))
+    })
+
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(result.current.sidebarWidth).toBe(500)
+    expect(result.current.isResizing).toBe(true)
+  })
+
+  it('persists the final width and restores body styles on pointer up', () => {
+    const { result } = renderHook(() =>
+      useChatSidebarResize({ mode: 'floating' }),
+    )
+
+    act(() => {
+      result.current.handleResizeStart(createResizeStartEvent())
+    })
+    expect(document.body.style.cursor).toBe('col-resize')
+    expect(document.body.style.userSelect).toBe('none')
+
+    act(() => {
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: 650 }))
+      window.dispatchEvent(new PointerEvent('pointerup'))
+    })
+
+    expect(window.localStorage.getItem('tabbin-ai-chat-sidebar-width')).toBe(
+      '550',
+    )
+    expect(result.current.isResizing).toBe(false)
+    expect(document.body.style.cssText).toBe('color: red;')
+  })
+
+  it('removes pointer listeners and restores body styles on unmount', () => {
+    const removeEventListener = vi.spyOn(window, 'removeEventListener')
+    const { result, unmount } = renderHook(() =>
+      useChatSidebarResize({ mode: 'floating' }),
+    )
+
+    act(() => {
+      result.current.handleResizeStart(createResizeStartEvent())
+    })
+    unmount()
+
+    expect(document.body.style.cssText).toBe('color: red;')
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'pointermove',
+      expect.any(Function),
+    )
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'pointerup',
+      expect.any(Function),
+    )
+  })
+
+  it('does not start sidebar resizing in page mode', () => {
+    const { result } = renderHook(() => useChatSidebarResize({ mode: 'page' }))
+    const event = createResizeStartEvent()
+
+    act(() => {
+      result.current.handleResizeStart(event)
+      window.dispatchEvent(new PointerEvent('pointermove', { clientX: 700 }))
+    })
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(result.current.isResizing).toBe(false)
+    expect(result.current.cardStyle).toBeUndefined()
+    expect(document.body.style.cssText).toBe('color: red;')
+  })
+})

--- a/src/features/ai-chat/hooks/useChatSidebarResize.ts
+++ b/src/features/ai-chat/hooks/useChatSidebarResize.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   clampSidebarWidth,
-  DEFAULT_CHAT_SIDEBAR_WIDTH,
   loadSidebarWidth,
   persistSidebarWidth,
 } from '@/features/ai-chat/components/savedTabsChat/storage'
@@ -17,11 +16,9 @@ type ResizeStartEvent = {
 }
 
 const useChatSidebarResize = ({ mode }: { mode: ChatSidebarMode }) => {
-  const [sidebarWidth, setSidebarWidth] = useState(() =>
-    mode === 'floating' ? loadSidebarWidth() : DEFAULT_CHAT_SIDEBAR_WIDTH,
-  )
+  const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth)
   const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth)
-  const [isResizing, setIsResizing] = useState(false)
+  const [resizeSession, setResizeSession] = useState<object | null>(null)
   const resizeCleanupRef = useRef<(() => void) | null>(null)
   const sidebarWidthRef = useRef(sidebarWidth)
 
@@ -31,6 +28,12 @@ const useChatSidebarResize = ({ mode }: { mode: ChatSidebarMode }) => {
   }, [])
 
   useEffect(() => stopResize, [stopResize])
+
+  useEffect(() => {
+    if (mode === 'page') {
+      stopResize()
+    }
+  }, [mode, stopResize])
 
   useEffect(() => {
     const handleWindowResize = () => {
@@ -59,7 +62,7 @@ const useChatSidebarResize = ({ mode }: { mode: ChatSidebarMode }) => {
 
       event.preventDefault()
       stopResize()
-      setIsResizing(true)
+      setResizeSession({})
 
       const previousBodyStyle = document.body.style.cssText
       const handlePointerMove = (moveEvent: PointerEvent) => {
@@ -71,7 +74,7 @@ const useChatSidebarResize = ({ mode }: { mode: ChatSidebarMode }) => {
       }
       const handlePointerUp = () => {
         persistSidebarWidth(sidebarWidthRef.current)
-        setIsResizing(false)
+        setResizeSession(null)
         stopResize()
       }
 
@@ -92,6 +95,10 @@ const useChatSidebarResize = ({ mode }: { mode: ChatSidebarMode }) => {
     mode === 'page'
       ? viewportWidth < TABLET_BREAKPOINT
       : sidebarWidth <= SIDEBAR_COMPACT_BREAKPOINT
+  const isResizing =
+    mode === 'floating' &&
+    resizeSession !== null &&
+    resizeCleanupRef.current !== null
   const cardStyle = useMemo(
     () => (mode === 'page' ? undefined : { width: `${sidebarWidth}px` }),
     [mode, sidebarWidth],

--- a/src/features/ai-chat/hooks/useChatSidebarResize.ts
+++ b/src/features/ai-chat/hooks/useChatSidebarResize.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  clampSidebarWidth,
+  DEFAULT_CHAT_SIDEBAR_WIDTH,
+  loadSidebarWidth,
+  persistSidebarWidth,
+} from '@/features/ai-chat/components/savedTabsChat/storage'
+
+const TABLET_BREAKPOINT = 768
+const SIDEBAR_COMPACT_BREAKPOINT = 360
+
+type ChatSidebarMode = 'floating' | 'page'
+
+type ResizeStartEvent = {
+  preventDefault: () => void
+}
+
+const useChatSidebarResize = ({ mode }: { mode: ChatSidebarMode }) => {
+  const [sidebarWidth, setSidebarWidth] = useState(() =>
+    mode === 'floating' ? loadSidebarWidth() : DEFAULT_CHAT_SIDEBAR_WIDTH,
+  )
+  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth)
+  const [isResizing, setIsResizing] = useState(false)
+  const resizeCleanupRef = useRef<(() => void) | null>(null)
+  const sidebarWidthRef = useRef(sidebarWidth)
+
+  const stopResize = useCallback(() => {
+    resizeCleanupRef.current?.()
+    resizeCleanupRef.current = null
+  }, [])
+
+  useEffect(() => stopResize, [stopResize])
+
+  useEffect(() => {
+    const handleWindowResize = () => {
+      setViewportWidth(window.innerWidth)
+      if (mode === 'floating') {
+        setSidebarWidth((currentWidth) => {
+          const nextWidth = clampSidebarWidth(currentWidth)
+          sidebarWidthRef.current = nextWidth
+          return nextWidth
+        })
+      }
+    }
+
+    window.addEventListener('resize', handleWindowResize)
+
+    return () => {
+      window.removeEventListener('resize', handleWindowResize)
+    }
+  }, [mode])
+
+  const handleResizeStart = useCallback(
+    (event: ResizeStartEvent) => {
+      if (mode === 'page') {
+        return
+      }
+
+      event.preventDefault()
+      stopResize()
+      setIsResizing(true)
+
+      const previousBodyStyle = document.body.style.cssText
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        const nextWidth = clampSidebarWidth(
+          window.innerWidth - moveEvent.clientX,
+        )
+        sidebarWidthRef.current = nextWidth
+        setSidebarWidth(nextWidth)
+      }
+      const handlePointerUp = () => {
+        persistSidebarWidth(sidebarWidthRef.current)
+        setIsResizing(false)
+        stopResize()
+      }
+
+      document.body.style.cssText = `${previousBodyStyle}; cursor: col-resize; user-select: none;`
+      window.addEventListener('pointermove', handlePointerMove)
+      window.addEventListener('pointerup', handlePointerUp)
+
+      resizeCleanupRef.current = () => {
+        document.body.style.cssText = previousBodyStyle
+        window.removeEventListener('pointermove', handlePointerMove)
+        window.removeEventListener('pointerup', handlePointerUp)
+      }
+    },
+    [mode, stopResize],
+  )
+
+  const isCompactLayout =
+    mode === 'page'
+      ? viewportWidth < TABLET_BREAKPOINT
+      : sidebarWidth <= SIDEBAR_COMPACT_BREAKPOINT
+  const cardStyle = useMemo(
+    () => (mode === 'page' ? undefined : { width: `${sidebarWidth}px` }),
+    [mode, sidebarWidth],
+  )
+
+  return {
+    cardStyle,
+    handleResizeStart,
+    isCompactLayout,
+    isResizing,
+    sidebarWidth,
+  }
+}
+
+export { useChatSidebarResize }

--- a/src/features/ai-chat/hooks/useConversationClipboard.test.tsx
+++ b/src/features/ai-chat/hooks/useConversationClipboard.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocked = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocked.toastError,
+    success: mocked.toastSuccess,
+  },
+}))
+
+import { COPIED_CONVERSATION_ICON_TIMEOUT } from '@/features/ai-chat/components/savedTabsChat/storage'
+
+import { useConversationClipboard } from './useConversationClipboard'
+
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+  window.navigator,
+  'clipboard',
+)
+
+const messages = [
+  {
+    attachments: [
+      {
+        content: 'Hello',
+        filename: 'tabs.txt',
+        kind: 'text' as const,
+        mediaType: 'text/plain',
+      },
+    ],
+    content: 'Show my tabs',
+    id: 'message-1',
+    role: 'user' as const,
+  },
+  {
+    content: 'Here are your tabs',
+    id: 'message-2',
+    role: 'assistant' as const,
+  },
+]
+
+const t = (key: string) =>
+  (
+    ({
+      'aiChat.copy.assistant': 'AI:',
+      'aiChat.copy.attachments': 'Attachments:',
+      'aiChat.copy.user': 'User:',
+      'aiChat.copyConversationError': 'Could not copy the conversation',
+      'aiChat.copyConversationSuccess': 'Copied the conversation',
+    }) satisfies Record<string, string>
+  )[key] ?? key
+
+const setClipboard = (clipboard: unknown) => {
+  Object.defineProperty(window.navigator, 'clipboard', {
+    configurable: true,
+    value: clipboard,
+  })
+}
+
+describe('useConversationClipboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(
+        window.navigator,
+        'clipboard',
+        originalClipboardDescriptor,
+      )
+    } else {
+      Reflect.deleteProperty(window.navigator, 'clipboard')
+    }
+  })
+
+  it('会話テキストを Clipboard API へ書き込み copied 状態を表示する', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard({ writeText })
+    const { result } = renderHook(() =>
+      useConversationClipboard({ messages, t }),
+    )
+
+    await act(async () => {
+      await result.current.copyConversation()
+    })
+
+    expect(writeText).toHaveBeenCalledWith(
+      [
+        'User:',
+        'Attachments: tabs.txt',
+        'Show my tabs',
+        '',
+        'AI:',
+        'Here are your tabs',
+      ].join('\n'),
+    )
+    expect(mocked.toastSuccess).toHaveBeenCalledWith('Copied the conversation')
+    expect(result.current.isConversationCopied).toBe(true)
+  })
+
+  it('Clipboard API がない場合は copy error を表示する', async () => {
+    setClipboard(undefined)
+    const { result } = renderHook(() =>
+      useConversationClipboard({ messages, t }),
+    )
+
+    await act(async () => {
+      await result.current.copyConversation()
+    })
+
+    expect(mocked.toastError).toHaveBeenCalledWith(
+      'Could not copy the conversation',
+    )
+    expect(mocked.toastSuccess).not.toHaveBeenCalled()
+    expect(result.current.isConversationCopied).toBe(false)
+  })
+
+  it('Clipboard API の書き込み失敗時は copy error を表示する', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    setClipboard({ writeText })
+    const { result } = renderHook(() =>
+      useConversationClipboard({ messages, t }),
+    )
+
+    await act(async () => {
+      await result.current.copyConversation()
+    })
+
+    expect(mocked.toastError).toHaveBeenCalledWith(
+      'Could not copy the conversation',
+    )
+    expect(result.current.isConversationCopied).toBe(false)
+  })
+
+  it('再コピー時は copied timeout を置き換える', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard({ writeText })
+    const { result } = renderHook(() =>
+      useConversationClipboard({ messages, t }),
+    )
+
+    await act(async () => {
+      await result.current.copyConversation()
+      vi.advanceTimersByTime(COPIED_CONVERSATION_ICON_TIMEOUT - 1)
+      await result.current.copyConversation()
+      vi.advanceTimersByTime(1)
+    })
+
+    expect(result.current.isConversationCopied).toBe(true)
+
+    act(() => {
+      vi.advanceTimersByTime(COPIED_CONVERSATION_ICON_TIMEOUT - 1)
+    })
+
+    expect(result.current.isConversationCopied).toBe(false)
+  })
+
+  it('unmount 時に copied timeout を破棄する', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard({ writeText })
+    const { result, unmount } = renderHook(() =>
+      useConversationClipboard({ messages, t }),
+    )
+
+    await act(async () => {
+      await result.current.copyConversation()
+    })
+    expect(vi.getTimerCount()).toBe(1)
+
+    unmount()
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('会話が置き換わると copied 状態と timeout をリセットする', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard({ writeText })
+    const { result, rerender } = renderHook(
+      ({ currentMessages }) =>
+        useConversationClipboard({ messages: currentMessages, t }),
+      { initialProps: { currentMessages: messages } },
+    )
+
+    await act(async () => {
+      await result.current.copyConversation()
+    })
+    expect(result.current.isConversationCopied).toBe(true)
+
+    rerender({ currentMessages: [] })
+
+    expect(result.current.isConversationCopied).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/features/ai-chat/hooks/useConversationClipboard.test.tsx
+++ b/src/features/ai-chat/hooks/useConversationClipboard.test.tsx
@@ -200,5 +200,10 @@ describe('useConversationClipboard', () => {
 
     expect(result.current.isConversationCopied).toBe(false)
     expect(vi.getTimerCount()).toBe(0)
+
+    rerender({ currentMessages: messages })
+
+    expect(result.current.isConversationCopied).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/src/features/ai-chat/hooks/useConversationClipboard.test.tsx
+++ b/src/features/ai-chat/hooks/useConversationClipboard.test.tsx
@@ -62,6 +62,20 @@ const setClipboard = (clipboard: unknown) => {
   })
 }
 
+const createDeferred = () => {
+  let resolveDeferred: () => void = () => {}
+  let rejectDeferred: (reason?: unknown) => void = () => {}
+  const promise = new Promise<void>((resolve, reject) => {
+    resolveDeferred = resolve
+    rejectDeferred = reject
+  })
+  return {
+    promise,
+    reject: rejectDeferred,
+    resolve: resolveDeferred,
+  }
+}
+
 describe('useConversationClipboard', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -204,6 +218,93 @@ describe('useConversationClipboard', () => {
     rerender({ currentMessages: messages })
 
     expect(result.current.isConversationCopied).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('pending copy の unmount 後 resolve は副作用を発生させない', async () => {
+    vi.useFakeTimers()
+    const deferred = createDeferred()
+    setClipboard({ writeText: vi.fn().mockReturnValue(deferred.promise) })
+    const { result, unmount } = renderHook(() =>
+      useConversationClipboard({ messages, t }),
+    )
+
+    const pendingCopy = result.current.copyConversation()
+    unmount()
+
+    await act(async () => {
+      deferred.resolve()
+      await pendingCopy
+    })
+
+    expect(mocked.toastSuccess).not.toHaveBeenCalled()
+    expect(mocked.toastError).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('pending copy の会話が A から B を経て同じ A に戻っても副作用を復活させない', async () => {
+    vi.useFakeTimers()
+    const deferred = createDeferred()
+    setClipboard({ writeText: vi.fn().mockReturnValue(deferred.promise) })
+    const { result, rerender } = renderHook(
+      ({ currentMessages }) =>
+        useConversationClipboard({ messages: currentMessages, t }),
+      { initialProps: { currentMessages: messages } },
+    )
+
+    const pendingCopy = result.current.copyConversation()
+    rerender({ currentMessages: [] })
+    rerender({ currentMessages: messages })
+
+    await act(async () => {
+      deferred.resolve()
+      await pendingCopy
+    })
+
+    expect(result.current.isConversationCopied).toBe(false)
+    expect(mocked.toastSuccess).not.toHaveBeenCalled()
+    expect(mocked.toastError).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('並行 copy が逆順 resolve しても古い要求は新しい timeout を上書きしない', async () => {
+    vi.useFakeTimers()
+    const firstDeferred = createDeferred()
+    const secondDeferred = createDeferred()
+    const writeText = vi
+      .fn()
+      .mockReturnValueOnce(firstDeferred.promise)
+      .mockReturnValueOnce(secondDeferred.promise)
+    setClipboard({ writeText })
+    const { result } = renderHook(() =>
+      useConversationClipboard({ messages, t }),
+    )
+
+    const firstCopy = result.current.copyConversation()
+    const secondCopy = result.current.copyConversation()
+
+    await act(async () => {
+      secondDeferred.resolve()
+      await secondCopy
+    })
+    expect(result.current.isConversationCopied).toBe(true)
+    expect(mocked.toastSuccess).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(COPIED_CONVERSATION_ICON_TIMEOUT / 2)
+    })
+
+    await act(async () => {
+      firstDeferred.resolve()
+      await firstCopy
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(COPIED_CONVERSATION_ICON_TIMEOUT / 2)
+    })
+
+    expect(result.current.isConversationCopied).toBe(false)
+    expect(mocked.toastSuccess).toHaveBeenCalledTimes(1)
     expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/src/features/ai-chat/hooks/useConversationClipboard.ts
+++ b/src/features/ai-chat/hooks/useConversationClipboard.ts
@@ -50,11 +50,18 @@ const useConversationClipboard = ({
   messages: ChatMessage[]
   t: TranslateFn
 }) => {
-  const [copiedMessages, setCopiedMessages] = useState<ChatMessage[] | null>(
-    null,
-  )
+  const [copiedState, setCopiedState] = useState<{
+    isCopied: boolean
+    messages: ChatMessage[]
+  }>({ isCopied: false, messages })
   const copiedTimeoutRef = useRef<number | null>(null)
-  const isConversationCopied = copiedMessages === messages
+
+  if (copiedState.messages !== messages) {
+    setCopiedState({ isCopied: false, messages })
+  }
+
+  const isConversationCopied =
+    copiedState.messages === messages && copiedState.isCopied
 
   const clearCopiedTimeout = useCallback(() => {
     if (copiedTimeoutRef.current === null) {
@@ -81,10 +88,10 @@ const useConversationClipboard = ({
     try {
       await clipboard.writeText(conversationCopyText)
       clearCopiedTimeout()
-      setCopiedMessages(messages)
+      setCopiedState({ isCopied: true, messages })
       toast.success(t('aiChat.copyConversationSuccess'))
       copiedTimeoutRef.current = window.setTimeout(() => {
-        setCopiedMessages(null)
+        setCopiedState({ isCopied: false, messages })
         copiedTimeoutRef.current = null
       }, COPIED_CONVERSATION_ICON_TIMEOUT)
     } catch {

--- a/src/features/ai-chat/hooks/useConversationClipboard.ts
+++ b/src/features/ai-chat/hooks/useConversationClipboard.ts
@@ -55,6 +55,8 @@ const useConversationClipboard = ({
     messages: ChatMessage[]
   }>({ isCopied: false, messages })
   const copiedTimeoutRef = useRef<number | null>(null)
+  const isMountedRef = useRef(true)
+  const copyRequestGenerationRef = useRef(0)
 
   if (copiedState.messages !== messages) {
     setCopiedState({ isCopied: false, messages })
@@ -71,9 +73,29 @@ const useConversationClipboard = ({
     copiedTimeoutRef.current = null
   }, [])
 
-  useEffect(() => clearCopiedTimeout, [clearCopiedTimeout, messages])
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      copyRequestGenerationRef.current += 1
+    }
+  }, [])
+
+  useEffect(
+    () => () => {
+      copyRequestGenerationRef.current += 1
+      clearCopiedTimeout()
+    },
+    [clearCopiedTimeout, messages],
+  )
 
   const copyConversation = useCallback(async () => {
+    const requestGeneration = copyRequestGenerationRef.current + 1
+    copyRequestGenerationRef.current = requestGeneration
+    const isCurrentRequest = () =>
+      isMountedRef.current &&
+      copyRequestGenerationRef.current === requestGeneration
+
     const conversationCopyText = getConversationCopyText(messages, t)
     if (!conversationCopyText) {
       return
@@ -87,6 +109,9 @@ const useConversationClipboard = ({
 
     try {
       await clipboard.writeText(conversationCopyText)
+      if (!isCurrentRequest()) {
+        return
+      }
       clearCopiedTimeout()
       setCopiedState({ isCopied: true, messages })
       toast.success(t('aiChat.copyConversationSuccess'))
@@ -95,6 +120,9 @@ const useConversationClipboard = ({
         copiedTimeoutRef.current = null
       }, COPIED_CONVERSATION_ICON_TIMEOUT)
     } catch {
+      if (!isCurrentRequest()) {
+        return
+      }
       toast.error(t('aiChat.copyConversationError'))
     }
   }, [clearCopiedTimeout, messages, t])

--- a/src/features/ai-chat/hooks/useConversationClipboard.ts
+++ b/src/features/ai-chat/hooks/useConversationClipboard.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+
+import { getConversationCopyText } from '@/features/ai-chat/components/savedTabsChat/messages'
+import type {
+  ChatMessage,
+  TranslateFn,
+} from '@/features/ai-chat/components/savedTabsChat/messages'
+import { COPIED_CONVERSATION_ICON_TIMEOUT } from '@/features/ai-chat/components/savedTabsChat/storage'
+
+type ClipboardWriter = {
+  writeText: (text: string) => Promise<void>
+}
+
+const getClipboardWriter = (): ClipboardWriter | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    const navigatorValue: unknown = Reflect.get(globalThis, 'navigator')
+    if (typeof navigatorValue !== 'object' || navigatorValue === null) {
+      return null
+    }
+
+    const clipboardValue: unknown = Reflect.get(navigatorValue, 'clipboard')
+    if (typeof clipboardValue !== 'object' || clipboardValue === null) {
+      return null
+    }
+
+    const writeTextValue: unknown = Reflect.get(clipboardValue, 'writeText')
+    if (typeof writeTextValue !== 'function') {
+      return null
+    }
+
+    return {
+      writeText: async (text) => {
+        await Reflect.apply(writeTextValue, clipboardValue, [text])
+      },
+    }
+  } catch {
+    return null
+  }
+}
+
+const useConversationClipboard = ({
+  messages,
+  t,
+}: {
+  messages: ChatMessage[]
+  t: TranslateFn
+}) => {
+  const [copiedMessages, setCopiedMessages] = useState<ChatMessage[] | null>(
+    null,
+  )
+  const copiedTimeoutRef = useRef<number | null>(null)
+  const isConversationCopied = copiedMessages === messages
+
+  const clearCopiedTimeout = useCallback(() => {
+    if (copiedTimeoutRef.current === null) {
+      return
+    }
+    window.clearTimeout(copiedTimeoutRef.current)
+    copiedTimeoutRef.current = null
+  }, [])
+
+  useEffect(() => clearCopiedTimeout, [clearCopiedTimeout, messages])
+
+  const copyConversation = useCallback(async () => {
+    const conversationCopyText = getConversationCopyText(messages, t)
+    if (!conversationCopyText) {
+      return
+    }
+
+    const clipboard = getClipboardWriter()
+    if (!clipboard) {
+      toast.error(t('aiChat.copyConversationError'))
+      return
+    }
+
+    try {
+      await clipboard.writeText(conversationCopyText)
+      clearCopiedTimeout()
+      setCopiedMessages(messages)
+      toast.success(t('aiChat.copyConversationSuccess'))
+      copiedTimeoutRef.current = window.setTimeout(() => {
+        setCopiedMessages(null)
+        copiedTimeoutRef.current = null
+      }, COPIED_CONVERSATION_ICON_TIMEOUT)
+    } catch {
+      toast.error(t('aiChat.copyConversationError'))
+    }
+  }, [clearCopiedTimeout, messages, t])
+
+  return {
+    copyConversation,
+    isConversationCopied,
+  }
+}
+
+export { useConversationClipboard }

--- a/src/features/ai-chat/hooks/useOllamaModelSettings.test.tsx
+++ b/src/features/ai-chat/hooks/useOllamaModelSettings.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import { act, renderHook } from '@testing-library/react'
+import { useLayoutEffect } from 'react'
+import { createRoot } from 'react-dom/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { defaultSettings } from '@/lib/storage/settings'
@@ -187,6 +189,54 @@ describe('useOllamaModelSettings', () => {
       'Could not save model settings',
     )
     expect(result.current.isSavingModel).toBe(false)
+  })
+
+  it('pending save 完了時は rerender 後の最新 callback だけへ通知する', async () => {
+    const deferred = createDeferred<undefined>()
+    mocked.saveUserSettings.mockReturnValue(deferred.promise)
+    const oldCallback = vi.fn()
+    const latestCallback = vi.fn()
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    const latestRenderCommitted = createDeferred<undefined>()
+    let selectModel: (modelName: string) => Promise<boolean> = async () => false
+    const HookHarness = ({
+      onCommit,
+      onSettingsSaved,
+    }: {
+      onCommit?: () => void
+      onSettingsSaved: (nextSettings: UserSettings) => void
+    }) => {
+      selectModel = useOllamaModelSettings({
+        onSettingsSaved,
+        settings,
+        t,
+      }).selectModel
+      useLayoutEffect(() => {
+        onCommit?.()
+      }, [onCommit])
+      return null
+    }
+    await act(async () => {
+      root.render(<HookHarness onSettingsSaved={oldCallback} />)
+    })
+    const savePromise = selectModel('qwen3')
+
+    root.render(
+      <HookHarness
+        onCommit={() => latestRenderCommitted.resolve(undefined)}
+        onSettingsSaved={latestCallback}
+      />,
+    )
+    await latestRenderCommitted.promise
+    deferred.resolve(undefined)
+    await savePromise
+
+    expect(oldCallback).not.toHaveBeenCalled()
+    expect(latestCallback).toHaveBeenCalledOnce()
+    await act(async () => {
+      root.unmount()
+    })
   })
 
   it('同一 hook で進行中の取得と保存を重複実行しない', async () => {

--- a/src/features/ai-chat/hooks/useOllamaModelSettings.test.tsx
+++ b/src/features/ai-chat/hooks/useOllamaModelSettings.test.tsx
@@ -1,0 +1,261 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { defaultSettings } from '@/lib/storage/settings'
+import type { OllamaErrorDetails } from '@/types/background'
+import type { UserSettings } from '@/types/storage'
+
+const mocked = vi.hoisted(() => ({
+  getRuntimePlatform: vi.fn(),
+  requestOllamaModels: vi.fn(),
+  saveUserSettings: vi.fn(),
+}))
+
+vi.mock('@/features/ai-chat/components/savedTabsChat/streaming', () => ({
+  getRuntimePlatform: mocked.getRuntimePlatform,
+  requestOllamaModels: mocked.requestOllamaModels,
+}))
+
+vi.mock('@/lib/storage/settings', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>(
+    '@/lib/storage/settings',
+  )
+  return {
+    ...actual,
+    saveUserSettings: mocked.saveUserSettings,
+  }
+})
+
+import { useOllamaModelSettings } from './useOllamaModelSettings'
+
+const settings: UserSettings = {
+  ...defaultSettings,
+  ollamaModel: '',
+}
+
+const translations: Record<string, string> = {
+  'aiChat.modelListLoadError': 'Could not load the model list',
+  'aiChat.modelSettingsSaveError': 'Could not save model settings',
+}
+const t = (key: string) => translations[key] ?? key
+
+const createDeferred = <T,>() => {
+  let resolveDeferred: (value: T) => void = () => {}
+  let rejectDeferred: (reason?: unknown) => void = () => {}
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveDeferred = resolve
+    rejectDeferred = reject
+  })
+  return {
+    promise,
+    reject: rejectDeferred,
+    resolve: resolveDeferred,
+  }
+}
+
+describe('useOllamaModelSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocked.getRuntimePlatform.mockResolvedValue('unknown')
+    mocked.saveUserSettings.mockResolvedValue(undefined)
+  })
+
+  it('取得中を表示し、取得したモデルを selector option へ変換する', async () => {
+    const deferred = createDeferred<{
+      models: { label: string; name: string }[]
+      status: 'ok'
+    }>()
+    mocked.requestOllamaModels.mockReturnValue(deferred.promise)
+    const { result } = renderHook(() =>
+      useOllamaModelSettings({ onSettingsSaved: vi.fn(), settings, t }),
+    )
+
+    let requestPromise: Promise<void> = Promise.resolve()
+    act(() => {
+      requestPromise = result.current.requestModels()
+    })
+    expect(result.current.isLoadingModels).toBe(true)
+
+    await act(async () => {
+      deferred.resolve({
+        models: [{ label: 'Llama 3.2 (8B)', name: 'llama3.2' }],
+        status: 'ok',
+      })
+      await requestPromise
+    })
+
+    expect(result.current.modelOptions).toEqual([
+      { label: 'Llama 3.2 (8B)', name: 'llama3.2' },
+    ])
+    expect(result.current.isLoadingModels).toBe(false)
+    expect(result.current.setupErrorMessage).toBe('')
+  })
+
+  it('モデル取得失敗時は一覧を消去して API の error と診断詳細を保持する', async () => {
+    const ollamaError: OllamaErrorDetails = {
+      allowedOrigins: 'chrome-extension://extension-id',
+      baseUrl: 'http://localhost:11434',
+      downloadUrl: 'https://ollama.com/download',
+      faqUrl: 'https://docs.ollama.com/faq',
+      kind: 'notInstalledOrNotRunning',
+      tagsUrl: 'http://localhost:11434/api/tags',
+    }
+    mocked.requestOllamaModels
+      .mockResolvedValueOnce({
+        models: [{ label: 'Llama', name: 'llama' }],
+        status: 'ok',
+      })
+      .mockResolvedValueOnce({
+        error: 'Could not connect to Ollama.',
+        ollamaError,
+        status: 'error',
+      })
+    const { result } = renderHook(() =>
+      useOllamaModelSettings({ onSettingsSaved: vi.fn(), settings, t }),
+    )
+
+    await act(async () => {
+      await result.current.requestModels()
+    })
+    await act(async () => {
+      await result.current.requestModels()
+    })
+
+    expect(result.current.modelOptions).toEqual([])
+    expect(result.current.setupErrorMessage).toBe(
+      'Could not connect to Ollama.',
+    )
+    expect(result.current.setupOllamaError).toEqual(ollamaError)
+  })
+
+  it('モデル取得結果が不正な場合は既定の error 文言を使う', async () => {
+    mocked.requestOllamaModels.mockResolvedValue(undefined)
+    const { result } = renderHook(() =>
+      useOllamaModelSettings({ onSettingsSaved: vi.fn(), settings, t }),
+    )
+
+    await act(async () => {
+      await result.current.requestModels()
+    })
+
+    expect(result.current.setupErrorMessage).toBe(
+      'Could not load the model list',
+    )
+  })
+
+  it('保存中を表示し、正規化した次設定を保存して owner へ通知する', async () => {
+    const deferred = createDeferred<undefined>()
+    mocked.saveUserSettings.mockReturnValue(deferred.promise)
+    const onSettingsSaved = vi.fn()
+    const { result } = renderHook(() =>
+      useOllamaModelSettings({ onSettingsSaved, settings, t }),
+    )
+
+    let savePromise: Promise<boolean> = Promise.resolve(false)
+    act(() => {
+      savePromise = result.current.selectModel('qwen3:latest')
+    })
+    expect(result.current.isSavingModel).toBe(true)
+
+    await act(async () => {
+      deferred.resolve(undefined)
+      await expect(savePromise).resolves.toBe(true)
+    })
+
+    const savedSettings = mocked.saveUserSettings.mock.calls[0][0]
+    expect(savedSettings).toEqual(
+      expect.objectContaining({ ollamaModel: 'qwen3:latest' }),
+    )
+    expect(onSettingsSaved).toHaveBeenCalledWith(savedSettings)
+    expect(result.current.isSavingModel).toBe(false)
+  })
+
+  it('保存失敗時は owner へ通知せず error を返す', async () => {
+    mocked.saveUserSettings.mockRejectedValue(new Error('storage failed'))
+    const onSettingsSaved = vi.fn()
+    const { result } = renderHook(() =>
+      useOllamaModelSettings({ onSettingsSaved, settings, t }),
+    )
+
+    await act(async () => {
+      await expect(result.current.selectModel('llama3.2')).resolves.toBe(false)
+    })
+
+    expect(onSettingsSaved).not.toHaveBeenCalled()
+    expect(result.current.setupErrorMessage).toBe(
+      'Could not save model settings',
+    )
+    expect(result.current.isSavingModel).toBe(false)
+  })
+
+  it('同一 hook で進行中の取得と保存を重複実行しない', async () => {
+    const fetchDeferred = createDeferred<undefined>()
+    const saveDeferred = createDeferred<undefined>()
+    mocked.requestOllamaModels.mockReturnValue(fetchDeferred.promise)
+    mocked.saveUserSettings.mockReturnValue(saveDeferred.promise)
+    const { result } = renderHook(() =>
+      useOllamaModelSettings({ onSettingsSaved: vi.fn(), settings, t }),
+    )
+
+    let firstFetch: Promise<void> = Promise.resolve()
+    let secondFetch: Promise<void> = Promise.resolve()
+    let firstSave: Promise<boolean> = Promise.resolve(false)
+    let secondSave: Promise<boolean> = Promise.resolve(true)
+    act(() => {
+      firstFetch = result.current.requestModels()
+      secondFetch = result.current.requestModels()
+      firstSave = result.current.selectModel('llama3.2')
+      secondSave = result.current.selectModel('qwen3')
+    })
+
+    expect(mocked.requestOllamaModels).toHaveBeenCalledOnce()
+    expect(mocked.saveUserSettings).toHaveBeenCalledOnce()
+    await expect(secondSave).resolves.toBe(false)
+
+    await act(async () => {
+      fetchDeferred.resolve(undefined)
+      saveDeferred.resolve(undefined)
+      await Promise.all([firstFetch, secondFetch, firstSave])
+    })
+  })
+
+  it.each([
+    ['mac', 'macos'],
+    ['win', 'windows'],
+  ] as const)(
+    'runtime platform %s を %s guidance 用に公開する',
+    async (os, _guidance) => {
+      mocked.getRuntimePlatform.mockResolvedValue(os)
+      const { result } = renderHook(() =>
+        useOllamaModelSettings({ onSettingsSaved: vi.fn(), settings, t }),
+      )
+
+      await act(async () => {
+        await mocked.getRuntimePlatform.mock.results[0].value
+      })
+
+      expect(result.current.platform).toBe(os)
+    },
+  )
+
+  it('unmount 後に pending 操作が完了しても owner と hook state を更新しない', async () => {
+    const fetchDeferred = createDeferred<undefined>()
+    const saveDeferred = createDeferred<undefined>()
+    mocked.requestOllamaModels.mockReturnValue(fetchDeferred.promise)
+    mocked.saveUserSettings.mockReturnValue(saveDeferred.promise)
+    const onSettingsSaved = vi.fn()
+    const { result, unmount } = renderHook(() =>
+      useOllamaModelSettings({ onSettingsSaved, settings, t }),
+    )
+    const requestPromise = result.current.requestModels()
+    const savePromise = result.current.selectModel('llama3.2')
+
+    unmount()
+    fetchDeferred.resolve(undefined)
+    saveDeferred.resolve(undefined)
+    await Promise.all([requestPromise, savePromise])
+
+    expect(onSettingsSaved).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/ai-chat/hooks/useOllamaModelSettings.ts
+++ b/src/features/ai-chat/hooks/useOllamaModelSettings.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
 
 import type { OllamaErrorPlatform } from '@/features/ai-chat/components/OllamaErrorNotice'
 import {
@@ -38,7 +44,10 @@ const useOllamaModelSettings = ({
   const fetchPromiseRef = useRef<Promise<void> | null>(null)
   const isSaveInFlightRef = useRef(false)
   const onSettingsSavedRef = useRef(onSettingsSaved)
-  onSettingsSavedRef.current = onSettingsSaved
+
+  useLayoutEffect(() => {
+    onSettingsSavedRef.current = onSettingsSaved
+  }, [onSettingsSaved])
 
   useEffect(() => {
     isMountedRef.current = true

--- a/src/features/ai-chat/hooks/useOllamaModelSettings.ts
+++ b/src/features/ai-chat/hooks/useOllamaModelSettings.ts
@@ -38,10 +38,7 @@ const useOllamaModelSettings = ({
   const fetchPromiseRef = useRef<Promise<void> | null>(null)
   const isSaveInFlightRef = useRef(false)
   const onSettingsSavedRef = useRef(onSettingsSaved)
-
-  useEffect(() => {
-    onSettingsSavedRef.current = onSettingsSaved
-  }, [onSettingsSaved])
+  onSettingsSavedRef.current = onSettingsSaved
 
   useEffect(() => {
     isMountedRef.current = true

--- a/src/features/ai-chat/hooks/useOllamaModelSettings.ts
+++ b/src/features/ai-chat/hooks/useOllamaModelSettings.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { OllamaErrorPlatform } from '@/features/ai-chat/components/OllamaErrorNotice'
+import {
+  getRuntimePlatform,
+  requestOllamaModels,
+} from '@/features/ai-chat/components/savedTabsChat/streaming'
+import { normalizeAiSystemPromptSettings } from '@/features/ai-chat/lib/systemPromptPresets'
+import { saveUserSettings } from '@/lib/storage/settings'
+import type { OllamaErrorDetails } from '@/types/background'
+import type { UserSettings } from '@/types/storage'
+
+type OllamaModelOption = {
+  label: string
+  name: string
+}
+
+type UseOllamaModelSettingsOptions = {
+  onSettingsSaved: (settings: UserSettings) => void
+  settings: UserSettings
+  t: (key: string) => string
+}
+
+const useOllamaModelSettings = ({
+  onSettingsSaved,
+  settings,
+  t,
+}: UseOllamaModelSettingsOptions) => {
+  const [modelOptions, setModelOptions] = useState<OllamaModelOption[]>([])
+  const [isLoadingModels, setIsLoadingModels] = useState(false)
+  const [isSavingModel, setIsSavingModel] = useState(false)
+  const [setupErrorMessage, setSetupErrorMessage] = useState('')
+  const [setupOllamaError, setSetupOllamaError] = useState<
+    OllamaErrorDetails | undefined
+  >(undefined)
+  const [platform, setPlatform] = useState<OllamaErrorPlatform>('unknown')
+  const isMountedRef = useRef(true)
+  const fetchPromiseRef = useRef<Promise<void> | null>(null)
+  const isSaveInFlightRef = useRef(false)
+  const onSettingsSavedRef = useRef(onSettingsSaved)
+
+  useEffect(() => {
+    onSettingsSavedRef.current = onSettingsSaved
+  }, [onSettingsSaved])
+
+  useEffect(() => {
+    isMountedRef.current = true
+
+    void getRuntimePlatform().then((nextPlatform) => {
+      if (isMountedRef.current) {
+        setPlatform(nextPlatform)
+      }
+    })
+
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
+  const requestModels = useCallback(async (): Promise<void> => {
+    if (fetchPromiseRef.current) {
+      return fetchPromiseRef.current
+    }
+
+    setIsLoadingModels(true)
+    setSetupErrorMessage('')
+    setSetupOllamaError(undefined)
+
+    const requestPromise = (async () => {
+      try {
+        const response = await requestOllamaModels()
+        if (!isMountedRef.current) {
+          return
+        }
+
+        if (response?.status !== 'ok' || !response.models) {
+          setModelOptions([])
+          setSetupErrorMessage(
+            response?.error || t('aiChat.modelListLoadError'), // eslint-disable-line typescript/prefer-nullish-coalescing -- empty error uses the localized fallback
+          )
+          setSetupOllamaError(response?.ollamaError)
+          return
+        }
+
+        setModelOptions(
+          response.models.map((model) => ({
+            label: model.label,
+            name: model.name,
+          })),
+        )
+        setSetupOllamaError(undefined)
+      } catch {
+        if (isMountedRef.current) {
+          setModelOptions([])
+          setSetupErrorMessage(t('aiChat.modelListLoadError'))
+          setSetupOllamaError(undefined)
+        }
+      } finally {
+        fetchPromiseRef.current = null
+        if (isMountedRef.current) {
+          setIsLoadingModels(false)
+        }
+      }
+    })()
+
+    fetchPromiseRef.current = requestPromise
+    return requestPromise
+  }, [t])
+
+  const selectModel = useCallback(
+    async (modelName: string): Promise<boolean> => {
+      if (isSaveInFlightRef.current) {
+        return false
+      }
+
+      isSaveInFlightRef.current = true
+      setIsSavingModel(true)
+      setSetupErrorMessage('')
+      setSetupOllamaError(undefined)
+
+      const nextSettings = normalizeAiSystemPromptSettings({
+        ...settings,
+        ollamaModel: modelName,
+      })
+
+      try {
+        await saveUserSettings(nextSettings)
+        if (!isMountedRef.current) {
+          return false
+        }
+
+        onSettingsSavedRef.current(nextSettings)
+        return true
+      } catch {
+        if (isMountedRef.current) {
+          setSetupErrorMessage(t('aiChat.modelSettingsSaveError'))
+        }
+        return false
+      } finally {
+        isSaveInFlightRef.current = false
+        if (isMountedRef.current) {
+          setIsSavingModel(false)
+        }
+      }
+    },
+    [settings, t],
+  )
+
+  return {
+    isLoadingModels,
+    isSavingModel,
+    modelOptions,
+    platform,
+    requestModels,
+    selectModel,
+    setupErrorMessage,
+    setupOllamaError,
+  }
+}
+
+export { useOllamaModelSettings }
+export type { OllamaModelOption }

--- a/src/features/ai-chat/hooks/useSavedTabsChatController.test.tsx
+++ b/src/features/ai-chat/hooks/useSavedTabsChatController.test.tsx
@@ -100,8 +100,7 @@ describe('useSavedTabsChatController', () => {
     mocked.connectRuntimePort.mockResolvedValue(null)
     mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
     mocked.saveUserSettings.mockResolvedValue(undefined)
-    ;(globalThis as unknown as { chrome: typeof chrome }).chrome =
-      createChromeMock()
+    vi.stubGlobal('chrome', createChromeMock())
   })
 
   afterEach(() => {
@@ -266,5 +265,96 @@ describe('useSavedTabsChatController', () => {
     })
     expect(result.current.messages.items).toEqual([])
     expect(result.current.errors.chatMessage).toBe('')
+  })
+
+  it('disconnects the previous conversation stream and ignores its completion', async () => {
+    const onMessagesChange = vi.fn()
+    let handlePortMessage: ((message: unknown) => void) | undefined
+    const port = {
+      disconnect: vi.fn(),
+      onDisconnect: { addListener: vi.fn() },
+      onMessage: {
+        addListener: vi.fn((listener: (message: unknown) => void) => {
+          handlePortMessage = listener
+        }),
+      },
+      postMessage: vi.fn(),
+    }
+    mocked.connectRuntimePort.mockResolvedValue(port)
+    const nextMessages: ChatMessage[] = [
+      { content: 'Conversation B', id: 'message-b', role: 'user' },
+    ]
+    const { result, rerender } = renderHook(
+      ({ conversationId, initialMessages }) =>
+        useSavedTabsChatController({
+          conversationId,
+          initialMessages,
+          mode: 'page',
+          onMessagesChange,
+        }),
+      {
+        initialProps: {
+          conversationId: 'conversation-a',
+          initialMessages: [] as ChatMessage[],
+        },
+      },
+    )
+    await waitFor(() => expect(result.current.status.isConfigured).toBe(true))
+
+    act(() => result.current.actions.handleSelectSuggestion('Question A'))
+    await waitFor(() => expect(port.postMessage).toHaveBeenCalled())
+    onMessagesChange.mockClear()
+
+    rerender({
+      conversationId: 'conversation-b',
+      initialMessages: nextMessages,
+    })
+
+    expect(port.disconnect).toHaveBeenCalledOnce()
+    expect(result.current.messages.items).toEqual(nextMessages)
+    expect(onMessagesChange).not.toHaveBeenCalled()
+
+    act(() => {
+      handlePortMessage?.({
+        answer: 'Late answer from A',
+        charts: [],
+        reasoning: 'Late completion',
+        toolTraces: [],
+        type: 'complete',
+      })
+    })
+    expect(result.current.messages.items).toEqual(nextMessages)
+    expect(onMessagesChange).not.toHaveBeenCalled()
+  })
+
+  it('disconnects a port that resolves after its conversation was reset', async () => {
+    let resolvePort: ((port: unknown) => void) | undefined
+    mocked.connectRuntimePort.mockImplementation(
+      async () =>
+        new Promise((resolve) => {
+          resolvePort = resolve
+        }),
+    )
+    const port = {
+      disconnect: vi.fn(),
+      onDisconnect: { addListener: vi.fn() },
+      onMessage: { addListener: vi.fn() },
+      postMessage: vi.fn(),
+    }
+    const { result } = renderHook(() => useSavedTabsChatController())
+    await waitFor(() => expect(result.current.status.isConfigured).toBe(true))
+
+    act(() => result.current.actions.handleSelectSuggestion('Question A'))
+    await waitFor(() => expect(resolvePort).toBeTypeOf('function'))
+    act(() => result.current.actions.handleCreateConversation())
+    await act(async () => {
+      resolvePort?.(port)
+      await Promise.resolve()
+    })
+
+    expect(port.disconnect).toHaveBeenCalledOnce()
+    expect(port.postMessage).not.toHaveBeenCalled()
+    expect(mocked.sendRuntimeMessage).not.toHaveBeenCalled()
+    expect(result.current.messages.items).toEqual([])
   })
 })

--- a/src/features/ai-chat/hooks/useSavedTabsChatController.test.tsx
+++ b/src/features/ai-chat/hooks/useSavedTabsChatController.test.tsx
@@ -357,4 +357,41 @@ describe('useSavedTabsChatController', () => {
     expect(mocked.sendRuntimeMessage).not.toHaveBeenCalled()
     expect(result.current.messages.items).toEqual([])
   })
+
+  it('disconnects a port that resolves after the controller unmounts', async () => {
+    const onMessagesChange = vi.fn()
+    let resolvePort: ((port: unknown) => void) | undefined
+    mocked.connectRuntimePort.mockImplementation(
+      async () =>
+        new Promise((resolve) => {
+          resolvePort = resolve
+        }),
+    )
+    const port = {
+      disconnect: vi.fn(),
+      onDisconnect: { addListener: vi.fn() },
+      onMessage: { addListener: vi.fn() },
+      postMessage: vi.fn(),
+    }
+    const { result, unmount } = renderHook(() =>
+      useSavedTabsChatController({ onMessagesChange }),
+    )
+    await waitFor(() => expect(result.current.status.isConfigured).toBe(true))
+
+    act(() => result.current.actions.handleSelectSuggestion('Question A'))
+    await waitFor(() => expect(resolvePort).toBeTypeOf('function'))
+    onMessagesChange.mockClear()
+    unmount()
+    await act(async () => {
+      resolvePort?.(port)
+      await Promise.resolve()
+    })
+
+    expect(port.disconnect).toHaveBeenCalledOnce()
+    expect(port.onMessage.addListener).not.toHaveBeenCalled()
+    expect(port.onDisconnect.addListener).not.toHaveBeenCalled()
+    expect(port.postMessage).not.toHaveBeenCalled()
+    expect(mocked.sendRuntimeMessage).not.toHaveBeenCalled()
+    expect(onMessagesChange).not.toHaveBeenCalled()
+  })
 })

--- a/src/features/ai-chat/hooks/useSavedTabsChatController.test.tsx
+++ b/src/features/ai-chat/hooks/useSavedTabsChatController.test.tsx
@@ -1,0 +1,270 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ChatMessage } from '@/features/ai-chat/components/savedTabsChat/messages'
+import type { UserSettings } from '@/types/storage'
+
+const mocked = vi.hoisted(() => ({
+  connectRuntimePort: vi.fn(),
+  defaultSettings: {
+    activeAiSystemPromptId: 'default-system-prompt',
+    aiSystemPrompts: [
+      {
+        createdAt: 0,
+        id: 'default-system-prompt',
+        name: 'Default',
+        template: 'Answer from saved tabs.',
+        updatedAt: 0,
+      },
+    ],
+    autoDeletePeriod: 'never',
+    clickBehavior: 'saveSameDomainTabs',
+    colors: {},
+    confirmDeleteAll: false,
+    confirmDeleteEach: false,
+    enableCategories: true,
+    excludePatterns: ['chrome://'],
+    excludePinnedTabs: true,
+    ollamaModel: '',
+    openAllInNewWindow: false,
+    openUrlInBackground: true,
+    removeTabAfterExternalDrop: true,
+    removeTabAfterOpen: true,
+    showSavedTime: false,
+  },
+  getUserSettings: vi.fn(),
+  saveUserSettings: vi.fn(),
+  sendRuntimeMessage: vi.fn(),
+}))
+
+vi.mock('@/lib/storage/settings', () => ({
+  defaultSettings: mocked.defaultSettings,
+  getUserSettings: mocked.getUserSettings,
+  saveUserSettings: mocked.saveUserSettings,
+}))
+
+vi.mock('@/lib/browser/runtime', () => ({
+  connectRuntimePort: mocked.connectRuntimePort,
+  sendRuntimeMessage: mocked.sendRuntimeMessage,
+}))
+
+vi.mock('@/features/i18n/context/I18nProvider', () => ({
+  useI18n: () => ({
+    language: 'en',
+    t: (key: string) => key,
+  }),
+}))
+
+import { useSavedTabsChatController } from './useSavedTabsChatController'
+
+type StorageListener = (
+  changes: Record<string, chrome.storage.StorageChange>,
+  areaName: string,
+) => void
+
+const storageListeners: StorageListener[] = []
+const buildConfiguredSettings = (): UserSettings => ({
+  ...(mocked.defaultSettings as UserSettings),
+  ollamaModel: 'llama3.2',
+})
+
+const createChromeMock = () =>
+  ({
+    runtime: {
+      getPlatformInfo: vi.fn(
+        (callback: (info: chrome.runtime.PlatformInfo) => void) => {
+          callback({ arch: 'x86-64', os: 'mac' })
+        },
+      ),
+    },
+    storage: {
+      onChanged: {
+        addListener: vi.fn((listener: StorageListener) => {
+          storageListeners.push(listener)
+        }),
+        removeListener: vi.fn((listener: StorageListener) => {
+          const index = storageListeners.indexOf(listener)
+          if (index >= 0) {
+            storageListeners.splice(index, 1)
+          }
+        }),
+      },
+    },
+  }) as unknown as typeof chrome
+
+describe('useSavedTabsChatController', () => {
+  beforeEach(() => {
+    storageListeners.length = 0
+    vi.clearAllMocks()
+    mocked.connectRuntimePort.mockResolvedValue(null)
+    mocked.getUserSettings.mockResolvedValue(buildConfiguredSettings())
+    mocked.saveUserSettings.mockResolvedValue(undefined)
+    ;(globalThis as unknown as { chrome: typeof chrome }).chrome =
+      createChromeMock()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps page mode open and owns floating open state callbacks', () => {
+    const onOpenChange = vi.fn()
+    const page = renderHook(() => useSavedTabsChatController({ mode: 'page' }))
+    const floating = renderHook(() =>
+      useSavedTabsChatController({ onOpenChange }),
+    )
+
+    expect(page.result.current.layout.isOpen).toBe(true)
+    expect(page.result.current.launcher.isVisible).toBe(false)
+    expect(floating.result.current.launcher.isVisible).toBe(true)
+
+    act(() => floating.result.current.launcher.handleOpen())
+    expect(floating.result.current.layout.isOpen).toBe(true)
+    expect(onOpenChange).toHaveBeenLastCalledWith(true)
+
+    act(() => floating.result.current.actions.handleClose())
+    expect(floating.result.current.layout.isOpen).toBe(false)
+    expect(onOpenChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('syncs an external conversation without notifying it back to the owner', () => {
+    const onMessagesChange = vi.fn()
+    const firstMessages: ChatMessage[] = [
+      { content: 'First', id: 'message-1', role: 'user' as const },
+    ]
+    const nextMessages: ChatMessage[] = [
+      { content: 'Second', id: 'message-2', role: 'assistant' as const },
+    ]
+    const { result, rerender } = renderHook(
+      ({ conversationId, initialMessages }) =>
+        useSavedTabsChatController({
+          conversationId,
+          initialMessages,
+          mode: 'page',
+          onMessagesChange,
+        }),
+      {
+        initialProps: {
+          conversationId: 'conversation-1',
+          initialMessages: firstMessages,
+        },
+      },
+    )
+
+    rerender({
+      conversationId: 'conversation-2',
+      initialMessages: nextMessages,
+    })
+
+    expect(result.current.messages.items).toEqual(nextMessages)
+    expect(onMessagesChange).not.toHaveBeenCalled()
+  })
+
+  it('reflects local user settings changes in the controller settings group', async () => {
+    const { result } = renderHook(() => useSavedTabsChatController())
+    await waitFor(() => {
+      expect(result.current.settings.modelName).toBe('llama3.2')
+    })
+
+    act(() => {
+      storageListeners[0]?.(
+        {
+          userSettings: {
+            newValue: { ...buildConfiguredSettings(), ollamaModel: 'qwen3' },
+          },
+        },
+        'local',
+      )
+    })
+
+    expect(result.current.settings.modelName).toBe('qwen3')
+  })
+
+  it('commits only stream start and completion', async () => {
+    const onMessagesChange = vi.fn()
+    let handlePortMessage: ((message: unknown) => void) | undefined
+    const port = {
+      disconnect: vi.fn(),
+      onDisconnect: { addListener: vi.fn() },
+      onMessage: {
+        addListener: vi.fn((listener: (message: unknown) => void) => {
+          handlePortMessage = listener
+        }),
+      },
+      postMessage: vi.fn(),
+    }
+    mocked.connectRuntimePort.mockResolvedValue(port)
+    const { result } = renderHook(() =>
+      useSavedTabsChatController({ onMessagesChange }),
+    )
+    await waitFor(() => expect(result.current.status.isConfigured).toBe(true))
+
+    act(() => result.current.actions.handleSelectSuggestion('Compare tabs'))
+    await waitFor(() => expect(onMessagesChange).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      handlePortMessage?.({
+        reasoning: 'Working',
+        toolTraces: [],
+        type: 'step',
+      })
+    })
+    expect(onMessagesChange).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      handlePortMessage?.({
+        answer: 'Done',
+        charts: [],
+        reasoning: 'Complete',
+        toolTraces: [],
+        type: 'complete',
+      })
+    })
+    await waitFor(() => expect(onMessagesChange).toHaveBeenCalledTimes(2))
+    expect(result.current.messages.items.at(-1)?.content).toBe('Done')
+  })
+
+  it('suppresses reset disconnect errors and ignores stale stream completion', async () => {
+    let handleDisconnect: (() => void) | undefined
+    let handlePortMessage: ((message: unknown) => void) | undefined
+    const port = {
+      disconnect: vi.fn(() => handleDisconnect?.()),
+      onDisconnect: {
+        addListener: vi.fn((listener: () => void) => {
+          handleDisconnect = listener
+        }),
+      },
+      onMessage: {
+        addListener: vi.fn((listener: (message: unknown) => void) => {
+          handlePortMessage = listener
+        }),
+      },
+      postMessage: vi.fn(),
+    }
+    mocked.connectRuntimePort.mockResolvedValue(port)
+    const { result } = renderHook(() => useSavedTabsChatController())
+    await waitFor(() => expect(result.current.status.isConfigured).toBe(true))
+
+    act(() => result.current.actions.handleSelectSuggestion('Compare tabs'))
+    await waitFor(() => expect(port.postMessage).toHaveBeenCalled())
+    act(() => result.current.actions.handleCreateConversation())
+
+    expect(port.disconnect).toHaveBeenCalled()
+    expect(result.current.messages.items).toEqual([])
+    expect(result.current.errors.chatMessage).toBe('')
+
+    act(() => {
+      handlePortMessage?.({
+        answer: 'Stale answer',
+        charts: [],
+        reasoning: 'Late completion',
+        toolTraces: [],
+        type: 'complete',
+      })
+    })
+    expect(result.current.messages.items).toEqual([])
+    expect(result.current.errors.chatMessage).toBe('')
+  })
+})

--- a/src/features/ai-chat/hooks/useSavedTabsChatController.ts
+++ b/src/features/ai-chat/hooks/useSavedTabsChatController.ts
@@ -102,7 +102,8 @@ const useSavedTabsChatController = ({
     activePort.disconnect()
   }, [])
 
-  const releaseChatWidgetResources = useCallback(() => {
+  const invalidateConversation = useCallback(() => {
+    conversationGenerationRef.current += 1
     disconnectActivePort()
   }, [disconnectActivePort])
 
@@ -121,8 +122,7 @@ const useSavedTabsChatController = ({
       return
     }
 
-    conversationGenerationRef.current += 1
-    disconnectActivePort()
+    invalidateConversation()
     syncExternalConversationState({
       conversationId,
       initialMessages,
@@ -134,7 +134,7 @@ const useSavedTabsChatController = ({
       setMessages,
       syncedConversationIdRef,
     })
-  }, [conversationId, disconnectActivePort, initialMessages, mode])
+  }, [conversationId, initialMessages, invalidateConversation, mode])
 
   useEffect(() => {
     let isMounted = true
@@ -150,7 +150,12 @@ const useSavedTabsChatController = ({
     }
   }, [])
 
-  useEffect(() => releaseChatWidgetResources, [releaseChatWidgetResources])
+  useEffect(
+    () => () => {
+      invalidateConversation()
+    },
+    [invalidateConversation],
+  )
 
   useEffect(() => {
     const storageChangeListener = (
@@ -220,14 +225,13 @@ const useSavedTabsChatController = ({
     )
 
   const resetConversation = useCallback(() => {
-    conversationGenerationRef.current += 1
-    disconnectActivePort()
+    invalidateConversation()
     setMessagesState([])
     setInput('')
     setErrorMessage('')
     setChatOllamaError(undefined)
     setIsSubmitting(false)
-  }, [disconnectActivePort])
+  }, [invalidateConversation])
 
   const {
     isLoadingModels,

--- a/src/features/ai-chat/hooks/useSavedTabsChatController.ts
+++ b/src/features/ai-chat/hooks/useSavedTabsChatController.ts
@@ -89,15 +89,22 @@ const useSavedTabsChatController = ({
   >(undefined)
   const activePortRef = useRef<{ disconnect: () => void } | null>(null)
   const conversationGenerationRef = useRef(0)
-  const ignoreNextDisconnectRef = useRef(false)
   const messagesRef = useRef<ChatMessage[]>(initialMessages)
   const syncedConversationIdRef = useRef<string | undefined>(conversationId)
   const isOpen = mode === 'page' || isFloatingOpen
 
-  const releaseChatWidgetResources = useCallback(() => {
-    activePortRef.current?.disconnect()
+  const disconnectActivePort = useCallback(() => {
+    const activePort = activePortRef.current
+    if (!activePort) {
+      return
+    }
     activePortRef.current = null
+    activePort.disconnect()
   }, [])
+
+  const releaseChatWidgetResources = useCallback(() => {
+    disconnectActivePort()
+  }, [disconnectActivePort])
 
   useEffect(() => {
     const shouldSyncExternalConversation =
@@ -114,6 +121,8 @@ const useSavedTabsChatController = ({
       return
     }
 
+    conversationGenerationRef.current += 1
+    disconnectActivePort()
     syncExternalConversationState({
       conversationId,
       initialMessages,
@@ -125,7 +134,7 @@ const useSavedTabsChatController = ({
       setMessages,
       syncedConversationIdRef,
     })
-  }, [conversationId, initialMessages, mode])
+  }, [conversationId, disconnectActivePort, initialMessages, mode])
 
   useEffect(() => {
     let isMounted = true
@@ -210,24 +219,9 @@ const useSavedTabsChatController = ({
       options,
     )
 
-  const disconnectActivePort = useCallback(
-    (suppressDisconnectError = false) => {
-      const activePort = activePortRef.current
-      if (!activePort) {
-        return
-      }
-      if (suppressDisconnectError) {
-        ignoreNextDisconnectRef.current = true
-      }
-      activePortRef.current = null
-      activePort.disconnect()
-    },
-    [],
-  )
-
   const resetConversation = useCallback(() => {
     conversationGenerationRef.current += 1
-    disconnectActivePort(true)
+    disconnectActivePort()
     setMessagesState([])
     setInput('')
     setErrorMessage('')
@@ -291,7 +285,6 @@ const useSavedTabsChatController = ({
     messages,
     activePortRef,
     conversationGenerationRef,
-    ignoreNextDisconnectRef,
     disconnectActivePort,
     replaceMessage,
     removeMessage,

--- a/src/features/ai-chat/hooks/useSavedTabsChatController.ts
+++ b/src/features/ai-chat/hooks/useSavedTabsChatController.ts
@@ -1,0 +1,409 @@
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+
+import type { ChatMessage } from '@/features/ai-chat/components/savedTabsChat/messages'
+import {
+  areMessagesEquivalent,
+  EMPTY_CHAT_MESSAGES,
+  EMPTY_HISTORY_ITEMS,
+  getResolvedSettings,
+  isAiChatConfigured,
+  loadWidgetSettings,
+  syncExternalConversationState,
+} from '@/features/ai-chat/components/savedTabsChat/storage'
+import { useChatPromptManager } from '@/features/ai-chat/components/savedTabsChat/useChatPromptManager'
+import { useChatStreamHandlers } from '@/features/ai-chat/components/savedTabsChat/useChatStreamHandlers'
+import {
+  getActiveAiSystemPrompt,
+  normalizeAiSystemPromptSettings,
+} from '@/features/ai-chat/lib/systemPromptPresets'
+import type { AiChatHistoryItem } from '@/features/ai-chat/types'
+import { useI18n } from '@/features/i18n/context/I18nProvider'
+import {
+  getChromeStorageOnChanged,
+  warnMissingChromeStorage,
+} from '@/lib/browser/chrome-storage'
+import { saveUserSettings } from '@/lib/storage/settings'
+import {
+  UserSettingsSchema,
+  fromStorageChange,
+} from '@/lib/storage/zod-storage'
+import type { OllamaErrorDetails } from '@/types/background'
+import type { UserSettings } from '@/types/storage'
+
+import { useChatSidebarResize } from './useChatSidebarResize'
+import { useConversationClipboard } from './useConversationClipboard'
+import { useOllamaModelSettings } from './useOllamaModelSettings'
+
+type SavedTabsChatControllerOptions = {
+  conversationId?: string
+  defaultOpen?: boolean
+  historyItems?: AiChatHistoryItem[]
+  historyVariant?: 'dropdown' | 'none' | 'sidebar-toggle'
+  initialMessages?: ChatMessage[]
+  mode?: 'floating' | 'page'
+  title?: string
+  onCreateConversation?: () => void
+  onDeleteHistoryItem?: (conversationId: string) => void
+  onMessagesChange?: (messages: ChatMessage[]) => void
+  onOpenChange?: (isOpen: boolean) => void
+  onSelectHistoryItem?: (conversationId: string) => void
+  onToggleHistory?: () => void
+}
+
+// eslint-disable-next-line eslint/max-statements
+const useSavedTabsChatController = ({
+  conversationId,
+  defaultOpen = false,
+  historyItems = EMPTY_HISTORY_ITEMS,
+  historyVariant = 'none',
+  initialMessages = EMPTY_CHAT_MESSAGES,
+  mode = 'floating',
+  title,
+  onCreateConversation,
+  onDeleteHistoryItem,
+  onMessagesChange,
+  onOpenChange,
+  onSelectHistoryItem,
+  onToggleHistory,
+}: SavedTabsChatControllerOptions = {}) => {
+  const { language, t } = useI18n()
+  const [settings, setSettings] = useState<UserSettings | null>(null)
+  const [isFloatingOpen, setIsFloatingOpen] = useState(
+    defaultOpen || mode === 'page',
+  )
+  const { cardStyle, handleResizeStart, isCompactLayout, isResizing } =
+    useChatSidebarResize({ mode })
+  const [input, setInput] = useState('')
+  const [messages, setMessages] = useReducer(
+    (_state: ChatMessage[], nextMessages: ChatMessage[]) => nextMessages,
+    initialMessages,
+  )
+  const { copyConversation, isConversationCopied } = useConversationClipboard({
+    messages,
+    t,
+  })
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState('')
+  const [chatOllamaError, setChatOllamaError] = useState<
+    OllamaErrorDetails | undefined
+  >(undefined)
+  const activePortRef = useRef<{ disconnect: () => void } | null>(null)
+  const conversationGenerationRef = useRef(0)
+  const ignoreNextDisconnectRef = useRef(false)
+  const messagesRef = useRef<ChatMessage[]>(initialMessages)
+  const syncedConversationIdRef = useRef<string | undefined>(conversationId)
+  const isOpen = mode === 'page' || isFloatingOpen
+
+  const releaseChatWidgetResources = useCallback(() => {
+    activePortRef.current?.disconnect()
+    activePortRef.current = null
+  }, [])
+
+  useEffect(() => {
+    const shouldSyncExternalConversation =
+      typeof conversationId === 'string' || mode === 'page'
+
+    if (!shouldSyncExternalConversation) {
+      return
+    }
+
+    if (
+      syncedConversationIdRef.current === conversationId &&
+      areMessagesEquivalent(initialMessages, messagesRef.current)
+    ) {
+      return
+    }
+
+    syncExternalConversationState({
+      conversationId,
+      initialMessages,
+      messagesRef,
+      setChatOllamaError,
+      setErrorMessage,
+      setInput,
+      setIsSubmitting,
+      setMessages,
+      syncedConversationIdRef,
+    })
+  }, [conversationId, initialMessages, mode])
+
+  useEffect(() => {
+    let isMounted = true
+
+    void loadWidgetSettings().then((nextSettings) => {
+      if (isMounted) {
+        setSettings(nextSettings)
+      }
+    })
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  useEffect(() => releaseChatWidgetResources, [releaseChatWidgetResources])
+
+  useEffect(() => {
+    const storageChangeListener = (
+      changes: Partial<Record<string, chrome.storage.StorageChange>>,
+      areaName: string,
+    ) => {
+      if (areaName !== 'local' || !changes.userSettings) {
+        return
+      }
+
+      setSettings(
+        fromStorageChange(UserSettingsSchema, changes.userSettings.newValue),
+      )
+    }
+
+    const storageOnChanged = getChromeStorageOnChanged()
+    if (!storageOnChanged) {
+      warnMissingChromeStorage('AI chat settings change watcher')
+      return undefined
+    }
+
+    storageOnChanged.addListener(storageChangeListener)
+    return () => {
+      storageOnChanged.removeListener(storageChangeListener)
+    }
+  }, [])
+
+  const resolvedSettings = getResolvedSettings(settings)
+  const activeSystemPrompt = getActiveAiSystemPrompt(resolvedSettings)
+  const isConfigured = isAiChatConfigured(resolvedSettings)
+
+  const setMessagesState = (nextMessages: ChatMessage[]) => {
+    messagesRef.current = nextMessages
+    setMessages(nextMessages)
+  }
+
+  const updateMessageList = (
+    update: (currentMessages: ChatMessage[]) => ChatMessage[],
+    options?: { commit?: boolean },
+  ): ChatMessage[] => {
+    const nextMessages = update(messagesRef.current)
+    setMessagesState(nextMessages)
+    if (options?.commit) {
+      onMessagesChange?.(nextMessages)
+    }
+    return nextMessages
+  }
+
+  const replaceMessage = (
+    messageId: string,
+    nextMessage: Partial<ChatMessage>,
+    options?: { commit?: boolean },
+  ) =>
+    updateMessageList(
+      (currentMessages) =>
+        currentMessages.map((message) =>
+          message.id === messageId ? { ...message, ...nextMessage } : message,
+        ),
+      options,
+    )
+
+  const removeMessage = (messageId: string, options?: { commit?: boolean }) =>
+    updateMessageList(
+      (currentMessages) =>
+        currentMessages.filter((message) => message.id !== messageId),
+      options,
+    )
+
+  const disconnectActivePort = useCallback(
+    (suppressDisconnectError = false) => {
+      const activePort = activePortRef.current
+      if (!activePort) {
+        return
+      }
+      if (suppressDisconnectError) {
+        ignoreNextDisconnectRef.current = true
+      }
+      activePortRef.current = null
+      activePort.disconnect()
+    },
+    [],
+  )
+
+  const resetConversation = useCallback(() => {
+    conversationGenerationRef.current += 1
+    disconnectActivePort(true)
+    setMessagesState([])
+    setInput('')
+    setErrorMessage('')
+    setChatOllamaError(undefined)
+    setIsSubmitting(false)
+  }, [disconnectActivePort])
+
+  const {
+    isLoadingModels,
+    isSavingModel,
+    modelOptions,
+    platform,
+    requestModels,
+    selectModel,
+    setupErrorMessage,
+    setupOllamaError,
+  } = useOllamaModelSettings({
+    onSettingsSaved: setSettings,
+    settings: resolvedSettings,
+    t,
+  })
+
+  const createConversation = useCallback(() => {
+    if (onCreateConversation) {
+      onCreateConversation()
+      return
+    }
+    resetConversation()
+  }, [onCreateConversation, resetConversation])
+
+  const selectSystemPrompt = useCallback(
+    async (promptId: string) => {
+      if (!promptId || promptId === resolvedSettings.activeAiSystemPromptId) {
+        return
+      }
+      const nextSettings = normalizeAiSystemPromptSettings({
+        ...resolvedSettings,
+        activeAiSystemPromptId: promptId,
+      })
+      try {
+        await saveUserSettings(nextSettings)
+        setSettings(nextSettings)
+        resetConversation()
+      } catch {
+        setChatOllamaError(undefined)
+        setErrorMessage(t('aiChat.systemPrompt.switchSaveError'))
+      }
+    },
+    [resetConversation, resolvedSettings, t],
+  )
+
+  const promptManager = useChatPromptManager({
+    resolvedSettings,
+    activeSystemPrompt,
+    language,
+    t,
+    handleResetConversation: resetConversation,
+    onSettingsChange: setSettings,
+  })
+  const { submitPrompt, handleSubmit } = useChatStreamHandlers({
+    messages,
+    activePortRef,
+    conversationGenerationRef,
+    ignoreNextDisconnectRef,
+    disconnectActivePort,
+    replaceMessage,
+    removeMessage,
+    updateMessageList,
+    setInput,
+    setErrorMessage,
+    setChatOllamaError,
+    setIsSubmitting,
+    isConfigured,
+    isSubmitting,
+    t,
+    language,
+  })
+
+  const close = useCallback(() => {
+    setIsFloatingOpen(false)
+    onOpenChange?.(false)
+  }, [onOpenChange])
+  const open = useCallback(() => {
+    setIsFloatingOpen(true)
+    onOpenChange?.(true)
+  }, [onOpenChange])
+
+  return {
+    actions: {
+      handleClose: close,
+      handleCopyConversation: () => void copyConversation(),
+      handleCreateConversation: createConversation,
+      handleFetchModels: () => void requestModels(),
+      handleInputChange: setInput,
+      handleOpen: open,
+      handleOpenSystemPromptManager:
+        promptManager.handleOpenSystemPromptManager,
+      handleResizeStart,
+      handleSelectModel: selectModel,
+      handleSelectSuggestion: (value: string) => void submitPrompt(value),
+      handleSelectSystemPrompt: (promptId: string) =>
+        void selectSystemPrompt(promptId),
+      handleSubmit,
+    },
+    dialog: {
+      activePromptId: promptManager.draftActivePromptId,
+      errorMessage: promptManager.promptManagerDisplayError,
+      isOpen: promptManager.isPromptManagerOpen,
+      isSaveDisabled: promptManager.isPromptManagerSaveDisabled,
+      isSaving: promptManager.isSavingPrompts,
+      onCancel: promptManager.handleCancelSystemPromptManager,
+      onChangePromptName: promptManager.handleChangePromptName,
+      onChangePromptTemplate: promptManager.handleChangePromptTemplate,
+      onCloseChange: promptManager.handlePromptManagerOpenChange,
+      onCreatePrompt: promptManager.handleCreatePrompt,
+      onDeletePrompt: promptManager.handleDeletePrompt,
+      onDuplicatePrompt: promptManager.handleDuplicatePrompt,
+      onSave: promptManager.handleSavePromptManager,
+      onSelectPrompt: (promptId: string) => {
+        promptManager.setPromptManagerError('')
+        promptManager.setSelectedPromptIdInModal(promptId)
+      },
+      presets: promptManager.promptDrafts,
+      selectedPromptId: promptManager.selectedPromptIdInModal,
+    },
+    errors: {
+      chatMessage: errorMessage,
+      chatOllama: chatOllamaError,
+      setupMessage: setupErrorMessage,
+      setupOllama: setupOllamaError,
+    },
+    history: {
+      items: historyItems,
+      handleDeleteItem: onDeleteHistoryItem,
+      handleSelectItem: onSelectHistoryItem,
+      handleToggle: onToggleHistory,
+      variant: historyVariant,
+    },
+    launcher: {
+      isVisible: mode === 'floating' && !isOpen,
+      label: t('aiChat.open'),
+      handleOpen: open,
+    },
+    layout: {
+      cardStyle,
+      isCompactLayout,
+      isOpen,
+      isResizing,
+      mode,
+      showCloseButton: mode === 'floating',
+    },
+    messages: {
+      input,
+      items: messages,
+    },
+    settings: {
+      activeSystemPromptId: resolvedSettings.activeAiSystemPromptId ?? '',
+      modelName: resolvedSettings.ollamaModel,
+      modelOptions,
+      platform,
+      systemPrompts: resolvedSettings.aiSystemPrompts ?? [],
+    },
+    status: {
+      isConfigured,
+      isConversationCopied,
+      isCopyDisabled: messages.every(
+        (message) => message.content.trim().length === 0,
+      ),
+      isLoadingModels,
+      isOpen,
+      isSavingModel,
+      isSubmitting,
+    },
+    title: title ?? t('aiChat.chatTitle'),
+  }
+}
+
+export { useSavedTabsChatController }
+export type { SavedTabsChatControllerOptions }


### PR DESCRIPTION
## 変更内容

- `SavedTabsChatWidget` を67行の composition componentへ縮小し、状態・storage同期・streaming lifecycleを `useSavedTabsChatController` へ移動
- resize、会話コピー、Ollama model設定を専用hookへ分離し、Header／Composer／Panelをview-only component化
- conversation切替、reset、unmount時のgeneration／runtime port raceを回帰テスト付きで修正
- 設計書とTDD実装計画を追加

## ローカル検証

- [x] `bun run format`
- [x] `bun run compile`
- [x] `bun run lint`
- [x] `bun run test:dom`（130 files / 901 tests）
- [x] `bun run test`（307 files / 3317 tests）
- [x] `bun run test:coverage`（全指標がclean develop以上）
- [x] React Doctor changed scope: no issues
- [x] `bun run check:duplication`
- [x] `bun run secretlint`
- [x] `bun run arch:check`
- [ ] `bun run quality`（Knipがsandboxのlocalhost port制限で停止。CIで確認するためdraft）

closes #654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed Saved Tabs AI chat experience with dedicated header, conversation panel, and prompt composer.
  * Added conversation history controls, deletion confirmation, system prompt selection, copy-to-clipboard, and new conversation actions.
  * Added floating sidebar resizing with saved width preferences.
  * Added Ollama model discovery, selection, and setup feedback.

* **Bug Fixes**
  * Preserved active conversations and draft input when switching models.
  * Improved handling of interrupted or outdated streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->