### PR TITLE
release: ZIP配布物にchecksum / build metadata / SBOMを付与する (issue-720)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,7 @@
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^5.2.1",
+        "@cyclonedx/cyclonedx-library": "^10.1.0",
         "@eslint-react/eslint-plugin": "^5.10.3",
         "@playwright/test": "^1.61.1",
         "@secretlint/secretlint-rule-preset-recommend": "^13.0.2",
@@ -99,6 +100,7 @@
         "html-validate": "^11.5.5",
         "jscpd": "^5.0.11",
         "jsdom": "^29.1.1",
+        "json5": "^2.2.3",
         "knip": "^6.24.0",
         "oxfmt": "^0.57.0",
         "oxlint": "^1.72.0",
@@ -224,6 +226,8 @@
     "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.3", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg=="],
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
+    "@cyclonedx/cyclonedx-library": ["@cyclonedx/cyclonedx-library@10.1.0", "", { "peerDependencies": { "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "ajv-formats-draft2019": "^1.6.1", "libxmljs2": "^0.35||^0.37", "packageurl-js": "*", "spdx-expression-parse": "*", "xmlbuilder2": "^3.0.2||^4.0.0" }, "optionalPeers": ["ajv", "ajv-formats", "ajv-formats-draft2019", "libxmljs2", "packageurl-js", "spdx-expression-parse", "xmlbuilder2"] }, "sha512-4yq0KTQIA32UHJwFMDeY5xj2asp3Mk5lzx4JRVXLOb0YE8w1KeR61c1m/gJ4sjMXpiiEDfaITVQu8BLUuy7t3A=="],
 
     "@devicefarmer/adbkit": ["@devicefarmer/adbkit@3.3.8", "", { "dependencies": { "@devicefarmer/adbkit-logcat": "^2.1.2", "@devicefarmer/adbkit-monkey": "~1.2.1", "bluebird": "~3.7", "commander": "^9.1.0", "debug": "~4.3.1", "node-forge": "^1.3.1", "split": "~1.0.1" }, "bin": { "adbkit": "bin/adbkit" } }, "sha512-7rBLLzWQnBwutH2WZ0EWUkQdihqrnLYCUMaB44hSol9e0/cdIhuNFcqZO0xNheAU6qqHVA8sMiLofkYTgb+lmw=="],
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -33,24 +33,64 @@ bun run release:zip
 1. `bun run release:check` — 上記の事前チェック
 2. `bun run zip` — Chrome 用 ZIP 生成
 3. `bun run zip:firefox` — Firefox 用 ZIP 生成
+4. `bun run release:provenance` — ビルドメタデータと SBOM の生成
+
+## Provenance / SBOM
+
+`bun run release:zip` の完了後、`.output/` に以下のファイルが生成されます。
+
+- `{appName}-{version}-build-metadata.json` — git SHA、runtime version、lockfile checksum、ZIP checksum などのビルド provenance
+- `{appName}-{version}-sbom.cdx.json` — CycloneDX 1.6 形式の依存関係 SBOM
+
+これらのファイルは、配布 ZIP がどのソース状態・依存関係・runtime から生成されたかを後から追跡するために使います。ZIP ファイルと同じリリース単位で保存し、Store アップロード時にはメタデータ内の checksum を参照してください。
+
+### 採用した SBOM 形式とツール
+
+- 形式: CycloneDX 1.6 (JSON)
+- ライブラリ: `@cyclonedx/cyclonedx-library`
+- データソース: `bun.lock` と `node_modules/<pkg>/package.json`
+
+Bun エコシステムに標準の SBOM 生成ツールがないため、`bun.lock` を直接読み取って依存関係名・バージョン・integrity hash・ライセンスを SBOM 化しています。これにより、npm 用 lockfile への変換や別ツールへの依存を避け、Bun の実際の解決状態をそのまま記録します。
+
+### メタデータに含まないもの
+
+以下は provenance 情報に含めません。
+
+- 絶対パスやマシン名・ユーザー名などのローカル環境情報
+- 認証情報やトークン
+- 開発用の内部パス
 
 ## Chrome ウェブストアへの公開
 
 1. `bun run release:zip` で生成された `.output/*.zip` を用意します
-2. [Chrome ウェブストア デベロッパーダッシュボード](https://chrome.google.com/webstore/devconsole) にアクセスします
-3. 該当の拡張機能を選択し、「新しいパッケージをアップロード」から ZIP をアップロードします
-4. ストアの掲載情報を確認し、必要に応じて更新します
-5. 審査を送信します
+2. `.output/tabbin-{version}-build-metadata.json` に記録された Chrome ZIP の SHA-256 を確認します
+3. [Chrome ウェブストア デベロッパーダッシュボード](https://chrome.google.com/webstore/devconsole) にアクセスします
+4. 該当の拡張機能を選択し、「新しいパッケージをアップロード」から ZIP をアップロードします
+5. ストアの掲載情報を確認し、必要に応じて更新します
+6. 審査を送信します
 
 ## Firefox アドオンへの公開
 
 1. `bun run release:zip` で生成された `.output/*.zip` を用意します
-2. [Firefox Add-on Developer Hub](https://addons.mozilla.org/ja/developers/) にアクセスします
-3. 該当のアドオンを選択し、新しいバージョンをアップロードします
-4. 必要に応じてソースコードをアップロードします
-5. 審査を送信します
+2. `.output/tabbin-{version}-build-metadata.json` に記録された Firefox ZIP の SHA-256 を確認します
+3. [Firefox Add-on Developer Hub](https://addons.mozilla.org/ja/developers/) にアクセスします
+4. 該当のアドオンを選択し、新しいバージョンをアップロードします
+5. 必要に応じてソースコードをアップロードします
+6. 審査を送信します
+
+## GitHub Release への添付（任意）
+
+GitHub Release を使う場合は、以下をリリース asset として添付することを検討してください。
+
+- Chrome ZIP
+- Firefox ZIP
+- `tabbin-{version}-build-metadata.json`
+- `tabbin-{version}-sbom.cdx.json`
+
+これにより、git commit / 依存関係状態 / 配布 artifact を同一の release unit で保存できます。
 
 ## 注意事項
 
 - `release:check` は通常の開発サイクルでは使用せず、配布前の最終確認に使います
-- `bun run release:check` をパスしない ZIP は配布しないでください
+- `bun run release:zip` をパスしない ZIP は配布しないでください
+- checksum は artifact の安全性そのものを保証するものではなく、配布物の同一性・追跡性を保つためのものです

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "zip": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",
     "release:check": "git diff --exit-code && bun run quality:check && bun run build && bun run build:firefox && bun run verify:app-version && git diff --exit-code",
-    "release:zip": "bun run release:check && bun run zip && bun run zip:firefox",
+    "release:zip": "bun run release:check && bun run zip && bun run zip:firefox && bun run release:provenance",
     "compile": "tsgo --noEmit",
     "secretlint": "secretlint \"**/*\"",
     "security:audit": "bun audit --audit-level=high --ignore GHSA-22p9-wv53-3rq4 --ignore GHSA-3ppc-4f35-3m26 --ignore GHSA-7r86-cg39-jmmj --ignore GHSA-23c5-xmqv-rm74 --ignore GHSA-c2c7-rcm5-vvqj --ignore GHSA-fx2h-pf6j-xcff --ignore GHSA-p9ff-h696-f583",
@@ -59,7 +59,8 @@
     "doctor": "react-doctor",
     "verify:app-version": "bun tools/scripts/verify-app-version.ts",
     "verify:toolchain-versions": "bun tools/scripts/verify-toolchain-versions.ts",
-    "sync:toolchain-versions": "bun tools/scripts/sync-toolchain-versions.ts"
+    "sync:toolchain-versions": "bun tools/scripts/sync-toolchain-versions.ts",
+    "release:provenance": "bun tools/scripts/generate-release-provenance.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -124,6 +125,7 @@
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.2.1",
+    "@cyclonedx/cyclonedx-library": "^10.1.0",
     "@eslint-react/eslint-plugin": "^5.10.3",
     "@playwright/test": "^1.61.1",
     "@secretlint/secretlint-rule-preset-recommend": "^13.0.2",
@@ -156,6 +158,7 @@
     "html-validate": "^11.5.5",
     "jscpd": "^5.0.11",
     "jsdom": "^29.1.1",
+    "json5": "^2.2.3",
     "knip": "^6.24.0",
     "oxfmt": "^0.57.0",
     "oxlint": "^1.72.0",

--- a/tools/scripts/generate-release-provenance.test.ts
+++ b/tools/scripts/generate-release-provenance.test.ts
@@ -1,0 +1,266 @@
+import { createHash } from 'node:crypto'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import * as CDX from '@cyclonedx/cyclonedx-library'
+import { describe, expect, it } from 'vitest'
+
+import {
+  extractLicense,
+  extractNameAndVersion,
+  generateBuildMetadata,
+  generateReleaseProvenance,
+  generateSbom,
+  parseBunLockPackages,
+} from './generate-release-provenance.ts'
+
+const createTempProject = (contents: {
+  packageJson?: Record<string, unknown>
+  bunLock?: Record<string, unknown>
+  nodeVersion?: string
+  bunVersion?: string
+}): string => {
+  const projectRoot = mkdtempSync(
+    path.join(tmpdir(), 'tabbin-release-provenance-'),
+  )
+  writeFileSync(
+    path.join(projectRoot, 'package.json'),
+    JSON.stringify(
+      contents.packageJson ?? { name: 'tabbin', version: '2.0.7' },
+    ),
+  )
+  writeFileSync(
+    path.join(projectRoot, 'bun.lock'),
+    JSON.stringify(contents.bunLock ?? { lockfileVersion: 1, packages: {} }),
+  )
+  writeFileSync(
+    path.join(projectRoot, '.node-version'),
+    contents.nodeVersion ?? '24',
+  )
+  writeFileSync(
+    path.join(projectRoot, '.bun-version'),
+    contents.bunVersion ?? '1.3.14',
+  )
+  return projectRoot
+}
+
+describe('extractNameAndVersion', () => {
+  it('parses an unscoped package reference', () => {
+    expect(extractNameAndVersion('react@19.2.7')).toEqual({
+      name: 'react',
+      version: '19.2.7',
+    })
+  })
+
+  it('parses a scoped package reference', () => {
+    expect(extractNameAndVersion('@types/node@24.0.0')).toEqual({
+      name: '@types/node',
+      version: '24.0.0',
+    })
+  })
+
+  it('throws for an invalid reference', () => {
+    expect(() => extractNameAndVersion('invalid')).toThrow(
+      /Unable to parse package reference/,
+    )
+  })
+})
+
+describe('extractLicense', () => {
+  it('returns an SPDX license for a known SPDX id', () => {
+    const license = extractLicense({ license: 'MIT' })
+    expect(license).toBeInstanceOf(CDX.Models.SpdxLicense)
+  })
+
+  it('returns a named license for an unknown string', () => {
+    const license = extractLicense({ license: 'Custom License' })
+    expect(license).toBeInstanceOf(CDX.Models.NamedLicense)
+  })
+
+  it('joins legacy license array with OR', () => {
+    const license = extractLicense({
+      licenses: [{ type: 'MIT' }, { type: 'Apache-2.0' }],
+    })
+    expect(license).toBeInstanceOf(CDX.Models.LicenseExpression)
+    expect((license as CDX.Models.LicenseExpression).expression).toBe(
+      'MIT OR Apache-2.0',
+    )
+  })
+
+  it('returns NOASSERTION when license is missing', () => {
+    const license = extractLicense({})
+    expect(license).toBeInstanceOf(CDX.Models.LicenseExpression)
+    expect((license as CDX.Models.LicenseExpression).expression).toBe(
+      'NOASSERTION',
+    )
+  })
+})
+
+describe('parseBunLockPackages', () => {
+  it('deduplicates packages by resolved name and version', () => {
+    const packages = parseBunLockPackages(
+      {
+        lockfileVersion: 1,
+        packages: {
+          react: ['react@18.3.1', '', {}, 'sha512-aaaa'],
+          'nested/react': ['react@18.3.1', '', {}, 'sha512-aaaa'],
+          'react-dom': ['react-dom@18.3.1', '', {}, 'sha512-bbbb'],
+        },
+      },
+      new Set(['react', 'react-dom']),
+    )
+
+    expect(packages).toHaveLength(2)
+    expect(packages.map((p) => p.name).toSorted()).toEqual([
+      'react',
+      'react-dom',
+    ])
+  })
+
+  it('skips malformed package entries', () => {
+    const packages = parseBunLockPackages(
+      {
+        lockfileVersion: 1,
+        packages: {
+          bad: ['not-a-version'],
+        },
+      },
+      new Set(),
+    )
+
+    expect(packages).toHaveLength(0)
+  })
+})
+
+describe('generateBuildMetadata', () => {
+  it('finds zip artifacts and records their sha256', () => {
+    const projectRoot = mkdtempSync(
+      path.join(tmpdir(), 'tabbin-release-provenance-zip-'),
+    )
+    const outputDir = path.join(projectRoot, '.output')
+    mkdirSync(outputDir, { recursive: true })
+    writeFileSync(path.join(outputDir, 'tabbin-2.0.7-chrome.zip'), 'chrome-zip')
+    writeFileSync(
+      path.join(outputDir, 'tabbin-2.0.7-firefox.zip'),
+      'firefox-zip',
+    )
+
+    const metadata = generateBuildMetadata({
+      appName: 'tabbin',
+      appVersion: '2.0.7',
+      gitSha: 'abc123',
+      nodeVersion: '24',
+      bunVersion: '1.3.14',
+      buildTimestamp: '2026-07-12T09:00:00.000Z',
+      bunLockSha256: 'lockhash',
+      outputDir,
+    })
+
+    expect(metadata.artifacts).toHaveLength(2)
+    expect(metadata.artifacts.map((a) => a.browser).toSorted()).toEqual([
+      'chrome',
+      'firefox',
+    ])
+    expect(metadata.artifacts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          browser: 'chrome',
+          fileName: 'tabbin-2.0.7-chrome.zip',
+          sha256: createHash('sha256').update('chrome-zip').digest('hex'),
+        }),
+        expect.objectContaining({
+          browser: 'firefox',
+          fileName: 'tabbin-2.0.7-firefox.zip',
+          sha256: createHash('sha256').update('firefox-zip').digest('hex'),
+        }),
+      ]),
+    )
+    expect(metadata.sbom).toEqual({
+      fileName: 'tabbin-2.0.7-sbom.cdx.json',
+      format: 'CycloneDX',
+      specVersion: '1.6',
+    })
+  })
+})
+
+describe('generateSbom', () => {
+  it('produces a CycloneDX BOM with an application component and dependencies', () => {
+    const projectRoot = createTempProject({
+      packageJson: { name: 'tabbin', version: '2.0.7' },
+    })
+    mkdirSync(path.join(projectRoot, 'node_modules', 'react'), {
+      recursive: true,
+    })
+    mkdirSync(path.join(projectRoot, 'node_modules', 'react'), {
+      recursive: true,
+    })
+    writeFileSync(
+      path.join(projectRoot, 'node_modules', 'react', 'package.json'),
+      JSON.stringify({ name: 'react', version: '18.3.1', license: 'MIT' }),
+    )
+
+    const bom = generateSbom({
+      appName: 'tabbin',
+      appVersion: '2.0.7',
+      packages: [
+        {
+          name: 'react',
+          version: '18.3.1',
+          integrity: 'sha512-aaaa',
+          metadata: {},
+          isProduction: true,
+        },
+      ],
+      projectRoot,
+      gitSha: 'abc123',
+      buildTimestamp: '2026-07-12T09:00:00.000Z',
+    })
+
+    expect(bom.metadata.component?.name).toBe('tabbin')
+    expect(bom.metadata.component?.version).toBe('2.0.7')
+    expect(Array.from(bom.components)).toHaveLength(1)
+    expect(Array.from(bom.components)[0]?.name).toBe('react')
+  })
+})
+
+describe('generateReleaseProvenance', () => {
+  it('generates metadata and SBOM from project files', () => {
+    const projectRoot = createTempProject({
+      packageJson: { name: 'tabbin', version: '2.0.7' },
+      bunLock: {
+        lockfileVersion: 1,
+        packages: {
+          react: ['react@18.3.1', '', { dependencies: {} }, 'sha512-aaaa'],
+          'react-dom': ['react-dom@18.3.1', '', {}, 'sha512-bbbb'],
+        },
+      },
+    })
+    mkdirSync(path.join(projectRoot, 'node_modules', 'react'), {
+      recursive: true,
+    })
+    writeFileSync(
+      path.join(projectRoot, 'node_modules', 'react', 'package.json'),
+      JSON.stringify({ name: 'react', version: '18.3.1', license: 'MIT' }),
+    )
+
+    const { metadata, sbomJson } = generateReleaseProvenance({
+      projectRoot,
+      outputDir: path.join(projectRoot, '.output'),
+      gitSha: 'abc123def456',
+      buildTimestamp: '2026-07-12T09:00:00.000Z',
+    })
+
+    expect(metadata.appName).toBe('tabbin')
+    expect(metadata.appVersion).toBe('2.0.7')
+    expect(metadata.gitSha).toBe('abc123def456')
+    expect(metadata.bunLockSha256).toHaveLength(64)
+    expect(metadata.artifacts).toHaveLength(0)
+    expect(metadata.sbom.format).toBe('CycloneDX')
+
+    const sbom = JSON.parse(sbomJson)
+    expect(sbom.bomFormat).toBe('CycloneDX')
+    expect(sbom.specVersion).toBe('1.6')
+    expect(sbom.metadata.component.name).toBe('tabbin')
+  })
+})

--- a/tools/scripts/generate-release-provenance.ts
+++ b/tools/scripts/generate-release-provenance.ts
@@ -1,0 +1,470 @@
+import { execFileSync } from 'node:child_process'
+import { createHash, randomUUID } from 'node:crypto'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+import * as CDX from '@cyclonedx/cyclonedx-library'
+import JSON5 from 'json5'
+
+type JsonObject = Record<string, unknown>
+
+type BunLockPackage = [
+  resolvedReference: string,
+  registryOrPath: string,
+  metadata: JsonObject,
+  integrity?: string,
+]
+
+type PackageInfo = {
+  name: string
+  version: string
+  integrity?: string
+  metadata: JsonObject
+  isProduction: boolean
+}
+
+type ArtifactInfo = {
+  browser: 'chrome' | 'firefox'
+  fileName: string
+  sha256: string
+}
+
+type BuildMetadata = {
+  appName: string
+  appVersion: string
+  gitSha: string
+  nodeVersion: string
+  bunVersion: string
+  buildTimestamp: string
+  bunLockSha256: string
+  artifacts: ArtifactInfo[]
+  sbom: {
+    fileName: string
+    format: string
+    specVersion: string
+  }
+}
+
+const isBunLockPackage = (value: unknown): value is BunLockPackage =>
+  Array.isArray(value) &&
+  value.length >= 2 &&
+  typeof value[0] === 'string' &&
+  typeof value[1] === 'string' &&
+  isRecord(value[2])
+
+const isRecord = (value: unknown): value is JsonObject =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const readTextFile = (filePath: string): string =>
+  readFileSync(filePath, 'utf8').trim()
+
+const parseJsonWithTrailingCommas = (content: string): unknown =>
+  JSON5.parse<unknown>(content)
+
+const readJsonFile = (filePath: string): JsonObject => {
+  const content = readFileSync(filePath, 'utf8')
+  const parsed: unknown = parseJsonWithTrailingCommas(content)
+  if (!isRecord(parsed)) {
+    throw new TypeError(`${filePath} is not a JSON object`)
+  }
+  return parsed
+}
+
+const computeSha256 = (filePath: string): string => {
+  const hash = createHash('sha256')
+  hash.update(readFileSync(filePath))
+  return hash.digest('hex')
+}
+
+const encodeNpmPurl = (name: string, version: string): string => {
+  const encodedName = name.replace(/^@/, '%40').replace(/\//g, '%2F')
+  return `pkg:npm/${encodedName}@${version}`
+}
+
+const base64ToHex = (base64: string): string =>
+  Buffer.from(base64, 'base64').toString('hex')
+
+export const extractNameAndVersion = (
+  resolvedReference: string,
+): { name: string; version: string } => {
+  const match = /^(?:@([^/]+)\/)?([^@]+)@(.+)$/.exec(resolvedReference)
+  if (!match) {
+    throw new TypeError(
+      `Unable to parse package reference: ${resolvedReference}`,
+    )
+  }
+  const [, scope, name, version] = match
+  const fullName = scope ? `@${scope}/${name}` : name
+  return { name: fullName, version }
+}
+
+export const extractLicense = (packageJson: JsonObject): CDX.Models.License => {
+  const license = packageJson.license
+  const licenses = packageJson.licenses
+  if (typeof license === 'string') {
+    if (CDX.SPDX.isSupportedSpdxId(license)) {
+      return new CDX.Models.SpdxLicense(license)
+    }
+    return new CDX.Models.NamedLicense(license)
+  }
+  if (Array.isArray(license)) {
+    const expressions = license
+      .filter(isRecord)
+      .map((entry) => entry.type)
+      .filter((type): type is string => typeof type === 'string')
+    if (expressions.length > 0) {
+      return new CDX.Models.LicenseExpression(expressions.join(' OR '))
+    }
+  }
+  if (Array.isArray(licenses)) {
+    const expressions = licenses
+      .filter(isRecord)
+      .map((entry) => entry.type)
+      .filter((type): type is string => typeof type === 'string')
+    if (expressions.length > 0) {
+      return new CDX.Models.LicenseExpression(expressions.join(' OR '))
+    }
+  }
+  return new CDX.Models.LicenseExpression('NOASSERTION')
+}
+
+const readPackageJson = (
+  projectRoot: string,
+  packageName: string,
+): JsonObject | undefined => {
+  const packageDir = path.join(projectRoot, 'node_modules', packageName)
+  const packageJsonPath = path.join(packageDir, 'package.json')
+  if (!existsSync(packageJsonPath)) {
+    return undefined
+  }
+  try {
+    return readJsonFile(packageJsonPath)
+  } catch {
+    return undefined
+  }
+}
+
+export const parseBunLockPackages = (
+  bunLock: unknown,
+  productionNames: Set<string>,
+): PackageInfo[] => {
+  if (!isRecord(bunLock)) {
+    throw new TypeError('bun.lock is not an object')
+  }
+  const packages = bunLock.packages
+  if (!isRecord(packages)) {
+    throw new TypeError('bun.lock packages is not an object')
+  }
+
+  const seen = new Set<string>()
+  const result: PackageInfo[] = []
+
+  for (const rawEntry of Object.values(packages)) {
+    if (!isBunLockPackage(rawEntry)) {
+      continue
+    }
+    const entry: BunLockPackage = rawEntry
+    const resolvedReference = entry[0]
+    const { name, version } = extractNameAndVersion(resolvedReference)
+    const packageId = `${name}@${version}`
+    if (seen.has(packageId)) {
+      continue
+    }
+    seen.add(packageId)
+
+    const metadata: JsonObject = entry[2]
+    const integrity = typeof entry[3] === 'string' ? entry[3] : undefined
+
+    result.push({
+      name,
+      version,
+      integrity,
+      metadata,
+      isProduction: productionNames.has(name),
+    })
+  }
+
+  return result
+}
+
+const addPackageComponent = (
+  bom: CDX.Models.Bom,
+  packageInfo: PackageInfo,
+  projectRoot: string,
+): void => {
+  const component = new CDX.Models.Component(
+    CDX.Enums.ComponentType.Library,
+    packageInfo.name,
+    {
+      version: packageInfo.version,
+      purl: encodeNpmPurl(packageInfo.name, packageInfo.version),
+      scope: packageInfo.isProduction
+        ? CDX.Enums.ComponentScope.Required
+        : CDX.Enums.ComponentScope.Excluded,
+    },
+  )
+
+  if (packageInfo.integrity?.startsWith('sha512-')) {
+    const hexHash = base64ToHex(packageInfo.integrity.slice('sha512-'.length))
+    if (hexHash.length === 128) {
+      component.hashes.set(CDX.Enums.HashAlgorithm['SHA-512'], hexHash)
+    }
+  }
+
+  const packageJson = readPackageJson(projectRoot, packageInfo.name)
+  if (packageJson !== undefined) {
+    component.licenses.add(extractLicense(packageJson))
+    if (typeof packageJson.description === 'string') {
+      component.description = packageJson.description
+    }
+  }
+
+  bom.components.add(component)
+}
+
+export const generateSbom = (options: {
+  appName: string
+  appVersion: string
+  packages: PackageInfo[]
+  projectRoot: string
+  gitSha: string
+  buildTimestamp: string
+}): CDX.Models.Bom => {
+  const { appName, appVersion, packages, projectRoot, gitSha, buildTimestamp } =
+    options
+
+  const bom = new CDX.Models.Bom()
+  bom.serialNumber = `urn:uuid:${randomUUID()}`
+
+  const appComponent = new CDX.Models.Component(
+    CDX.Enums.ComponentType.Application,
+    appName,
+    {
+      version: appVersion,
+      purl: encodeNpmPurl(appName, appVersion),
+    },
+  )
+  appComponent.properties.add(new CDX.Models.Property('gitSha', gitSha))
+
+  const toolRepository = new CDX.Models.ToolRepository()
+  toolRepository.add(
+    new CDX.Models.Tool({
+      name: 'tabbin-release-provenance',
+      version: appVersion,
+    }),
+  )
+
+  bom.metadata = new CDX.Models.Metadata({
+    timestamp: new Date(buildTimestamp),
+    component: appComponent,
+    tools: new CDX.Models.Tools({ tools: toolRepository }),
+  })
+
+  for (const packageInfo of packages) {
+    addPackageComponent(bom, packageInfo, projectRoot)
+  }
+
+  return bom
+}
+
+const findZipArtifacts = (
+  outputDir: string,
+  appVersion: string,
+): ArtifactInfo[] => {
+  const expectedArtifacts: {
+    browser: 'chrome' | 'firefox'
+    fileName: string
+  }[] = [
+    { browser: 'chrome', fileName: `tabbin-${appVersion}-chrome.zip` },
+    { browser: 'firefox', fileName: `tabbin-${appVersion}-firefox.zip` },
+  ]
+
+  return expectedArtifacts
+    .map((expected) => {
+      const filePath = path.join(outputDir, expected.fileName)
+      if (!existsSync(filePath)) {
+        return undefined
+      }
+      return {
+        browser: expected.browser,
+        fileName: expected.fileName,
+        sha256: computeSha256(filePath),
+      }
+    })
+    .filter((artifact): artifact is ArtifactInfo => artifact !== undefined)
+}
+
+export const generateBuildMetadata = (options: {
+  appName: string
+  appVersion: string
+  gitSha: string
+  nodeVersion: string
+  bunVersion: string
+  buildTimestamp: string
+  bunLockSha256: string
+  outputDir: string
+}): BuildMetadata => {
+  const {
+    appName,
+    appVersion,
+    gitSha,
+    nodeVersion,
+    bunVersion,
+    buildTimestamp,
+    bunLockSha256,
+    outputDir,
+  } = options
+
+  const artifacts = findZipArtifacts(outputDir, appVersion)
+  const sbomFileName = `${appName}-${appVersion}-sbom.cdx.json`
+
+  return {
+    appName,
+    appVersion,
+    gitSha,
+    nodeVersion,
+    bunVersion,
+    buildTimestamp,
+    bunLockSha256,
+    artifacts,
+    sbom: {
+      fileName: sbomFileName,
+      format: 'CycloneDX',
+      specVersion: '1.6',
+    },
+  }
+}
+
+const getGitSha = (projectRoot: string): string => {
+  try {
+    const porcelainStatus = execFileSync('git', ['status', '--porcelain'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim()
+    if (porcelainStatus !== '') {
+      throw new TypeError(
+        'Git worktree is not clean; commit or stash changes before generating release provenance',
+      )
+    }
+
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim()
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw error
+    }
+    throw new TypeError(
+      'Unable to determine git commit SHA; ensure the project is in a git repository',
+      { cause: error },
+    )
+  }
+}
+
+type ProvenanceInputs = {
+  projectRoot: string
+  outputDir: string
+  buildTimestamp?: string
+  gitSha?: string
+}
+
+export const generateReleaseProvenance = (
+  inputs: ProvenanceInputs,
+): { metadata: BuildMetadata; sbomJson: string } => {
+  const {
+    projectRoot,
+    outputDir,
+    buildTimestamp = new Date().toISOString(),
+    gitSha = getGitSha(projectRoot),
+  } = inputs
+
+  const packageJson = readJsonFile(path.join(projectRoot, 'package.json'))
+  const appVersion = packageJson.version
+  if (typeof appVersion !== 'string' || appVersion === '') {
+    throw new TypeError('package.json version is missing or not a string')
+  }
+  const appName = packageJson.name
+  if (typeof appName !== 'string' || appName === '') {
+    throw new TypeError('package.json name is missing or not a string')
+  }
+
+  const nodeVersion = readTextFile(path.join(projectRoot, '.node-version'))
+  const bunVersion = readTextFile(path.join(projectRoot, '.bun-version'))
+  const productionNames = isRecord(packageJson.dependencies)
+    ? new Set(Object.keys(packageJson.dependencies))
+    : new Set<string>()
+
+  const bunLockSha256 = computeSha256(path.join(projectRoot, 'bun.lock'))
+  const bunLock = readJsonFile(path.join(projectRoot, 'bun.lock'))
+  const packages = parseBunLockPackages(bunLock, productionNames)
+
+  const sbom = generateSbom({
+    appName,
+    appVersion,
+    packages,
+    projectRoot,
+    gitSha,
+    buildTimestamp,
+  })
+
+  const serializer = new CDX.Serialize.JsonSerializer(
+    new CDX.Serialize.JSON.Normalize.Factory(CDX.Spec.Spec1dot6),
+  )
+  const sbomJson = serializer.serialize(sbom, { space: 2 })
+
+  const metadata = generateBuildMetadata({
+    appName,
+    appVersion,
+    gitSha,
+    nodeVersion,
+    bunVersion,
+    buildTimestamp,
+    bunLockSha256,
+    outputDir,
+  })
+
+  return { metadata, sbomJson }
+}
+
+export const writeReleaseProvenance = (inputs: ProvenanceInputs): void => {
+  const { outputDir } = inputs
+  const { metadata, sbomJson } = generateReleaseProvenance(inputs)
+
+  const artifactBrowsers = new Set(
+    metadata.artifacts.map((artifact) => artifact.browser),
+  )
+  if (!artifactBrowsers.has('chrome') || !artifactBrowsers.has('firefox')) {
+    throw new TypeError(
+      'Both Chrome and Firefox ZIP artifacts must exist before writing release provenance',
+    )
+  }
+
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true })
+  }
+
+  const metadataFileName = `${metadata.appName}-${metadata.appVersion}-build-metadata.json`
+  writeFileSync(
+    path.join(outputDir, metadataFileName),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+  )
+
+  const sbomFileName = metadata.sbom.fileName
+  writeFileSync(path.join(outputDir, sbomFileName), `${sbomJson}\n`)
+
+  console.log(`Generated ${metadataFileName}`)
+  console.log(`Generated ${sbomFileName}`)
+  for (const artifact of metadata.artifacts) {
+    console.log(`Recorded ${artifact.browser} artifact: ${artifact.fileName}`)
+  }
+}
+
+const projectRoot = path.resolve(import.meta.dirname, '..', '..')
+const outputDir = path.join(projectRoot, '.output')
+
+if (import.meta.main) {
+  writeReleaseProvenance({ projectRoot, outputDir })
+}


### PR DESCRIPTION
## Summary

<!-- 変更の概要を簡潔に説明してください -->

## Changes

<!-- 具体的な変更内容を箇条書きで記載してください -->

## Test

<!-- テスト手順と結果を記載してください -->

## Screenshot / Video

<!-- UI 変更がある場合はスクリーンショットや動画を添付してください（任意） -->

## Related Issue

<!-- 関連する Issue があれば#684 の形式でリンクしてください（任意） -->

---

## Checklist

- [ ] `bun run quality` が成功している
- [ ] 変更箇所のテストが追加 / 更新されている
- [ ] ローカル環境で意図通り動作することを確認した
- [ ] 生成 artifact（`.output/`, `coverage/` など）が含まれていない


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release packages now include build metadata with version, environment, and SHA-256 checksums.
  * CycloneDX 1.6 software bills of materials (SBOMs) are generated for each release.
  * Chrome Web Store, Firefox Add-ons, and GitHub Release publishing guidance now includes checksum verification and required release assets.

* **Documentation**
  * Expanded release procedures and clarified provenance, artifact handling, and checksum limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->