### PR TITLE
fix: application version を package.json の single source of truth 化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Build extension
         run: bun run build
 
+      - name: Build Firefox extension
+        run: bun run build:firefox
+
       - name: Archive build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -73,6 +76,9 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
           retention-days: 7
+
+      - name: Verify generated manifest version
+        run: bun run verify:app-version
 
   run-tests-shard-1:
     name: Run Vitest Tests

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,5 +1,10 @@
 # リリース手順
 
+## バージョン更新
+
+拡張機能のバージョンは `package.json` の `version` を authoritative source とする。
+リリース前に `package.json` の `version` を更新するだけでよく、`wxt.config.ts` やバックアップコードに version literal を重複定義する必要はない。
+
 ## 事前チェック
 
 配布前に以下のコマンドで品質とビルドを確認します。
@@ -13,6 +18,7 @@ bun run release:check
 1. `bun run quality` — フォーマット、lint、テスト、重複チェックなど
 2. `bun run build` — Chrome 拡張機能のビルド
 3. `bun run build:firefox` — Firefox 拡張機能のビルド
+4. `bun run verify:app-version` — 生成された manifest version が package.json と一致することを確認
 
 ## ZIP 生成
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:firefox": "wxt build -b firefox",
     "zip": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",
-    "release:check": "git diff --exit-code && bun run quality:check && bun run build && bun run build:firefox && git diff --exit-code",
+    "release:check": "git diff --exit-code && bun run quality:check && bun run build && bun run build:firefox && bun run verify:app-version && git diff --exit-code",
     "release:zip": "bun run release:check && bun run zip && bun run zip:firefox",
     "compile": "tsgo --noEmit",
     "secretlint": "secretlint \"**/*\"",
@@ -55,7 +55,8 @@
     "build-storybook": "storybook build",
     "e2e": "playwright test e2e",
     "knip": "knip",
-    "doctor": "react-doctor"
+    "doctor": "react-doctor",
+    "verify:app-version": "bun tools/scripts/verify-app-version.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/constants/app-version.test.ts
+++ b/src/constants/app-version.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
+
+import { getAppVersion } from './app-version'
+
+type GlobalWithChrome = Omit<typeof globalThis, 'chrome'> & {
+  chrome?: {
+    runtime?: {
+      getManifest?: () => { version?: string }
+    }
+  }
+}
+
+const globalWithChrome = globalThis as GlobalWithChrome
+const originalChrome = globalWithChrome.chrome
+
+describe('getAppVersion', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    globalWithChrome.chrome = originalChrome
+  })
+
+  it('build-time に注入された __APP_VERSION__ があればそれを返す', () => {
+    vi.stubGlobal('__APP_VERSION__', '2.0.7')
+    expect(getAppVersion()).toBe('2.0.7')
+  })
+
+  it('__APP_VERSION__ が未定義なら manifest version を返す', () => {
+    const getManifest = vi.fn(() => ({ version: '9.9.9' }))
+    globalWithChrome.chrome = {
+      runtime: {
+        getManifest,
+      },
+    }
+
+    expect(getAppVersion()).toBe('9.9.9')
+  })
+
+  it('manifest version も空ならデフォルト値を返す', () => {
+    const getManifest = vi.fn(() => ({}))
+    globalWithChrome.chrome = {
+      runtime: {
+        getManifest,
+      },
+    }
+
+    expect(getAppVersion()).toBe('1.0.0')
+  })
+})

--- a/src/constants/app-version.ts
+++ b/src/constants/app-version.ts
@@ -1,0 +1,19 @@
+import { getManifestVersion } from '@/lib/browser/runtime'
+
+const DEFAULT_APP_VERSION = '1.0.0'
+
+/**
+ * package.json version をビルド時に Vite define された値、または実行時の
+ * manifest version から取得する。
+ *
+ * プロダクションビルドでは `__APP_VERSION__` が package.json.version から注入される。
+ * テスト環境では注入されないため、mock された manifest version にフォールバックする。
+ * manifest version が空文字列の場合はデフォルト値を返す。
+ */
+export const getAppVersion = (): string => {
+  if (typeof __APP_VERSION__ !== 'undefined') {
+    return __APP_VERSION__
+  }
+  // eslint-disable-next-line typescript/prefer-nullish-coalescing -- empty version string should fall through to default
+  return getManifestVersion() || DEFAULT_APP_VERSION
+}

--- a/src/features/options/lib/import-export/flows.ts
+++ b/src/features/options/lib/import-export/flows.ts
@@ -1,3 +1,4 @@
+import { getAppVersion } from '@/constants/app-version'
 import {
   ACTIVE_AI_CHAT_CONVERSATION_ID_KEY,
   AI_CHAT_CONVERSATIONS_KEY,
@@ -5,7 +6,6 @@ import {
 } from '@/features/ai-chat/lib/conversation-history'
 import type { AiChatConversation } from '@/features/ai-chat/types'
 import { getChromeStorageLocal } from '@/lib/browser/chrome-storage'
-import { getManifestVersion } from '@/lib/browser/runtime'
 import { redactUrlForLog } from '@/lib/logging/redact-url'
 import { loadSavedAnalyticsViews } from '@/lib/storage/analytics'
 import {
@@ -194,8 +194,7 @@ const exportSettings = async (): Promise<BackupData> => {
       timestamp: new Date().toISOString(),
       urls: exportUrlRecords,
       userSettings,
-      // eslint-disable-next-line typescript/prefer-nullish-coalescing -- empty version string should fall through to default
-      version: getManifestVersion() || '1.0.0',
+      version: getAppVersion(),
     }
     return backupData
   } catch (error) {

--- a/src/types/app-version.d.ts
+++ b/src/types/app-version.d.ts
@@ -1,0 +1,1 @@
+declare const __APP_VERSION__: string | undefined

--- a/tools/scripts/verify-app-version.ts
+++ b/tools/scripts/verify-app-version.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const projectRoot = path.resolve(import.meta.dirname, '..', '..')
+
+const readJsonFile = (filePath: string): unknown => {
+  const content = readFileSync(filePath, 'utf8')
+  return JSON.parse(content)
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const readStringProperty = (parsed: unknown, key: string): string => {
+  if (!isRecord(parsed)) {
+    throw new TypeError(`${key} source is not an object`)
+  }
+  const value: unknown = parsed[key]
+  if (typeof value !== 'string') {
+    throw new TypeError(`${key} is missing or not a string`)
+  }
+  return value
+}
+
+const packageJsonPath = path.join(projectRoot, 'package.json')
+const expectedVersion = readStringProperty(
+  readJsonFile(packageJsonPath),
+  'version',
+)
+
+const manifestPaths = [
+  path.join(projectRoot, '.output', 'chrome-mv3', 'manifest.json'),
+  path.join(projectRoot, '.output', 'firefox-mv2', 'manifest.json'),
+]
+
+const mismatches: string[] = []
+for (const manifestPath of manifestPaths) {
+  const manifestVersion = readStringProperty(
+    readJsonFile(manifestPath),
+    'version',
+  )
+  if (manifestVersion !== expectedVersion) {
+    mismatches.push(
+      `${manifestPath} has ${manifestVersion}, expected ${expectedVersion}`,
+    )
+  } else {
+    console.log(`verified: ${manifestPath} version ${manifestVersion}`)
+  }
+}
+
+if (mismatches.length > 0) {
+  throw new TypeError(`version mismatch:\n${mismatches.join('\n')}`)
+}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,7 +1,30 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
 import tailwindcss from '@tailwindcss/vite'
 import { type WxtViteConfig, defineConfig } from 'wxt' // eslint-disable-line
 
 import '@wxt-dev/module-react' // eslint-disable-line
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const readPackageVersion = (): string => {
+  const packageJsonPath = path.resolve(import.meta.dirname, 'package.json')
+  const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+  if (!isRecord(parsed)) {
+    throw new TypeError('package.json is not an object')
+  }
+  const version: unknown = parsed.version
+  if (typeof version !== 'string' || version === '') {
+    throw new TypeError(
+      'package.json version is missing, not a string, or empty',
+    )
+  }
+  return version
+}
+
+const APP_VERSION = readPackageVersion()
 
 const vitePlugins = tailwindcss()
 
@@ -12,7 +35,7 @@ export default defineConfig({
     default_locale: 'ja',
     name: '__MSG_extensionName__',
     description: '__MSG_extensionDescription__',
-    version: '2.0.7',
+    version: APP_VERSION,
     host_permissions: ['http://localhost:11434/*', 'http://127.0.0.1:11434/*'],
     permissions: ['alarms', 'tabs', 'storage', 'contextMenus', 'notifications'],
     action: {
@@ -39,6 +62,9 @@ export default defineConfig({
   }),
   modules: ['@wxt-dev/module-react', '@wxt-dev/i18n/module'],
   vite: () => ({
+    define: {
+      __APP_VERSION__: JSON.stringify(APP_VERSION),
+    },
     plugins: vitePlugins,
   }),
 })


### PR DESCRIPTION
## 変更内容

- `wxt.config.ts` の manifest version を `package.json` から動的に読み込むように変更
- バックアップの `version` も同じ package.json version を参照するよう、`__APP_VERSION__` ビルド時定数を介して統合
- 生成された Chrome / Firefox manifest version が `package.json` と一致することを検証する `verify:app-version` スクリプトを追加
- `release:check` と CI の verify-build job に上記検証を組み込み
- `docs/release.md` に version bump 手順を追記

## 問題の原因

application version が `package.json` と `wxt.config.ts` の manifest 定義で二重管理されており、version bump 時の更新漏れにより package metadata、generated manifest、backup、release artifact metadata の間で不一致が生じる可能性があった。

## 採用した解決方法

`package.json` の `version` を authoritative source とし、WXT ビルド時にそれを manifest version と Vite `define` 経由のビルド時定数 `__APP_VERSION__` の両方に注入する。backup 生成時はこの定数を優先し、テスト等で定数が注入されない場合のみ manifest version にフォールバックする。さらに CI / リリースチェックで生成済み manifest version が package.json と一致することを検証する。

## 主要な変更内容

- `wxt.config.ts`: `package.json` から `APP_VERSION` を読み込み、`manifest.version` と `vite.define.__APP_VERSION__` に設定
- `src/constants/app-version.ts`: ビルド時定数 `__APP_VERSION__` → manifest version → デフォルト値 の優先順位で version を解決する `getAppVersion()` を追加
- `src/features/options/lib/import-export/flows.ts`: バックアップの `version` 取得を `getAppVersion()` に変更
- `src/types/app-version.d.ts`: `__APP_VERSION__` の型宣言
- `tools/scripts/verify-app-version.ts`: package.json と `.output/{chrome-mv3,firefox-mv2}/manifest.json` の version 一致を検証
- `package.json`: `verify:app-version` script を追加、`release:check` に組み込み
- `.github/workflows/ci.yml`: verify-build job に Firefox build と `verify:app-version` を追加
- `docs/release.md`: version bump 手順を追記
- `src/constants/app-version.test.ts`: `getAppVersion()` の regression test を追加

## regression risk と確認内容

- 既存 backup 形式は `version` フィールド名を維持。値の取得元のみが package.json 由来の定数に変わるため、互換性は維持される。
- テスト環境では `__APP_VERSION__` が注入されないため、既存の `chrome.runtime.getManifest` mock を引き続き利用。
- manifest version が空文字列の場合のフォールバック動作も従来通り維持。
- Chrome / Firefox 両方の生成 manifest version が package.json と一致することを build 後に検証済み。

## 実行した test / quality command

- `bun run format:check` ✅
- `bun run compile` ✅
- `bun run lint` ✅
- `bun run test` ✅ (309 files / 3336 tests)
- `bun run quality:check` ✅ （knip は sandbox 外で実行）
- `bun run build && bun run build:firefox && bun run verify:app-version` ✅
- `bun run release:check` は未コミット変更があるため先頭の `git diff --exit-code` で停止。残りの `quality:check → build → build:firefox → verify:app-version` は個別に実行してすべて通過。

## acceptance criteria

- [x] application version の authoritative source が1つである (`package.json`)
- [x] `wxt.config.ts` に同じ version literal を重複定義しない (`APP_VERSION` 変数経由)
- [x] generated Chrome / Firefox manifest の version が authoritative source と一致する (`verify:app-version` で検証)
- [x] backup `appVersion` が同じ version source を利用する (`getAppVersion()` 経由で `__APP_VERSION__` を使用)
- [x] version drift を CI または test で検出できる (`verify:app-version` script + CI step + regression test)
- [x] release docs の version bump 手順が更新されている (`docs/release.md`)

closes #716


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Firefox extension builds to the release workflow.
  * Ensured extension versions are consistently derived from the project version.
  * Added version verification for generated Chrome and Firefox manifests.
  * Backup exports now use the current application version.

* **Documentation**
  * Added release guidance for managing and validating extension versions.

* **Tests**
  * Added coverage for application-version fallbacks and build-time version injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->