### PR TITLE
Renovateによる依存更新基盤を導入する

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":configMigration",
+    "abandonments:recommended"
+  ],
+  "enabledManagers": ["bun", "github-actions"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 6am on monday"],
+  "dependencyDashboard": true,
+  "dependencyDashboardOSVVulnerabilitySummary": "all",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "prCreation": "not-pending",
+  "internalChecksFilter": "strict",
+  "automerge": false,
+  "ignoreScripts": true,
+  "rangeStrategy": "pin",
+  "separateMajorMinor": true,
+  "separateMinorPatch": true,
+  "rebaseWhen": "behind-base-branch",
+  "osvVulnerabilityAlerts": true,
+  "major": {
+    "dependencyDashboardApproval": true
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "automerge": false,
+    "labels": ["security"],
+    "vulnerabilityFixStrategy": "lowest"
+  },
+  "prBodyNotes": [
+    "## Dependency security review\n\n- [ ] Release notes / changelog を確認した\n- [ ] major update の migration guide を確認した\n- [ ] package owner / repository / rename に不自然な変更がない\n- [ ] lifecycle script の追加・変更を確認した\n- [ ] `bun.lock` に予期しない transitive dependency 増加がない\n- [ ] third-party GitHub Action の owner / permissions 変更を確認した\n- [ ] CI を通すために `any` / `@ts-ignore` / lint disable / test skip を追加していない\n\n詳細: `docs/maintenance/dependency-updates.md`"
+  ],
+  "packageRules": [
+    {
+      "description": "Wait before proposing npm-sourced dependency updates",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "description": "Keep the initial exact-version migration separate",
+      "matchUpdateTypes": ["pin"],
+      "groupName": "Pin dependency versions",
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Keep high-impact dependencies out of broad custom groups",
+      "matchPackageNames": [
+        "typescript",
+        "@typescript/native-preview",
+        "react",
+        "react-dom",
+        "wxt",
+        "vite",
+        "vitest",
+        "playwright",
+        "@playwright/test",
+        "storybook",
+        "ai",
+        "ai-sdk-ollama"
+      ],
+      "groupName": null
+    },
+    {
+      "description": "Handle TypeScript native preview separately",
+      "matchPackageNames": ["@typescript/native-preview"],
+      "schedule": ["before 6am on the first day of the month"],
+      "dependencyDashboardApproval": true,
+      "groupName": null
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.14'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Audit dependencies
+        run: bun run security:audit
 
       - name: Run type checking
         run: bun run compile
@@ -47,15 +50,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.14'
 
@@ -66,7 +69,7 @@ jobs:
         run: bun run build
 
       - name: Archive build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: extension-build-chrome
           path: .output/chrome-mv3
@@ -79,15 +82,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.14'
 
@@ -102,15 +105,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.3.14'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -51,6 +53,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -83,6 +87,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -106,6 +112,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -31,6 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: millionco/react-doctor@8a8ab66c1200ed5eb0f7249b9ed7a4fdaceba261 # v2

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -29,11 +29,11 @@ jobs:
   react-doctor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
-      - uses: millionco/react-doctor@v2
+      - uses: millionco/react-doctor@8a8ab66c1200ed5eb0f7249b9ed7a4fdaceba261 # v2
         # Strict gate: any new error-severity finding fails the check and
         # red-Xes the PR. The action also posts a sticky summary comment,
         # inline review comments on changed lines, and a commit status with

--- a/.github/workflows/update-pr-branches.yml
+++ b/.github/workflows/update-pr-branches.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Update open pull requests based on develop
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const owner = context.repo.owner;
@@ -43,6 +43,14 @@ jobs:
             const failed = [];
 
             for (const pull of openPulls) {
+              if (
+                pull.user.login === 'renovate[bot]' ||
+                pull.head.ref.startsWith('renovate/')
+              ) {
+                skipped.push({ number: pull.number, reason: 'renovate' });
+                continue;
+              }
+
               if (pull.draft) {
                 skipped.push({ number: pull.number, reason: 'draft' });
                 continue;

--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,15 @@
       },
     },
   },
+  "overrides": {
+    "defu": "6.1.7",
+    "lodash-es": "4.18.1",
+    "node-forge": "1.4.0",
+    "rollup": "4.62.2",
+    "shell-quote": "1.10.0",
+    "tmp": "0.2.7",
+    "undici": "7.28.0",
+  },
   "packages": {
     "@1natsu/wait-element": ["@1natsu/wait-element@4.1.2", "", { "dependencies": { "defu": "^6.1.4", "many-keys-map": "^2.0.1" } }, "sha512-qWxSJD+Q5b8bKOvESFifvfZ92DuMsY+03SBNjTO34ipJLP6mZ9yK4bQz/vlh48aEQXoJfaZBqUwKL5BdI5iiWw=="],
 
@@ -696,49 +705,55 @@
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" } }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.53.3", "", { "os": "android", "cpu": "arm" }, "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w=="],
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.2", "", { "os": "android", "cpu": "arm" }, "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg=="],
 
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.53.3", "", { "os": "android", "cpu": "arm64" }, "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w=="],
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.2", "", { "os": "android", "cpu": "arm64" }, "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw=="],
 
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.53.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA=="],
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A=="],
 
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.53.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ=="],
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA=="],
 
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.53.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w=="],
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw=="],
 
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.53.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q=="],
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg=="],
 
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.53.3", "", { "os": "linux", "cpu": "arm" }, "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw=="],
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.2", "", { "os": "linux", "cpu": "arm" }, "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg=="],
 
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.53.3", "", { "os": "linux", "cpu": "arm" }, "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg=="],
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.2", "", { "os": "linux", "cpu": "arm" }, "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA=="],
 
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.53.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w=="],
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA=="],
 
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.53.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A=="],
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ=="],
 
-    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.53.3", "", { "os": "linux", "cpu": "none" }, "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g=="],
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg=="],
 
-    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.53.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw=="],
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ=="],
 
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.53.3", "", { "os": "linux", "cpu": "none" }, "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g=="],
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A=="],
 
-    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.53.3", "", { "os": "linux", "cpu": "none" }, "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A=="],
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w=="],
 
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.53.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg=="],
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg=="],
 
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.53.3", "", { "os": "linux", "cpu": "x64" }, "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w=="],
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.2", "", { "os": "linux", "cpu": "none" }, "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q=="],
 
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.53.3", "", { "os": "linux", "cpu": "x64" }, "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q=="],
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg=="],
 
-    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.53.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw=="],
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.2", "", { "os": "linux", "cpu": "x64" }, "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A=="],
 
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.53.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw=="],
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg=="],
 
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.53.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA=="],
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg=="],
 
-    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg=="],
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.2", "", { "os": "none", "cpu": "arm64" }, "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA=="],
 
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.53.3", "", { "os": "win32", "cpu": "x64" }, "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ=="],
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.2", "", { "os": "win32", "cpu": "x64" }, "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA=="],
 
     "@secretlint/config-creator": ["@secretlint/config-creator@13.0.2", "", { "dependencies": { "@secretlint/types": "13.0.2" } }, "sha512-wEHE/x7jeaWnDqVhzUg3qLsnl3NOQTA2fVnxwc0Z7dn3SOSh5sEKFr6xTp/LhZxyuHnKJltlcF085UDUFOoqYQ=="],
 
@@ -1408,7 +1423,7 @@
 
     "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
-    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "delaunator": ["delaunator@5.0.1", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw=="],
 
@@ -1866,7 +1881,7 @@
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
-    "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
@@ -2044,7 +2059,7 @@
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
-    "node-forge": ["node-forge@1.3.3", "", {}, "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg=="],
+    "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
 
     "node-notifier": ["node-notifier@10.0.1", "", { "dependencies": { "growly": "^1.3.0", "is-wsl": "^2.2.0", "semver": "^7.3.5", "shellwords": "^0.1.1", "uuid": "^8.3.2", "which": "^2.0.2" } }, "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ=="],
 
@@ -2304,7 +2319,7 @@
 
     "rolldown": ["rolldown@1.1.4", "", { "dependencies": { "@oxc-project/types": "=0.138.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.4", "@rolldown/binding-darwin-arm64": "1.1.4", "@rolldown/binding-darwin-x64": "1.1.4", "@rolldown/binding-freebsd-x64": "1.1.4", "@rolldown/binding-linux-arm-gnueabihf": "1.1.4", "@rolldown/binding-linux-arm64-gnu": "1.1.4", "@rolldown/binding-linux-arm64-musl": "1.1.4", "@rolldown/binding-linux-ppc64-gnu": "1.1.4", "@rolldown/binding-linux-s390x-gnu": "1.1.4", "@rolldown/binding-linux-x64-gnu": "1.1.4", "@rolldown/binding-linux-x64-musl": "1.1.4", "@rolldown/binding-openharmony-arm64": "1.1.4", "@rolldown/binding-wasm32-wasi": "1.1.4", "@rolldown/binding-win32-arm64-msvc": "1.1.4", "@rolldown/binding-win32-x64-msvc": "1.1.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA=="],
 
-    "rollup": ["rollup@4.53.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.53.3", "@rollup/rollup-android-arm64": "4.53.3", "@rollup/rollup-darwin-arm64": "4.53.3", "@rollup/rollup-darwin-x64": "4.53.3", "@rollup/rollup-freebsd-arm64": "4.53.3", "@rollup/rollup-freebsd-x64": "4.53.3", "@rollup/rollup-linux-arm-gnueabihf": "4.53.3", "@rollup/rollup-linux-arm-musleabihf": "4.53.3", "@rollup/rollup-linux-arm64-gnu": "4.53.3", "@rollup/rollup-linux-arm64-musl": "4.53.3", "@rollup/rollup-linux-loong64-gnu": "4.53.3", "@rollup/rollup-linux-ppc64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-gnu": "4.53.3", "@rollup/rollup-linux-riscv64-musl": "4.53.3", "@rollup/rollup-linux-s390x-gnu": "4.53.3", "@rollup/rollup-linux-x64-gnu": "4.53.3", "@rollup/rollup-linux-x64-musl": "4.53.3", "@rollup/rollup-openharmony-arm64": "4.53.3", "@rollup/rollup-win32-arm64-msvc": "4.53.3", "@rollup/rollup-win32-ia32-msvc": "4.53.3", "@rollup/rollup-win32-x64-gnu": "4.53.3", "@rollup/rollup-win32-x64-msvc": "4.53.3", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA=="],
+    "rollup": ["rollup@4.62.2", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.2", "@rollup/rollup-android-arm64": "4.62.2", "@rollup/rollup-darwin-arm64": "4.62.2", "@rollup/rollup-darwin-x64": "4.62.2", "@rollup/rollup-freebsd-arm64": "4.62.2", "@rollup/rollup-freebsd-x64": "4.62.2", "@rollup/rollup-linux-arm-gnueabihf": "4.62.2", "@rollup/rollup-linux-arm-musleabihf": "4.62.2", "@rollup/rollup-linux-arm64-gnu": "4.62.2", "@rollup/rollup-linux-arm64-musl": "4.62.2", "@rollup/rollup-linux-loong64-gnu": "4.62.2", "@rollup/rollup-linux-loong64-musl": "4.62.2", "@rollup/rollup-linux-ppc64-gnu": "4.62.2", "@rollup/rollup-linux-ppc64-musl": "4.62.2", "@rollup/rollup-linux-riscv64-gnu": "4.62.2", "@rollup/rollup-linux-riscv64-musl": "4.62.2", "@rollup/rollup-linux-s390x-gnu": "4.62.2", "@rollup/rollup-linux-x64-gnu": "4.62.2", "@rollup/rollup-linux-x64-musl": "4.62.2", "@rollup/rollup-openbsd-x64": "4.62.2", "@rollup/rollup-openharmony-arm64": "4.62.2", "@rollup/rollup-win32-arm64-msvc": "4.62.2", "@rollup/rollup-win32-ia32-msvc": "4.62.2", "@rollup/rollup-win32-x64-gnu": "4.62.2", "@rollup/rollup-win32-x64-msvc": "4.62.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA=="],
 
     "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
@@ -2344,7 +2359,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.7.3", "", {}, "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw=="],
+    "shell-quote": ["shell-quote@1.10.0", "", {}, "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA=="],
 
     "shellwords": ["shellwords@0.1.1", "", {}, "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="],
 
@@ -2474,7 +2489,7 @@
 
     "tldts-core": ["tldts-core@7.0.23", "", {}, "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ=="],
 
-    "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
+    "tmp": ["tmp@0.2.7", "", {}, "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -2520,7 +2535,7 @@
 
     "unbash": ["unbash@4.0.2", "", {}, "sha512-8gwNZ29+0/3zmXw7ToIHZtg6wK37xnniRUdBt7B27xZxaxfgR5tGMaGHT0t0dLtBV9fXE7zurh0s6Z1DHVjfWg=="],
 
-    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -2808,8 +2823,6 @@
 
     "buffer-image-size/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
-    "c12/defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
-
     "c12/giget": ["giget@3.3.0", "", { "bin": { "giget": "dist/cli.mjs" } }, "sha512-gzi2D96p+AMfDcmJHGDj3KJ9NRiwvlFAU5yfa3ROwWZmFUjX4P43x3BcyRaOMMLto1vUo7C+86+MFhYTl6Ryiw=="],
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -2976,8 +2989,6 @@
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
-    "rc9/defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
-
     "react-doctor/oxlint": ["oxlint@1.66.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.66.0", "@oxlint/binding-android-arm64": "1.66.0", "@oxlint/binding-darwin-arm64": "1.66.0", "@oxlint/binding-darwin-x64": "1.66.0", "@oxlint/binding-freebsd-x64": "1.66.0", "@oxlint/binding-linux-arm-gnueabihf": "1.66.0", "@oxlint/binding-linux-arm-musleabihf": "1.66.0", "@oxlint/binding-linux-arm64-gnu": "1.66.0", "@oxlint/binding-linux-arm64-musl": "1.66.0", "@oxlint/binding-linux-ppc64-gnu": "1.66.0", "@oxlint/binding-linux-riscv64-gnu": "1.66.0", "@oxlint/binding-linux-riscv64-musl": "1.66.0", "@oxlint/binding-linux-s390x-gnu": "1.66.0", "@oxlint/binding-linux-x64-gnu": "1.66.0", "@oxlint/binding-linux-x64-musl": "1.66.0", "@oxlint/binding-openharmony-arm64": "1.66.0", "@oxlint/binding-win32-arm64-msvc": "1.66.0", "@oxlint/binding-win32-ia32-msvc": "1.66.0", "@oxlint/binding-win32-x64-msvc": "1.66.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-N4LLxYLd94KEBqXDMDM5f+2PUpItTjDLreXe2Gn5KhjhCK4Qp2YUXaBi8Yu325ryOgKwt22m45fpD7nPOn69Yw=="],
 
     "react-doctor/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -2993,6 +3004,10 @@
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "rollup/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/docs/maintenance/dependency-updates.md
+++ b/docs/maintenance/dependency-updates.md
@@ -1,0 +1,84 @@
+# Dependency update policy
+
+TABBIN は Renovate で dependency update を検知し、CI と手動 review を経て merge する。
+CI success や vulnerability warning がないことだけを安全性の保証にしない。
+
+## Renovate の責務
+
+- `bun` と `github-actions` の version / lockfile update と PR 作成
+- Dependency Dashboard で pending、approval、vulnerability、abandonment を可視化
+- 通常 update は月曜 06:00 前（Asia/Tokyo）、npm release から14日待機
+- major と `@typescript/native-preview` は Dashboard 承認後に PR 作成
+- `rangeStrategy: pin` の初回 exact-version migration は専用 group として承認する
+- automerge は patch、minor、major、security、Actions のすべてで禁止
+
+breaking change に伴う application migration と実動作確認は人間または coding agent が
+担当する。Renovate branch の rebase は Renovate だけが担当し、
+`update-pr-branches.yml` は Renovate PR を更新しない。
+
+## Review checklist
+
+### CI
+
+- `bun install --frozen-lockfile`
+- `bun run security:audit`
+- `bun run compile`、`bun run check`、`bun run arch:check`
+- `bun run secretlint`、`bun run test`、`bun run build`
+- major / high-impact update は `bun run release:check`
+- browser behavior に影響する場合は E2E と手動確認
+
+### Upstream change
+
+- release notes、changelog、major migration guide を確認する
+- deprecated / removed API、runtime、compiler、bundler option の変更を確認する
+- preview package は更新目的と必要性を先に確認する
+
+### Supply chain
+
+- package name、scope、repository、owner、rename、replacement を確認する
+- install / preinstall / postinstall script の追加・変更を確認する
+- `bun.lock` の不自然な package と大量の transitive dependency 増加を確認する
+- third-party Action の owner、権限、参照 SHA を確認する
+- `any`、`@ts-ignore`、lint disable、test skip で CI を通さない
+
+## Bun lifecycle scripts
+
+`trustedDependencies` は明示 allowlist で管理する。2026-07-12 の
+`bun pm untrusted` では `spawn-sync@1.0.15` の postinstall だけが blocked され、
+baseline test と build に不要だったため allowlist は空にした。
+
+追加する場合は package source、script 内容、実行理由を確認し、追加前後に
+`bun install --frozen-lockfile`、`bun pm untrusted`、build、test を実行する。
+`bun pm trust --all` は使用しない。
+
+## Temporary audit exceptions
+
+次の例外は、同一 package の複数 major が lockfile に共存する、または親 package が
+旧 major を固定しているため、top-level `overrides` では安全に解消できない。
+期限: 2026-08-12。期限までに親 package と lockfile を再確認し、修正版へ進めるなら
+例外を削除する。期限延長には新しい Issue、upstream status、影響評価が必要。
+
+- `GHSA-22p9-wv53-3rq4`: `ansi-to-react` が旧 `linkify-it` major を要求するため。
+- `GHSA-3ppc-4f35-3m26`: `minimatch` 3系と10系が共存するため。
+- `GHSA-7r86-cg39-jmmj`: 同じ `minimatch` 複数世代制約のため。
+- `GHSA-23c5-xmqv-rm74`: 同じ `minimatch` 複数世代制約のため。
+- `GHSA-c2c7-rcm5-vvqj`: `picomatch` 2系と4系が共存するため。
+- `GHSA-fx2h-pf6j-xcff`: direct Vite 8 と WXT 経由の Vite 6 が共存するため。
+- `GHSA-p9ff-h696-f583`: 同じ WXT / Vite 6 経路のため。
+
+修正版が同じ互換世代にある `defu`、`lodash-es`、`node-forge`、`rollup`、
+`shell-quote`、`tmp`、`undici` は `overrides` で固定し、例外にしない。
+
+## Vulnerability response
+
+security update は14日待機を機械的に適用せず urgency を判断する。GitHub vulnerability
+alerts、Renovate vulnerability PR、OSV、`bun audit` の結果を突き合わせる。
+一時 ignore が必要な場合は advisory、dependency path、影響、upstream status、期限、
+owner をこの文書または専用 Issue に残し、恒久的な ignore にしない。
+
+## Initial rollout
+
+最初の Renovate dependency PR は exact-version pin migration 専用として扱い、通常 update
+と混在させない。`package.json` と `bun.lock` の差分、CI、PR 本文の security checklist、
+high-impact package の grouping、Dashboard approval を確認してから手動 merge する。
+定期的な lockfile maintenance は初期運用では有効化しない。

--- a/docs/plans/2026-07-12-issue-685-renovate-design.md
+++ b/docs/plans/2026-07-12-issue-685-renovate-design.md
@@ -1,0 +1,34 @@
+# Issue #685 Renovate 導入設計
+
+## 目的
+
+Renovate に依存更新の検知、更新 branch、PR、Dependency Dashboard を担当させ、
+CI と人手 review により breaking change と supply-chain risk を判断する。
+自動 merge は行わず、Renovate を application migration tool として扱わない。
+
+## 構成
+
+- `.github/renovate.json` を Renovate policy の source of truth とする。
+- `bun` と `github-actions` のみを manager として有効化する。
+- 通常 npm update は月曜早朝、公開から14日後、major は Dashboard 承認後とする。
+- preview dependency、脆弱性修正、GitHub Actions を通常 update と分離する。
+- `package.json` と CI に `bun audit --audit-level=high` を追加する。
+- GitHub Actions は full commit SHA に固定し、Renovate に digest update を任せる。
+- `update-pr-branches.yml` は Renovate bot/branch を除外し、rebase の二重管理を防ぐ。
+- `docs/maintenance/dependency-updates.md` に review と incident 対応を記録する。
+
+## Security boundary
+
+Renovate の `ignoreScripts: true` を不変条件として明示する。Bun の
+`trustedDependencies` は `bun pm ls --trusted` と `bun pm untrusted` の実測結果から、
+install/build に必要な package だけを許可する。GitHub vulnerability alerts、OSV、
+`bun audit` は相互補完とし、いずれも安全性の保証として扱わない。
+
+## 検証
+
+Node project の静的テストで Renovate policy、audit script/CI、Action SHA、Renovate PR
+除外を検証する。Renovate config validator、`bun run security:audit`、全 test、coverage、
+quality、release build を実行し、最後に security review と fresh-context evaluator を行う。
+
+GitHub App はユーザーが TABBIN に Interactive mode で設定済みであり、初回 job の結果と
+Dependency Dashboard/onboarding の生成は外部状態として確認する。

--- a/docs/plans/2026-07-12-issue-685-renovate.md
+++ b/docs/plans/2026-07-12-issue-685-renovate.md
@@ -1,0 +1,88 @@
+# Issue #685 Renovate Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Renovate を手動 review 前提の安全な依存更新基盤として TABBIN に導入する。
+
+**Architecture:** Renovate policy を `.github/renovate.json` に集約し、CI、workflow、
+package lifecycle allowlist、運用文書を静的テストで拘束する。Renovate、OSV、GitHub
+vulnerability alerts、Bun audit を多層化し、自動 merge と lifecycle script 実行は許可しない。
+
+**Tech Stack:** Renovate, Bun 1.3.14, GitHub Actions, Vitest, TypeScript
+
+---
+
+### Task 1: Policy regression test
+
+**Files:**
+
+- Create: `tools/renovate-policy.test.ts`
+
+1. `.github/renovate.json` が存在し、manager、schedule、approval、separation、limits、
+   vulnerability、script、preset、preview rule、lockfile policy を満たすテストを書く。
+2. package/CI の security audit、full SHA、Renovate PR 除外を検証するテストを書く。
+3. `rtk bunx vitest run tools/renovate-policy.test.ts` を実行し、必要ファイル・設定の欠如で
+   FAIL することを確認する。
+
+### Task 2: Renovate policy
+
+**Files:**
+
+- Create: `.github/renovate.json`
+
+1. Issue の設定案を基礎に、`config:recommended`、Action digest pin、config migration、
+   abandonments、Bun/GitHub Actions manager、weekly/preview schedule を追加する。
+2. npm の14日待機、major/preview approval、manual merge、OSV/GitHub vulnerability policy、
+   PR checklist を設定する。
+3. テストを再実行し、Renovate policy 部分が PASS することを確認する。
+4. 公式 validator で config schema と preset を検証する。
+
+### Task 3: Bun audit and lifecycle allowlist
+
+**Files:**
+
+- Modify: `package.json`
+- Modify: `bun.lock` only if Bun updates lock metadata
+- Modify: `.github/workflows/ci.yml`
+
+1. `bun pm ls --trusted` と `bun pm untrusted` を記録し、必要 package を特定する。
+2. `security:audit: bun audit --audit-level=high` と最小 `trustedDependencies` を追加する。
+3. CI install 後に `bun run security:audit` を実行する blocking step を追加する。
+4. policy test と `rtk bun run security:audit` を実行して PASS を確認する。
+
+### Task 4: Immutable Actions and lifecycle ownership
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/workflows/react-doctor.yml`
+- Modify: `.github/workflows/update-pr-branches.yml`
+
+1. 全 external Action を現在 tag の full commit SHA と可読性コメントへ置き換える。
+2. `update-pr-branches.yml` で `renovate[bot]` と `renovate/` branch を除外する。
+3. policy test を実行し、tag reference と二重 branch update が無いことを確認する。
+
+### Task 5: Review policy documentation
+
+**Files:**
+
+- Create: `docs/maintenance/dependency-updates.md`
+
+1. Dashboard approval、pin migration、CI、upstream change、supply-chain、behavior review、
+   CVE ignore の期限/理由、trustedDependencies 変更手順を記載する。
+2. 初回 Renovate PR は pin migration 専用にし、通常 update と混在させない手順を記載する。
+3. formatter と secretlint で文書を検証する。
+
+### Task 6: Full verification and evaluation
+
+**Files:**
+
+- Review all modified files
+
+1. `rtk bunx vitest run tools/renovate-policy.test.ts` を実行する。
+2. Renovate config validator と `rtk bun run security:audit` を実行する。
+3. `rtk bun run test:coverage` で 100% coverage を確認する。
+4. `rtk bun run quality` と `rtk bun run release:check` を実行する。
+5. security review で Action permission、script trust、vulnerability path を確認する。
+6. `rtk bun run harness:validate`、`harness:audit`、fresh-context evaluator を実行する。
+7. Issue の受け入れ条件を差分、コマンド、外部 Interactive job に対応付ける。

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "release:zip": "bun run release:check && bun run zip && bun run zip:firefox",
     "compile": "tsgo --noEmit",
     "secretlint": "secretlint \"**/*\"",
+    "security:audit": "bun audit --audit-level=high --ignore GHSA-22p9-wv53-3rq4 --ignore GHSA-3ppc-4f35-3m26 --ignore GHSA-7r86-cg39-jmmj --ignore GHSA-23c5-xmqv-rm74 --ignore GHSA-c2c7-rcm5-vvqj --ignore GHSA-fx2h-pf6j-xcff --ignore GHSA-p9ff-h696-f583",
     "postinstall": "wxt prepare",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",
@@ -167,9 +168,19 @@
     "vitest": "^4.1.9",
     "wxt": "^0.20.27"
   },
+  "overrides": {
+    "defu": "6.1.7",
+    "lodash-es": "4.18.1",
+    "node-forge": "1.4.0",
+    "rollup": "4.62.2",
+    "shell-quote": "1.10.0",
+    "tmp": "0.2.7",
+    "undici": "7.28.0"
+  },
   "engines": {
     "bun": "1.3.14",
     "node": "24.x"
   },
-  "packageManager": "bun@1.3.14"
+  "packageManager": "bun@1.3.14",
+  "trustedDependencies": []
 }

--- a/src/features/options/SubCategoryKeywordManager.test.tsx
+++ b/src/features/options/SubCategoryKeywordManager.test.tsx
@@ -219,7 +219,9 @@ describe('SubCategoryKeywordManager', () => {
     cleanup()
     vi.unstubAllGlobals()
     vi.clearAllTimers()
-    await new Promise((resolve) => setTimeout(resolve, 500))
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve())
+    })
   })
 
   it('helper は tab 差し替え、keyword fallback、rename no-op を扱う', async () => {

--- a/tools/renovate-policy.test.ts
+++ b/tools/renovate-policy.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+type RenovatePackageRule = {
+  dependencyDashboardApproval?: boolean
+  description?: string
+  groupName?: string | null
+  matchDatasources?: string[]
+  matchPackageNames?: string[]
+  minimumReleaseAge?: string
+  schedule?: string[]
+}
+
+type RenovateConfig = {
+  automerge: boolean
+  dependencyDashboard: boolean
+  dependencyDashboardOSVVulnerabilitySummary: string
+  enabledManagers: string[]
+  extends: string[]
+  ignoreScripts: boolean
+  internalChecksFilter: string
+  lockFileMaintenance?: unknown
+  major: { dependencyDashboardApproval: boolean }
+  osvVulnerabilityAlerts: boolean
+  packageRules: RenovatePackageRule[]
+  prBodyNotes: string[]
+  prConcurrentLimit: number
+  prCreation: string
+  prHourlyLimit: number
+  rangeStrategy: string
+  rebaseWhen: string
+  schedule: string[]
+  separateMajorMinor: boolean
+  separateMinorPatch: boolean
+  timezone: string
+  vulnerabilityAlerts: {
+    automerge: boolean
+    enabled: boolean
+    labels: string[]
+    vulnerabilityFixStrategy: string
+  }
+}
+
+const readRepositoryFile = (path: string) => readFileSync(path, 'utf8')
+
+describe('Renovate dependency update policy', () => {
+  it('keeps routine updates reviewable and security-sensitive updates manual', () => {
+    const config = JSON.parse(
+      readRepositoryFile('.github/renovate.json'),
+    ) as RenovateConfig
+
+    expect(config.enabledManagers).toEqual(['bun', 'github-actions'])
+    expect(config.timezone).toBe('Asia/Tokyo')
+    expect(config.schedule).toEqual(['before 6am on monday'])
+    expect(config.automerge).toBe(false)
+    expect(config.ignoreScripts).toBe(true)
+    expect(config.rangeStrategy).toBe('pin')
+    expect(config.separateMajorMinor).toBe(true)
+    expect(config.separateMinorPatch).toBe(true)
+    expect(config.major.dependencyDashboardApproval).toBe(true)
+    expect(config.prConcurrentLimit).toBe(5)
+    expect(config.prHourlyLimit).toBe(2)
+    expect(config.prCreation).toBe('not-pending')
+    expect(config.internalChecksFilter).toBe('strict')
+    expect(config.rebaseWhen).toBe('behind-base-branch')
+    expect(config.lockFileMaintenance).toBeUndefined()
+  })
+
+  it('enables dashboard, vulnerability, migration, and abandonment safeguards', () => {
+    const config = JSON.parse(
+      readRepositoryFile('.github/renovate.json'),
+    ) as RenovateConfig
+
+    expect(config.extends).toEqual(
+      expect.arrayContaining([
+        'config:recommended',
+        'helpers:pinGitHubActionDigests',
+        ':configMigration',
+        'abandonments:recommended',
+      ]),
+    )
+    expect(config.dependencyDashboard).toBe(true)
+    expect(config.osvVulnerabilityAlerts).toBe(true)
+    expect(config.dependencyDashboardOSVVulnerabilitySummary).toBe('all')
+    expect(config.vulnerabilityAlerts).toEqual({
+      enabled: true,
+      automerge: false,
+      labels: ['security'],
+      vulnerabilityFixStrategy: 'lowest',
+    })
+    expect(config.prBodyNotes.join('\n')).toContain(
+      'Dependency security review',
+    )
+  })
+
+  it('waits for npm releases and isolates the TypeScript native preview', () => {
+    const config = JSON.parse(
+      readRepositoryFile('.github/renovate.json'),
+    ) as RenovateConfig
+    const npmRule = config.packageRules.find((rule) =>
+      rule.matchDatasources?.includes('npm'),
+    )
+    const previewRule = config.packageRules.find(
+      (rule) =>
+        rule.description === 'Handle TypeScript native preview separately',
+    )
+
+    expect(npmRule?.minimumReleaseAge).toBe('14 days')
+    expect(previewRule).toMatchObject({
+      schedule: ['before 6am on the first day of the month'],
+      dependencyDashboardApproval: true,
+      groupName: null,
+    })
+  })
+
+  it('runs a blocking high-severity Bun audit in CI', () => {
+    const packageJson = JSON.parse(readRepositoryFile('package.json')) as {
+      scripts: Record<string, string>
+      trustedDependencies?: string[]
+    }
+    const ciWorkflow = readRepositoryFile('.github/workflows/ci.yml')
+
+    expect(packageJson.scripts['security:audit']).toMatch(
+      /^bun audit --audit-level=high(?: --ignore GHSA-[\w-]+)*$/,
+    )
+    expect(packageJson.trustedDependencies).toEqual(expect.any(Array))
+    expect(ciWorkflow).toContain('run: bun run security:audit')
+  })
+
+  it('documents every temporary audit exception with an expiry date', () => {
+    const packageJson = JSON.parse(readRepositoryFile('package.json')) as {
+      scripts: Record<string, string>
+    }
+    const policy = readRepositoryFile('docs/maintenance/dependency-updates.md')
+    const ignoredAdvisories = [
+      ...packageJson.scripts['security:audit'].matchAll(
+        /--ignore (GHSA-[\w-]+)/g,
+      ),
+    ].map(([, advisory]) => advisory)
+
+    expect(ignoredAdvisories.length).toBeGreaterThan(0)
+    for (const advisory of ignoredAdvisories) {
+      expect(policy).toContain(advisory)
+    }
+    expect(policy).toContain('期限: 2026-08-12')
+  })
+
+  it('pins external Actions and leaves Renovate branch updates to Renovate', () => {
+    const workflowPaths = [
+      '.github/workflows/ci.yml',
+      '.github/workflows/react-doctor.yml',
+      '.github/workflows/update-pr-branches.yml',
+    ]
+    const workflows = workflowPaths.map(readRepositoryFile).join('\n')
+    const externalActionReferences = [
+      ...workflows.matchAll(/uses: ([^\s@]+)@([^\s]+)/g),
+    ]
+
+    expect(externalActionReferences.length).toBeGreaterThan(0)
+    for (const [, action, reference] of externalActionReferences) {
+      expect(reference, `${action} must use a full commit SHA`).toMatch(
+        /^[0-9a-f]{40}$/,
+      )
+    }
+
+    const updateWorkflow = readRepositoryFile(
+      '.github/workflows/update-pr-branches.yml',
+    )
+    expect(updateWorkflow).toContain("pull.user.login === 'renovate[bot]'")
+    expect(updateWorkflow).toContain("pull.head.ref.startsWith('renovate/')")
+  })
+})

--- a/tools/renovate-policy.test.ts
+++ b/tools/renovate-policy.test.ts
@@ -170,4 +170,22 @@ describe('Renovate dependency update policy', () => {
     expect(updateWorkflow).toContain("pull.user.login === 'renovate[bot]'")
     expect(updateWorkflow).toContain("pull.head.ref.startsWith('renovate/')")
   })
+
+  it('does not persist credentials in checkout steps', () => {
+    const workflowPaths = [
+      '.github/workflows/ci.yml',
+      '.github/workflows/react-doctor.yml',
+    ]
+    const checkoutSteps = workflowPaths.flatMap((path) =>
+      readRepositoryFile(path)
+        .split('- uses: actions/checkout@')
+        .slice(1)
+        .map((section) => section.split('\n      - ')[0]),
+    )
+
+    expect(checkoutSteps).toHaveLength(5)
+    for (const checkoutStep of checkoutSteps) {
+      expect(checkoutStep).toContain('persist-credentials: false')
+    }
+  })
 })


### PR DESCRIPTION
## 変更内容

- Renovate を Bun / GitHub Actions 向けに導入し、weekly schedule、14日待機、Dashboard承認、PR制限、自動merge禁止を設定
- `bun audit --audit-level=high` をCI gateへ追加し、安全なtransitive dependency overrideと期限付きGHSA例外を文書化
- 全GitHub Actionsをfull commit SHAへ固定し、Renovate PRを既存branch自動更新の対象外に変更
- Dependency updateのreview policyと、Renovate policyを拘束する静的テストを追加
- full coverageで露呈したテストの固定500ms待機を1 animation frame待機へ置換

## 外部設定

- [x] Mend Renovate AppをInteractive modeで有効化
- [x] GitHub vulnerability alertsを有効化（API: HTTP 204）
- [x] Renovate公式validatorで設定検証

## ローカル検証

- [x] `bunx vitest run --config vitest.ci.config.ts --project=node tools/renovate-policy.test.ts`（6 tests）
- [x] `bun run security:audit`
- [x] `bun run test:coverage`
- [x] `bun run quality`
- [x] `bun run release:check`（Chrome / Firefox）
- [x] `bun run doctor -- --verbose --scope changed --base HEAD`（100/100）
- [x] `npx -y --package renovate renovate-config-validator .github/renovate.json`
- [x] `bun run harness:validate`

Closes #685


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated dependency update management with scheduled, review-gated updates.
  * Added high-severity dependency auditing and safeguards for dependency installation.
  * Pinned CI workflow actions to immutable versions and excluded automated update branches from branch maintenance.

* **Documentation**
  * Added dependency update policies, security review guidance, vulnerability handling, and rollout plans.

* **Tests**
  * Added validation for dependency policies, security auditing, documentation coverage, and workflow safeguards.
  * Improved test cleanup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->