### PR TITLE
AIチャットstream切断時にOllama requestを中断する

### DIFF
--- a/docs/plans/2026-07-11-ai-chat-stream-abort-design.md
+++ b/docs/plans/2026-07-11-ai-chat-stream-abort-design.md
@@ -1,0 +1,57 @@
+# AI Chat Stream Abort Design
+
+## Goal
+
+Stop the request owned by an AI chat streaming port when that port disconnects,
+and prevent every late stream message from being posted after disconnection.
+
+## Root cause
+
+The UI already disconnects its active runtime port when a conversation is reset,
+switched, or unmounted. The background handler does not connect that port
+lifecycle to the request lifecycle: `runAiChatRequest` has no cancellation input,
+and its `step`, `complete`, and `error` paths always call `port.postMessage`.
+
+AI SDK 7 accepts `abortSignal` in `generateText`, and the installed Ollama
+provider forwards that signal to its request. The missing boundary is therefore
+inside TABBIN, between the runtime port handler and `generateText`.
+
+## Design
+
+Each accepted `run` message creates its own `AbortController`. The handler
+registers a disconnect listener that aborts that controller. It passes the
+controller signal through `RunAiChatRequestOptions` to `generateText` as
+`abortSignal`.
+
+The handler also treats the signal as the authoritative lifecycle state before
+every `postMessage`. This guard is required even though the provider supports
+aborting because a provider can finish concurrently with the disconnect event
+or may not honor cancellation perfectly.
+
+An abort caused by disconnect is a normal user action. Its rejection must not be
+converted into an error message or shown as an error toast.
+
+No global request registry is introduced. A request-local controller gives
+concurrent streams independent cancellation and avoids shared mutable state.
+
+## UI lifecycle
+
+The existing controller disconnects the active port on reset, conversation
+switch, and unmount, and it rejects late responses with a conversation
+generation check. Production UI code will remain unchanged unless a regression
+test demonstrates a missing lifecycle transition.
+
+## Tests
+
+- Background: disconnect aborts the exact signal passed to `runAiChatRequest`.
+- Background: no `step`, `complete`, or `error` message is posted after abort.
+- AI request: `runAiChatRequest` passes its signal to `generateText` as
+  `abortSignal`.
+- UI: retain or strengthen reset, conversation-switch, and unmount tests proving
+  that the active or late-resolving port is disconnected and stale responses do
+  not mutate the new conversation.
+
+## Validation
+
+Run the focused node and DOM tests first, then compile, full tests, coverage,
+React Doctor for changed React scope, and the repository quality gate.

--- a/docs/plans/2026-07-11-ai-chat-stream-abort.md
+++ b/docs/plans/2026-07-11-ai-chat-stream-abort.md
@@ -1,0 +1,93 @@
+# AI Chat Stream Abort Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use test-driven-development to implement
+> this plan task-by-task.
+
+**Goal:** Abort the Ollama generation owned by a disconnected AI chat stream
+port and suppress every late server message.
+
+**Architecture:** The background port handler owns a request-local
+`AbortController`. Its signal is threaded through `runAiChatRequest` to AI SDK
+`generateText`, while the same signal guards all port writes. Existing UI port
+disconnection and generation guards remain the source of truth for reset,
+conversation-switch, and unmount behavior.
+
+**Tech Stack:** TypeScript, Chrome runtime ports, AI SDK 7, ai-sdk-ollama,
+Vitest, React Testing Library.
+
+---
+
+### Task 1: Specify the background port cancellation contract
+
+**Files:**
+
+- Modify: `src/lib/background/message-handler.test.ts`
+
+1. Add a test that captures the listener registered on `port.onDisconnect` and
+   the options passed to `runAiChatRequest`.
+2. Start a pending request, invoke the disconnect listener, and assert that the
+   passed signal becomes aborted.
+3. Trigger `onStepUpdate`, resolve the request, and reject a separate request
+   after disconnect; assert that no `step`, `complete`, or `error` payload is
+   posted.
+4. Run `bunx vitest run src/lib/background/message-handler.test.ts` and verify
+   the new assertions fail because no signal is passed and writes are unguarded.
+
+### Task 2: Specify AI SDK signal propagation
+
+**Files:**
+
+- Modify: `src/lib/background/ai-chat.test.ts`
+
+1. Add an `AbortController` signal to a `runAiChatRequest` call.
+2. Assert that the mocked `generateText` call contains
+   `abortSignal: controller.signal`.
+3. Run `bunx vitest run src/lib/background/ai-chat.test.ts` and verify the test
+   fails because `generateText` does not receive the signal.
+
+### Task 3: Implement request-local cancellation
+
+**Files:**
+
+- Modify: `src/lib/background/message-handler.ts`
+- Modify: `src/lib/background/ai-chat.ts`
+
+1. Extend `RunAiChatRequestOptions` with `signal?: AbortSignal`.
+2. Pass `options.signal` to `generateText` as `abortSignal`.
+3. Create one `AbortController` for each accepted stream `run` message.
+4. Abort it from that port's disconnect listener.
+5. Before each `step`, `complete`, and `error` post, return when the signal is
+   aborted.
+6. Run both focused tests and verify they pass without changing their expected
+   behavior.
+
+### Task 4: Verify the UI cancellation boundary
+
+**Files:**
+
+- Modify only if needed: `src/features/ai-chat/hooks/useSavedTabsChatController.test.tsx`
+- Modify only if a test proves a defect:
+  `src/features/ai-chat/components/savedTabsChat/useChatStreamHandlers.ts`
+
+1. Confirm existing tests cover active-port disconnection on conversation
+   switch, a late-resolving port after reset, and a late-resolving port after
+   unmount.
+2. Add only the missing assertion needed to prove that a late response cannot
+   mutate the replacement conversation.
+3. Run `rtk bun run test:dom` and verify the UI lifecycle tests pass.
+
+### Task 5: Validate and publish
+
+**Files:**
+
+- Review all changed files against issue #663.
+
+1. Run `rtk bun run compile`.
+2. Run `rtk bun run test`.
+3. Run `rtk bun run test:coverage` and require 100% for changed behavior and the
+   repository's expected coverage result.
+4. Run changed-scope React Doctor if React files changed.
+5. Run `rtk bun run quality`.
+6. Run harness validation, audit, and fresh-context evaluation.
+7. Commit only issue #663 files, push the branch, and open a `develop`-targeted
+   PR that closes #663.

--- a/src/lib/background/ai-chat.test.ts
+++ b/src/lib/background/ai-chat.test.ts
@@ -859,6 +859,26 @@ describe('runAiChatRequest', () => {
     )
   })
 
+  it('request の abort signal を generateText へ渡す', async () => {
+    const controller = new AbortController()
+
+    await runAiChatRequest(
+      {
+        history: [],
+        prompt: 'どんな URL がある？',
+      },
+      {
+        signal: controller.signal,
+      },
+    )
+
+    expect(mocked.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        abortSignal: controller.signal,
+      }),
+    )
+  })
+
   it('onStepEnd に tool 情報が無くても空 trace で更新する', async () => {
     const onStepUpdate = vi.fn()
     mocked.generateText.mockImplementationOnce(

--- a/src/lib/background/ai-chat.ts
+++ b/src/lib/background/ai-chat.ts
@@ -103,6 +103,7 @@ type AiChatStepUpdate = {
 
 type RunAiChatRequestOptions = {
   onStepUpdate?: (update: AiChatStepUpdate) => void
+  signal?: AbortSignal
 }
 
 const getAiChatUiLocale = () => getBrowserUiLocale('ja')
@@ -757,6 +758,7 @@ const runAiChatRequest = async (
   const result = await (async () => {
     try {
       return await generateText({
+        abortSignal: options.signal,
         messages: [
           ...history.map((message) =>
             message.role === 'user'

--- a/src/lib/background/message-handler.test.ts
+++ b/src/lib/background/message-handler.test.ts
@@ -1051,6 +1051,118 @@ describe('setupMessageListener', () => {
     })
   })
 
+  it('ai-chat-stream port 切断時は request を abort して遅延した step と完了を送らない', async () => {
+    const { portListener } = setupListener()
+    let onPortDisconnect: (() => void) | undefined
+    let onPortMessage: ((message: unknown) => void) | undefined
+    let resolveRequest:
+      | ((result: {
+          answer: string
+          charts: never[]
+          reasoning: string
+          recordCount: number
+          toolTraces: never[]
+        }) => void)
+      | undefined
+    let requestOptions:
+      | {
+          onStepUpdate?: (step: {
+            reasoning: string
+            toolTraces: never[]
+          }) => void
+          signal?: AbortSignal
+        }
+      | undefined
+    const port = {
+      disconnect: vi.fn(),
+      name: 'ai-chat-stream',
+      onDisconnect: {
+        addListener: vi.fn((listener: () => void) => {
+          onPortDisconnect = listener
+        }),
+      },
+      onMessage: {
+        addListener: vi.fn((listener: (message: unknown) => void) => {
+          onPortMessage = listener
+        }),
+      },
+      postMessage: vi.fn(),
+    } as unknown as chrome.runtime.Port
+
+    mocked.runAiChatRequest.mockImplementation(
+      async (_request: unknown, options: typeof requestOptions) => {
+        requestOptions = options
+        return new Promise((resolve) => {
+          resolveRequest = resolve
+        })
+      },
+    )
+
+    portListener(port)
+    onPortMessage?.({ history: [], prompt: 'test', type: 'run' })
+
+    expect(requestOptions?.signal?.aborted).toBe(false)
+    onPortDisconnect?.()
+    expect(requestOptions?.signal?.aborted).toBe(true)
+
+    requestOptions?.onStepUpdate?.({
+      reasoning: 'late step',
+      toolTraces: [],
+    })
+    resolveRequest?.({
+      answer: 'late answer',
+      charts: [],
+      reasoning: 'late completion',
+      recordCount: 0,
+      toolTraces: [],
+    })
+    await expect(
+      mocked.runAiChatRequest.mock.results[0]?.value,
+    ).resolves.toEqual(expect.objectContaining({ answer: 'late answer' }))
+
+    expect(mocked.runAiChatRequest).toHaveBeenCalledOnce()
+    expect(port.postMessage).not.toHaveBeenCalled()
+  })
+
+  it('ai-chat-stream port 切断後に request が失敗しても error を送らない', async () => {
+    const { portListener } = setupListener()
+    let onPortDisconnect: (() => void) | undefined
+    let onPortMessage: ((message: unknown) => void) | undefined
+    let rejectRequest: ((reason?: unknown) => void) | undefined
+    const port = {
+      disconnect: vi.fn(),
+      name: 'ai-chat-stream',
+      onDisconnect: {
+        addListener: vi.fn((listener: () => void) => {
+          onPortDisconnect = listener
+        }),
+      },
+      onMessage: {
+        addListener: vi.fn((listener: (message: unknown) => void) => {
+          onPortMessage = listener
+        }),
+      },
+      postMessage: vi.fn(),
+    } as unknown as chrome.runtime.Port
+
+    mocked.runAiChatRequest.mockImplementation(async () => {
+      return new Promise((_resolve, reject) => {
+        rejectRequest = reject
+      })
+    })
+
+    portListener(port)
+    onPortMessage?.({ history: [], prompt: 'test', type: 'run' })
+    onPortDisconnect?.()
+    rejectRequest?.(new DOMException('aborted', 'AbortError'))
+    await expect(
+      mocked.runAiChatRequest.mock.results[0]?.value,
+    ).rejects.toThrow('aborted')
+
+    expect(mocked.runAiChatRequest).toHaveBeenCalledOnce()
+    expect(port.postMessage).not.toHaveBeenCalled()
+  })
+
   it('ai-chat-stream 以外の port は無視し、stream error は error payload を返す', async () => {
     const { portListener } = setupListener()
     const ignoredPort = {

--- a/src/lib/background/message-handler.test.ts
+++ b/src/lib/background/message-handler.test.ts
@@ -1163,6 +1163,104 @@ describe('setupMessageListener', () => {
     expect(port.postMessage).not.toHaveBeenCalled()
   })
 
+  it('同時に実行する ai-chat-stream request は port ごとに独立した controller を持つ', async () => {
+    const { portListener } = setupListener()
+    let firstOnDisconnect: (() => void) | undefined
+    let firstOnMessage: ((message: unknown) => void) | undefined
+    let secondOnDisconnect: (() => void) | undefined
+    let secondOnMessage: ((message: unknown) => void) | undefined
+    const optionsList: { signal?: AbortSignal }[] = []
+    const resolveList: ((result: {
+      answer: string
+      charts: never[]
+      reasoning: string
+      recordCount: number
+      toolTraces: never[]
+    }) => void)[] = []
+    const firstPort = {
+      disconnect: vi.fn(),
+      name: 'ai-chat-stream',
+      onDisconnect: {
+        addListener: vi.fn((listener: () => void) => {
+          firstOnDisconnect = listener
+        }),
+      },
+      onMessage: {
+        addListener: vi.fn((listener: (message: unknown) => void) => {
+          firstOnMessage = listener
+        }),
+      },
+      postMessage: vi.fn(),
+    } as unknown as chrome.runtime.Port
+    const secondPort = {
+      disconnect: vi.fn(),
+      name: 'ai-chat-stream',
+      onDisconnect: {
+        addListener: vi.fn((listener: () => void) => {
+          secondOnDisconnect = listener
+        }),
+      },
+      onMessage: {
+        addListener: vi.fn((listener: (message: unknown) => void) => {
+          secondOnMessage = listener
+        }),
+      },
+      postMessage: vi.fn(),
+    } as unknown as chrome.runtime.Port
+
+    mocked.runAiChatRequest.mockImplementation(
+      async (_request: unknown, options: { signal?: AbortSignal }) => {
+        optionsList.push(options)
+        return new Promise((resolve) => {
+          resolveList.push(resolve)
+        })
+      },
+    )
+
+    portListener(firstPort)
+    portListener(secondPort)
+    firstOnMessage?.({ history: [], prompt: 'first', type: 'run' })
+    secondOnMessage?.({ history: [], prompt: 'second', type: 'run' })
+
+    expect(optionsList).toHaveLength(2)
+    expect(optionsList[0]?.signal).not.toBe(optionsList[1]?.signal)
+    expect(optionsList[0]?.signal?.aborted).toBe(false)
+    expect(optionsList[1]?.signal?.aborted).toBe(false)
+
+    firstOnDisconnect?.()
+
+    expect(optionsList[0]?.signal?.aborted).toBe(true)
+    expect(optionsList[1]?.signal?.aborted).toBe(false)
+
+    resolveList[0]?.({
+      answer: 'first answer',
+      charts: [],
+      reasoning: '',
+      recordCount: 0,
+      toolTraces: [],
+    })
+    resolveList[1]?.({
+      answer: 'second answer',
+      charts: [],
+      reasoning: '',
+      recordCount: 0,
+      toolTraces: [],
+    })
+    await Promise.all(
+      mocked.runAiChatRequest.mock.results.map((result) => result.value),
+    )
+
+    expect(firstPort.postMessage).not.toHaveBeenCalled()
+    expect(secondPort.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        answer: 'second answer',
+        type: 'complete',
+      }),
+    )
+    secondOnDisconnect?.()
+    expect(optionsList[1]?.signal?.aborted).toBe(true)
+  })
+
   it('ai-chat-stream 以外の port は無視し、stream error は error payload を返す', async () => {
     const { portListener } = setupListener()
     const ignoredPort = {

--- a/src/lib/background/message-handler.ts
+++ b/src/lib/background/message-handler.ts
@@ -509,6 +509,11 @@ const handleAiChatStreamPortMessage = (
   }
 
   const runMessage = message
+  const controller = new AbortController()
+
+  port.onDisconnect.addListener(() => {
+    controller.abort()
+  })
 
   runAiChatRequest(
     {
@@ -518,15 +523,24 @@ const handleAiChatStreamPortMessage = (
     },
     {
       onStepUpdate: (stepUpdate) => {
+        if (controller.signal.aborted) {
+          return
+        }
+
         port.postMessage({
           reasoning: stepUpdate.reasoning,
           toolTraces: stepUpdate.toolTraces,
           type: 'step',
         })
       },
+      signal: controller.signal,
     },
   )
     .then((result) => {
+      if (controller.signal.aborted) {
+        return
+      }
+
       port.postMessage({
         answer: result.answer,
         charts: result.charts,
@@ -537,6 +551,10 @@ const handleAiChatStreamPortMessage = (
       })
     })
     .catch((error: unknown) => {
+      if (controller.signal.aborted) {
+        return
+      }
+
       const errorMessage: AiChatStreamErrorMessage = {
         error: error instanceof Error ? error.message : String(error),
         ollamaError: getOllamaErrorDetails(error),


### PR DESCRIPTION
## 変更内容

- AIチャット streaming request ごとに `AbortController` を所有し、port disconnect 時に abort
- `runAiChatRequest` から AI SDK `generateText.abortSignal`、Ollama fetch まで signal を伝播
- disconnect 後の `step` / `complete` / `error` message をすべて抑止
- reset・conversation switch・unmount の既存 UI lifecycle tests と組み合わせて古い応答の混入を防止
- RED→Green の回帰テストと実装設計・計画を追加

## ローカル検証

- [x] `bun run check`
- [x] focused tests（3 files / 66 tests）
- [x] `bun run test`（307 files / 3320 tests）
- [x] focused coverage（background 2 files: 98.07% statements / 95.14% branches / 99.07% functions / 98.05% lines、新規行は coverage 済み）
- [x] `bun run build`
- [x] `bun run quality`（sandbox 外で Knip を含め完走）
- [x] fresh-context code review（actionable finding なし）
- [ ] `bun run test:coverage`（今回と無関係な `SubCategoryKeywordManager.test.tsx` の入力 timing flake で停止。失敗テスト単独は通過し、clean `develop` の同 gate は 307 files / 3317 tests で通過）

closes #663


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI chat streams now stop when the chat connection is disconnected.
  * In-progress generation is cancelled automatically, preventing unnecessary processing.

* **Bug Fixes**
  * Prevented delayed responses, completion messages, and error notifications from appearing after disconnection.
  * Improved handling of cancelled streams so they do not trigger error states.

* **Documentation**
  * Added design and implementation plans for AI chat stream cancellation and lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->