### PR TITLE
fix: flaky test の根本原因を修正し調査手順を追加

### DIFF
--- a/docs/testing/flaky-tests.md
+++ b/docs/testing/flaky-tests.md
@@ -1,0 +1,51 @@
+# Flaky Test Investigation
+
+TABBIN aims to keep the test baseline green. A flaky test is treated as a bug,
+not as an acceptable existing issue.
+
+## Principles
+
+- Do not hide timing issues with arbitrary `sleep`, increased timeouts, skipped
+  tests, or retry-only success.
+- Fix the root cause: race conditions between async input, React state updates,
+  and browser APIs are common sources.
+- Record reproduction details: failing seed, iteration count, duration, and the
+  exact failure message.
+
+## Repeating a test
+
+Use the helper script to run a single test file many times and collect a
+pass/fail summary:
+
+```bash
+bun tools/scripts/test-flake.mjs --config vitest.ci.config.ts \
+  src/features/options/SubCategoryKeywordManager.test.tsx \
+  --repeat 100 --project dom
+```
+
+For node-project tests, override the project:
+
+```bash
+bun tools/scripts/test-flake.mjs --config vitest.ci.config.ts \
+  src/lib/example.test.ts --repeat 100 --project node
+```
+
+The script runs the file once per Vitest process so each iteration starts from
+a clean module state. Failures are summarized at the end.
+
+## Case study: `SubCategoryKeywordManager` rename input
+
+The rename input was focused and selected with `requestAnimationFrame` in the
+parent component. This scheduled selection could run while `userEvent.type`
+was typing in the same input, causing the first typed character to be selected
+and overwritten by the next keystroke. The saved result was then missing the
+first letter.
+
+The fix moved focus and selection into the input component itself:
+
+- The input is focused on mount with `useEffect`.
+- `onFocus` selects the current value.
+- The parent no longer schedules selection with `requestAnimationFrame`.
+
+This keeps the selection deterministic and prevents it from racing with
+`userEvent.type`.

--- a/src/features/options/SubCategoryKeywordManager.tsx
+++ b/src/features/options/SubCategoryKeywordManager.tsx
@@ -229,14 +229,6 @@ const useSubCategoryKeywordManagerView = ({
   const startRenameMode = useCallback(() => {
     setIsRenamingSubCategory(true)
     setNewCategoryName(getRenameDraftName(activeCategory))
-
-    // 入力フィールドにフォーカスを当てる
-    requestAnimationFrame(() => {
-      if (renameInputRef.current) {
-        renameInputRef.current.focus()
-        renameInputRef.current.select()
-      }
-    })
   }, [activeCategory])
 
   // カテゴリ名変更の処理関数

--- a/src/features/options/SubCategoryRenameSection.tsx
+++ b/src/features/options/SubCategoryRenameSection.tsx
@@ -1,5 +1,5 @@
 import { Check, X } from 'lucide-react'
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -30,6 +30,18 @@ export const SubCategoryRenameSection = ({
     void onCompleteRename()
   }, [onCompleteRename])
 
+  const handleFocus = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    e.currentTarget.select()
+  }, [])
+
+  useEffect(() => {
+    const input = renameInputRef.current
+    if (input) {
+      input.focus()
+      input.select()
+    }
+  }, [renameInputRef])
+
   return (
     <div className='relative mb-4'>
       <Label
@@ -46,6 +58,7 @@ export const SubCategoryRenameSection = ({
           value={newCategoryName}
           onChange={onChange}
           onKeyDown={onKeyDown}
+          onFocus={handleFocus}
           className='grow rounded-l border border-border bg-input p-2 text-foreground'
         />
         <div className='flex shrink-0'>

--- a/tools/scripts/test-flake.mjs
+++ b/tools/scripts/test-flake.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import process from 'node:process'
+
+const args = process.argv.slice(2)
+
+/**
+ * @param {string} name
+ * @returns {string | undefined}
+ */
+function findArg(name) {
+  const idx = args.indexOf(name)
+  if (idx >= 0 && idx + 1 < args.length) {
+    return args[idx + 1]
+  }
+  return undefined
+}
+
+const repeatRaw = findArg('--repeat') ?? '10'
+const repeat = Math.trunc(Number(repeatRaw))
+const configArg = findArg('--config') ?? 'vitest.ci.config.ts'
+const projectOverride = findArg('--project')
+
+const reserved = new Set(['--repeat', '--config', '--project'])
+const positional = args.filter((arg, idx) => {
+  const prev = args[idx - 1]
+  return !reserved.has(arg) && !reserved.has(prev)
+})
+
+if (positional.length === 0 || Number.isNaN(repeat) || repeat <= 0) {
+  console.error(
+    'Usage: bun tools/scripts/test-flake.mjs -- <file> --repeat <n> [--project <dom|node>]',
+  )
+  process.exit(1)
+}
+
+const file = positional[0]
+const project = projectOverride ?? (file.endsWith('.test.tsx') ? 'dom' : 'node')
+
+console.log(
+  `Running ${file} ${repeat} times (project: ${project}, config: ${configArg})...`,
+)
+
+let pass = 0
+let fail = 0
+const failureDetails = []
+
+const SUMMARY_CONTEXT_LINES = 30
+const FALLBACK_TAIL_LINES = 40
+
+for (let i = 1; i <= repeat; i++) {
+  const vitestArgs = [
+    'vitest',
+    'run',
+    file,
+    '--config',
+    configArg,
+    '--project',
+    project,
+  ]
+
+  const result = spawnSync('bunx', vitestArgs, {
+    stdio: 'pipe',
+    cwd: process.cwd(),
+    env: process.env,
+  })
+
+  const status = result.status ?? 1
+  const output = `${result.stdout.toString('utf8')}\n${result.stderr.toString('utf8')}`
+
+  if (status === 0) {
+    pass++
+    console.log(`Run ${i}/${repeat}: PASS`)
+  } else {
+    fail++
+    console.log(`Run ${i}/${repeat}: FAIL`)
+    const lines = output.split('\n')
+    const failuresStart = lines.findIndex((line) => line.includes('FAILURES'))
+    const summary =
+      failuresStart >= 0
+        ? lines
+            .slice(failuresStart, failuresStart + SUMMARY_CONTEXT_LINES)
+            .join('\n')
+        : lines.slice(-FALLBACK_TAIL_LINES).join('\n')
+    failureDetails.push(`=== Run ${i} ===\n${summary.trim()}`)
+  }
+}
+
+console.log('\n=== Summary ===')
+console.log(`Total: ${repeat}, Pass: ${pass}, Fail: ${fail}`)
+
+if (failureDetails.length > 0) {
+  console.log(`\n${failureDetails.join('\n\n')}`)
+  process.exit(1)
+}


### PR DESCRIPTION
## 問題の原因

`SubCategoryKeywordManager.test.tsx` の rename 系テストで、期待値 `Reference` に対して保存結果が `eference` になる timing flake が発生していました。

原因は `SubCategoryKeywordManager.tsx` の `startRenameMode` が `requestAnimationFrame` を使って `renameInputRef.current.select()` をスケジュールしていたことです。`userEvent.type` は非同期に各文字を入力するため、スケジュールされた `select()` がタイピング途中に発火すると、既に入力された先頭文字が選択状態になり、次の文字で上書きされて消失していました。

## 採用した解決方法

focus/select のタイミングを決定的にし、親コンポーネント側の非同期スケジュールを排除しました。

- `SubCategoryRenameSection` マウント時に `useEffect` で input を focus + select する。
- input の `onFocus` ハンドラでも常に全選択する。
- `SubCategoryKeywordManager` から `requestAnimationFrame` による select スケジュールを削除する。

これにより `userEvent.type` と select が競合する余地がなくなり、rename 入力が安定します。

## 主要な変更内容

- `src/features/options/SubCategoryKeywordManager.tsx`
  - `startRenameMode` から `requestAnimationFrame` + `select()` を削除
- `src/features/options/SubCategoryRenameSection.tsx`
  - マウント時の `useEffect` で input.focus/select
  - `onFocus` ハンドラで `e.currentTarget.select()`
- `tools/scripts/test-flake.mjs`（新規）
  - 単一テストファイルを指定回数反復実行し、失敗を集計する調査用スクリプト
- `docs/testing/flaky-tests.md`（新規）
  - 調査手順と今回の case study を記載

## regression risk と確認内容

- rename 開始時の UX（focus + 全選択）は維持されています。
- `SubCategoryKeywordManager.test.tsx` を 50 回反復実行して全 PASS を確認しました。
- 全テスト、lint、型チェック、build、architecture check が通過しています。

## 実行した test / quality command

- `bun tools/scripts/test-flake.mjs --config vitest.ci.config.ts src/features/options/SubCategoryKeywordManager.test.tsx --repeat 50 --project dom` → 50/50 PASS
- `bun run test` → 308 files / 3333 tests PASS
- `bun run test:coverage` → tests PASS
- `bun run compile` / `bun run lint` → PASS
- `bun run quality` → `knip` 以外 PASS（`knip` は本環境の `localhost` ランダムポート取得問題で失敗しますが、CI では発生しません）

## 受け入れ条件への対応

- `SubCategoryKeywordManager.test.tsx` の既知 timing flake の root cause を特定・修正: `SubCategoryKeywordManager.tsx` / `SubCategoryRenameSection.tsx`
- 対象 test を十分な回数反復して安定性確認: `test-flake.mjs` で 50 回実行
- flaky test 調査の標準手順を docs/script として残す: `docs/testing/flaky-tests.md` + `tools/scripts/test-flake.mjs`
- `test.skip` / timeout 増加だけで問題を隠していない: コード・テストの本質的な修正
- retry を使う場合、初回 failure を検知: retry は使用していません
- clean `develop` の test baseline が green: `bun run test` 通過
- `bun run test` / `bun run test:coverage` が通る: 通過

closes #710
