### PR TITLE
Storage API の直接利用を repository / adapter に限定する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -625,6 +625,18 @@
           {
             "name": "browser",
             "message": "features / components 層は browser.* を直接利用できません（adapter / infrastructure / repository 経由）"
+          },
+          {
+            "name": "localStorage",
+            "message": "features / components 層は localStorage を直接利用できません（src/lib/storage/local-storage-adapter 経由）"
+          },
+          {
+            "name": "sessionStorage",
+            "message": "features / components 層は sessionStorage を直接利用できません（storage adapter 経由）"
+          },
+          {
+            "name": "indexedDB",
+            "message": "features / components 層は indexedDB を直接利用できません（repository / storage adapter 経由）"
           }
         ],
         "eslint/no-restricted-properties": [
@@ -658,6 +670,26 @@
             "object": "chrome",
             "property": "alarms",
             "message": "features / components 層は chrome.alarms を直接利用できません（AlarmAdapter 経由）"
+          },
+          {
+            "object": "window",
+            "property": "localStorage",
+            "message": "features / components 層は window.localStorage を直接利用できません（src/lib/storage/local-storage-adapter 経由）"
+          },
+          {
+            "object": "window",
+            "property": "sessionStorage",
+            "message": "features / components 層は window.sessionStorage を直接利用できません（storage adapter 経由）"
+          },
+          {
+            "object": "window",
+            "property": "indexedDB",
+            "message": "features / components 層は window.indexedDB を直接利用できません（repository / storage adapter 経由）"
+          },
+          {
+            "object": "browser",
+            "property": "storage",
+            "message": "features / components 層は browser.storage を直接利用できません（repository / storage adapter 経由）"
           }
         ]
       }
@@ -756,6 +788,10 @@
           {
             "name": "window",
             "message": "domain 層は window に依存できません"
+          },
+          {
+            "name": "indexedDB",
+            "message": "domain 層は indexedDB を直接利用できません"
           }
         ],
         "eslint/no-restricted-properties": [
@@ -804,6 +840,26 @@
             "object": "crypto",
             "property": "randomUUID",
             "message": "domain 層は crypto.randomUUID() を直接利用できません。IdGeneratorPort 経由で ID を生成してください"
+          },
+          {
+            "object": "window",
+            "property": "localStorage",
+            "message": "domain 層は window.localStorage を直接利用できません（storage adapter 経由）"
+          },
+          {
+            "object": "window",
+            "property": "sessionStorage",
+            "message": "domain 層は window.sessionStorage を直接利用できません（storage adapter 経由）"
+          },
+          {
+            "object": "window",
+            "property": "indexedDB",
+            "message": "domain 層は window.indexedDB を直接利用できません（storage adapter 経由）"
+          },
+          {
+            "object": "browser",
+            "property": "storage",
+            "message": "domain 層は browser.storage を直接利用できません（repository 経由）"
           }
         ]
       }
@@ -857,6 +913,26 @@
             "object": "crypto",
             "property": "randomUUID",
             "message": "application 層は crypto.randomUUID() を直接利用できません。IdGeneratorPort 経由で ID を生成してください"
+          },
+          {
+            "object": "window",
+            "property": "localStorage",
+            "message": "application 層は window.localStorage を直接利用できません（storage adapter 経由）"
+          },
+          {
+            "object": "window",
+            "property": "sessionStorage",
+            "message": "application 層は window.sessionStorage を直接利用できません（storage adapter 経由）"
+          },
+          {
+            "object": "window",
+            "property": "indexedDB",
+            "message": "application 層は window.indexedDB を直接利用できません（repository / storage adapter 経由）"
+          },
+          {
+            "object": "browser",
+            "property": "storage",
+            "message": "application 層は browser.storage を直接利用できません（repository 経由）"
           }
         ],
         "eslint/no-restricted-globals": [
@@ -868,6 +944,18 @@
           {
             "name": "browser",
             "message": "application 層は browser.* を直接利用できません（adapter / port 経由）"
+          },
+          {
+            "name": "localStorage",
+            "message": "application 層は localStorage を直接利用できません（storage adapter 経由）"
+          },
+          {
+            "name": "sessionStorage",
+            "message": "application 層は sessionStorage を直接利用できません（storage adapter 経由）"
+          },
+          {
+            "name": "indexedDB",
+            "message": "application 層は indexedDB を直接利用できません（repository / storage adapter 経由）"
           }
         ]
       }
@@ -906,6 +994,26 @@
             "object": "chrome",
             "property": "notifications",
             "message": "presentation 層は chrome.notifications を直接利用できません（NotificationPort 経由）"
+          },
+          {
+            "object": "window",
+            "property": "localStorage",
+            "message": "presentation 層は window.localStorage を直接利用できません（src/lib/storage/local-storage-adapter 経由）"
+          },
+          {
+            "object": "window",
+            "property": "sessionStorage",
+            "message": "presentation 層は window.sessionStorage を直接利用できません（storage adapter 経由）"
+          },
+          {
+            "object": "window",
+            "property": "indexedDB",
+            "message": "presentation 層は window.indexedDB を直接利用できません（repository / storage adapter 経由）"
+          },
+          {
+            "object": "browser",
+            "property": "storage",
+            "message": "presentation 層は browser.storage を直接利用できません（repository 経由）"
           }
         ],
         "eslint/no-restricted-globals": [
@@ -917,6 +1025,18 @@
           {
             "name": "browser",
             "message": "presentation 層は browser.* を直接利用できません（adapter / port 経由）"
+          },
+          {
+            "name": "localStorage",
+            "message": "presentation 層は localStorage を直接利用できません（storage adapter 経由）"
+          },
+          {
+            "name": "sessionStorage",
+            "message": "presentation 層は sessionStorage を直接利用できません（storage adapter 経由）"
+          },
+          {
+            "name": "indexedDB",
+            "message": "presentation 層は indexedDB を直接利用できません（repository / storage adapter 経由）"
           }
         ]
       }

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -16,6 +16,10 @@ import {
 } from '@/components/ui/tooltip'
 import { useI18nText } from '@/features/i18n/lib/useI18nText'
 import { useIsMobile } from '@/hooks/use-mobile'
+import {
+  readLocalStorage,
+  writeLocalStorage,
+} from '@/lib/storage/local-storage-adapter'
 import { cn } from '@/lib/utils'
 
 const SECONDS_IN_MINUTE_SB = 60
@@ -52,7 +56,7 @@ const loadSidebarWidth = (): number => {
     return SIDEBAR_WIDTH_ICON_PX
   }
 
-  const storedWidth = window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)
+  const storedWidth = readLocalStorage(SIDEBAR_WIDTH_STORAGE_KEY)
   if (!storedWidth) {
     return clampSidebarWidth(SIDEBAR_WIDTH_ICON_PX)
   }
@@ -69,14 +73,7 @@ const persistSidebarWidth = (width: number): void => {
     return
   }
 
-  try {
-    window.localStorage.setItem(
-      SIDEBAR_WIDTH_STORAGE_KEY,
-      String(clampSidebarWidth(width)),
-    )
-  } catch {
-    // LocalStorage が使えない環境では保持をスキップする
-  }
+  writeLocalStorage(SIDEBAR_WIDTH_STORAGE_KEY, String(clampSidebarWidth(width)))
 }
 
 type SidebarContextProps = {

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -344,13 +344,15 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       )
     })
 
-    it('chrome / localStorage / sessionStorage / document / window の global 参照を禁止している', () => {
+    it('chrome / localStorage / sessionStorage / indexedDB / document / window の global 参照を禁止している', () => {
       const names = getRestrictedGlobals(globalsOverride)
       expect(names).toContain('chrome')
       expect(names).toContain('localStorage')
       expect(names).toContain('sessionStorage')
       expect(names).toContain('document')
       expect(names).toContain('window')
+      // issue #646: indexedDB も storage adapter 経由に限定
+      expect(names).toContain('indexedDB')
     })
 
     it('chrome.tabs / chrome.storage / chrome.contextMenus / chrome.alarms / chrome.notifications / chrome.runtime の直叩きを禁止している', () => {
@@ -361,6 +363,14 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       expect(names).toContain('chrome.alarms')
       expect(names).toContain('chrome.notifications')
       expect(names).toContain('chrome.runtime')
+    })
+
+    it('issue #646: window.localStorage / window.sessionStorage / window.indexedDB / browser.storage の直叩きを禁止している', () => {
+      const names = getRestrictedProperties(propertiesOverride)
+      expect(names).toContain('window.localStorage')
+      expect(names).toContain('window.sessionStorage')
+      expect(names).toContain('window.indexedDB')
+      expect(names).toContain('browser.storage')
     })
 
     it('issue #582: Date.now() を no-restricted-properties で禁止している', () => {
@@ -432,9 +442,30 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       'application',
       'eslint/no-restricted-properties',
     )
+    const globalsOverride = findOverride(
+      config,
+      'application',
+      'eslint/no-restricted-globals',
+    )
 
     it('override が定義されている', () => {
       expect(propertiesOverride).toBeDefined()
+      expect(globalsOverride).toBeDefined()
+    })
+
+    it('issue #646: localStorage / sessionStorage / indexedDB の global 参照を禁止している', () => {
+      const names = getRestrictedGlobals(globalsOverride)
+      expect(names).toContain('localStorage')
+      expect(names).toContain('sessionStorage')
+      expect(names).toContain('indexedDB')
+    })
+
+    it('issue #646: window.localStorage / window.sessionStorage / window.indexedDB / browser.storage の直叩きを禁止している', () => {
+      const names = getRestrictedProperties(propertiesOverride)
+      expect(names).toContain('window.localStorage')
+      expect(names).toContain('window.sessionStorage')
+      expect(names).toContain('window.indexedDB')
+      expect(names).toContain('browser.storage')
     })
 
     it('UI / routing / notification / animation 系 package の import を禁止している', () => {
@@ -528,9 +559,30 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       'presentation',
       'eslint/no-restricted-properties',
     )
+    const globalsOverride = findOverride(
+      config,
+      'presentation',
+      'eslint/no-restricted-globals',
+    )
 
     it('override が定義されている', () => {
       expect(propertiesOverride).toBeDefined()
+      expect(globalsOverride).toBeDefined()
+    })
+
+    it('issue #646: localStorage / sessionStorage / indexedDB の global 参照を禁止している', () => {
+      const names = getRestrictedGlobals(globalsOverride)
+      expect(names).toContain('localStorage')
+      expect(names).toContain('sessionStorage')
+      expect(names).toContain('indexedDB')
+    })
+
+    it('issue #646: window.localStorage / window.sessionStorage / window.indexedDB / browser.storage の直叩きを禁止している', () => {
+      const names = getRestrictedProperties(propertiesOverride)
+      expect(names).toContain('window.localStorage')
+      expect(names).toContain('window.sessionStorage')
+      expect(names).toContain('window.indexedDB')
+      expect(names).toContain('browser.storage')
     })
 
     it('chrome.storage / chrome.tabs / chrome.contextMenus / chrome.alarms / chrome.runtime の直叩きを禁止している', () => {

--- a/src/features/ai-chat/components/savedTabsChat/storage.ts
+++ b/src/features/ai-chat/components/savedTabsChat/storage.ts
@@ -1,5 +1,9 @@
 import { normalizeAiSystemPromptSettings } from '@/features/ai-chat/lib/systemPromptPresets'
 import type { AiChatHistoryItem } from '@/features/ai-chat/types'
+import {
+  readLocalStorage,
+  writeLocalStorage,
+} from '@/lib/storage/local-storage-adapter'
 import { defaultSettings, getUserSettings } from '@/lib/storage/settings'
 import type { AiChatToolTrace, OllamaErrorDetails } from '@/types/background'
 import type { UserSettings } from '@/types/storage'
@@ -35,7 +39,7 @@ const loadSidebarWidth = (): number => {
     return DEFAULT_CHAT_SIDEBAR_WIDTH
   }
 
-  const storedWidth = window.localStorage.getItem(CHAT_SIDEBAR_STORAGE_KEY)
+  const storedWidth = readLocalStorage(CHAT_SIDEBAR_STORAGE_KEY)
   if (!storedWidth) {
     return clampSidebarWidth(DEFAULT_CHAT_SIDEBAR_WIDTH)
   }
@@ -52,14 +56,7 @@ const persistSidebarWidth = (width: number): void => {
     return
   }
 
-  try {
-    window.localStorage.setItem(
-      CHAT_SIDEBAR_STORAGE_KEY,
-      String(clampSidebarWidth(width)),
-    )
-  } catch {
-    // Skip persistence when localStorage is unavailable.
-  }
+  writeLocalStorage(CHAT_SIDEBAR_STORAGE_KEY, String(clampSidebarWidth(width)))
 }
 
 const syncExternalConversationState = ({

--- a/src/features/navigation/components/ExtensionSidebar.tsx
+++ b/src/features/navigation/components/ExtensionSidebar.tsx
@@ -42,6 +42,7 @@ import type {
   SidebarItemId,
   SidebarState,
 } from '@/features/navigation/lib/pageNavigation'
+import { writeLocalStorage } from '@/lib/storage/local-storage-adapter'
 import { cn } from '@/lib/utils'
 
 type ExtensionSidebarProps = {
@@ -442,27 +443,16 @@ export const ExtensionSidebar = ({ state }: ExtensionSidebarProps) => {
     setOpen(true)
     setSidebarWidth(ICON_RAIL_WIDTH_PX)
 
-    try {
-      window.localStorage.setItem(
-        SIDEBAR_WIDTH_STORAGE_KEY,
-        String(ICON_RAIL_WIDTH_PX),
-      )
-    } catch {
-      // LocalStorage が使えない環境では保持をスキップする
-    }
+    writeLocalStorage(SIDEBAR_WIDTH_STORAGE_KEY, String(ICON_RAIL_WIDTH_PX))
   }, [setOpen, setSidebarWidth])
   const handleExpandSidebar = useCallback(() => {
     setOpen(true)
     setSidebarWidth(EXPANDED_SIDEBAR_WIDTH_PX)
 
-    try {
-      window.localStorage.setItem(
-        SIDEBAR_WIDTH_STORAGE_KEY,
-        String(EXPANDED_SIDEBAR_WIDTH_PX),
-      )
-    } catch {
-      // LocalStorage が使えない環境では保持をスキップする
-    }
+    writeLocalStorage(
+      SIDEBAR_WIDTH_STORAGE_KEY,
+      String(EXPANDED_SIDEBAR_WIDTH_PX),
+    )
   }, [setOpen, setSidebarWidth])
   const savedTabsHref = getSavedTabsEntryRoute()
   const railItems: RailItem[] = useMemo(

--- a/src/lib/storage/local-storage-adapter.test.ts
+++ b/src/lib/storage/local-storage-adapter.test.ts
@@ -75,8 +75,7 @@ describe('local-storage-adapter', () => {
     it('window が未定義の場合は何もしない', () => {
       delete (globalThis as Record<string, unknown>).window
 
-      // Should not throw
-      writeLocalStorage('any-key', 'value')
+      expect(() => writeLocalStorage('any-key', 'value')).not.toThrow()
     })
 
     it('localStorage.setItem が例外を投げた場合は何もしない', () => {
@@ -88,8 +87,9 @@ describe('local-storage-adapter', () => {
         configurable: true,
       })
 
-      // Should not throw
-      writeLocalStorage('overflow-key', 'x'.repeat(10_000_000))
+      expect(() =>
+        writeLocalStorage('overflow-key', 'x'.repeat(10_000_000)),
+      ).not.toThrow()
     })
   })
 })

--- a/src/lib/storage/local-storage-adapter.test.ts
+++ b/src/lib/storage/local-storage-adapter.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  readLocalStorage,
+  writeLocalStorage,
+} from '@/lib/storage/local-storage-adapter'
+
+const originalWindow = globalThis.window
+
+afterEach(() => {
+  // Restore window if it was deleted by a test
+  if (originalWindow === undefined) {
+    delete (globalThis as Record<string, unknown>).window
+  } else {
+    globalThis.window = originalWindow
+  }
+  vi.restoreAllMocks()
+})
+
+describe('local-storage-adapter', () => {
+  describe('readLocalStorage', () => {
+    it('window.localStorage から値を読み込む', () => {
+      const getItem = vi.fn().mockReturnValue('42')
+      Object.defineProperty(globalThis, 'window', {
+        value: { localStorage: { getItem } },
+        configurable: true,
+      })
+
+      expect(readLocalStorage('sidebar-width')).toBe('42')
+      expect(getItem).toHaveBeenCalledWith('sidebar-width')
+    })
+
+    it('window.localStorage.getItem が null を返す場合は null を返す', () => {
+      const getItem = vi.fn().mockReturnValue(null)
+      Object.defineProperty(globalThis, 'window', {
+        value: { localStorage: { getItem } },
+        configurable: true,
+      })
+
+      expect(readLocalStorage('missing-key')).toBeNull()
+    })
+
+    it('window が未定義の場合は null を返す', () => {
+      delete (globalThis as Record<string, unknown>).window
+
+      expect(readLocalStorage('any-key')).toBeNull()
+    })
+
+    it('localStorage.getItem が例外を投げた場合は null を返す', () => {
+      const getItem = vi.fn().mockImplementation(() => {
+        throw new Error('SecurityError')
+      })
+      Object.defineProperty(globalThis, 'window', {
+        value: { localStorage: { getItem } },
+        configurable: true,
+      })
+
+      expect(readLocalStorage('blocked-key')).toBeNull()
+    })
+  })
+
+  describe('writeLocalStorage', () => {
+    it('window.localStorage に値を書き込む', () => {
+      const setItem = vi.fn()
+      Object.defineProperty(globalThis, 'window', {
+        value: { localStorage: { setItem } },
+        configurable: true,
+      })
+
+      writeLocalStorage('sidebar-width', '320')
+
+      expect(setItem).toHaveBeenCalledWith('sidebar-width', '320')
+    })
+
+    it('window が未定義の場合は何もしない', () => {
+      delete (globalThis as Record<string, unknown>).window
+
+      // Should not throw
+      writeLocalStorage('any-key', 'value')
+    })
+
+    it('localStorage.setItem が例外を投げた場合は何もしない', () => {
+      const setItem = vi.fn().mockImplementation(() => {
+        throw new Error('QuotaExceededError')
+      })
+      Object.defineProperty(globalThis, 'window', {
+        value: { localStorage: { setItem } },
+        configurable: true,
+      })
+
+      // Should not throw
+      writeLocalStorage('overflow-key', 'x'.repeat(10_000_000))
+    })
+  })
+})

--- a/src/lib/storage/local-storage-adapter.ts
+++ b/src/lib/storage/local-storage-adapter.ts
@@ -1,0 +1,29 @@
+/**
+ * localStorage への safe access adapter。
+ *
+ * presentation / feature / component 層が localStorage を直接触らないようにする
+ * ため (issue #646)、この adapter 経由でアクセスする。SSR / test 環境の
+ * `typeof window === 'undefined'` と quota error を吸収する。
+ */
+
+export function readLocalStorage(key: string): string | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  try {
+    return window.localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+export function writeLocalStorage(key: string, value: string): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  try {
+    window.localStorage.setItem(key, value)
+  } catch {
+    // localStorage が使えない環境では書き込みをスキップする
+  }
+}


### PR DESCRIPTION
## 変更内容

- `src/lib/storage/local-storage-adapter.ts` を新設し、localStorage への safe access を adapter 経由に集約した（SSR guard / try-catch 吸収）
- 検出された `window.localStorage` 直接利用 3 件を adapter 経由に置き換えた
  - `src/components/ui/sidebar.tsx`（sidebar width persistence）
  - `src/features/navigation/components/ExtensionSidebar.tsx`（sidebar width persistence）
  - `src/features/ai-chat/components/savedTabsChat/storage.ts`（chat sidebar width persistence）
- `.oxlintrc.json` の `no-restricted-globals` / `no-restricted-properties` に storage API 制限を追加した
  - 対象: `src/contexts/*/domain/**`, `src/contexts/*/application/**`, `src/contexts/*/presentation/**`, `src/features/**`, `src/components/**`
  - 制限する global: `localStorage`, `sessionStorage`, `indexedDB`
  - 制限する property: `window.localStorage`, `window.sessionStorage`, `window.indexedDB`, `browser.storage`
  - 既存の `chrome.storage` 制限に加え `browser.storage` も追加
- `dddLayerGuard.test.ts` に domain / application / presentation 層の storage API 制限 assertion を追加した
- `local-storage-adapter.test.ts` で adapter の全 branch をカバーするテストを追加した

### 許可するディレクトリ（Storage API 直接利用可）

- `src/lib/storage/**` — storage adapter / repository 実装
- `src/lib/browser/chrome-storage.ts` — Chrome storage API wrapper
- `src/contexts/*/infrastructure/**` — infrastructure / persistence 実装
- `src/entrypoints/**` — 初期化・bridge 部分
- test helper / mock / fixture

### 禁止するディレクトリ（本 PR で lint 強制）

- `src/contexts/*/domain/**`
- `src/contexts/*/application/**`
- `src/contexts/*/presentation/**`
- `src/features/**`
- `src/components/**`

## ローカル検証

- [x] `bun run lint`
- [x] `bun run compile`
- [x] `bun run test`（307 files / 3326 tests passed）
- [x] `bun run build`
- [x] `bun run quality`
- [x] `bun run test:coverage`（adapter ファイル 100% coverage、SubCategoryKeywordManager の既存 flaky test 2 件は本変更と無関係）

closes #646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar width persistence across the main sidebar, extension sidebar, and saved-tabs chat.
  * Prevented storage-related errors from disrupting the interface, including in environments where browser storage is unavailable.
  * Preserved safe defaults and width validation when saved settings are missing or invalid.

* **Tests**
  * Added coverage for successful, unavailable, and failing local storage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->