### PR TITLE
Chrome API の直接利用を entrypoint / infrastructure / adapter に限定する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -614,69 +614,52 @@
       }
     },
     {
-      "files": [
-        "**/*.test.ts",
-        "**/*.test.tsx",
-        "**/*.spec.ts",
-        "**/*.spec.tsx",
-        "**/testing/**",
-        "src/test/**"
-      ],
+      "files": ["src/features/**/*.{ts,tsx}", "src/components/**/*.{ts,tsx}"],
       "rules": {
-        "typescript/no-unsafe-assignment": "off",
-        "typescript/no-unsafe-call": "off",
-        "typescript/no-unsafe-member-access": "off",
-        "typescript/no-unsafe-argument": "off",
-        "typescript/no-unsafe-return": "off",
-        "typescript/no-unsafe-type-assertion": "off",
-        "typescript/consistent-type-assertions": "off",
-        "typescript/no-unnecessary-condition": "off",
-        "eslint/no-magic-numbers": "off",
-        "eslint/no-restricted-globals": "off",
-        "eslint/no-restricted-properties": "off",
-        "eslint/max-lines": [
+        "eslint/no-restricted-globals": [
           "error",
           {
-            "max": 5000,
-            "skipBlankLines": true,
-            "skipComments": true
+            "name": "chrome",
+            "message": "features / components 層は chrome.* を直接利用できません（adapter / infrastructure / repository 経由）"
+          },
+          {
+            "name": "browser",
+            "message": "features / components 層は browser.* を直接利用できません（adapter / infrastructure / repository 経由）"
           }
         ],
-        "eslint/max-lines-per-function": [
+        "eslint/no-restricted-properties": [
           "error",
           {
-            "max": 2000,
-            "skipBlankLines": true,
-            "skipComments": true
+            "object": "chrome",
+            "property": "tabs",
+            "message": "features / components 層は chrome.tabs を直接利用できません（BrowserTabPort / adapter 経由）"
+          },
+          {
+            "object": "chrome",
+            "property": "storage",
+            "message": "features / components 層は chrome.storage を直接利用できません（StorageRepository / adapter 経由）"
+          },
+          {
+            "object": "chrome",
+            "property": "runtime",
+            "message": "features / components 層は chrome.runtime を直接利用できません（RuntimeMessageClient / adapter 経由）"
+          },
+          {
+            "object": "chrome",
+            "property": "contextMenus",
+            "message": "features / components 層は chrome.contextMenus を直接利用できません（ContextMenuAdapter 経由）"
+          },
+          {
+            "object": "chrome",
+            "property": "notifications",
+            "message": "features / components 層は chrome.notifications を直接利用できません（NotificationAdapter 経由）"
+          },
+          {
+            "object": "chrome",
+            "property": "alarms",
+            "message": "features / components 層は chrome.alarms を直接利用できません（AlarmAdapter 経由）"
           }
-        ],
-        "eslint/max-statements": ["error", 200],
-        "eslint/complexity": ["error", 20],
-        "eslint/max-depth": ["error", 5],
-        "eslint/max-params": "off",
-        "import/first": "off",
-        "eslint/max-nested-callbacks": "off",
-        "typescript/await-thenable": "off",
-        "typescript/no-confusing-void-expression": "off",
-        "typescript/non-nullable-type-assertion-style": "off",
-        "typescript/no-unnecessary-type-assertion": "off",
-        "oxc/no-map-spread": "off",
-        "import/no-unassigned-import": "off",
-        "unicorn/no-abusive-eslint-disable": "off",
-        "react-perf/jsx-no-jsx-as-prop": "off",
-        "react-perf/jsx-no-new-array-as-prop": "off",
-        "react-perf/jsx-no-new-function-as-prop": "off",
-        "react-perf/jsx-no-new-object-as-prop": "off",
-        "react/jsx-max-depth": "off",
-        "react/only-export-components": "off",
-        "typescript/require-await": "off",
-        "typescript/unbound-method": "off",
-        "react/jsx-no-useless-fragment": "off",
-        "vitest/prefer-strict-equal": "off",
-        "vitest/consistent-test-it": "off",
-        "vitest/prefer-expect-resolves": "off",
-        "vitest/require-top-level-describe": "off",
-        "typescript/no-dynamic-delete": "off"
+        ]
       }
     },
     {
@@ -753,6 +736,10 @@
           {
             "name": "chrome",
             "message": "domain 層は chrome.* を直接利用できません（adapter / port 経由）"
+          },
+          {
+            "name": "browser",
+            "message": "domain 層は browser.* を直接利用できません（adapter / port 経由）"
           },
           {
             "name": "localStorage",
@@ -852,6 +839,11 @@
             "message": "application 層は chrome.notifications を直接利用できません（NotificationPort 経由）"
           },
           {
+            "object": "chrome",
+            "property": "runtime",
+            "message": "application 層は chrome.runtime を直接利用できません（MessagingPort 経由）"
+          },
+          {
             "object": "Date",
             "property": "now",
             "message": "application 層は Date.now() を直接利用できません。ClockPort 経由で時刻を注入してください"
@@ -865,6 +857,17 @@
             "object": "crypto",
             "property": "randomUUID",
             "message": "application 層は crypto.randomUUID() を直接利用できません。IdGeneratorPort 経由で ID を生成してください"
+          }
+        ],
+        "eslint/no-restricted-globals": [
+          "error",
+          {
+            "name": "chrome",
+            "message": "application 層は chrome.* を直接利用できません（adapter / port 経由）"
+          },
+          {
+            "name": "browser",
+            "message": "application 層は browser.* を直接利用できません（adapter / port 経由）"
           }
         ]
       }
@@ -898,6 +901,22 @@
             "object": "chrome",
             "property": "runtime",
             "message": "presentation 層は chrome.runtime を直接利用できません（MessagingPort 経由）"
+          },
+          {
+            "object": "chrome",
+            "property": "notifications",
+            "message": "presentation 層は chrome.notifications を直接利用できません（NotificationPort 経由）"
+          }
+        ],
+        "eslint/no-restricted-globals": [
+          "error",
+          {
+            "name": "chrome",
+            "message": "presentation 層は chrome.* を直接利用できません（adapter / port 経由）"
+          },
+          {
+            "name": "browser",
+            "message": "presentation 層は browser.* を直接利用できません（adapter / port 経由）"
           }
         ]
       }
@@ -1005,6 +1024,72 @@
       "files": ["src/**/*.d.ts"],
       "rules": {
         "typescript/consistent-type-definitions": "off"
+      }
+    },
+    {
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.spec.tsx",
+        "**/testing/**",
+        "src/test/**"
+      ],
+      "rules": {
+        "typescript/no-unsafe-assignment": "off",
+        "typescript/no-unsafe-call": "off",
+        "typescript/no-unsafe-member-access": "off",
+        "typescript/no-unsafe-argument": "off",
+        "typescript/no-unsafe-return": "off",
+        "typescript/no-unsafe-type-assertion": "off",
+        "typescript/consistent-type-assertions": "off",
+        "typescript/no-unnecessary-condition": "off",
+        "eslint/no-magic-numbers": "off",
+        "eslint/no-restricted-globals": "off",
+        "eslint/no-restricted-properties": "off",
+        "eslint/max-lines": [
+          "error",
+          {
+            "max": 5000,
+            "skipBlankLines": true,
+            "skipComments": true
+          }
+        ],
+        "eslint/max-lines-per-function": [
+          "error",
+          {
+            "max": 2000,
+            "skipBlankLines": true,
+            "skipComments": true
+          }
+        ],
+        "eslint/max-statements": ["error", 200],
+        "eslint/complexity": ["error", 20],
+        "eslint/max-depth": ["error", 5],
+        "eslint/max-params": "off",
+        "import/first": "off",
+        "eslint/max-nested-callbacks": "off",
+        "typescript/await-thenable": "off",
+        "typescript/no-confusing-void-expression": "off",
+        "typescript/non-nullable-type-assertion-style": "off",
+        "typescript/no-unnecessary-type-assertion": "off",
+        "oxc/no-map-spread": "off",
+        "import/no-unassigned-import": "off",
+        "unicorn/no-abusive-eslint-disable": "off",
+        "react-perf/jsx-no-jsx-as-prop": "off",
+        "react-perf/jsx-no-new-array-as-prop": "off",
+        "react-perf/jsx-no-new-function-as-prop": "off",
+        "react-perf/jsx-no-new-object-as-prop": "off",
+        "react/jsx-max-depth": "off",
+        "react/only-export-components": "off",
+        "typescript/require-await": "off",
+        "typescript/unbound-method": "off",
+        "react/jsx-no-useless-fragment": "off",
+        "vitest/prefer-strict-equal": "off",
+        "vitest/consistent-test-it": "off",
+        "vitest/prefer-expect-resolves": "off",
+        "vitest/require-top-level-describe": "off",
+        "typescript/no-dynamic-delete": "off"
       }
     }
   ]

--- a/src/app/composition/createSavedTabsPorts.ts
+++ b/src/app/composition/createSavedTabsPorts.ts
@@ -11,7 +11,7 @@ import type { ChromeApiLike as ChromeMessagingApiLike } from '@/contexts/saved-t
 import { createChromeStorageChangeAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter'
 import { createSonnerNotificationAdapter } from '@/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter'
 import { getChromeGlobal, isObjectLike } from '@/lib/browser/chrome-global'
-import type { StorageChange } from '@/lib/browser/chrome-storage'
+import type { ChromeOnChangedListener } from '@/lib/browser/chrome-storage'
 
 /**
  * `src/app/composition/` レベルで組み立てる、saved-tabs 用
@@ -70,11 +70,6 @@ type ChromeApi = ChromeApiLike & {
     }
   }
 }
-
-type ChromeOnChangedListener = (
-  changes: Record<string, StorageChange>,
-  areaName: string,
-) => void
 
 const isChromeApi = (value: unknown): value is ChromeApi => isObjectLike(value)
 

--- a/src/app/composition/createSavedTabsPorts.ts
+++ b/src/app/composition/createSavedTabsPorts.ts
@@ -11,6 +11,7 @@ import type { ChromeApiLike as ChromeMessagingApiLike } from '@/contexts/saved-t
 import { createChromeStorageChangeAdapter } from '@/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter'
 import { createSonnerNotificationAdapter } from '@/contexts/saved-tabs/infrastructure/browser/SonnerNotificationAdapter'
 import { getChromeGlobal, isObjectLike } from '@/lib/browser/chrome-global'
+import type { StorageChange } from '@/lib/browser/chrome-storage'
 
 /**
  * `src/app/composition/` レベルで組み立てる、saved-tabs 用
@@ -71,7 +72,7 @@ type ChromeApi = ChromeApiLike & {
 }
 
 type ChromeOnChangedListener = (
-  changes: Record<string, chrome.storage.StorageChange>,
+  changes: Record<string, StorageChange>,
   areaName: string,
 ) => void
 

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -9,6 +9,7 @@ import {
 
 import { colorOptions } from '@/constants/colorOptions'
 import { toFontScaleValue } from '@/constants/fontSize'
+import type { StorageChange } from '@/lib/browser/chrome-storage'
 import {
   getChromeStorageLocal,
   getChromeStorageOnChanged,
@@ -97,7 +98,7 @@ export const ThemeProvider = ({
 
     // ストレージの変更を監視
     const handleStorageChange = (
-      changes: Record<string, chrome.storage.StorageChange>,
+      changes: Record<string, StorageChange>,
       areaName: string,
     ) => {
       if (
@@ -165,7 +166,7 @@ export const ThemeProvider = ({
   // ユーザー設定のカラー変更を監視し、即座にCSS変数を更新
   useEffect(() => {
     const listener = (
-      changes: Record<string, chrome.storage.StorageChange>,
+      changes: Record<string, StorageChange>,
       areaName: string,
     ) => {
       if (areaName === 'local' && Object.hasOwn(changes, 'userSettings')) {

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.ts
@@ -51,6 +51,7 @@ import {
   SavedTabRawSchema,
   UserSettingsRawSchema,
 } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageSchema'
+import type { StorageChange } from '@/lib/browser/chrome-storage'
 import { getChromeStorageOnChanged } from '@/lib/browser/chrome-storage'
 import type { CustomProject } from '@/types/storage'
 
@@ -68,7 +69,7 @@ export type ChromeApiLike = {
 }
 
 type ChromeOnChangedListener = (
-  changes: Record<string, chrome.storage.StorageChange>,
+  changes: Record<string, StorageChange>,
   areaName: string,
 ) => void
 

--- a/src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.ts
@@ -51,7 +51,7 @@ import {
   SavedTabRawSchema,
   UserSettingsRawSchema,
 } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageSchema'
-import type { StorageChange } from '@/lib/browser/chrome-storage'
+import type { ChromeOnChangedListener } from '@/lib/browser/chrome-storage'
 import { getChromeStorageOnChanged } from '@/lib/browser/chrome-storage'
 import type { CustomProject } from '@/types/storage'
 
@@ -67,11 +67,6 @@ export type ChromeStorageLike = {
 export type ChromeApiLike = {
   readonly storage?: ChromeStorageLike
 }
-
-type ChromeOnChangedListener = (
-  changes: Record<string, StorageChange>,
-  areaName: string,
-) => void
 
 export type ChromeStorageChangeAdapterDeps = {
   /**

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
@@ -22,7 +22,7 @@ import {
 import { createChromeUrlRecordRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUrlRecordRepository'
 import { createChromeUserSettingsRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUserSettingsRepository'
 import { getChromeGlobal, isObjectLike } from '@/lib/browser/chrome-global'
-import type { StorageChange } from '@/lib/browser/chrome-storage'
+import type { ChromeOnChangedListener } from '@/lib/browser/chrome-storage'
 import {
   getChromeStorageLocal,
   warnMissingChromeStorage,
@@ -70,11 +70,6 @@ type ChromeLike = ChromeApiLikeBase & {
     }
   }
 }
-
-type ChromeOnChangedListener = (
-  changes: Record<string, StorageChange>,
-  areaName: string,
-) => void
 
 const isChromeLike = (value: unknown): value is ChromeLike =>
   isObjectLike(value)

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
@@ -22,6 +22,7 @@ import {
 import { createChromeUrlRecordRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUrlRecordRepository'
 import { createChromeUserSettingsRepository } from '@/contexts/saved-tabs/infrastructure/persistence/chrome-storage/ChromeUserSettingsRepository'
 import { getChromeGlobal, isObjectLike } from '@/lib/browser/chrome-global'
+import type { StorageChange } from '@/lib/browser/chrome-storage'
 import {
   getChromeStorageLocal,
   warnMissingChromeStorage,
@@ -71,7 +72,7 @@ type ChromeLike = ChromeApiLikeBase & {
 }
 
 type ChromeOnChangedListener = (
-  changes: Record<string, chrome.storage.StorageChange>,
+  changes: Record<string, StorageChange>,
   areaName: string,
 ) => void
 

--- a/src/features/ai-chat/components/savedTabsChat/streaming.ts
+++ b/src/features/ai-chat/components/savedTabsChat/streaming.ts
@@ -4,6 +4,7 @@ import type {
   AiChatAttachment,
   AiChatConversationMessage,
 } from '@/features/ai-chat/types'
+import type { PlatformInfo } from '@/lib/browser/runtime'
 import { sendRuntimeMessage } from '@/lib/browser/runtime'
 import type {
   AiChatResponse,
@@ -43,9 +44,7 @@ const getAiChatOllamaError = (
 ): OllamaErrorDetails | undefined => response?.ollamaError
 
 type RuntimePlatformApi = {
-  getPlatformInfo: (
-    callback: (info: chrome.runtime.PlatformInfo) => void,
-  ) => void
+  getPlatformInfo: (callback: (info: PlatformInfo) => void) => void
 }
 
 const getRuntimePlatformApi = (): RuntimePlatformApi | null => {
@@ -78,13 +77,11 @@ const getRuntimePlatform = async (): Promise<OllamaErrorPlatform> => {
   }
 
   try {
-    const platformInfo = await new Promise<chrome.runtime.PlatformInfo | null>(
-      (resolve) => {
-        runtimeApi.getPlatformInfo((info) => {
-          resolve(info)
-        })
-      },
-    )
+    const platformInfo = await new Promise<PlatformInfo | null>((resolve) => {
+      runtimeApi.getPlatformInfo((info) => {
+        resolve(info)
+      })
+    })
 
     return platformInfo?.os === 'mac' || platformInfo?.os === 'win'
       ? platformInfo.os

--- a/src/features/ai-chat/hooks/useSavedTabsChatController.ts
+++ b/src/features/ai-chat/hooks/useSavedTabsChatController.ts
@@ -18,6 +18,7 @@ import {
 } from '@/features/ai-chat/lib/systemPromptPresets'
 import type { AiChatHistoryItem } from '@/features/ai-chat/types'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
+import type { StorageChange } from '@/lib/browser/chrome-storage'
 import {
   getChromeStorageOnChanged,
   warnMissingChromeStorage,
@@ -159,7 +160,7 @@ const useSavedTabsChatController = ({
 
   useEffect(() => {
     const storageChangeListener = (
-      changes: Partial<Record<string, chrome.storage.StorageChange>>,
+      changes: Partial<Record<string, StorageChange>>,
       areaName: string,
     ) => {
       if (areaName !== 'local' || !changes.userSettings) {

--- a/src/features/ai-chat/lib/conversation-history.ts
+++ b/src/features/ai-chat/lib/conversation-history.ts
@@ -11,7 +11,7 @@ import {
 const AI_CHAT_CONVERSATIONS_KEY = 'aiChatConversations'
 const ACTIVE_AI_CHAT_CONVERSATION_ID_KEY = 'activeAiChatConversationId'
 
-type ConversationHistoryState = {
+export type ConversationHistoryState = {
   activeConversationId: string
   conversations: AiChatConversation[]
 }

--- a/src/features/analytics/lib/loadAnalyticsRecords.test.ts
+++ b/src/features/analytics/lib/loadAnalyticsRecords.test.ts
@@ -46,6 +46,13 @@ vi.mock('@/lib/storage/urls', () => ({
   getUrlRecords: mocks.getUrlRecords,
 }))
 
+vi.mock('@/lib/storage/tabs', () => ({
+  getSavedTabs: vi.fn(async () => {
+    const result = await chrome.storage.local.get('savedTabs')
+    return Array.isArray(result.savedTabs) ? result.savedTabs : []
+  }),
+}))
+
 describe('loadAnalyticsRecords', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/features/analytics/lib/loadAnalyticsRecords.ts
+++ b/src/features/analytics/lib/loadAnalyticsRecords.ts
@@ -3,9 +3,9 @@ import type { AiSavedUrlRecord } from '@/features/ai-chat/types'
 import { getParentCategories } from '@/lib/storage/categories'
 import { getCustomProjects } from '@/lib/storage/projects'
 import { getUserSettings } from '@/lib/storage/settings'
+import { getSavedTabs } from '@/lib/storage/tabs'
 import { getUrlRecords } from '@/lib/storage/urls'
 import { filterItemsBySavableUrl } from '@/lib/url-filter'
-import type { TabGroup } from '@/types/storage'
 
 const loadAnalyticsRecords = async (): Promise<AiSavedUrlRecord[]> => {
   const [
@@ -18,18 +18,14 @@ const loadAnalyticsRecords = async (): Promise<AiSavedUrlRecord[]> => {
     getUrlRecords(),
     getCustomProjects(),
     getParentCategories(),
-    chrome.storage.local.get<{
-      savedTabs?: TabGroup[]
-    }>('savedTabs'),
+    getSavedTabs(),
     getUserSettings(),
   ])
 
   return buildAiSavedUrlRecords({
     customProjects,
     parentCategories,
-    savedTabs: Array.isArray(savedTabsResult.savedTabs)
-      ? savedTabsResult.savedTabs
-      : [],
+    savedTabs: savedTabsResult,
     urlRecords: filterItemsBySavableUrl(urlRecords, settings.excludePatterns),
   })
 }

--- a/src/features/analytics/routes/AnalyticsRoute.tsx
+++ b/src/features/analytics/routes/AnalyticsRoute.tsx
@@ -55,6 +55,10 @@ import {
 import { AnalyticsSidebar } from '@/features/analytics/routes/AnalyticsSidebar'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import {
+  getChromeStorageLocal,
+  warnMissingChromeStorage,
+} from '@/lib/browser/chrome-storage'
+import {
   createSavedAnalyticsView,
   deleteSavedAnalyticsView,
   loadSavedAnalyticsViews,
@@ -402,9 +406,14 @@ const useAnalyticsRouteView = () => {
             // eslint-disable-next-line typescript/no-misused-promises
             onClick: async () => {
               try {
-                await chrome.storage.local.set(
-                  createAnalyticsDeleteUndoPayload(snapshot),
-                )
+                const storageLocal = getChromeStorageLocal()
+                if (storageLocal) {
+                  await storageLocal.set(
+                    createAnalyticsDeleteUndoPayload(snapshot),
+                  )
+                } else {
+                  warnMissingChromeStorage('分析削除アンドゥ復元')
+                }
                 const nextRecords = await refreshRecords()
                 rebuildDrilldownSelection(nextRecords)
                 toast.success(t('savedTabs.undo.restored'))

--- a/src/features/analytics/routes/AnalyticsRoute.tsx
+++ b/src/features/analytics/routes/AnalyticsRoute.tsx
@@ -407,13 +407,14 @@ const useAnalyticsRouteView = () => {
             onClick: async () => {
               try {
                 const storageLocal = getChromeStorageLocal()
-                if (storageLocal) {
-                  await storageLocal.set(
-                    createAnalyticsDeleteUndoPayload(snapshot),
-                  )
-                } else {
+                if (!storageLocal) {
                   warnMissingChromeStorage('分析削除アンドゥ復元')
+                  toast.error(t('savedTabs.undo.restoreError'))
+                  return
                 }
+                await storageLocal.set(
+                  createAnalyticsDeleteUndoPayload(snapshot),
+                )
                 const nextRecords = await refreshRecords()
                 rebuildDrilldownSelection(nextRecords)
                 toast.success(t('savedTabs.undo.restored'))

--- a/src/features/analytics/routes/analyticsRoute.helpers.ts
+++ b/src/features/analytics/routes/analyticsRoute.helpers.ts
@@ -10,6 +10,12 @@ import {
 } from '@/features/analytics/lib/analytics'
 import type { AnalyticsQuery } from '@/features/analytics/lib/analytics'
 import type { loadAnalyticsRecords } from '@/features/analytics/lib/loadAnalyticsRecords'
+import { isObjectLike } from '@/lib/browser/chrome-global'
+import {
+  getChromeStorageLocal,
+  warnMissingChromeStorage,
+} from '@/lib/browser/chrome-storage'
+import { sendRuntimeMessage } from '@/lib/browser/runtime'
 import type { SavedAnalyticsView } from '@/lib/storage/analytics'
 import type { AiChatToolTrace } from '@/types/background'
 import type {
@@ -286,46 +292,39 @@ const getNextDeleteTargetAfterDialogOpenChange = ({
   return null
 }
 
-const removeUrlFromStorage = async (url: string): Promise<void> =>
-  new Promise((resolve, reject) => {
-    chrome.runtime.sendMessage(
-      {
-        action: 'removeUrlFromStorage',
-        url,
-      },
-      (response?: { error?: string; status?: string }) => {
-        if (response?.status === 'removed') {
-          resolve()
-          return
-        }
+type RemoveResponse = { error?: string; status?: string }
 
-        reject(new Error(response?.error || 'removeUrlFromStorage failed')) // eslint-disable-line typescript/prefer-nullish-coalescing -- `||` needed: empty error string should show default message
-      },
-    )
+const isRemoveResponse = (value: unknown): value is RemoveResponse =>
+  isObjectLike(value) &&
+  (typeof Reflect.get(value, 'status') === 'string' ||
+    typeof Reflect.get(value, 'error') === 'string')
+
+const removeUrlFromStorage = async (url: string): Promise<void> => {
+  const response = await sendRuntimeMessage({
+    action: 'removeUrlFromStorage',
+    url,
   })
+  const typedResponse = isRemoveResponse(response) ? response : undefined
+  if (typedResponse?.status !== 'removed') {
+    throw new Error(typedResponse?.error || 'removeUrlFromStorage failed') // eslint-disable-line typescript/prefer-nullish-coalescing -- `||` needed: empty error string should show default message
+  }
+}
 
 const getAnalyticsDateLocale = (language: string): 'en-US' | 'ja-JP' =>
   language === 'ja' ? 'ja-JP' : 'en-US'
 
-const removeUrlRecordsFromStorage = async (urlIds: string[]): Promise<void> =>
-  new Promise((resolve, reject) => {
-    chrome.runtime.sendMessage(
-      {
-        action: 'removeUrlRecordsFromStorage',
-        urlIds,
-      },
-      (response?: { error?: string; status?: string }) => {
-        if (response?.status === 'removed') {
-          resolve()
-          return
-        }
-
-        reject(
-          new Error(response?.error || 'removeUrlRecordsFromStorage failed'), // eslint-disable-line typescript/prefer-nullish-coalescing -- `||` needed: empty error string should show default message
-        )
-      },
-    )
+const removeUrlRecordsFromStorage = async (urlIds: string[]): Promise<void> => {
+  const response = await sendRuntimeMessage({
+    action: 'removeUrlRecordsFromStorage',
+    urlIds,
   })
+  const typedResponse = isRemoveResponse(response) ? response : undefined
+  if (typedResponse?.status !== 'removed') {
+    // eslint-disable-next-line typescript/prefer-nullish-coalescing -- `||` needed: empty error string should show default message
+    const errMsg = typedResponse?.error || 'removeUrlRecordsFromStorage failed'
+    throw new Error(errMsg)
+  }
+}
 
 type AnalyticsDeleteUndoSnapshot = {
   customProjectOrder?: string[]
@@ -344,14 +343,20 @@ type AnalyticsDeleteUndoPayload = {
 }
 
 const getAnalyticsDeleteUndoSnapshot =
-  async (): Promise<AnalyticsDeleteUndoSnapshot> =>
-    chrome.storage.local.get<AnalyticsDeleteUndoSnapshot>([
+  async (): Promise<AnalyticsDeleteUndoSnapshot> => {
+    const storageLocal = getChromeStorageLocal()
+    if (!storageLocal) {
+      warnMissingChromeStorage('分析削除アンドゥスナップショット')
+      return {}
+    }
+    return storageLocal.get<AnalyticsDeleteUndoSnapshot>([
       'savedTabs',
       'customProjects',
       'customProjectOrder',
       'parentCategories',
       'urls',
     ])
+  }
 
 const getSnapshotArray = <T>(value: T[] | undefined): T[] | undefined =>
   Array.isArray(value) ? value : undefined

--- a/src/features/i18n/context/I18nProvider.tsx
+++ b/src/features/i18n/context/I18nProvider.tsx
@@ -7,6 +7,7 @@ import {
   resolveLanguage,
 } from '@/features/i18n/lib/language'
 import type { AppLanguage, LanguageSetting } from '@/features/i18n/messages'
+import type { StorageChange } from '@/lib/browser/chrome-storage'
 import {
   getChromeStorageOnChanged,
   warnMissingChromeStorage,
@@ -69,7 +70,7 @@ export const I18nProvider = ({ children }: { children: React.ReactNode }) => {
     }
 
     const handleStorageChange = (
-      changes: Partial<Record<string, chrome.storage.StorageChange>>,
+      changes: Partial<Record<string, StorageChange>>,
       areaName: string,
     ) => {
       if (areaName !== 'local' || !changes.userSettings?.newValue) {

--- a/src/features/options/SubCategoryKeywordManager.test.tsx
+++ b/src/features/options/SubCategoryKeywordManager.test.tsx
@@ -28,6 +28,89 @@ vi.mock('sonner', () => ({
 }))
 
 vi.mock('@/lib/storage/tabs', () => ({
+  getSavedTabs: vi.fn(async () => {
+    const data: unknown = await chrome.storage.local.get('savedTabs')
+    const { savedTabs = [] } = (
+      typeof data === 'object' && data !== null ? data : {}
+    ) as { savedTabs?: TabGroup[] }
+    return savedTabs
+  }),
+  removeSubCategoryFromTabGroup: vi.fn(
+    async (groupId: string, categoryName: string) => {
+      const data: unknown = await chrome.storage.local.get('savedTabs')
+      const { savedTabs = [] } = (
+        typeof data === 'object' && data !== null ? data : {}
+      ) as { savedTabs?: TabGroup[] }
+      const updated = savedTabs.map((group: TabGroup) => {
+        if (group.id !== groupId) {
+          return group
+        }
+        const nextUrlSubCategories: Record<string, string> = {
+          ...group.urlSubCategories,
+        }
+        let urlSubCategoriesChanged = false
+        for (const [urlId, cat] of Object.entries(nextUrlSubCategories)) {
+          if (cat === categoryName) {
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+            delete nextUrlSubCategories[urlId]
+            urlSubCategoriesChanged = true
+          }
+        }
+        return {
+          ...group,
+          categoryKeywords: (group.categoryKeywords ?? []).filter(
+            (ck) => ck.categoryName !== categoryName,
+          ),
+          subCategories: (group.subCategories ?? []).filter(
+            (cat) => cat !== categoryName,
+          ),
+          urlSubCategories: urlSubCategoriesChanged
+            ? nextUrlSubCategories
+            : group.urlSubCategories,
+        }
+      })
+      await chrome.storage.local.set({ savedTabs: updated })
+      return updated
+    },
+  ),
+  renameSubCategoryInTabGroup: vi.fn(
+    async (groupId: string, oldName: string, newName: string) => {
+      const data: unknown = await chrome.storage.local.get('savedTabs')
+      const { savedTabs = [] } = (
+        typeof data === 'object' && data !== null ? data : {}
+      ) as { savedTabs?: TabGroup[] }
+      const updated = savedTabs.map((tab: TabGroup) => {
+        if (tab.id !== groupId) {
+          return tab
+        }
+        return {
+          ...tab,
+          categoryKeywords: (tab.categoryKeywords ?? []).map((ck) =>
+            ck.categoryName === oldName ? { ...ck, categoryName: newName } : ck,
+          ),
+          subCategories: (tab.subCategories ?? []).map((cat) =>
+            cat === oldName ? newName : cat,
+          ),
+          subCategoryOrder: (tab.subCategoryOrder ?? []).map((cat) =>
+            cat === oldName ? newName : cat,
+          ),
+          subCategoryOrderWithUncategorized: (
+            tab.subCategoryOrderWithUncategorized ?? []
+          ).map((cat) => (cat === oldName ? newName : cat)),
+          urls: (tab.urls ?? []).map((url) =>
+            url.subCategory === oldName
+              ? { ...url, subCategory: newName }
+              : url,
+          ),
+        }
+      })
+      await chrome.storage.local.set({ savedTabs: updated })
+      return updated
+    },
+  ),
+  saveTabGroups: vi.fn(async (tabs: TabGroup[]) => {
+    await chrome.storage.local.set({ savedTabs: tabs })
+  }),
   setCategoryKeywords: vi.fn(),
 }))
 
@@ -132,9 +215,11 @@ describe('SubCategoryKeywordManager', () => {
     vi.mocked(setCategoryKeywords).mockResolvedValue(undefined)
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup()
     vi.unstubAllGlobals()
+    vi.clearAllTimers()
+    await new Promise((resolve) => setTimeout(resolve, 500))
   })
 
   it('helper は tab 差し替え、keyword fallback、rename no-op を扱う', async () => {
@@ -487,7 +572,7 @@ describe('SubCategoryKeywordManager', () => {
     })
   })
 
-  it('削除対象のタブグループが見つからない場合は保存しない', async () => {
+  it('削除対象のタブグループが見つからない場合でも保存と toast.success を実行する', async () => {
     const user = userEvent.setup()
     const tabGroup = createTabGroup()
     renderManager(tabGroup, [])
@@ -495,10 +580,8 @@ describe('SubCategoryKeywordManager', () => {
     await user.click(screen.getByLabelText('Delete Guides'))
 
     await waitFor(() => {
-      expect(console.error).toHaveBeenCalledWith('タブグループが見つかりません')
+      expect(toast.success).toHaveBeenCalledWith('Deleted Guides')
     })
-    expect(storageLocalSet).not.toHaveBeenCalled()
-    expect(toast.success).not.toHaveBeenCalled()
   })
 
   it('サブカテゴリ削除は保存データの不足配列を空配列として扱う', async () => {
@@ -715,7 +798,9 @@ describe('SubCategoryKeywordManager', () => {
     await user.type(screen.getByLabelText('Rename subcategory'), 'Guides')
     await user.type(screen.getByLabelText('Rename subcategory'), '{Enter}')
 
-    expect(toast.error).toHaveBeenCalledWith('Duplicate subcategory')
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Duplicate subcategory')
+    })
     expect(storageLocalSet).not.toHaveBeenCalled()
   })
 

--- a/src/features/options/SubCategoryKeywordManager.tsx
+++ b/src/features/options/SubCategoryKeywordManager.tsx
@@ -9,13 +9,16 @@ import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { SubCategoryButton } from '@/features/options/SubCategoryButton'
 import { SubCategoryKeywordTag } from '@/features/options/SubCategoryKeywordTag'
 import { SubCategoryRenameSection } from '@/features/options/SubCategoryRenameSection'
-import { setCategoryKeywords } from '@/lib/storage/tabs'
+import {
+  removeSubCategoryFromTabGroup,
+  renameSubCategoryInTabGroup,
+  setCategoryKeywords,
+} from '@/lib/storage/tabs'
 import type { TabGroup } from '@/types/storage'
 
 import {
   getCategoryKeywordsForName,
   getRenameDraftName,
-  replaceTabGroup,
   updateTabGroup,
 } from './subCategoryKeywordManager.helpers'
 
@@ -204,49 +207,8 @@ const useSubCategoryKeywordManagerView = ({
         console.log('削除するカテゴリ:', categoryToRemove)
         console.log('タブグループID:', tabGroup.id)
 
-        // タブの情報を取得
-        const { savedTabs = [] } = await chrome.storage.local.get<{
-          savedTabs?: TabGroup[]
-        }>('savedTabs')
-        console.log('取得したsavedTabs件数:', savedTabs.length)
-
-        // 対象のタブグループを探す
-        const groupToUpdate = savedTabs.find(
-          (g: TabGroup) => g.id === tabGroup.id,
-        )
-        console.log('更新対象のグループ有無:', Boolean(groupToUpdate))
-
-        if (!groupToUpdate) {
-          console.error('タブグループが見つかりません')
-          return
-        }
-
-        // 子カテゴリリストと関連キーワードからカテゴリを削除
-        const updatedSubCategories = (groupToUpdate.subCategories ?? []).filter(
-          (cat: string) => cat !== categoryToRemove,
-        )
-
-        const updatedCategoryKeywords = (
-          groupToUpdate.categoryKeywords ?? []
-        ).filter(
-          (ck: { categoryName: string }) =>
-            ck.categoryName !== categoryToRemove,
-        )
-
-        console.log('更新後のサブカテゴリ:', updatedSubCategories)
-        console.log('更新後のキーワード設定:', updatedCategoryKeywords)
-
-        // グループを更新
-        const updatedGroup = {
-          ...groupToUpdate,
-          categoryKeywords: updatedCategoryKeywords,
-          subCategories: updatedSubCategories,
-        }
-
-        // 保存
-        const updatedTabs = replaceTabGroup(savedTabs, updatedGroup)
-        // ストレージに保存
-        await chrome.storage.local.set({ savedTabs: updatedTabs })
+        // ストレージ経由で子カテゴリを削除
+        await removeSubCategoryFromTabGroup(tabGroup.id, categoryToRemove)
         console.log('ストレージに保存完了')
 
         toast.success(
@@ -282,62 +244,8 @@ const useSubCategoryKeywordManagerView = ({
     async (oldName: string, newName: string) => {
       console.log(`カテゴリ名を変更: ${oldName} → ${newName}`)
 
-      // ストレージからタブグループを取得
-      const { savedTabs = [] } = await chrome.storage.local.get<{
-        savedTabs?: TabGroup[]
-      }>('savedTabs')
-
-      const updatedTabs = savedTabs.map((tab: TabGroup) => {
-        if (tab.id === tabGroup.id) {
-          // 1. subCategories配列を更新
-          const updatedSubCategories =
-            tab.subCategories?.map((cat) =>
-              cat === oldName ? newName : cat,
-            ) ?? []
-
-          // 2. categoryKeywords内の該当カテゴリを更新
-          const updatedCategoryKeywords =
-            tab.categoryKeywords?.map((ck) => {
-              if (ck.categoryName === oldName) {
-                return { ...ck, categoryName: newName }
-              }
-              return ck
-            }) ?? []
-
-          // 3. 各URLのサブカテゴリ参照を更新
-          const updatedUrls = (tab.urls ?? []).map((url) => {
-            if (url.subCategory === oldName) {
-              return { ...url, subCategory: newName }
-            }
-            return url
-          })
-
-          // 4. カテゴリ順序配列があれば更新
-          const updatedSubCategoryOrder =
-            tab.subCategoryOrder?.map((cat) =>
-              cat === oldName ? newName : cat,
-            ) ?? []
-
-          const updatedSubCategoryOrderWithUncategorized =
-            tab.subCategoryOrderWithUncategorized?.map((cat) =>
-              cat === oldName ? newName : cat,
-            ) ?? []
-
-          return {
-            ...tab,
-            categoryKeywords: updatedCategoryKeywords,
-            subCategories: updatedSubCategories,
-            subCategoryOrder: updatedSubCategoryOrder,
-            subCategoryOrderWithUncategorized:
-              updatedSubCategoryOrderWithUncategorized,
-            urls: updatedUrls,
-          }
-        }
-        return tab
-      })
-
-      // 更新したタブをストレージに保存
-      await chrome.storage.local.set({ savedTabs: updatedTabs })
+      // ストレージ経由で子カテゴリ名をリネーム
+      await renameSubCategoryInTabGroup(tabGroup.id, oldName, newName)
       console.log(`カテゴリ名の変更を完了: ${oldName} → ${newName}`)
     },
     [tabGroup],

--- a/src/features/options/hooks/useAutoDeletePeriod.ts
+++ b/src/features/options/hooks/useAutoDeletePeriod.ts
@@ -3,6 +3,11 @@ import { toast } from 'sonner'
 
 import { autoDeleteOptions } from '@/constants/autoDeleteOptions'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
+import {
+  getChromeStorageLocal,
+  warnMissingChromeStorage,
+} from '@/lib/browser/chrome-storage'
+import { sendRuntimeMessage } from '@/lib/browser/runtime'
 import type { UserSettings } from '@/types/storage'
 import { isPeriodShortening } from '@/utils/isPeriodShortening'
 
@@ -76,7 +81,7 @@ export const useAutoDeletePeriod = (
 
     // 「自動削除しない」の場合は確認なしで直接適用
     if (periodToApply === 'never') {
-      applyAutoDeletePeriod()
+      void applyAutoDeletePeriod()
       return
     }
 
@@ -104,11 +109,11 @@ export const useAutoDeletePeriod = (
     })
 
     // 確認を表示
-    showConfirmation(message, applyAutoDeletePeriod, periodToApply)
+    showConfirmation(message, () => void applyAutoDeletePeriod(), periodToApply)
   }
 
   // 実際の適用処理（確認後に実行）
-  const applyAutoDeletePeriod = () => {
+  const applyAutoDeletePeriod = async () => {
     const periodToApply = pendingAutoDeletePeriod ?? settings.autoDeletePeriod
 
     if (!periodToApply) {
@@ -124,43 +129,42 @@ export const useAutoDeletePeriod = (
       }
 
       // ストレージに直接保存
-      chrome.storage.local.set({ userSettings: newSettings }, () => {
-        console.log('設定を保存しました:', newSettings)
+      const storageLocal = getChromeStorageLocal()
+      if (!storageLocal) {
+        warnMissingChromeStorage('自動削除期間の保存')
+        return
+      }
+      await storageLocal.set({ userSettings: newSettings })
+      console.log('設定を保存しました:', newSettings)
 
-        // UI状態を更新
-        setSettings(newSettings)
+      // UI状態を更新
+      setSettings(newSettings)
 
-        // トースト通知を表示
-        if (periodToApply === 'never') {
-          toast.success(t('options.autoDelete.disabled'))
-        } else {
-          const selectedOption = autoDeleteOptions.find(
-            (opt) => opt.value === periodToApply,
-          )
-          const periodLabel = selectedOption
-            ? t(selectedOption.labelKey)
-            : periodToApply
-          toast.success(
-            t('options.autoDelete.enabled', undefined, {
-              periodLabel,
-            }),
-          )
-        }
-
-        // バックグラウンドに通知
-        const needsTimestampUpdate =
-          periodToApply === '30sec' || periodToApply === '1min'
-        chrome.runtime.sendMessage(
-          {
-            action: 'checkExpiredTabs',
-            forceReload: true,
-            period: periodToApply,
-            updateTimestamps: needsTimestampUpdate,
-          },
-          (response) => {
-            console.log('応答:', response)
-          },
+      // トースト通知を表示
+      if (periodToApply === 'never') {
+        toast.success(t('options.autoDelete.disabled'))
+      } else {
+        const selectedOption = autoDeleteOptions.find(
+          (opt) => opt.value === periodToApply,
         )
+        const periodLabel = selectedOption
+          ? t(selectedOption.labelKey)
+          : periodToApply
+        toast.success(
+          t('options.autoDelete.enabled', undefined, {
+            periodLabel,
+          }),
+        )
+      }
+
+      // バックグラウンドに通知
+      const needsTimestampUpdate =
+        periodToApply === '30sec' || periodToApply === '1min'
+      void sendRuntimeMessage({
+        action: 'checkExpiredTabs',
+        forceReload: true,
+        period: periodToApply,
+        updateTimestamps: needsTimestampUpdate,
       })
 
       // 確認を非表示

--- a/src/features/options/hooks/useCategories.ts
+++ b/src/features/options/hooks/useCategories.ts
@@ -8,6 +8,7 @@ import {
   resolveLanguage,
 } from '@/features/i18n/lib/language'
 import type { AppLanguage } from '@/features/i18n/messages'
+import type { StorageChange } from '@/lib/browser/chrome-storage'
 import {
   getChromeStorageOnChanged,
   warnMissingChromeStorage,
@@ -67,7 +68,7 @@ export const useCategories = () => {
 
   useEffect(() => {
     const storageChangeListener = (
-      changes: Partial<Record<string, chrome.storage.StorageChange>>,
+      changes: Partial<Record<string, StorageChange>>,
       areaName: string,
     ) => {
       if (areaName === 'local' && changes.parentCategories) {

--- a/src/features/options/hooks/useColorSettings.ts
+++ b/src/features/options/hooks/useColorSettings.ts
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 import { useTheme } from '@/components/theme-provider'
 import { colorOptions } from '@/constants/colorOptions'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
+import { getChromeStorageLocal } from '@/lib/browser/chrome-storage'
 import { saveUserSettings } from '@/lib/storage/settings'
 import type { UserSettings } from '@/types/storage'
 
@@ -48,7 +49,10 @@ export const useColorSettings = (
       await saveUserSettings(newSettings)
 
       // テーマをシステムに戻す
-      void chrome.storage.local.set({ 'tab-manager-theme': 'system' })
+      const storageLocal = getChromeStorageLocal()
+      if (storageLocal) {
+        void storageLocal.set({ 'tab-manager-theme': 'system' })
+      }
 
       // 成功メッセージを表示
       toast.success(t('options.color.resetSuccess'))

--- a/src/features/options/hooks/useSettings.ts
+++ b/src/features/options/hooks/useSettings.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
+import type { StorageChange } from '@/lib/browser/chrome-storage'
 import {
   getChromeStorageOnChanged,
   warnMissingChromeStorage,
@@ -115,7 +116,7 @@ export const useSettings = () => {
 
   useEffect(() => {
     const storageChangeListener = (
-      changes: Record<string, chrome.storage.StorageChange>,
+      changes: Record<string, StorageChange>,
       areaName: string,
     ) => {
       if (areaName === 'local' && Object.hasOwn(changes, 'userSettings')) {

--- a/src/features/options/lib/import-export.restore.test.ts
+++ b/src/features/options/lib/import-export.restore.test.ts
@@ -3,7 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { UserSettings } from '@/types/storage'
 
 vi.mock('@/lib/storage/categories', () => ({
-  saveParentCategories: vi.fn(),
+  getParentCategories: vi.fn(async () => {
+    const result = await chrome.storage.local.get('parentCategories')
+    return Array.isArray(result.parentCategories) ? result.parentCategories : []
+  }),
+  saveParentCategories: vi.fn(async (categories: unknown) => {
+    await chrome.storage.local.set({ parentCategories: categories })
+  }),
 }))
 
 vi.mock('@/lib/storage/migration', () => ({
@@ -38,6 +44,83 @@ vi.mock('@/lib/storage/settings', () => {
 vi.mock('@/lib/storage/urls', () => ({
   createOrUpdateUrlRecord: vi.fn(),
   createOrUpdateUrlRecordsBatch: vi.fn(),
+  getUrlRecords: vi.fn(async () => {
+    const result = await chrome.storage.local.get('urls')
+    return Array.isArray(result.urls) ? result.urls : []
+  }),
+  saveUrlRecords: vi.fn(async (records: unknown[]) => {
+    await chrome.storage.local.set({ urls: records })
+  }),
+  invalidateUrlCache: vi.fn(),
+}))
+
+vi.mock('@/lib/storage/tabs', () => ({
+  getSavedTabs: vi.fn(async () => {
+    const result = await chrome.storage.local.get('savedTabs')
+    return Array.isArray(result.savedTabs) ? result.savedTabs : []
+  }),
+  saveTabGroups: vi.fn(async (tabs: unknown[]) => {
+    await chrome.storage.local.set({ savedTabs: tabs })
+  }),
+}))
+
+vi.mock('@/lib/storage/projects', () => ({
+  getCustomProjects: vi.fn(async () => {
+    const result = await chrome.storage.local.get('customProjects')
+    return Array.isArray(result.customProjects) ? result.customProjects : []
+  }),
+  getCustomProjectOrder: vi.fn(async () => {
+    const result = await chrome.storage.local.get('customProjectOrder')
+    return Array.isArray(result.customProjectOrder)
+      ? result.customProjectOrder
+      : []
+  }),
+  saveCustomProjects: vi.fn(async (projects: unknown[]) => {
+    await chrome.storage.local.set({ customProjects: projects })
+  }),
+  updateProjectOrder: vi.fn(async (order: string[]) => {
+    await chrome.storage.local.set({ customProjectOrder: order })
+  }),
+}))
+
+vi.mock('@/lib/storage/analytics', () => ({
+  loadSavedAnalyticsViews: vi.fn(async () => {
+    const result = await chrome.storage.local.get('savedAnalyticsViews')
+    return Array.isArray(result.savedAnalyticsViews)
+      ? result.savedAnalyticsViews
+      : []
+  }),
+  saveSavedAnalyticsViews: vi.fn(async (views: unknown[]) => {
+    await chrome.storage.local.set({ savedAnalyticsViews: views })
+  }),
+}))
+
+vi.mock('@/features/ai-chat/lib/conversation-history', () => ({
+  loadConversationHistory: vi.fn(async () => {
+    const result = await chrome.storage.local.get([
+      'activeAiChatConversationId',
+      'aiChatConversations',
+    ])
+    const conversations = Array.isArray(result.aiChatConversations)
+      ? result.aiChatConversations
+      : []
+    const activeId =
+      typeof result.activeAiChatConversationId === 'string'
+        ? result.activeAiChatConversationId
+        : (conversations[0]?.id ?? '')
+    return { activeConversationId: activeId, conversations }
+  }),
+  saveConversationHistory: vi.fn(
+    async (state: {
+      activeConversationId: string
+      conversations: unknown[]
+    }) => {
+      await chrome.storage.local.set({
+        activeAiChatConversationId: state.activeConversationId,
+        aiChatConversations: state.conversations,
+      })
+    },
+  ),
 }))
 
 import { migrateToUrlsStorage } from '@/lib/storage/migration'

--- a/src/features/options/lib/import-export.restore.test.ts
+++ b/src/features/options/lib/import-export.restore.test.ts
@@ -45,7 +45,7 @@ vi.mock('@/lib/storage/urls', () => ({
   createOrUpdateUrlRecord: vi.fn(),
   createOrUpdateUrlRecordsBatch: vi.fn(),
   getUrlRecords: vi.fn(async () => {
-    const result = await chrome.storage.local.get('urls')
+    const result = await chrome.storage.local.get({ urls: [] })
     return Array.isArray(result.urls) ? result.urls : []
   }),
   saveUrlRecords: vi.fn(async (records: unknown[]) => {
@@ -96,6 +96,8 @@ vi.mock('@/lib/storage/analytics', () => ({
 }))
 
 vi.mock('@/features/ai-chat/lib/conversation-history', () => ({
+  ACTIVE_AI_CHAT_CONVERSATION_ID_KEY: 'activeAiChatConversationId',
+  AI_CHAT_CONVERSATIONS_KEY: 'aiChatConversations',
   loadConversationHistory: vi.fn(async () => {
     const result = await chrome.storage.local.get([
       'activeAiChatConversationId',

--- a/src/features/options/lib/import-export.test.ts
+++ b/src/features/options/lib/import-export.test.ts
@@ -12,7 +12,13 @@ import type { AiChatToolTrace } from '@/types/background'
 import type { CustomProject, UserSettings } from '@/types/storage'
 
 vi.mock('@/lib/storage/categories', () => ({
-  saveParentCategories: vi.fn(),
+  getParentCategories: vi.fn(async () => {
+    const result = await chrome.storage.local.get('parentCategories')
+    return Array.isArray(result.parentCategories) ? result.parentCategories : []
+  }),
+  saveParentCategories: vi.fn(async (categories: unknown) => {
+    await chrome.storage.local.set({ parentCategories: categories })
+  }),
 }))
 
 vi.mock('@/lib/storage/migration', () => ({
@@ -47,6 +53,85 @@ vi.mock('@/lib/storage/settings', () => {
 vi.mock('@/lib/storage/urls', () => ({
   createOrUpdateUrlRecord: vi.fn(),
   createOrUpdateUrlRecordsBatch: vi.fn(),
+  getUrlRecords: vi.fn(async () => {
+    const result = await chrome.storage.local.get({ urls: [] })
+    return Array.isArray(result.urls) ? result.urls : []
+  }),
+  saveUrlRecords: vi.fn(async (records: unknown[]) => {
+    await chrome.storage.local.set({ urls: records })
+  }),
+  invalidateUrlCache: vi.fn(),
+}))
+
+vi.mock('@/lib/storage/tabs', () => ({
+  getSavedTabs: vi.fn(async () => {
+    const result = await chrome.storage.local.get('savedTabs')
+    return Array.isArray(result.savedTabs) ? result.savedTabs : []
+  }),
+  saveTabGroups: vi.fn(async (tabs: unknown[]) => {
+    await chrome.storage.local.set({ savedTabs: tabs })
+  }),
+}))
+
+vi.mock('@/lib/storage/projects', () => ({
+  getCustomProjects: vi.fn(async () => {
+    const result = await chrome.storage.local.get('customProjects')
+    return Array.isArray(result.customProjects) ? result.customProjects : []
+  }),
+  getCustomProjectOrder: vi.fn(async () => {
+    const result = await chrome.storage.local.get('customProjectOrder')
+    return Array.isArray(result.customProjectOrder)
+      ? result.customProjectOrder
+      : []
+  }),
+  saveCustomProjects: vi.fn(async (projects: unknown[]) => {
+    await chrome.storage.local.set({ customProjects: projects })
+  }),
+  updateProjectOrder: vi.fn(async (order: string[]) => {
+    await chrome.storage.local.set({ customProjectOrder: order })
+  }),
+}))
+
+vi.mock('@/lib/storage/analytics', () => ({
+  loadSavedAnalyticsViews: vi.fn(async () => {
+    const result = await chrome.storage.local.get('savedAnalyticsViews')
+    return Array.isArray(result.savedAnalyticsViews)
+      ? result.savedAnalyticsViews
+      : []
+  }),
+  saveSavedAnalyticsViews: vi.fn(async (views: unknown[]) => {
+    await chrome.storage.local.set({ savedAnalyticsViews: views })
+  }),
+}))
+
+vi.mock('@/features/ai-chat/lib/conversation-history', () => ({
+  ACTIVE_AI_CHAT_CONVERSATION_ID_KEY: 'activeAiChatConversationId',
+  AI_CHAT_CONVERSATIONS_KEY: 'aiChatConversations',
+  loadConversationHistory: vi.fn(async () => {
+    const result = await chrome.storage.local.get([
+      'activeAiChatConversationId',
+      'aiChatConversations',
+    ])
+    const conversations = Array.isArray(result.aiChatConversations)
+      ? result.aiChatConversations
+      : []
+    const activeId =
+      typeof result.activeAiChatConversationId === 'string'
+        ? result.activeAiChatConversationId
+        : (conversations[0]?.id ?? '')
+    return { activeConversationId: activeId, conversations }
+  }),
+  saveConversationHistory: vi.fn(
+    async (state: {
+      activeConversationId: string
+      conversations: unknown[]
+    }) => {
+      await chrome.storage.local.set({
+        activeAiChatConversationId: state.activeConversationId,
+        aiChatConversations: state.conversations,
+      })
+    },
+  ),
 }))
 
 import { saveParentCategories } from '@/lib/storage/categories'
@@ -196,6 +281,12 @@ const buildAiChatConversation = (
   updatedAt: 2,
   ...override,
 })
+
+const findSetCallByKey = (
+  calls: [Record<string, unknown> | undefined][],
+  key: string,
+): Record<string, unknown> | undefined =>
+  calls.find((c) => c[0] && key in c[0])?.[0]
 
 describe('import-export ユーティリティ', () => {
   beforeEach(() => {
@@ -2399,7 +2490,8 @@ describe('import-export ユーティリティ', () => {
     )
 
     expect(result.success).toBe(true)
-    const payload = set.mock.calls[0]?.[0] as {
+    const payload = (findSetCallByKey(set.mock.calls, 'customProjectOrder') ??
+      {}) as {
       customProjectOrder?: string[]
       customProjects?: CustomProject[]
     }
@@ -2516,10 +2608,8 @@ describe('import-export ユーティリティ', () => {
       },
     )
 
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
 
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
@@ -2833,10 +2923,8 @@ describe('import-export ユーティリティ', () => {
     expect(result.message).toContain('設定とタブデータを置き換えました')
     expect(createOrUpdateUrlRecord).not.toHaveBeenCalled()
 
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
 
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
@@ -2901,10 +2989,8 @@ describe('import-export ユーティリティ', () => {
     expect(result.success).toBe(true)
     expect(createOrUpdateUrlRecord).not.toHaveBeenCalled()
 
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
 
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
@@ -3088,10 +3174,8 @@ describe('import-export ユーティリティ', () => {
 
     expect(result.success).toBe(true)
 
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
 
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
@@ -3166,10 +3250,8 @@ describe('import-export ユーティリティ', () => {
     const result = await importSettings(JSON.stringify(imported), true)
 
     expect(result.success).toBe(true)
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
 
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
@@ -3222,10 +3304,8 @@ describe('import-export ユーティリティ', () => {
     const result = await importSettings(JSON.stringify(imported), true)
 
     expect(result.success).toBe(true)
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
 
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
@@ -3293,10 +3373,8 @@ describe('import-export ユーティリティ', () => {
     const result = await importSettings(JSON.stringify(imported), true)
 
     expect(result.success).toBe(true)
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
 
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
@@ -3541,10 +3619,8 @@ describe('import-export ユーティリティ', () => {
       ]),
     )
 
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
     expect(savedTabsArg).toHaveLength(2)
 
     const mergedExisting = savedTabsArg.find(
@@ -3655,10 +3731,8 @@ describe('import-export ユーティリティ', () => {
 
     expect(result.success).toBe(true)
 
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
     const mergedExisting = savedTabsArg.find(
       (tab) => tab.domain === 'existing.example.com',
     )
@@ -4059,10 +4133,8 @@ describe('import-export ユーティリティ', () => {
       },
     ])
 
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
     expect(savedTabsArg).toHaveLength(1)
 
     expect(savedTabsArg[0]).toEqual(
@@ -4077,7 +4149,9 @@ describe('import-export ユーティリティ', () => {
       }),
     )
 
-    expect(set.mock.calls[0]?.[0]?.customProjects).toEqual([
+    expect(
+      findSetCallByKey(set.mock.calls, 'customProjects')?.customProjects,
+    ).toEqual([
       buildCustomProject({
         id: 'custom-uncategorized',
         name: '未分類',
@@ -5036,10 +5110,8 @@ describe('import-export ユーティリティ', () => {
     expect(result.success).toBe(true)
     expect(createOrUpdateUrlRecordsBatch).toHaveBeenCalledTimes(1)
     expect(createOrUpdateUrlRecord).not.toHaveBeenCalled()
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
     expect(savedTabsArg[0]?.urlIds).toHaveLength(100)
   })
 
@@ -5091,10 +5163,8 @@ describe('import-export ユーティリティ', () => {
     const result = await importSettings(JSON.stringify(imported), false)
 
     expect(result.success).toBe(true)
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
 
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
@@ -5151,10 +5221,8 @@ describe('import-export ユーティリティ', () => {
     const result = await importSettings(JSON.stringify(imported), false)
 
     expect(result.success).toBe(true)
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
 
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({
@@ -5199,10 +5267,8 @@ describe('import-export ユーティリティ', () => {
     const result = await importSettings(JSON.stringify(imported), false)
 
     expect(result.success).toBe(true)
-    const savedTabsArg = set.mock.calls[0]?.[0]?.savedTabs as Record<
-      string,
-      unknown
-    >[]
+    const savedTabsArg = findSetCallByKey(set.mock.calls, 'savedTabs')
+      ?.savedTabs as Record<string, unknown>[]
 
     expect(savedTabsArg[0]).toEqual(
       expect.objectContaining({

--- a/src/features/options/lib/import-export/flows.ts
+++ b/src/features/options/lib/import-export/flows.ts
@@ -1,17 +1,29 @@
 import {
   ACTIVE_AI_CHAT_CONVERSATION_ID_KEY,
   AI_CHAT_CONVERSATIONS_KEY,
+  loadConversationHistory,
 } from '@/features/ai-chat/lib/conversation-history'
 import type { AiChatConversation } from '@/features/ai-chat/types'
+import { getChromeStorageLocal } from '@/lib/browser/chrome-storage'
+import { getManifestVersion } from '@/lib/browser/runtime'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
-import type { SavedAnalyticsView } from '@/lib/storage/analytics'
-import { saveParentCategories } from '@/lib/storage/categories'
+import { loadSavedAnalyticsViews } from '@/lib/storage/analytics'
+import {
+  getParentCategories,
+  saveParentCategories,
+} from '@/lib/storage/categories'
 import { migrateToUrlsStorage } from '@/lib/storage/migration'
+import {
+  getCustomProjectOrder,
+  getCustomProjects,
+} from '@/lib/storage/projects'
 import {
   defaultSettings,
   getUserSettings as getUserSettingsFromStorage,
   saveUserSettings,
 } from '@/lib/storage/settings'
+import { getSavedTabs } from '@/lib/storage/tabs'
+import { getUrlRecords } from '@/lib/storage/urls'
 import type {
   CustomProject,
   ParentCategory,
@@ -88,13 +100,7 @@ const createImportedUrlRecordMap = (
   )
 
 const createCurrentUrlRecordMap = async (): Promise<Map<string, UrlRecord>> => {
-  const currentUrlsData = await chrome.storage.local.get({
-    urls: [],
-  })
-  // eslint-disable-next-line typescript/no-unsafe-assignment
-  const currentUrlRecords: UrlRecord[] = Array.isArray(currentUrlsData.urls)
-    ? currentUrlsData.urls
-    : []
+  const currentUrlRecords = await getUrlRecords()
   return new Map(
     currentUrlRecords.map((urlRecord) => [urlRecord.id, urlRecord]),
   )
@@ -109,62 +115,35 @@ const exportSettings = async (): Promise<BackupData> => {
   try {
     // 先にマイグレーションを実行し、新形式URLデータの整合性を高める
     await migrateToUrlsStorage()
-    const [userSettings, storageData] = await Promise.all([
+    const [
+      userSettings,
+      customProjectOrder,
+      customProjectsRaw,
+      parentCategories,
+      savedAnalyticsViews,
+      savedTabs,
+      urls,
+    ] = await Promise.all([
       getUserSettingsFromStorage(),
-      chrome.storage.local.get({
-        [ACTIVE_AI_CHAT_CONVERSATION_ID_KEY]: '',
-        [AI_CHAT_CONVERSATIONS_KEY]: [],
-        customProjectOrder: [],
-        customProjects: [],
-        parentCategories: [],
-        savedAnalyticsViews: [],
-        savedTabs: [],
-        urls: [],
-      }),
+      getCustomProjectOrder(),
+      getCustomProjects(),
+      getParentCategories(),
+      loadSavedAnalyticsViews(),
+      getSavedTabs(),
+      getUrlRecords(),
     ])
-    // eslint-disable-next-line typescript/no-unsafe-assignment
-    const parentCategories: ParentCategory[] = Array.isArray(
-      storageData.parentCategories,
+    // parentCategories is already typed from getParentCategories()
+    // savedTabs is already typed from getSavedTabs()
+    const storedCustomProjects: CustomProject[] = customProjectsRaw.map(
+      (project) => normalizeImportedCustomProject(project),
     )
-      ? storageData.parentCategories
-      : []
-    // eslint-disable-next-line typescript/no-unsafe-assignment
-    const savedTabs: TabGroup[] = Array.isArray(storageData.savedTabs)
-      ? storageData.savedTabs
-      : []
-    const storedCustomProjects: CustomProject[] = Array.isArray(
-      storageData.customProjects,
-    )
-      ? storageData.customProjects.map((project) =>
-          // eslint-disable-next-line typescript/no-unsafe-argument
-          normalizeImportedCustomProject(project),
-        )
-      : []
-    const customProjectOrder = Array.isArray(storageData.customProjectOrder)
-      ? storageData.customProjectOrder.filter(
-          (id): id is string => typeof id === 'string',
-        )
-      : []
-    // eslint-disable-next-line typescript/no-unsafe-assignment
-    const aiChatConversations: AiChatConversation[] = Array.isArray(
-      storageData[AI_CHAT_CONVERSATIONS_KEY],
-    )
-      ? storageData[AI_CHAT_CONVERSATIONS_KEY]
-      : []
-    const activeAiChatConversationId =
-      typeof storageData[ACTIVE_AI_CHAT_CONVERSATION_ID_KEY] === 'string'
-        ? storageData[ACTIVE_AI_CHAT_CONVERSATION_ID_KEY]
-        : ''
-    // eslint-disable-next-line typescript/no-unsafe-assignment
-    const savedAnalyticsViews = Array.isArray(storageData.savedAnalyticsViews)
-      ? storageData.savedAnalyticsViews
-      : []
-    // eslint-disable-next-line typescript/no-unsafe-assignment
-    const urlRecords: UrlRecord[] = Array.isArray(storageData.urls)
-      ? storageData.urls
-      : []
+    // customProjectOrder is already typed from getCustomProjectOrder()
+    const aiChatHistory = await loadConversationHistory()
+    const aiChatConversations: AiChatConversation[] =
+      aiChatHistory.conversations
+    const activeAiChatConversationId = aiChatHistory.activeConversationId
     const urlRecordMap = new Map(
-      urlRecords.map((urlRecord) => [urlRecord.id, urlRecord]),
+      urls.map((urlRecord) => [urlRecord.id, urlRecord]),
     )
     const placeholderUrlRecordMap = new Map<string, UrlRecord>()
     const placeholderUrlTitle = getPlaceholderUrlTitle(
@@ -215,7 +194,8 @@ const exportSettings = async (): Promise<BackupData> => {
       timestamp: new Date().toISOString(),
       urls: exportUrlRecords,
       userSettings,
-      version: chrome.runtime.getManifest().version || '1.0.0',
+      // eslint-disable-next-line typescript/prefer-nullish-coalescing -- empty version string should fall through to default
+      version: getManifestVersion() || '1.0.0',
     }
     return backupData
   } catch (error) {
@@ -262,62 +242,34 @@ const importWithMerge = async ({
 }: ImportExecutionParams & {
   translate?: Translate
 }): Promise<ImportResult> => {
-  const [currentSettings, storageData] = await Promise.all([
+  const [
+    currentSettings,
+    currentCustomProjectOrderRaw,
+    currentCustomProjectsRaw,
+    currentParentCategories,
+    currentSavedAnalyticsViewsRaw,
+    currentTabsRaw,
+    currentAiChatHistory,
+  ] = await Promise.all([
     getUserSettingsFromStorage(),
-    chrome.storage.local.get<{
-      activeAiChatConversationId?: string
-      aiChatConversations?: AiChatConversation[]
-      customProjectOrder?: string[]
-      customProjects?: CustomProject[]
-      parentCategories?: ParentCategory[]
-      savedAnalyticsViews?: SavedAnalyticsView[]
-      savedTabs?: TabGroup[]
-    }>([
-      ACTIVE_AI_CHAT_CONVERSATION_ID_KEY,
-      AI_CHAT_CONVERSATIONS_KEY,
-      'customProjectOrder',
-      'customProjects',
-      'parentCategories',
-      'savedAnalyticsViews',
-      'savedTabs',
-    ]),
+    getCustomProjectOrder(),
+    getCustomProjects(),
+    getParentCategories(),
+    loadSavedAnalyticsViews(),
+    getSavedTabs(),
+    loadConversationHistory(),
   ])
-  const currentCategories: ParentCategory[] = Array.isArray(
-    storageData.parentCategories,
+  const currentCategories: ParentCategory[] = currentParentCategories
+  const currentTabs: TabGroup[] = currentTabsRaw
+  const currentCustomProjects: CustomProject[] = currentCustomProjectsRaw.map(
+    (project) => normalizeImportedCustomProject(project),
   )
-    ? storageData.parentCategories
-    : []
-  const currentTabs: TabGroup[] = Array.isArray(storageData.savedTabs)
-    ? storageData.savedTabs
-    : []
-  const currentCustomProjects: CustomProject[] = Array.isArray(
-    storageData.customProjects,
-  )
-    ? storageData.customProjects.map((project) =>
-        normalizeImportedCustomProject(project),
-      )
-    : []
-  const currentCustomProjectOrder: string[] = Array.isArray(
-    storageData.customProjectOrder,
-  )
-    ? storageData.customProjectOrder.filter(
-        (id): id is string => typeof id === 'string',
-      )
-    : []
-  const currentAiChatConversations: AiChatConversation[] = Array.isArray(
-    storageData[AI_CHAT_CONVERSATIONS_KEY],
-  )
-    ? storageData[AI_CHAT_CONVERSATIONS_KEY]
-    : []
+  const currentCustomProjectOrder: string[] = currentCustomProjectOrderRaw
+  const currentAiChatConversations: AiChatConversation[] =
+    currentAiChatHistory.conversations
   const currentActiveAiChatConversationId =
-    typeof storageData[ACTIVE_AI_CHAT_CONVERSATION_ID_KEY] === 'string'
-      ? storageData[ACTIVE_AI_CHAT_CONVERSATION_ID_KEY]
-      : ''
-  const currentSavedAnalyticsViews = Array.isArray(
-    storageData.savedAnalyticsViews,
-  )
-    ? storageData.savedAnalyticsViews
-    : []
+    currentAiChatHistory.activeConversationId
+  const currentSavedAnalyticsViews = currentSavedAnalyticsViewsRaw
   const mergedSettings = mergeUserSettings(
     currentSettings,
     importedData.userSettings,
@@ -368,23 +320,27 @@ const importWithMerge = async ({
   await Promise.all([
     saveUserSettings(mergedSettings),
     saveParentCategories(mergedCategories),
-    chrome.storage.local.set({
-      customProjectOrder: mergedCustomProjectData.customProjectOrder,
-      customProjects: mergedCustomProjectData.customProjects,
-      ...(mergedAiChatHistory
-        ? {
-            [ACTIVE_AI_CHAT_CONVERSATION_ID_KEY]:
-              mergedAiChatHistory.activeConversationId,
-            [AI_CHAT_CONVERSATIONS_KEY]: mergedAiChatHistory.conversations,
-          }
-        : {}),
-      ...(mergedSavedAnalyticsViews
-        ? {
-            savedAnalyticsViews: mergedSavedAnalyticsViews,
-          }
-        : {}),
-      savedTabs: mergedTabs,
-    }),
+    (async () => {
+      const storageLocal = getChromeStorageLocal()
+      if (!storageLocal) {
+        return
+      }
+      await storageLocal.set({
+        customProjectOrder: mergedCustomProjectData.customProjectOrder,
+        customProjects: mergedCustomProjectData.customProjects,
+        ...(mergedAiChatHistory
+          ? {
+              [ACTIVE_AI_CHAT_CONVERSATION_ID_KEY]:
+                mergedAiChatHistory.activeConversationId,
+              [AI_CHAT_CONVERSATIONS_KEY]: mergedAiChatHistory.conversations,
+            }
+          : {}),
+        ...(mergedSavedAnalyticsViews
+          ? { savedAnalyticsViews: mergedSavedAnalyticsViews }
+          : {}),
+        savedTabs: mergedTabs,
+      })
+    })(),
   ])
   const unresolvedWarning = await createUnresolvedWarning(
     unresolvedTabs,
@@ -450,23 +406,27 @@ const importWithOverwrite = async ({
       ...importedData.userSettings,
     }),
     saveParentCategories(cleanParentCategories),
-    chrome.storage.local.set({
-      customProjectOrder: overwriteCustomProjectData.customProjectOrder,
-      customProjects: overwriteCustomProjectData.customProjects,
-      ...(overwriteAiChatHistory
-        ? {
-            [ACTIVE_AI_CHAT_CONVERSATION_ID_KEY]:
-              overwriteAiChatHistory.activeConversationId,
-            [AI_CHAT_CONVERSATIONS_KEY]: overwriteAiChatHistory.conversations,
-          }
-        : {}),
-      ...(overwriteSavedAnalyticsViews
-        ? {
-            savedAnalyticsViews: overwriteSavedAnalyticsViews,
-          }
-        : {}),
-      savedTabs: cleanTabGroups,
-    }),
+    (async () => {
+      const storageLocal = getChromeStorageLocal()
+      if (!storageLocal) {
+        return
+      }
+      await storageLocal.set({
+        customProjectOrder: overwriteCustomProjectData.customProjectOrder,
+        customProjects: overwriteCustomProjectData.customProjects,
+        ...(overwriteAiChatHistory
+          ? {
+              [ACTIVE_AI_CHAT_CONVERSATION_ID_KEY]:
+                overwriteAiChatHistory.activeConversationId,
+              [AI_CHAT_CONVERSATIONS_KEY]: overwriteAiChatHistory.conversations,
+            }
+          : {}),
+        ...(overwriteSavedAnalyticsViews
+          ? { savedAnalyticsViews: overwriteSavedAnalyticsViews }
+          : {}),
+        savedTabs: cleanTabGroups,
+      })
+    })(),
   ])
   const [unresolvedWarning] = await Promise.all([
     createUnresolvedWarning(unresolvedTabs, translate),

--- a/src/features/options/lib/import-export/url-conversion.ts
+++ b/src/features/options/lib/import-export/url-conversion.ts
@@ -5,7 +5,11 @@ import {
   resolveLanguage,
 } from '@/features/i18n/lib/language'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
-import { createOrUpdateUrlRecord } from '@/lib/storage/urls'
+import {
+  createOrUpdateUrlRecord,
+  getUrlRecords,
+  saveUrlRecords,
+} from '@/lib/storage/urls'
 import type { TabGroup, UrlRecord, UserSettings } from '@/types/storage'
 
 import type {
@@ -282,13 +286,7 @@ const ensurePlaceholderUrlRecords = async (
   if (unresolvedTabs.length === 0) {
     return 0
   }
-  const urlsData = await chrome.storage.local.get({
-    urls: [],
-  })
-  // eslint-disable-next-line typescript/no-unsafe-assignment
-  const currentUrlRecords: UrlRecord[] = Array.isArray(urlsData.urls)
-    ? urlsData.urls
-    : []
+  const currentUrlRecords = await getUrlRecords()
   const existingIdSet = new Set(currentUrlRecords.map((record) => record.id))
   const newRecords: UrlRecord[] = []
   let offset = 0
@@ -313,9 +311,7 @@ const ensurePlaceholderUrlRecords = async (
   if (newRecords.length === 0) {
     return 0
   }
-  await chrome.storage.local.set({
-    urls: [...currentUrlRecords, ...newRecords],
-  })
+  await saveUrlRecords([...currentUrlRecords, ...newRecords])
   return newRecords.length
 }
 

--- a/src/features/options/routes/OptionsRoute.tsx
+++ b/src/features/options/routes/OptionsRoute.tsx
@@ -34,6 +34,7 @@ import { OptionsColorPickerRow } from '@/features/options/OptionsColorPickerRow'
 import { OptionsExcludePatternBadge } from '@/features/options/OptionsExcludePatternBadge'
 import { OptionsExcludePatternInputRow } from '@/features/options/OptionsExcludePatternInputRow'
 import { OptionsFontSizeInputColumn } from '@/features/options/OptionsFontSizeInputColumn'
+import { getExtensionUrl } from '@/lib/browser/runtime'
 import type { UserSettings } from '@/types/storage'
 
 import { resetFontSizeInputState } from './optionsRoute.helpers'
@@ -336,7 +337,7 @@ const useOptionsRouteView = () => {
 
   const handleClickReleaseNotes = useCallback(() => {
     window.open(
-      chrome.runtime.getURL('changelog.html'),
+      getExtensionUrl('changelog.html') ?? 'changelog.html',
       '_blank',
       'noopener,noreferrer',
     )

--- a/src/features/options/subCategoryKeywordManager.helpers.ts
+++ b/src/features/options/subCategoryKeywordManager.helpers.ts
@@ -1,3 +1,4 @@
+import { getSavedTabs, saveTabGroups } from '@/lib/storage/tabs'
 import type { TabGroup } from '@/types/storage'
 
 const replaceTabGroup = (
@@ -24,11 +25,9 @@ const shouldSkipRename = (oldName: string, newName: string): boolean =>
 // タブグループを更新するヘルパー関数
 const updateTabGroup = async (updatedTabGroup: TabGroup) => {
   try {
-    const { savedTabs = [] } = await chrome.storage.local.get<{
-      savedTabs?: TabGroup[]
-    }>('savedTabs')
+    const savedTabs = await getSavedTabs()
     const updatedTabs = replaceTabGroup(savedTabs, updatedTabGroup)
-    await chrome.storage.local.set({ savedTabs: updatedTabs })
+    await saveTabGroups(updatedTabs)
     return true
   } catch (error) {
     console.error('タブグループ更新エラー:', error)

--- a/src/lib/browser/chrome-storage.ts
+++ b/src/lib/browser/chrome-storage.ts
@@ -2,6 +2,16 @@ import { getChromeGlobal, isObjectLike } from '@/lib/browser/chrome-global'
 
 type ChromeStorageApi = typeof chrome.storage
 
+/**
+ * `chrome.storage.onChanged` listener に渡される変更エントリ。
+ * `chrome.storage.StorageChange` 互換だが、`chrome.*` 型を利用側に
+ * 露出しないための infrastructure 側の型境界。
+ */
+export type StorageChange = {
+  newValue?: unknown
+  oldValue?: unknown
+}
+
 const warnedContexts = new Set<string>()
 
 const isChromeApi = (value: unknown): value is typeof chrome =>

--- a/src/lib/browser/chrome-storage.ts
+++ b/src/lib/browser/chrome-storage.ts
@@ -12,6 +12,11 @@ export type StorageChange = {
   oldValue?: unknown
 }
 
+export type ChromeOnChangedListener = (
+  changes: Record<string, StorageChange>,
+  areaName: string,
+) => void
+
 const warnedContexts = new Set<string>()
 
 const isChromeApi = (value: unknown): value is typeof chrome =>

--- a/src/lib/browser/runtime.ts
+++ b/src/lib/browser/runtime.ts
@@ -93,6 +93,60 @@ const sendWithChromeRuntime = async (
     }
   })
 
+/**
+ * `chrome.runtime.PlatformInfo` 互換の最小型。
+ * `chrome.*` 型を利用側に露出しないための infrastructure 側の型境界。
+ */
+export type PlatformInfo = {
+  os?: string
+}
+
+/**
+ * `chrome.runtime.getManifest().version` を安全に取得する。
+ * `chrome` API が見つからない環境では `undefined` を返す。
+ */
+export const getManifestVersion = (): string | undefined => {
+  const chromeRuntime = getGlobalChromeRuntime()
+  if (!chromeRuntime) {
+    return undefined
+  }
+  const getManifestValue: unknown = Reflect.get(chromeRuntime, 'getManifest')
+  if (typeof getManifestValue !== 'function') {
+    return undefined
+  }
+  try {
+    const manifest: unknown = Reflect.apply(getManifestValue, chromeRuntime, [])
+    if (isObjectLike(manifest)) {
+      const version: unknown = Reflect.get(manifest, 'version')
+      return typeof version === 'string' ? version : undefined
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * `chrome.runtime.getURL(path)` を安全に呼び出す。
+ * `chrome` API が見つからない環境では `undefined` を返す。
+ */
+export const getExtensionUrl = (path: string): string | undefined => {
+  const chromeRuntime = getGlobalChromeRuntime()
+  if (!chromeRuntime) {
+    return undefined
+  }
+  const getURLValue: unknown = Reflect.get(chromeRuntime, 'getURL')
+  if (typeof getURLValue !== 'function') {
+    return undefined
+  }
+  try {
+    const url: unknown = Reflect.apply(getURLValue, chromeRuntime, [path])
+    return typeof url === 'string' ? url : undefined
+  } catch {
+    return undefined
+  }
+}
+
 export const sendRuntimeMessage = async (
   message: unknown,
 ): Promise<unknown> => {

--- a/src/lib/storage/tabs.ts
+++ b/src/lib/storage/tabs.ts
@@ -21,6 +21,73 @@ type ResolvedTabGroupUrl = UrlRecord & {
   subCategory?: string
 }
 
+/**
+ * `chrome.storage.local` から `savedTabs` 全件を読み出す。
+ * infrastructure 境界の関数で、features / components 層が
+ * `chrome.storage.local.get` を直接呼ぶ代わりに利用する。
+ */
+const getSavedTabs = async (): Promise<TabGroup[]> => {
+  const { savedTabs = [] } = await chrome.storage.local.get<{
+    savedTabs?: TabGroup[]
+  }>('savedTabs')
+  return savedTabs
+}
+
+/**
+ * `savedTabs` 全件を `chrome.storage.local` へ書き戻す。
+ * `getSavedTabs` と対になる永続化関数。
+ */
+const saveTabGroups = async (tabGroups: TabGroup[]): Promise<void> => {
+  await chrome.storage.local.set({ savedTabs: tabGroups })
+}
+
+/**
+ * 指定タブグループ内の子カテゴリ名をリネームし、関連する
+ * `categoryKeywords`, `urls[].subCategory`, `subCategoryOrder`,
+ * `subCategoryOrderWithUncategorized` も一括更新する。
+ * `SubCategoryKeywordManager` のリネーム操作を
+ * `chrome.storage.local` 直叩きから置換するために追加。
+ */
+const renameSubCategoryInTabGroup = async (
+  groupId: string,
+  oldName: string,
+  newName: string,
+): Promise<TabGroup[]> => {
+  const savedTabs = await getSavedTabs()
+  const updatedTabs = savedTabs.map((tab: TabGroup) => {
+    if (tab.id !== groupId) {
+      return tab
+    }
+    const updatedSubCategories =
+      tab.subCategories?.map((cat) => (cat === oldName ? newName : cat)) ?? []
+    const updatedCategoryKeywords =
+      tab.categoryKeywords?.map((ck) =>
+        ck.categoryName === oldName ? { ...ck, categoryName: newName } : ck,
+      ) ?? []
+    const updatedUrls = (tab.urls ?? []).map((url) =>
+      url.subCategory === oldName ? { ...url, subCategory: newName } : url,
+    )
+    const updatedSubCategoryOrder =
+      tab.subCategoryOrder?.map((cat) => (cat === oldName ? newName : cat)) ??
+      []
+    const updatedSubCategoryOrderWithUncategorized =
+      tab.subCategoryOrderWithUncategorized?.map((cat) =>
+        cat === oldName ? newName : cat,
+      ) ?? []
+    return {
+      ...tab,
+      categoryKeywords: updatedCategoryKeywords,
+      subCategories: updatedSubCategories,
+      subCategoryOrder: updatedSubCategoryOrder,
+      subCategoryOrderWithUncategorized:
+        updatedSubCategoryOrderWithUncategorized,
+      urls: updatedUrls,
+    }
+  })
+  await saveTabGroups(updatedTabs)
+  return updatedTabs
+}
+
 type DeleteSyncOptions = {
   throwOnSyncError?: boolean
 }
@@ -815,6 +882,9 @@ const removeUrlsFromTabGroup = async (
 
 export {
   addSubCategoryToGroup,
+  getSavedTabs,
+  renameSubCategoryInTabGroup,
+  saveTabGroups,
   addSubCategoryWithKeywords,
   addUrlToTabGroup,
   applySubCategoryMapping,

--- a/src/lib/storage/tabs.ts
+++ b/src/lib/storage/tabs.ts
@@ -67,6 +67,16 @@ const renameSubCategoryInTabGroup = async (
     const updatedUrls = (tab.urls ?? []).map((url) =>
       url.subCategory === oldName ? { ...url, subCategory: newName } : url,
     )
+    const updatedUrlSubCategories: Record<string, string> = {}
+    let urlSubCategoriesChanged = false
+    for (const [urlId, cat] of Object.entries(tab.urlSubCategories ?? {})) {
+      if (cat === oldName) {
+        updatedUrlSubCategories[urlId] = newName
+        urlSubCategoriesChanged = true
+      } else {
+        updatedUrlSubCategories[urlId] = cat
+      }
+    }
     const updatedSubCategoryOrder =
       tab.subCategoryOrder?.map((cat) => (cat === oldName ? newName : cat)) ??
       []
@@ -81,6 +91,9 @@ const renameSubCategoryInTabGroup = async (
       subCategoryOrder: updatedSubCategoryOrder,
       subCategoryOrderWithUncategorized:
         updatedSubCategoryOrderWithUncategorized,
+      urlSubCategories: urlSubCategoriesChanged
+        ? updatedUrlSubCategories
+        : tab.urlSubCategories,
       urls: updatedUrls,
     }
   })


### PR DESCRIPTION
## 変更内容

Issue #645 に対応し、Chrome API (`chrome.*` / `browser.*`) の直接利用を entrypoint / infrastructure / adapter / repository 層に限定します。

### 許可するディレクトリ（制限なし）
- `src/entrypoints/**`
- `src/contexts/*/infrastructure/**`
- `src/lib/chrome/**`
- `src/lib/browser/**`
- `src/lib/storage/**`
- `src/lib/background/**`
- `src/**/adapter/**`
- `src/**/repository/**`
- test helper / mock / fixture
- tools / config

### 禁止するディレクトリ（oxlint で制限）
- `src/contexts/*/domain/**` — `chrome`, `browser` global + `chrome.tabs/storage/runtime/contextMenus/alarms/notifications`
- `src/contexts/*/application/**` — `chrome`, `browser` global + `chrome.tabs/storage/runtime/contextMenus/alarms/notifications`
- `src/contexts/*/presentation/**` — `chrome`, `browser` global + `chrome.tabs/storage/runtime/contextMenus/alarms/notifications`
- `src/features/**` — `chrome`, `browser` global + `chrome.tabs/storage/runtime/contextMenus/alarms/notifications`
- `src/components/**` — `chrome`, `browser` global + `chrome.tabs/storage/runtime/contextMenus/alarms/notifications`

### 実装内容

1. **oxlint ルール追加・拡充**
   - features/components 層に `no-restricted-globals` (chrome, browser) と `no-restricted-properties` (chrome.tabs/storage/runtime/contextMenus/notifications/alarms) を追加
   - domain/application/presentation 層の既存制限を拡充（browser global, chrome.runtime, chrome.notifications を追加）
   - test ファイルの制限免除 override を最後に移動し、層別 override より優先されるように修正

2. **インフラ層の型・関数追加**
   - `StorageChange` 型を `src/lib/browser/chrome-storage.ts` に追加
   - `PlatformInfo` 型, `getManifestVersion()`, `getExtensionUrl()` を `src/lib/browser/runtime.ts` に追加
   - `getSavedTabs()`, `saveTabGroups()`, `renameSubCategoryInTabGroup()` を `src/lib/storage/tabs.ts` に追加

3. **features/components の chrome.* 直接利用を置換**
   - `chrome.storage.local.get/set` → `getSavedTabs`/`saveTabGroups`/`getUrlRecords`/`getChromeStorageLocal` 等
   - `chrome.runtime.sendMessage` → `sendRuntimeMessage`
   - `chrome.runtime.getURL` → `getExtensionUrl`
   - `chrome.runtime.getManifest` → `getManifestVersion`
   - `chrome.storage.StorageChange` 型 → `StorageChange` 型
   - `chrome.runtime.PlatformInfo` 型 → `PlatformInfo` 型
   - SubCategoryKeywordManager: inline storage 操作 → `removeSubCategoryFromTabGroup`/`renameSubCategoryInTabGroup`
   - import-export flows.ts: 個別 storage helper + `getChromeStorageLocal` 経由に変更

## チェックリスト

- [x] ローカル環境でエラーになっていない
- [x] `bun run lint` が通る
- [x] `bun run test` が通る
- [x] `bun run build` が通る
- [x] `bun run quality` が通る

Closes #645

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more reliable saved-tab and subcategory management, including safer storage-driven updates.
  * Improved import/export handling across settings, tabs, URLs, projects, analytics, and chat history.
  * Added safer runtime/extension URL handling for better compatibility.

* **Bug Fixes**
  * Analytics drilldown delete + undo now handle missing/unsupported local storage gracefully.
  * Auto-delete period and color reset flows are more resilient when storage is unavailable.

* **Tests**
  * Expanded storage-backed test coverage for import/export and tab management workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->