### PR TITLE
production outbound通信をallowlistで制限する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Verify generated manifest version
         run: bun run verify:app-version
 
+      - name: Verify production network policy
+        run: bun run verify:production-network-policy
+
   run-tests-shard-1:
     name: Run Vitest Tests
     runs-on: ubuntu-latest

--- a/docs/plans/2026-07-13-production-network-policy-design.md
+++ b/docs/plans/2026-07-13-production-network-policy-design.md
@@ -12,7 +12,7 @@ runtime request guard.
 
 Use one typed production network policy as the source of truth for both the
 Ollama transport and generated manifest permissions. Verify that policy at
-three distinct boundaries:
+four distinct boundaries:
 
 1. A TypeScript-AST inventory detects direct browser network APIs and approved
    explicit network-client imports in production source, including aliases,
@@ -20,7 +20,7 @@ three distinct boundaries:
 2. A post-build verifier requires Chrome and Firefox manifests to contain
    exactly the allowed host permissions and a restrictive `connect-src` CSP.
 3. The extension CSP blocks non-allowlisted connections at runtime and disables
-   form and frame based transmission.
+   form and frame-based transmission.
 4. The shared Playwright fixture rejects HTTP(S)/WS(S) requests initiated by an
    extension page or extension service worker unless their origin is allowed.
 

--- a/docs/plans/2026-07-13-production-network-policy-design.md
+++ b/docs/plans/2026-07-13-production-network-policy-design.md
@@ -1,0 +1,55 @@
+# Production Network Policy Design
+
+## Context
+
+TABBIN is local-first. Production network access is currently intended only for
+the user's local Ollama server, while the generated manifests grant access to
+`localhost:11434` and `127.0.0.1:11434`. That invariant is duplicated between
+runtime code and `wxt.config.ts`, and there is no automated inventory or
+runtime request guard.
+
+## Decision
+
+Use one typed production network policy as the source of truth for both the
+Ollama transport and generated manifest permissions. Verify that policy at
+three distinct boundaries:
+
+1. A TypeScript-AST inventory detects direct browser network APIs and approved
+   explicit network-client imports in production source, including aliases,
+   computed global access, and dynamic imports.
+2. A post-build verifier requires Chrome and Firefox manifests to contain
+   exactly the allowed host permissions and a restrictive `connect-src` CSP.
+3. The extension CSP blocks non-allowlisted connections at runtime and disables
+   form and frame based transmission.
+4. The shared Playwright fixture rejects HTTP(S)/WS(S) requests initiated by an
+   extension page or extension service worker unless their origin is allowed.
+
+The existing `fetch(blob:)` call is classified as local data conversion, not
+outbound traffic. The inventory records it explicitly so a new call site cannot
+appear unnoticed. The AI SDK Ollama transport remains the only production
+outbound client and receives its base URL from the shared policy.
+
+## Alternatives
+
+- Manifest-only verification was rejected because host permissions do not
+  describe every runtime request or network call site.
+- A generic runtime fetch wrapper was rejected because it would not cover the
+  AI SDK transport and would add an incomplete compatibility layer.
+- Text search for URL literals was rejected because documentation links, blob
+  URLs, and navigation URLs are not outbound application requests.
+
+## Failure behavior
+
+Verification fails closed when a generated manifest is missing, a permission
+or CSP source is missing or added, a production network call site is not
+inventoried, or an extension-initiated E2E request targets an unapproved origin.
+Expanding the allowlist therefore requires an explicit policy change and
+security review.
+
+## Regression strategy
+
+Unit tests cover URL classification, AST call-site discovery, exact manifest
+comparison, and the current repository inventory. Existing Ollama tests prove
+the configured base URL remains usable. The E2E fixture applies the request
+guard to the existing major extension flows. `bun run quality` and
+`bun run release:check` remain the final repository gates.

--- a/docs/plans/2026-07-13-production-network-policy.md
+++ b/docs/plans/2026-07-13-production-network-policy.md
@@ -1,0 +1,84 @@
+# Production Network Policy Implementation Plan
+
+> **For Codex:** REQUIRED SUB-SKILL: Use test-driven-development and verification-before-completion task-by-task.
+
+**Goal:** Enforce TABBIN's local-only production outbound network policy across source inventory, generated manifests, and extension E2E flows.
+
+**Architecture:** A shared typed policy supplies Ollama's runtime origin and WXT host permissions. A TypeScript-AST verifier compares discovered call sites with a checked-in inventory and validates built manifests. The Playwright fixture attributes requests to extension pages/service workers and fails on disallowed outbound origins.
+
+**Tech Stack:** TypeScript, WXT, TypeScript compiler API, Vitest, Playwright
+
+---
+
+### Task 1: Shared policy behavior
+
+**Files:**
+
+- Create: `src/constants/productionNetworkPolicy.test.ts`
+- Create: `src/constants/productionNetworkPolicy.ts`
+- Modify: `src/lib/background/ai-chat.ts`
+- Modify: `wxt.config.ts`
+
+1. Write failing tests proving loopback Ollama URLs are allowed and external,
+   malformed, and non-network URLs are rejected or ignored as specified.
+2. Run `bun run test:node -- src/constants/productionNetworkPolicy.test.ts` and
+   confirm failure because the policy module does not exist.
+3. Implement the minimal typed policy, URL classifier, Ollama base URL, and host
+   permissions; replace duplicated literals in runtime and WXT configuration.
+4. Run the focused test and existing `src/lib/background/ai-chat.test.ts`.
+
+### Task 2: AST inventory and manifest verifier
+
+**Files:**
+
+- Create: `tools/scripts/production-network-policy.ts`
+- Create: `tools/scripts/production-network-policy.test.ts`
+- Create: `tools/scripts/verify-production-network-policy.ts`
+- Modify: `package.json`
+- Modify: `.github/workflows/ci.yml`
+
+1. Write failing fixture tests for detection of `fetch`, `XMLHttpRequest`,
+   `WebSocket`, `EventSource`, `navigator.sendBeacon`, and explicit network
+   client imports, plus exact manifest permission comparison.
+2. Add a failing live-repository test whose expected inventory contains only
+   the blob conversion and `ai-sdk-ollama` import.
+3. Run `bun run test:node -- tools/scripts/production-network-policy.test.ts` and
+   verify the expected missing-implementation failures.
+4. Implement alias-aware AST discovery, inventory comparison, exact host
+   permission validation, and a fail-closed production extension CSP.
+5. Add `verify:production-network-policy` after both production builds in
+   `release:check` and the CI Verify Build job.
+6. Re-run the focused tests and build/verifier commands.
+
+### Task 3: Runtime request interception and security policy
+
+**Files:**
+
+- Create: `e2e/helpers/network-policy.ts`
+- Modify: `e2e/helpers/extension.ts`
+- Create: `docs/security/production-network-policy.md`
+
+1. Add classifier tests in Task 1 that distinguish extension initiators and
+   outbound schemes from browser navigation and extension resources.
+2. Implement an automatic Playwright fixture that records requests initiated by
+   extension frames/service workers and asserts every outbound URL is allowed.
+3. Document the production inventory, allowlist, generated-manifest/runtime
+   verification commands, and required security-review checklist.
+4. Run `bun run build` followed by targeted or full `bun run e2e`.
+
+### Task 4: Completion gates and publication
+
+**Files:**
+
+- Update harness state under `.agents/harness/` only through harness commands.
+
+1. Run focused tests, `bun run test:coverage`, `bun run quality`, and
+   `bun run release:check`; investigate any failure rather than weakening a
+   gate.
+2. Run React Doctor only if React production code changes beyond replacing the
+   blob helper.
+3. Record checkpoints, run `harness:validate`, `harness:audit`, and a
+   fresh-context evaluator review.
+4. Inspect the scoped diff, commit in Japanese, push
+   `codex/issue-721-network-allowlist`, and create a non-draft PR to `develop`
+   that closes #721 and maps each acceptance criterion to evidence.

--- a/docs/plans/2026-07-13-production-network-policy.md
+++ b/docs/plans/2026-07-13-production-network-policy.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Shared policy behavior
+## Task 1: Shared policy behavior
 
 **Files:**
 
@@ -27,7 +27,7 @@
    permissions; replace duplicated literals in runtime and WXT configuration.
 4. Run the focused test and existing `src/lib/background/ai-chat.test.ts`.
 
-### Task 2: AST inventory and manifest verifier
+## Task 2: AST inventory and manifest verifier
 
 **Files:**
 
@@ -50,7 +50,7 @@
    `release:check` and the CI Verify Build job.
 6. Re-run the focused tests and build/verifier commands.
 
-### Task 3: Runtime request interception and security policy
+## Task 3: Runtime request interception and security policy
 
 **Files:**
 
@@ -66,7 +66,7 @@
    verification commands, and required security-review checklist.
 4. Run `bun run build` followed by targeted or full `bun run e2e`.
 
-### Task 4: Completion gates and publication
+## Task 4: Completion gates and publication
 
 **Files:**
 
@@ -81,4 +81,6 @@
    fresh-context evaluator review.
 4. Inspect the scoped diff, commit in Japanese, push
    `codex/issue-721-network-allowlist`, and create a non-draft PR to `develop`
-   that closes #721 and maps each acceptance criterion to evidence.
+   that closes #721 and maps each acceptance criterion to evidence. The
+   `develop` base is an explicitly approved exception for this task because the
+   user requested it when assigning Issue #721.

--- a/docs/security/production-network-policy.md
+++ b/docs/security/production-network-policy.md
@@ -35,7 +35,19 @@ Current production call sites are:
 
 There are no production `XMLHttpRequest`, WebSocket, EventSource, or
 `sendBeacon` call sites. Ollama download and FAQ URLs are user navigation links;
-the extension does not fetch them.
+the extension does not fetch them. Both links open a new top-level tab with
+`target="_blank"`. They remain normal user navigation in production, but the
+Playwright request hook intentionally treats any document request attributed to
+an extension frame or service worker as a policy violation. E2E coverage that
+clicks these links must therefore verify that Playwright attributes the new-tab
+navigation to the new page rather than weakening the extension-initiated
+document guard.
+
+WebSocket transports are not currently supported. The HTTP Ollama origins in
+`connect-src` do not grant `ws:` access, and the runtime URL classifier likewise
+rejects `ws://localhost:11434` and `ws://127.0.0.1:11434`. Adding a WebSocket
+transport requires an explicit allowlist, CSP, manifest, and regression-test
+change.
 
 ## Automated enforcement
 

--- a/docs/security/production-network-policy.md
+++ b/docs/security/production-network-policy.md
@@ -1,0 +1,87 @@
+# Production Outbound Network Policy
+
+## Policy
+
+TABBIN is local-first. Production code may send network requests only to the
+user's local Ollama service at these origins:
+
+- `http://localhost:11434`
+- `http://127.0.0.1:11434`
+
+The corresponding manifest host permissions are derived from the same typed
+policy in `src/constants/productionNetworkPolicy.ts`. IPv6 loopback, LAN hosts,
+custom Ollama endpoints, cloud AI endpoints, HTTPS, WebSocket, and EventSource
+origins are not currently allowed. Adding one is a privacy-design change, not a
+routine allowlist update.
+
+## Production network inventory
+
+The automated AST inventory in
+`tools/scripts/production-network-policy.ts` recognizes `fetch`,
+`XMLHttpRequest`, `WebSocket`, `EventSource`, `navigator.sendBeacon`, and known
+explicit network-client imports. It follows local aliases, destructured globals,
+computed global properties, and dynamic imports. Test files and stories are
+excluded.
+
+Current production call sites are:
+
+- `src/lib/background/ai-chat.ts` imports `ai-sdk-ollama`. It sends the user's
+  prompt, chat history, attachments, system instructions, and locally derived
+  saved-tab context to the configured local Ollama origin. The base URL comes
+  from the shared production policy.
+- `src/components/ai-elements/prompt-input.tsx` calls `fetch` only for a
+  `blob:` URL created from a user-selected local file. This converts local Blob
+  data to a data URL and is not outbound traffic.
+
+There are no production `XMLHttpRequest`, WebSocket, EventSource, or
+`sendBeacon` call sites. Ollama download and FAQ URLs are user navigation links;
+the extension does not fetch them.
+
+## Automated enforcement
+
+- `bun run test:node` checks the AST inventory and policy URL behavior. A new
+  detected call site fails until it is explicitly reviewed and inventoried.
+- `bun run build && bun run build:firefox && bun run
+verify:production-network-policy` checks both generated manifests. Required
+  host permissions must exactly match the allowlist, optional host permissions
+  must be absent or empty, and `connect-src` must contain only the extension
+  itself, local `blob:` data, and the two Ollama origins.
+- The generated extension CSP is the runtime enforcement boundary. It also sets
+  a self-only `default-src`, explicit local data rules, `frame-src 'none'`,
+  `form-action 'none'`, `object-src 'none'`, and `base-uri 'none'`. This prevents
+  dependency or alias tricks from bypassing the call-site inventory through
+  fetch-like APIs, subresources, forms, frames, or base URL rewriting.
+- `.github/workflows/ci.yml` runs the generated-manifest verifier in the Verify
+  Build job. `bun run release:check` runs the same gate for releases.
+- The shared Playwright context fixture attaches its listener immediately after
+  browser launch and before the context is exposed to page or service-worker
+  fixtures. It observes requests initiated by extension pages and extension
+  service workers, including document requests, and fails when an HTTP(S)/WS(S)
+  origin is outside the allowlist. The CSP covers extension startup before the
+  Playwright context becomes observable. Existing E2E major flows inherit this
+  guard automatically.
+
+The AST inventory intentionally analyzes syntax instead of URL text. A docs
+link or browser navigation therefore does not become a false positive, while a
+new request API or explicit network client becomes reviewable.
+
+## Security review checklist for endpoint changes
+
+Any PR that adds an endpoint, network client, or request call site must explain
+and verify all of the following before changing the policy:
+
+- What exact data is transmitted, including derived metadata, attachments,
+  identifiers, URL parameters, headers, and logs.
+- Why transmission is required and why a local-only design cannot satisfy the
+  use case.
+- How the user gives informed consent and can disable or revoke the behavior.
+- Required privacy-policy, browser-store disclosure, and data-collection
+  declaration changes.
+- Whether host or optional permissions change and whether they remain as narrow
+  as possible.
+- Redaction, retention, telemetry, error-reporting, and diagnostic-log policy.
+- Authentication, secret storage, transport security, and failure behavior.
+- Updates to the typed allowlist, AST inventory, generated-manifest tests, E2E
+  interception coverage, and user-facing documentation.
+
+Do not silently expand the allowlist to make a new feature or dependency work.

--- a/e2e/helpers/extension.ts
+++ b/e2e/helpers/extension.ts
@@ -5,7 +5,9 @@ import os from 'node:os'
 import path from 'node:path'
 
 import { test as base, chromium, expect } from '@playwright/test'
-import type { BrowserContext, Page, Worker } from '@playwright/test'
+import type { BrowserContext, Page, Request, Worker } from '@playwright/test'
+
+import { getUnexpectedPlaywrightExtensionOutboundRequest } from './network-policy'
 
 type ExtensionFixtures = {
   extensionContext: BrowserContext
@@ -33,14 +35,30 @@ export const test = base.extend<ExtensionFixtures>({
         ],
       },
     )
+    const violations = new Set<string>()
+    const handleRequest = (request: Request) => {
+      const violation = getUnexpectedPlaywrightExtensionOutboundRequest(request)
+      if (violation !== null) {
+        violations.add(violation)
+      }
+    }
+    extensionContext.on('request', handleRequest)
 
-    await runFixture(extensionContext)
+    try {
+      await runFixture(extensionContext)
+    } finally {
+      extensionContext.off('request', handleRequest)
+      await extensionContext.close()
+      await rm(userDataDir, {
+        force: true,
+        recursive: true,
+      })
+    }
 
-    await extensionContext.close()
-    await rm(userDataDir, {
-      force: true,
-      recursive: true,
-    })
+    expect(
+      [...violations],
+      'unexpected outbound request from an extension page or service worker',
+    ).toEqual([])
   },
   extensionId: async ({ serviceWorker }, runFixture) => {
     const extensionId = new URL(serviceWorker.url()).host

--- a/e2e/helpers/network-policy.ts
+++ b/e2e/helpers/network-policy.ts
@@ -1,0 +1,24 @@
+import { getUnexpectedExtensionOutboundRequest } from '#production-network-policy'
+import type { Request } from '@playwright/test'
+
+const getRequestInitiatorUrl = (request: Request): string | null => {
+  const serviceWorker = request.serviceWorker()
+  if (serviceWorker !== null) {
+    return serviceWorker.url()
+  }
+  try {
+    return request.frame().url()
+  } catch {
+    return null
+  }
+}
+
+export const getUnexpectedPlaywrightExtensionOutboundRequest = (
+  request: Request,
+): string | null =>
+  getUnexpectedExtensionOutboundRequest({
+    initiatorUrl: getRequestInitiatorUrl(request),
+    method: request.method(),
+    resourceType: request.resourceType(),
+    url: request.url(),
+  })

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "An extension for organizing and categorizing browser tabs so cluttered tab lists stay manageable.",
   "type": "module",
   "imports": {
-    "#harness-state": "./tools/harness/state/index.ts"
+    "#harness-state": "./tools/harness/state/index.ts",
+    "#production-network-policy": "./src/constants/productionNetworkPolicy.ts"
   },
   "scripts": {
     "dev": "wxt",
@@ -14,7 +15,7 @@
     "build:firefox": "wxt build -b firefox",
     "zip": "wxt zip",
     "zip:firefox": "wxt zip -b firefox",
-    "release:check": "git diff --exit-code && bun run quality:check && bun run build && bun run build:firefox && bun run verify:production-logging && bun run verify:app-version && git diff --exit-code",
+    "release:check": "git diff --exit-code && bun run quality:check && bun run build && bun run build:firefox && bun run verify:production-logging && bun run verify:app-version && bun run verify:production-network-policy && git diff --exit-code",
     "release:zip": "bun run release:check && bun run zip && bun run zip:firefox && bun run release:provenance",
     "compile": "tsgo --noEmit",
     "secretlint": "secretlint \"**/*\"",
@@ -27,6 +28,7 @@
     "validate:html": "html-validate --config .htmlvalidate.json --ext tsx,html src",
     "verify:tooling-dependencies": "node tools/scripts/verify-tooling-dependencies.mjs",
     "verify:production-logging": "bun tools/scripts/verify-production-logging.ts",
+    "verify:production-network-policy": "bun tools/scripts/verify-production-network-policy.ts",
     "check": "bun run format:check && bun run compile && bun run lint",
     "check:write": "bun run lint:fix && bun run format",
     "check:duplication": "jscpd --config .jscpd.json",

--- a/src/constants/productionNetworkPolicy.test.ts
+++ b/src/constants/productionNetworkPolicy.test.ts
@@ -109,4 +109,14 @@ describe('production network policy', () => {
   ])('ignores allowed or non-outbound request %#', (request) => {
     expect(getUnexpectedExtensionOutboundRequest(request)).toBeNull()
   })
+
+  it.each([
+    'ws://localhost:11434/api/events',
+    'ws://127.0.0.1:11434/api/events',
+  ])(
+    'does not treat unsupported WebSocket transports as allowed: %s',
+    (url) => {
+      expect(isAllowedProductionOutboundUrl(url)).toBe(false)
+    },
+  )
 })

--- a/src/constants/productionNetworkPolicy.test.ts
+++ b/src/constants/productionNetworkPolicy.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  OLLAMA_BASE_URL,
+  PRODUCTION_OUTBOUND_HOST_PERMISSIONS,
+  createProductionExtensionCsp,
+  getUnexpectedExtensionOutboundRequest,
+  isAllowedProductionOutboundUrl,
+  isExtensionInitiatorUrl,
+  isOutboundNetworkUrl,
+} from './productionNetworkPolicy'
+
+describe('production network policy', () => {
+  it.each([
+    'http://localhost:11434/api/tags',
+    'http://127.0.0.1:11434/api/generate',
+  ])('allows the configured Ollama loopback endpoint: %s', (url) => {
+    expect(isAllowedProductionOutboundUrl(url)).toBe(true)
+  })
+
+  it.each([
+    'https://localhost:11434/api/tags',
+    'http://localhost:11435/api/tags',
+    'http://192.168.1.10:11434/api/tags',
+    'https://api.example.com/v1/chat',
+    'not a url',
+  ])('rejects an endpoint outside the production allowlist: %s', (url) => {
+    expect(isAllowedProductionOutboundUrl(url)).toBe(false)
+  })
+
+  it.each([
+    ['http://localhost:11434', true],
+    ['https://example.com', true],
+    ['ws://localhost:11434', true],
+    ['wss://example.com', true],
+    ['blob:chrome-extension://extension-id/value', false],
+    ['chrome-extension://extension-id/app.html', false],
+    ['data:text/plain,local', false],
+    ['not a url', false],
+  ])('classifies outbound network schemes for %s', (url, expected) => {
+    expect(isOutboundNetworkUrl(url)).toBe(expected)
+  })
+
+  it('keeps the runtime Ollama URL inside the manifest allowlist', () => {
+    expect(OLLAMA_BASE_URL).toBe('http://localhost:11434')
+    expect(PRODUCTION_OUTBOUND_HOST_PERMISSIONS).toEqual([
+      'http://localhost:11434/*',
+      'http://127.0.0.1:11434/*',
+    ])
+  })
+
+  it('creates fail-closed extension CSP for MV2 and MV3', () => {
+    expect(createProductionExtensionCsp(2)).toBe(
+      "default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; media-src 'self' data: blob:; connect-src 'self' blob: http://localhost:11434 http://127.0.0.1:11434; worker-src 'self'; frame-src 'none'; form-action 'none'; base-uri 'none'",
+    )
+    expect(createProductionExtensionCsp(3)).toBe(
+      "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; object-src 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; media-src 'self' data: blob:; connect-src 'self' blob: http://localhost:11434 http://127.0.0.1:11434; worker-src 'self'; frame-src 'none'; form-action 'none'; base-uri 'none'",
+    )
+  })
+
+  it.each([
+    ['chrome-extension://extension-id/background.js', true],
+    ['moz-extension://extension-id/background.js', true],
+    ['https://example.com/', false],
+    ['about:blank', false],
+    ['not a url', false],
+  ])('classifies extension request initiators for %s', (url, expected) => {
+    expect(isExtensionInitiatorUrl(url)).toBe(expected)
+  })
+
+  it.each([
+    ['fetch', 'POST', 'https://api.example.com/v1/chat'],
+    ['document', 'GET', 'https://api.example.com/collect?secret=value'],
+  ])(
+    'reports external %s requests from extension pages and service workers',
+    (resourceType, method, url) => {
+      expect(
+        getUnexpectedExtensionOutboundRequest({
+          initiatorUrl: 'chrome-extension://extension-id/app.html',
+          method,
+          resourceType,
+          url,
+        }),
+      ).toBe(
+        `${method} ${url} (initiator: chrome-extension://extension-id/app.html)`,
+      )
+    },
+  )
+
+  it.each([
+    {
+      initiatorUrl: 'chrome-extension://extension-id/background.js',
+      method: 'POST',
+      resourceType: 'fetch',
+      url: 'http://localhost:11434/api/generate',
+    },
+    {
+      initiatorUrl: 'https://visited.example.com/',
+      method: 'GET',
+      resourceType: 'image',
+      url: 'https://cdn.example.com/image.png',
+    },
+    {
+      initiatorUrl: 'chrome-extension://extension-id/app.html',
+      method: 'GET',
+      resourceType: 'fetch',
+      url: 'blob:chrome-extension://extension-id/local-file',
+    },
+  ])('ignores allowed or non-outbound request %#', (request) => {
+    expect(getUnexpectedExtensionOutboundRequest(request)).toBeNull()
+  })
+})

--- a/src/constants/productionNetworkPolicy.ts
+++ b/src/constants/productionNetworkPolicy.ts
@@ -1,0 +1,84 @@
+export const PRODUCTION_OUTBOUND_ALLOWED_ORIGINS = [
+  'http://localhost:11434',
+  'http://127.0.0.1:11434',
+] as const
+
+export const PRODUCTION_OUTBOUND_HOST_PERMISSIONS =
+  PRODUCTION_OUTBOUND_ALLOWED_ORIGINS.map((origin) => `${origin}/*`)
+
+export const OLLAMA_BASE_URL = PRODUCTION_OUTBOUND_ALLOWED_ORIGINS[0]
+
+const MANIFEST_VERSION_3 = '3'
+
+export const createProductionExtensionCsp = (
+  manifestVersion: number,
+): string => {
+  const scriptSources =
+    String(manifestVersion) === MANIFEST_VERSION_3
+      ? "'self' 'wasm-unsafe-eval'"
+      : "'self'"
+  return [
+    "default-src 'self'",
+    `script-src ${scriptSources}`,
+    "object-src 'none'",
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self' data:",
+    "media-src 'self' data: blob:",
+    `connect-src 'self' blob: ${PRODUCTION_OUTBOUND_ALLOWED_ORIGINS.join(' ')}`,
+    "worker-src 'self'",
+    "frame-src 'none'",
+    "form-action 'none'",
+    "base-uri 'none'",
+  ].join('; ')
+}
+
+const OUTBOUND_NETWORK_PROTOCOLS = new Set(['http:', 'https:', 'ws:', 'wss:'])
+const EXTENSION_PROTOCOLS = new Set(['chrome-extension:', 'moz-extension:'])
+const ALLOWED_ORIGINS = new Set<string>(PRODUCTION_OUTBOUND_ALLOWED_ORIGINS)
+
+export type ExtensionNetworkRequestObservation = {
+  initiatorUrl: string | null
+  method: string
+  resourceType: string
+  url: string
+}
+
+const parseUrl = (url: string): URL | null => {
+  try {
+    return new URL(url)
+  } catch {
+    return null
+  }
+}
+
+export const isOutboundNetworkUrl = (url: string): boolean => {
+  const parsedUrl = parseUrl(url)
+  return (
+    parsedUrl !== null && OUTBOUND_NETWORK_PROTOCOLS.has(parsedUrl.protocol)
+  )
+}
+
+export const isAllowedProductionOutboundUrl = (url: string): boolean => {
+  const parsedUrl = parseUrl(url)
+  return parsedUrl !== null && ALLOWED_ORIGINS.has(parsedUrl.origin)
+}
+
+export const isExtensionInitiatorUrl = (url: string): boolean => {
+  const parsedUrl = parseUrl(url)
+  return parsedUrl !== null && EXTENSION_PROTOCOLS.has(parsedUrl.protocol)
+}
+
+export const getUnexpectedExtensionOutboundRequest = (
+  request: ExtensionNetworkRequestObservation,
+): string | null => {
+  if (
+    request.initiatorUrl === null ||
+    !isExtensionInitiatorUrl(request.initiatorUrl) ||
+    !isOutboundNetworkUrl(request.url) ||
+    isAllowedProductionOutboundUrl(request.url)
+  ) {
+    return null
+  }
+  return `${request.method} ${request.url} (initiator: ${request.initiatorUrl})`
+}

--- a/src/lib/background/ai-chat.ts
+++ b/src/lib/background/ai-chat.ts
@@ -2,6 +2,7 @@ import { generateText, isStepCount } from 'ai'
 import { createOllama } from 'ai-sdk-ollama'
 
 import { getAiChatToolTitle } from '@/constants/aiChatTools'
+import { OLLAMA_BASE_URL } from '@/constants/productionNetworkPolicy'
 import { buildTextAttachmentContext } from '@/features/ai-chat/lib/attachments'
 import { buildAiSavedUrlRecords } from '@/features/ai-chat/lib/buildAiContext'
 import { inferUserInterests } from '@/features/ai-chat/lib/inferInterests'
@@ -112,7 +113,6 @@ const normalizeLoadedAiChatSettings = (settings: UserSettings | undefined) =>
 const getNormalizedAiChatSettings = async () =>
   normalizeLoadedAiChatSettings(await getUserSettings())
 
-const OLLAMA_BASE_URL = 'http://localhost:11434'
 const OLLAMA_TAGS_URL = `${OLLAMA_BASE_URL}/api/tags`
 const OLLAMA_DOWNLOAD_URL = 'https://ollama.com/download'
 const OLLAMA_FAQ_URL =

--- a/tools/scripts/production-network-policy-aliases.test.ts
+++ b/tools/scripts/production-network-policy-aliases.test.ts
@@ -1,0 +1,36 @@
+import ts from 'typescript'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { NetworkCallsiteKind } from './production-network-policy'
+import { collectPotentialNetworkAliasKinds } from './production-network-policy-aliases'
+
+describe('collectPotentialNetworkAliasKinds', () => {
+  it('stops evaluating assignments once their alias kinds converge', () => {
+    const source = ts.createSourceFile(
+      'aliases.ts',
+      `
+        const first = fetch
+        const second = first
+      `,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    )
+    const resolveDirectReferences = vi.fn(
+      (node: ts.Node): ReadonlySet<NetworkCallsiteKind> =>
+        ts.isIdentifier(node) && node.text === 'fetch'
+          ? new Set(['fetch'])
+          : new Set(),
+    )
+
+    const summaries = collectPotentialNetworkAliasKinds(
+      source,
+      resolveDirectReferences,
+    )
+
+    expect(summaries.get(source)?.bindings.get('second')).toEqual(
+      new Set(['fetch']),
+    )
+    expect(resolveDirectReferences).toHaveBeenCalledTimes(4)
+  })
+})

--- a/tools/scripts/production-network-policy-aliases.ts
+++ b/tools/scripts/production-network-policy-aliases.ts
@@ -1,0 +1,392 @@
+import ts from 'typescript'
+
+import type { NetworkCallsiteKind } from './production-network-policy'
+
+type PotentialAliasAssignment = {
+  captured: boolean
+  environment: PotentialAliasEnvironment
+  expression: ts.Expression
+  name: string
+}
+
+type PotentialAliasEnvironment = {
+  assignments: PotentialAliasAssignment[]
+  capturedKinds: Map<string, ReadonlySet<NetworkCallsiteKind>>
+  declaredNames: Set<string>
+  kinds: Map<string, ReadonlySet<NetworkCallsiteKind>>
+  node: ts.Node
+  parent: PotentialAliasEnvironment | null
+  type: 'block' | 'function' | 'source'
+}
+
+type PendingAliasAssignment = PotentialAliasAssignment & {
+  environment: PotentialAliasEnvironment
+}
+
+type DirectReferenceResolver = (
+  node: ts.Node,
+) => ReadonlySet<NetworkCallsiteKind>
+
+export type PotentialAliasSummary = {
+  bindings: ReadonlyMap<string, ReadonlySet<NetworkCallsiteKind>>
+  capturedBindings: ReadonlyMap<string, ReadonlySet<NetworkCallsiteKind>>
+}
+
+const collectBindingNames = (name: ts.BindingName): string[] => {
+  if (ts.isIdentifier(name)) {
+    return [name.text]
+  }
+  return name.elements.flatMap((element) =>
+    ts.isOmittedExpression(element) ? [] : collectBindingNames(element.name),
+  )
+}
+
+const getPotentialAliasKinds = (
+  environment: PotentialAliasEnvironment,
+  name: string,
+): ReadonlySet<NetworkCallsiteKind> => {
+  for (
+    let current: PotentialAliasEnvironment | null = environment;
+    current !== null;
+    current = current.parent
+  ) {
+    const kinds = current.kinds.get(name)
+    if (kinds !== undefined) {
+      return kinds
+    }
+  }
+  return new Set()
+}
+
+const isLogicalExpression = (node: ts.Node): node is ts.BinaryExpression =>
+  ts.isBinaryExpression(node) &&
+  [
+    ts.SyntaxKind.AmpersandAmpersandToken,
+    ts.SyntaxKind.BarBarToken,
+    ts.SyntaxKind.QuestionQuestionToken,
+  ].includes(node.operatorToken.kind)
+
+const resolvePotentialAliasKinds = (
+  expression: ts.Expression,
+  environment: PotentialAliasEnvironment,
+  resolveDirectReferences: DirectReferenceResolver,
+): ReadonlySet<NetworkCallsiteKind> => {
+  const directKinds = resolveDirectReferences(expression)
+  const environmentKinds = ts.isIdentifier(expression)
+    ? getPotentialAliasKinds(environment, expression.text)
+    : new Set<NetworkCallsiteKind>()
+  if (directKinds.size > 0 || environmentKinds.size > 0) {
+    return new Set([...directKinds, ...environmentKinds])
+  }
+  if (ts.isConditionalExpression(expression)) {
+    return new Set([
+      ...resolvePotentialAliasKinds(
+        expression.whenTrue,
+        environment,
+        resolveDirectReferences,
+      ),
+      ...resolvePotentialAliasKinds(
+        expression.whenFalse,
+        environment,
+        resolveDirectReferences,
+      ),
+    ])
+  }
+  if (isLogicalExpression(expression)) {
+    return new Set([
+      ...resolvePotentialAliasKinds(
+        expression.left,
+        environment,
+        resolveDirectReferences,
+      ),
+      ...resolvePotentialAliasKinds(
+        expression.right,
+        environment,
+        resolveDirectReferences,
+      ),
+    ])
+  }
+  if (!ts.isCallExpression(expression)) {
+    return new Set()
+  }
+  const callee = expression.expression
+  if (!ts.isPropertyAccessExpression(callee) || callee.name.text !== 'bind') {
+    return new Set()
+  }
+  return resolvePotentialAliasKinds(
+    callee.expression,
+    environment,
+    resolveDirectReferences,
+  )
+}
+
+const createEnvironment = (
+  environments: PotentialAliasEnvironment[],
+  node: ts.Node,
+  parent: PotentialAliasEnvironment | null,
+  type: PotentialAliasEnvironment['type'],
+): PotentialAliasEnvironment => {
+  const environment: PotentialAliasEnvironment = {
+    assignments: [],
+    capturedKinds: new Map(),
+    declaredNames: new Set(),
+    kinds: new Map(),
+    node,
+    parent,
+    type,
+  }
+  environments.push(environment)
+  return environment
+}
+
+const getEnvironmentType = (
+  node: ts.Node,
+): PotentialAliasEnvironment['type'] | null => {
+  if (ts.isFunctionLike(node)) {
+    return 'function'
+  }
+  if (
+    ts.isBlock(node) ||
+    ts.isCatchClause(node) ||
+    ts.isForStatement(node) ||
+    ts.isForInStatement(node) ||
+    ts.isForOfStatement(node) ||
+    ts.isSwitchStatement(node)
+  ) {
+    return 'block'
+  }
+  return null
+}
+
+const findVariableEnvironment = (
+  environment: PotentialAliasEnvironment,
+): PotentialAliasEnvironment => {
+  let current = environment
+  while (current.type === 'block' && current.parent !== null) {
+    current = current.parent
+  }
+  return current
+}
+
+const registerVariableDeclaration = (
+  node: ts.VariableDeclaration,
+  environment: PotentialAliasEnvironment,
+): void => {
+  const declarationList = ts.isVariableDeclarationList(node.parent)
+    ? node.parent
+    : null
+  const isBlockScoped =
+    ts.isCatchClause(node.parent) ||
+    (declarationList !== null &&
+      (declarationList.flags & ts.NodeFlags.BlockScoped) !== 0)
+  const declarationEnvironment = isBlockScoped
+    ? environment
+    : findVariableEnvironment(environment)
+  for (const name of collectBindingNames(node.name)) {
+    declarationEnvironment.declaredNames.add(name)
+  }
+  if (ts.isIdentifier(node.name) && node.initializer !== undefined) {
+    declarationEnvironment.assignments.push({
+      captured: false,
+      environment,
+      expression: node.initializer,
+      name: node.name.text,
+    })
+  }
+}
+
+const findDeclaredEnvironment = (
+  environment: PotentialAliasEnvironment,
+  name: string,
+): PotentialAliasEnvironment | null => {
+  let current: PotentialAliasEnvironment | null = environment
+  while (current !== null) {
+    if (current.declaredNames.has(name)) {
+      return current
+    }
+    current = current.parent
+  }
+  return null
+}
+
+const findFunctionEnvironment = (
+  environment: PotentialAliasEnvironment,
+): PotentialAliasEnvironment => {
+  let current = environment
+  while (current.type === 'block' && current.parent !== null) {
+    current = current.parent
+  }
+  return current
+}
+
+const isEnvironmentAncestor = (
+  ancestor: PotentialAliasEnvironment,
+  environment: PotentialAliasEnvironment,
+): boolean => {
+  let current = environment.parent
+  while (current !== null) {
+    if (current === ancestor) {
+      return true
+    }
+    current = current.parent
+  }
+  return false
+}
+
+const assignPendingAliases = (
+  pendingAssignments: readonly PendingAliasAssignment[],
+): void => {
+  for (const assignment of pendingAssignments) {
+    const declaredEnvironment = findDeclaredEnvironment(
+      assignment.environment,
+      assignment.name,
+    )
+    const functionEnvironment = findFunctionEnvironment(assignment.environment)
+    const target =
+      declaredEnvironment === null ||
+      (functionEnvironment.type === 'function' &&
+        isEnvironmentAncestor(declaredEnvironment, functionEnvironment))
+        ? functionEnvironment
+        : declaredEnvironment
+    target.assignments.push({
+      captured: false,
+      environment: assignment.environment,
+      expression: assignment.expression,
+      name: assignment.name,
+    })
+    if (
+      declaredEnvironment !== null &&
+      target !== declaredEnvironment &&
+      isEnvironmentAncestor(declaredEnvironment, target)
+    ) {
+      declaredEnvironment.assignments.push({
+        captured: true,
+        environment: assignment.environment,
+        expression: assignment.expression,
+        name: assignment.name,
+      })
+    }
+  }
+}
+
+const registerFunctionParameters = (
+  node: ts.SignatureDeclaration,
+  environment: PotentialAliasEnvironment,
+): void => {
+  for (const parameter of node.parameters) {
+    for (const name of collectBindingNames(parameter.name)) {
+      environment.declaredNames.add(name)
+    }
+  }
+}
+
+const collectPotentialEnvironments = (
+  source: ts.SourceFile,
+): PotentialAliasEnvironment[] => {
+  const environments: PotentialAliasEnvironment[] = []
+  const pendingAssignments: PendingAliasAssignment[] = []
+  const sourceEnvironment = createEnvironment(
+    environments,
+    source,
+    null,
+    'source',
+  )
+  const visit = (
+    node: ts.Node,
+    environment: PotentialAliasEnvironment,
+  ): void => {
+    if (node !== source) {
+      const environmentType = getEnvironmentType(node)
+      if (environmentType !== null) {
+        if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
+          environment.declaredNames.add(node.name.text)
+        }
+        const childEnvironment = createEnvironment(
+          environments,
+          node,
+          environment,
+          environmentType,
+        )
+        if (ts.isFunctionLike(node)) {
+          registerFunctionParameters(node, childEnvironment)
+        }
+        ts.forEachChild(node, (child) => {
+          visit(child, childEnvironment)
+        })
+        return
+      }
+    }
+    if (ts.isVariableDeclaration(node)) {
+      registerVariableDeclaration(node, environment)
+    } else if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left)
+    ) {
+      pendingAssignments.push({
+        captured: false,
+        environment,
+        expression: node.right,
+        name: node.left.text,
+      })
+    }
+    ts.forEachChild(node, (child) => {
+      visit(child, environment)
+    })
+  }
+  visit(source, sourceEnvironment)
+  assignPendingAliases(pendingAssignments)
+  return environments
+}
+
+const applyPotentialAssignment = (
+  target: PotentialAliasEnvironment,
+  assignment: PotentialAliasAssignment,
+  resolveDirectReferences: DirectReferenceResolver,
+): void => {
+  const resolvedKinds = resolvePotentialAliasKinds(
+    assignment.expression,
+    assignment.environment,
+    resolveDirectReferences,
+  )
+  const existing = target.kinds.get(assignment.name) ?? new Set()
+  target.kinds.set(assignment.name, new Set([...existing, ...resolvedKinds]))
+  if (!assignment.captured) {
+    return
+  }
+  const capturedKinds = target.capturedKinds.get(assignment.name) ?? new Set()
+  target.capturedKinds.set(
+    assignment.name,
+    new Set([...capturedKinds, ...resolvedKinds]),
+  )
+}
+
+export const collectPotentialNetworkAliasKinds = (
+  source: ts.SourceFile,
+  resolveDirectReferences: DirectReferenceResolver,
+): WeakMap<ts.Node, PotentialAliasSummary> => {
+  const environments = collectPotentialEnvironments(source)
+  const assignmentCount = environments.reduce(
+    (count, environment) => count + environment.assignments.length,
+    0,
+  )
+  for (let pass = 0; pass <= assignmentCount; pass += 1) {
+    for (const environment of environments) {
+      for (const assignment of environment.assignments) {
+        applyPotentialAssignment(
+          environment,
+          assignment,
+          resolveDirectReferences,
+        )
+      }
+    }
+  }
+  const result = new WeakMap<ts.Node, PotentialAliasSummary>()
+  for (const environment of environments) {
+    result.set(environment.node, {
+      bindings: environment.kinds,
+      capturedBindings: environment.capturedKinds,
+    })
+  }
+  return result
+}

--- a/tools/scripts/production-network-policy-aliases.ts
+++ b/tools/scripts/production-network-policy-aliases.ts
@@ -209,16 +209,6 @@ const findDeclaredEnvironment = (
   return null
 }
 
-const findFunctionEnvironment = (
-  environment: PotentialAliasEnvironment,
-): PotentialAliasEnvironment => {
-  let current = environment
-  while (current.type === 'block' && current.parent !== null) {
-    current = current.parent
-  }
-  return current
-}
-
 const isEnvironmentAncestor = (
   ancestor: PotentialAliasEnvironment,
   environment: PotentialAliasEnvironment,
@@ -241,7 +231,7 @@ const assignPendingAliases = (
       assignment.environment,
       assignment.name,
     )
-    const functionEnvironment = findFunctionEnvironment(assignment.environment)
+    const functionEnvironment = findVariableEnvironment(assignment.environment)
     const target =
       declaredEnvironment === null ||
       (functionEnvironment.type === 'function' &&
@@ -343,22 +333,35 @@ const applyPotentialAssignment = (
   target: PotentialAliasEnvironment,
   assignment: PotentialAliasAssignment,
   resolveDirectReferences: DirectReferenceResolver,
-): void => {
+): boolean => {
   const resolvedKinds = resolvePotentialAliasKinds(
     assignment.expression,
     assignment.environment,
     resolveDirectReferences,
   )
+  const hasExisting = target.kinds.has(assignment.name)
   const existing = target.kinds.get(assignment.name) ?? new Set()
-  target.kinds.set(assignment.name, new Set([...existing, ...resolvedKinds]))
-  if (!assignment.captured) {
-    return
+  const newKinds = [...resolvedKinds].filter((kind) => !existing.has(kind))
+  const kindsChanged = !hasExisting || newKinds.length > 0
+  if (kindsChanged) {
+    target.kinds.set(assignment.name, new Set([...existing, ...newKinds]))
   }
+  if (!assignment.captured) {
+    return kindsChanged
+  }
+  const hasCapturedKinds = target.capturedKinds.has(assignment.name)
   const capturedKinds = target.capturedKinds.get(assignment.name) ?? new Set()
-  target.capturedKinds.set(
-    assignment.name,
-    new Set([...capturedKinds, ...resolvedKinds]),
+  const newCapturedKinds = [...resolvedKinds].filter(
+    (kind) => !capturedKinds.has(kind),
   )
+  const capturedKindsChanged = !hasCapturedKinds || newCapturedKinds.length > 0
+  if (capturedKindsChanged) {
+    target.capturedKinds.set(
+      assignment.name,
+      new Set([...capturedKinds, ...newCapturedKinds]),
+    )
+  }
+  return kindsChanged || capturedKindsChanged
 }
 
 export const collectPotentialNetworkAliasKinds = (
@@ -371,14 +374,19 @@ export const collectPotentialNetworkAliasKinds = (
     0,
   )
   for (let pass = 0; pass <= assignmentCount; pass += 1) {
+    let changed = false
     for (const environment of environments) {
       for (const assignment of environment.assignments) {
-        applyPotentialAssignment(
-          environment,
-          assignment,
-          resolveDirectReferences,
-        )
+        changed =
+          applyPotentialAssignment(
+            environment,
+            assignment,
+            resolveDirectReferences,
+          ) || changed
       }
+    }
+    if (!changed) {
+      break
     }
   }
   const result = new WeakMap<ts.Node, PotentialAliasSummary>()

--- a/tools/scripts/production-network-policy-ast.ts
+++ b/tools/scripts/production-network-policy-ast.ts
@@ -1,0 +1,367 @@
+import ts from 'typescript'
+
+import type { NetworkCallsiteKind } from './production-network-policy'
+
+export type AliasScope = {
+  bindings: Map<string, ReadonlySet<NetworkCallsiteKind>>
+  capturedBindings: ReadonlyMap<string, ReadonlySet<NetworkCallsiteKind>>
+  potentialBindings: ReadonlyMap<string, ReadonlySet<NetworkCallsiteKind>>
+  type: 'block' | 'function' | 'source'
+}
+
+export const collectBindingIdentifiers = (name: ts.BindingName): string[] => {
+  if (ts.isIdentifier(name)) {
+    return [name.text]
+  }
+  return name.elements.flatMap((element) =>
+    ts.isOmittedExpression(element)
+      ? []
+      : collectBindingIdentifiers(element.name),
+  )
+}
+
+export const cloneAliasScopes = (
+  sourceScopes: readonly AliasScope[],
+): AliasScope[] =>
+  sourceScopes.map((scope) => ({
+    bindings: new Map(
+      [...scope.bindings].map(([name, kinds]) => [name, new Set(kinds)]),
+    ),
+    capturedBindings: scope.capturedBindings,
+    potentialBindings: scope.potentialBindings,
+    type: scope.type,
+  }))
+
+export const mergeAliasScopeStates = (
+  states: readonly AliasScope[][],
+): AliasScope[] =>
+  states[0].map((scope, scopeIndex) => {
+    const names = new Set(
+      states.flatMap((state) => [
+        ...(state[scopeIndex]?.bindings.keys() ?? []),
+      ]),
+    )
+    return {
+      bindings: new Map(
+        [...names].map((name) => [
+          name,
+          new Set(
+            states.flatMap((state) => [
+              ...(state[scopeIndex]?.bindings.get(name) ?? []),
+            ]),
+          ),
+        ]),
+      ),
+      capturedBindings: scope.capturedBindings,
+      potentialBindings: scope.potentialBindings,
+      type: scope.type,
+    }
+  })
+
+type NetworkAstTraversalContext = {
+  cloneScopes: (scopes: readonly AliasScope[]) => AliasScope[]
+  createScope: (type: AliasScope['type'], node: ts.Node) => AliasScope
+  declareAlias: (name: string, kinds: ReadonlySet<NetworkCallsiteKind>) => void
+  enterNodeScope: (node: ts.Node) => boolean
+  getScopes: () => AliasScope[]
+  mergeScopeStates: (states: readonly AliasScope[][]) => AliasScope[]
+  recordNetworkCallsite: (node: ts.Node) => void
+  registerNodeAliases: (node: ts.Node) => void
+  setScopes: (scopes: AliasScope[]) => void
+  traverseFromClonedState: (
+    initialScopes: readonly AliasScope[],
+    traverse: () => void,
+  ) => AliasScope[]
+}
+
+export class NetworkAstTraverser {
+  private readonly context: NetworkAstTraversalContext
+
+  constructor(context: NetworkAstTraversalContext) {
+    this.context = context
+  }
+
+  traverse(node: ts.Node): void {
+    if (
+      this.visitFunction(node) ||
+      this.visitConditional(node) ||
+      this.visitLoop(node) ||
+      this.visitSwitch(node) ||
+      this.visitTry(node)
+    ) {
+      return
+    }
+    const createdScope = this.context.enterNodeScope(node)
+    this.context.registerNodeAliases(node)
+    this.context.recordNetworkCallsite(node)
+    ts.forEachChild(node, (child) => {
+      this.traverse(child)
+    })
+    if (createdScope) {
+      this.context.getScopes().pop()
+    }
+  }
+
+  private visitFunction(node: ts.Node): boolean {
+    if (!ts.isFunctionLike(node)) {
+      return false
+    }
+    if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
+      this.context.declareAlias(node.name.text, new Set())
+    }
+    const previousScopes = this.context.getScopes()
+    const functionScopes = this.context.cloneScopes(previousScopes)
+    functionScopes.push(this.context.createScope('function', node))
+    this.context.setScopes(functionScopes)
+    for (const parameter of node.parameters) {
+      for (const name of collectBindingIdentifiers(parameter.name)) {
+        this.context.declareAlias(name, new Set())
+      }
+    }
+    ts.forEachChild(node, (child) => {
+      this.traverse(child)
+    })
+    this.context.setScopes(previousScopes)
+    return true
+  }
+
+  private visitConditional(node: ts.Node): boolean {
+    if (this.visitShortCircuitExpression(node)) {
+      return true
+    }
+    if (ts.isIfStatement(node)) {
+      this.visitIfStatement(node)
+      return true
+    }
+    if (!ts.isConditionalExpression(node)) {
+      return false
+    }
+    this.traverse(node.condition)
+    const initialState = this.context.cloneScopes(this.context.getScopes())
+    const whenTrueState = this.context.traverseFromClonedState(
+      initialState,
+      () => {
+        this.traverse(node.whenTrue)
+      },
+    )
+    const whenFalseState = this.context.traverseFromClonedState(
+      initialState,
+      () => {
+        this.traverse(node.whenFalse)
+      },
+    )
+    this.context.setScopes(
+      this.context.mergeScopeStates([whenTrueState, whenFalseState]),
+    )
+    return true
+  }
+
+  private visitShortCircuitExpression(node: ts.Node): boolean {
+    if (
+      !ts.isBinaryExpression(node) ||
+      ![
+        ts.SyntaxKind.AmpersandAmpersandToken,
+        ts.SyntaxKind.BarBarToken,
+        ts.SyntaxKind.QuestionQuestionToken,
+      ].includes(node.operatorToken.kind)
+    ) {
+      return false
+    }
+    this.traverse(node.left)
+    const beforeRight = this.context.cloneScopes(this.context.getScopes())
+    const afterRight = this.context.traverseFromClonedState(beforeRight, () => {
+      this.traverse(node.right)
+    })
+    this.context.setScopes(
+      this.context.mergeScopeStates([beforeRight, afterRight]),
+    )
+    return true
+  }
+
+  private visitIfStatement(node: ts.IfStatement): void {
+    this.traverse(node.expression)
+    const initialState = this.context.cloneScopes(this.context.getScopes())
+    const thenState = this.context.traverseFromClonedState(initialState, () => {
+      this.traverse(node.thenStatement)
+    })
+    const elseStatement = node.elseStatement
+    const elseState =
+      elseStatement === undefined
+        ? initialState
+        : this.context.traverseFromClonedState(initialState, () => {
+            this.traverse(elseStatement)
+          })
+    this.context.setScopes(
+      this.context.mergeScopeStates([thenState, elseState]),
+    )
+  }
+
+  private visitLoop(node: ts.Node): boolean {
+    if (ts.isForStatement(node)) {
+      this.visitForStatement(node)
+      return true
+    }
+    if (ts.isForInStatement(node) || ts.isForOfStatement(node)) {
+      this.visitForEachStatement(node)
+      return true
+    }
+    if (ts.isWhileStatement(node) || ts.isDoStatement(node)) {
+      this.visitWhileStatement(node)
+      return true
+    }
+    return false
+  }
+
+  private visitWhileStatement(node: ts.WhileStatement | ts.DoStatement): void {
+    if (ts.isWhileStatement(node)) {
+      this.traverse(node.expression)
+    }
+    const beforeIteration = this.context.cloneScopes(this.context.getScopes())
+    const afterIteration = this.context.traverseFromClonedState(
+      beforeIteration,
+      () => {
+        this.traverse(node.statement)
+        if (ts.isDoStatement(node)) {
+          this.traverse(node.expression)
+        }
+      },
+    )
+    if (ts.isDoStatement(node)) {
+      const afterAdditionalIteration = this.context.traverseFromClonedState(
+        afterIteration,
+        () => {
+          this.traverse(node.statement)
+          this.traverse(node.expression)
+        },
+      )
+      this.context.setScopes(
+        this.context.mergeScopeStates([
+          afterIteration,
+          afterAdditionalIteration,
+        ]),
+      )
+      return
+    }
+    this.context.setScopes(
+      this.context.mergeScopeStates([beforeIteration, afterIteration]),
+    )
+  }
+
+  private visitForStatement(node: ts.ForStatement): void {
+    const scopes = this.context.getScopes()
+    scopes.push(this.context.createScope('block', node))
+    if (node.initializer !== undefined) {
+      this.traverse(node.initializer)
+    }
+    if (node.condition !== undefined) {
+      this.traverse(node.condition)
+    }
+    const beforeIteration = this.context.cloneScopes(this.context.getScopes())
+    const afterIteration = this.context.traverseFromClonedState(
+      beforeIteration,
+      () => {
+        this.traverse(node.statement)
+        if (node.incrementor !== undefined) {
+          this.traverse(node.incrementor)
+        }
+      },
+    )
+    this.context.setScopes(
+      this.context.mergeScopeStates([beforeIteration, afterIteration]),
+    )
+    this.context.getScopes().pop()
+  }
+
+  private visitForEachStatement(
+    node: ts.ForInStatement | ts.ForOfStatement,
+  ): void {
+    this.context.getScopes().push(this.context.createScope('block', node))
+    this.traverse(node.expression)
+    this.traverse(node.initializer)
+    const beforeIteration = this.context.cloneScopes(this.context.getScopes())
+    const afterIteration = this.context.traverseFromClonedState(
+      beforeIteration,
+      () => {
+        this.traverse(node.statement)
+      },
+    )
+    this.context.setScopes(
+      this.context.mergeScopeStates([beforeIteration, afterIteration]),
+    )
+    this.context.getScopes().pop()
+  }
+
+  private visitSwitch(node: ts.Node): boolean {
+    if (!ts.isSwitchStatement(node)) {
+      return false
+    }
+    this.traverse(node.expression)
+    this.context.getScopes().push(this.context.createScope('block', node))
+    const beforeSwitch = this.context.cloneScopes(this.context.getScopes())
+    const sequentialState = this.context.traverseFromClonedState(
+      beforeSwitch,
+      () => {
+        this.traverse(node.caseBlock)
+      },
+    )
+    const clauseStates = node.caseBlock.clauses.map((clause) =>
+      this.context.traverseFromClonedState(beforeSwitch, () => {
+        if (ts.isCaseClause(clause)) {
+          this.traverse(clause.expression)
+        }
+        for (const statement of clause.statements) {
+          this.traverse(statement)
+        }
+      }),
+    )
+    this.context.setScopes(
+      this.context.mergeScopeStates([
+        beforeSwitch,
+        sequentialState,
+        ...clauseStates,
+      ]),
+    )
+    this.context.getScopes().pop()
+    return true
+  }
+
+  private visitTry(node: ts.Node): boolean {
+    if (!ts.isTryStatement(node)) {
+      return false
+    }
+    const beforeTry = this.context.cloneScopes(this.context.getScopes())
+    const tryState = this.context.traverseFromClonedState(beforeTry, () => {
+      this.traverse(node.tryBlock)
+    })
+    const catchClause = node.catchClause
+    const catchState =
+      catchClause === undefined
+        ? null
+        : this.context.traverseFromClonedState(beforeTry, () => {
+            this.traverseCatchClause(catchClause)
+          })
+    const mergedState = this.context.mergeScopeStates([
+      tryState,
+      ...(catchState === null ? [] : [catchState]),
+    ])
+    const finallyBlock = node.finallyBlock
+    if (finallyBlock === undefined) {
+      this.context.setScopes(mergedState)
+      return true
+    }
+    const finalState = this.context.traverseFromClonedState(mergedState, () => {
+      this.traverse(finallyBlock)
+    })
+    this.context.setScopes(finalState)
+    return true
+  }
+
+  private traverseCatchClause(node: ts.CatchClause): void {
+    this.context.getScopes().push(this.context.createScope('block', node))
+    if (node.variableDeclaration !== undefined) {
+      this.context.registerNodeAliases(node.variableDeclaration)
+    }
+    this.traverse(node.block)
+    this.context.getScopes().pop()
+  }
+}

--- a/tools/scripts/production-network-policy.test.ts
+++ b/tools/scripts/production-network-policy.test.ts
@@ -173,6 +173,273 @@ describe('collectSourceNetworkCallsites', () => {
       ),
     ).toEqual([])
   })
+
+  it('isolates nested function assignments from enclosing aliases', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/nested-assignment.ts',
+        `
+          const request = fetch
+          function localHelper() {
+            request = () => undefined
+            request('local')
+          }
+          request('https://example.com/outbound')
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([{ kind: 'fetch', path: 'src/nested-assignment.ts' }])
+  })
+
+  it('preserves possible network aliases after conditional assignments', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/conditional-assignment.ts',
+        `
+          let request = fetch
+          if (useLocal) {
+            request = () => undefined
+          }
+          request('https://example.com/outbound')
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([{ kind: 'fetch', path: 'src/conditional-assignment.ts' }])
+
+    expect(
+      collectSourceNetworkCallsites(
+        'src/conditional-global-assignment.ts',
+        `
+          if (useLocal) {
+            fetch = () => undefined
+          }
+          fetch('https://example.com/outbound')
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([{ kind: 'fetch', path: 'src/conditional-global-assignment.ts' }])
+  })
+
+  it('keeps for and switch lexical bindings from overwriting outer aliases', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/control-flow-bindings.ts',
+        `
+          const request = fetch
+          for (const request of localRequests) {
+            request('local')
+          }
+          switch (mode) {
+            case 'local':
+              const request = () => undefined
+              request('local')
+              break
+          }
+          request('https://example.com/outbound')
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([{ kind: 'fetch', path: 'src/control-flow-bindings.ts' }])
+  })
+
+  it('preserves possible aliases after loop and switch assignments', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/control-flow-assignments.ts',
+        `
+          let loopRequest = fetch
+          for (const item of items) {
+            loopRequest = () => item
+          }
+          loopRequest('https://example.com/after-loop')
+
+          let switchRequest = fetch
+          switch (mode) {
+            case 'local':
+              switchRequest = () => undefined
+              break
+          }
+          switchRequest('https://example.com/after-switch')
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([
+      { kind: 'fetch', path: 'src/control-flow-assignments.ts' },
+      { kind: 'fetch', path: 'src/control-flow-assignments.ts' },
+    ])
+  })
+
+  it('preserves possible aliases after while and short-circuit assignments', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/additional-control-flow.ts',
+        `
+          let loopRequest = fetch
+          while (shouldReplace) {
+            loopRequest = () => undefined
+          }
+          loopRequest('https://example.com/after-while')
+
+          let branchRequest = fetch
+          shouldReplace && (branchRequest = () => undefined)
+          branchRequest('https://example.com/after-short-circuit')
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([
+      { kind: 'fetch', path: 'src/additional-control-flow.ts' },
+      { kind: 'fetch', path: 'src/additional-control-flow.ts' },
+    ])
+  })
+
+  it('includes captured aliases assigned after a function declaration', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/later-captured-alias.ts',
+        `
+          let request
+          function send() {
+            request('https://example.com/from-closure')
+          }
+          request = fetch
+          send()
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([{ kind: 'fetch', path: 'src/later-captured-alias.ts' }])
+  })
+
+  it('tracks aliases assigned from conditional and logical expressions', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/expression-aliases.ts',
+        `
+          const conditionalRequest = flag ? fetch : (() => undefined)
+          conditionalRequest('https://example.com/conditional')
+
+          const logicalRequest = flag && fetch
+          logicalRequest('https://example.com/logical')
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([
+      { kind: 'fetch', path: 'src/expression-aliases.ts' },
+      { kind: 'fetch', path: 'src/expression-aliases.ts' },
+    ])
+  })
+
+  it('keeps potential captured aliases isolated by function environment', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/isolated-potential-aliases.ts',
+        `
+          let request = () => undefined
+          function send() {
+            request('local')
+          }
+          function unrelated() {
+            const request = fetch
+            request('https://example.com/unrelated')
+          }
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([{ kind: 'fetch', path: 'src/isolated-potential-aliases.ts' }])
+  })
+
+  it('tracks nested closures by lexical binding scope', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/nested-closure-alias.ts',
+        `
+          function outer() {
+            let request
+            function inner() {
+              request('https://example.com/nested')
+            }
+            request = fetch
+          }
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([{ kind: 'fetch', path: 'src/nested-closure-alias.ts' }])
+  })
+
+  it('does not pollute outer aliases with block-shadowed potentials', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/block-shadow-potential.ts',
+        `
+          let request = () => undefined
+          function send() {
+            request('local')
+          }
+          {
+            const request = fetch
+            request('https://example.com/block')
+          }
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([{ kind: 'fetch', path: 'src/block-shadow-potential.ts' }])
+  })
+
+  it('merges try and catch aliases while preserving catch binding scope', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/try-catch-alias.ts',
+        `
+          let request = fetch
+          try {
+            work()
+          } catch {
+            request = () => undefined
+          }
+          request('https://example.com/after-catch')
+
+          let shadowedRequest = fetch
+          try {
+            work()
+          } catch (shadowedRequest) {
+            shadowedRequest = () => undefined
+          }
+          shadowedRequest('https://example.com/after-shadowed-catch')
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([
+      { kind: 'fetch', path: 'src/try-catch-alias.ts' },
+      { kind: 'fetch', path: 'src/try-catch-alias.ts' },
+    ])
+  })
+
+  it('propagates captured network aliases from callable functions', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/callable-captured-alias.ts',
+        `
+          let iifeRequest = () => undefined
+          ;(() => {
+            iifeRequest = fetch
+          })()
+          iifeRequest('https://example.com/iife')
+
+          let namedRequest = () => undefined
+          function enableNetwork() {
+            namedRequest = fetch
+          }
+          enableNetwork()
+          namedRequest('https://example.com/named')
+        `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([
+      { kind: 'fetch', path: 'src/callable-captured-alias.ts' },
+      { kind: 'fetch', path: 'src/callable-captured-alias.ts' },
+    ])
+  })
+
+  it('does not include an impossible zero-iteration path for do-while', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/do-while-alias.ts',
+        `
+          let request = fetch
+          do {
+            request = () => undefined
+          } while (false)
+          request('local')
+        `,
+      ),
+    ).toEqual([])
+  })
 })
 
 describe('production network call-site inventory', () => {
@@ -225,6 +492,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             'http://127.0.0.1:11434/*',
             'http://localhost:11434/*',
           ],
+          manifest_version: 3,
         },
         'manifest.json',
       ),
@@ -271,6 +539,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             'http://localhost:11434/*',
             'https://api.example.com/*',
           ],
+          manifest_version: 3,
         },
         'added.json',
       ),
@@ -280,6 +549,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
       assertManifestMatchesProductionNetworkPolicy(
         {
           host_permissions: ['http://localhost:11434/*'],
+          manifest_version: 3,
         },
         'missing.json',
       ),
@@ -292,6 +562,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             'http://localhost:11434/*',
             'http://127.0.0.1:11434/*',
           ],
+          manifest_version: 3,
           optional_host_permissions: ['https://api.example.com/*'],
         },
         'optional.json',
@@ -300,7 +571,10 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
 
     expect(() =>
       assertManifestMatchesProductionNetworkPolicy(
-        { host_permissions: 'http://localhost:11434/*' },
+        {
+          host_permissions: 'http://localhost:11434/*',
+          manifest_version: 3,
+        },
         'malformed.json',
       ),
     ).toThrow(/malformed\.json.*host_permissions/)
@@ -314,6 +588,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             'http://localhost:11434/*',
             'http://127.0.0.1:11434/*',
           ],
+          manifest_version: 3,
         },
         'missing-csp.json',
       ),
@@ -330,6 +605,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             'http://localhost:11434/*',
             'http://127.0.0.1:11434/*',
           ],
+          manifest_version: 3,
         },
         'broad-csp.json',
       ),
@@ -357,6 +633,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             ),
           },
           host_permissions,
+          manifest_version: 3,
         },
         'object-src.json',
       ),
@@ -372,6 +649,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             ),
           },
           host_permissions,
+          manifest_version: 3,
         },
         'script-src.json',
       ),
@@ -384,6 +662,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             extension_pages: `${csp}; report-uri https://example.com/csp`,
           },
           host_permissions,
+          manifest_version: 3,
         },
         'extra-directive.json',
       ),
@@ -401,6 +680,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             'http://localhost:11434/*',
             'http://127.0.0.1:11434/*',
           ],
+          manifest_version: 3,
         },
         'duplicate-csp.json',
       ),
@@ -418,10 +698,35 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             'http://localhost:11434/*',
             'http://127.0.0.1:11434/*',
           ],
+          manifest_version: 3,
           optional_host_permissions: [],
         },
         'empty-optional.json',
       ),
     ).not.toThrow()
+  })
+
+  it.each([
+    ['missing', undefined],
+    ['string', '3'],
+    ['unsupported', 4],
+  ])('rejects %s manifest_version values', (label, manifestVersion) => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: createProductionExtensionCsp(3),
+          },
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+          ...(manifestVersion === undefined
+            ? {}
+            : { manifest_version: manifestVersion }),
+        },
+        `${label}-version.json`,
+      ),
+    ).toThrow(new RegExp(`${label}-version\\.json.*manifest_version.*2 or 3`))
   })
 })

--- a/tools/scripts/production-network-policy.test.ts
+++ b/tools/scripts/production-network-policy.test.ts
@@ -1,0 +1,427 @@
+import path from 'node:path'
+
+import { createProductionExtensionCsp } from '#production-network-policy'
+import { describe, expect, it } from 'vitest'
+
+import {
+  assertManifestMatchesProductionNetworkPolicy,
+  assertProductionNetworkCallsiteInventory,
+  collectProductionNetworkCallsites,
+  collectSourceNetworkCallsites,
+  normalizeNetworkCallsite,
+} from './production-network-policy'
+
+describe('collectSourceNetworkCallsites', () => {
+  it('discovers browser network APIs and explicit network clients from syntax', () => {
+    const callsites = collectSourceNetworkCallsites(
+      'src/network.ts',
+      `
+        import { generateText } from 'ai'
+        import { createOllama } from 'ai-sdk-ollama'
+        import axios from 'axios'
+
+        fetch('https://example.com')
+        new XMLHttpRequest()
+        new WebSocket('wss://example.com')
+        new EventSource('https://example.com/events')
+        navigator.sendBeacon('https://example.com/events')
+      `,
+    )
+
+    expect(callsites.map(normalizeNetworkCallsite)).toEqual([
+      {
+        detail: 'ai-sdk-ollama',
+        kind: 'network-client-import',
+        path: 'src/network.ts',
+      },
+      {
+        detail: 'axios',
+        kind: 'network-client-import',
+        path: 'src/network.ts',
+      },
+      { kind: 'fetch', path: 'src/network.ts' },
+      { kind: 'xml-http-request', path: 'src/network.ts' },
+      { kind: 'websocket', path: 'src/network.ts' },
+      { kind: 'event-source', path: 'src/network.ts' },
+      { kind: 'send-beacon', path: 'src/network.ts' },
+    ])
+  })
+
+  it('does not treat URL strings or navigation APIs as network call sites', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/links.ts',
+        `
+          const docs = 'https://example.com/docs'
+          window.open(docs)
+          chrome.tabs.create({ url: docs })
+        `,
+      ),
+    ).toEqual([])
+  })
+
+  it('resolves global API aliases, computed access, and dynamic network-client imports', () => {
+    const callsites = collectSourceNetworkCallsites(
+      'src/indirect-network.ts',
+      `
+        import OpenAI from 'openai'
+        const request = fetch
+        const computedRequest = globalThis['fetch']
+        const { fetch: destructuredRequest } = globalThis
+        const Socket = globalThis['WebSocket']
+
+        request('https://example.com/one')
+        computedRequest('https://example.com/two')
+        destructuredRequest('https://example.com/three')
+        new Socket('wss://example.com')
+        await import('axios')
+      `,
+    )
+
+    expect(callsites.map(normalizeNetworkCallsite)).toEqual([
+      {
+        detail: 'axios',
+        kind: 'network-client-import',
+        path: 'src/indirect-network.ts',
+      },
+      {
+        detail: 'openai',
+        kind: 'network-client-import',
+        path: 'src/indirect-network.ts',
+      },
+      { kind: 'fetch', path: 'src/indirect-network.ts' },
+      { kind: 'fetch', path: 'src/indirect-network.ts' },
+      { kind: 'fetch', path: 'src/indirect-network.ts' },
+      { kind: 'websocket', path: 'src/indirect-network.ts' },
+    ])
+  })
+
+  it('resolves shorthand and navigator aliases without treating unrelated bindings as network calls', () => {
+    const callsites = collectSourceNetworkCallsites(
+      'src/bindings.ts',
+      `
+        let uninitialized
+        const { fetch } = globalThis
+        const { 'fetch': quotedFetch, unknown } = globalThis
+        const { sendBeacon: beacon } = navigator
+        const [arrayBinding] = [fetch]
+
+        fetch('https://example.com/one')
+        quotedFetch('https://example.com/two')
+        beacon('https://example.com/three')
+      `,
+    )
+
+    expect(callsites.map(normalizeNetworkCallsite)).toEqual([
+      { kind: 'fetch', path: 'src/bindings.ts' },
+      { kind: 'fetch', path: 'src/bindings.ts' },
+      { kind: 'send-beacon', path: 'src/bindings.ts' },
+    ])
+  })
+
+  it('tracks assigned and bound aliases plus call/apply invocations without stale aliases', () => {
+    const callsites = collectSourceNetworkCallsites(
+      'src/assigned-network.ts',
+      `
+        let assignedRequest
+        assignedRequest = fetch
+        assignedRequest('https://example.com/assigned')
+
+        const boundRequest = fetch.bind(globalThis)
+        boundRequest('https://example.com/bound')
+        fetch.call(globalThis, 'https://example.com/call')
+        fetch.apply(globalThis, ['https://example.com/apply'])
+
+        assignedRequest = () => undefined
+        assignedRequest('not a network call')
+      `,
+    )
+
+    expect(callsites.map(normalizeNetworkCallsite)).toEqual([
+      { kind: 'fetch', path: 'src/assigned-network.ts' },
+      { kind: 'fetch', path: 'src/assigned-network.ts' },
+      { kind: 'fetch', path: 'src/assigned-network.ts' },
+      { kind: 'fetch', path: 'src/assigned-network.ts' },
+    ])
+  })
+
+  it('restores outer aliases after nested lexical shadowing', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/scoped-network.ts',
+        `
+        const request = fetch
+        function localHelper() {
+          const request = () => undefined
+          request('local')
+        }
+        request('https://example.com/outbound')
+      `,
+      ).map(normalizeNetworkCallsite),
+    ).toEqual([{ kind: 'fetch', path: 'src/scoped-network.ts' }])
+  })
+
+  it('does not treat a shadowed fetch parameter as the global network API', () => {
+    expect(
+      collectSourceNetworkCallsites(
+        'src/injected-network.ts',
+        `
+          function injectedHelper(fetch) {
+            fetch('local')
+          }
+        `,
+      ),
+    ).toEqual([])
+  })
+})
+
+describe('production network call-site inventory', () => {
+  it('requires every production network call site to be explicitly inventoried', () => {
+    const projectRoot = path.resolve(import.meta.dirname, '..', '..')
+
+    const callsites = collectProductionNetworkCallsites(projectRoot)
+    expect(callsites.map(normalizeNetworkCallsite)).toEqual([
+      {
+        detail: 'ai-sdk-ollama',
+        kind: 'network-client-import',
+        path: 'src/lib/background/ai-chat.ts',
+      },
+      {
+        kind: 'fetch',
+        path: 'src/components/ai-elements/prompt-input.tsx',
+      },
+    ])
+    expect(() =>
+      assertProductionNetworkCallsiteInventory(callsites),
+    ).not.toThrow()
+  })
+
+  it('reports the full changed inventory with source locations', () => {
+    expect(() =>
+      assertProductionNetworkCallsiteInventory([
+        { kind: 'fetch', line: 4, path: 'src/new-client.ts' },
+        {
+          detail: 'openai',
+          kind: 'network-client-import',
+          line: 1,
+          path: 'src/new-client.ts',
+        },
+      ]),
+    ).toThrow(
+      /src\/new-client\.ts:4 fetch[\s\S]*src\/new-client\.ts:1 network-client-import \(openai\)/,
+    )
+  })
+})
+
+describe('assertManifestMatchesProductionNetworkPolicy', () => {
+  it('accepts the exact required host permissions', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: createProductionExtensionCsp(3),
+          },
+          host_permissions: [
+            'http://127.0.0.1:11434/*',
+            'http://localhost:11434/*',
+          ],
+        },
+        'manifest.json',
+      ),
+    ).not.toThrow()
+  })
+
+  it('extracts host patterns from Firefox MV2 permissions', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: createProductionExtensionCsp(2),
+          manifest_version: 2,
+          permissions: [
+            'storage',
+            'http://127.0.0.1:11434/*',
+            'http://localhost:11434/*',
+          ],
+        },
+        'firefox.json',
+      ),
+    ).not.toThrow()
+
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          manifest_version: 2,
+          permissions: [
+            'storage',
+            'http://127.0.0.1:11434/*',
+            'http://localhost:11434/*',
+          ],
+          optional_permissions: ['tabs', 'https://api.example.com/*'],
+        },
+        'firefox-optional.json',
+      ),
+    ).toThrow(/firefox-optional\.json.*optional_permissions/)
+  })
+
+  it('rejects added, missing, optional, or malformed host permissions', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          host_permissions: [
+            'http://localhost:11434/*',
+            'https://api.example.com/*',
+          ],
+        },
+        'added.json',
+      ),
+    ).toThrow(/added\.json.*host_permissions/)
+
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          host_permissions: ['http://localhost:11434/*'],
+        },
+        'missing.json',
+      ),
+    ).toThrow(/missing\.json.*host_permissions/)
+
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+          optional_host_permissions: ['https://api.example.com/*'],
+        },
+        'optional.json',
+      ),
+    ).toThrow(/optional\.json.*optional_host_permissions/)
+
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        { host_permissions: 'http://localhost:11434/*' },
+        'malformed.json',
+      ),
+    ).toThrow(/malformed\.json.*host_permissions/)
+  })
+
+  it('rejects missing or broad extension connect-src policy', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+        },
+        'missing-csp.json',
+      ),
+    ).toThrow(/missing-csp\.json.*content_security_policy/)
+
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages:
+              "script-src 'self'; object-src 'none'; connect-src *; frame-src 'none'; form-action 'none';",
+          },
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+        },
+        'broad-csp.json',
+      ),
+    ).toThrow(/broad-csp\.json.*connect-src/)
+  })
+
+  it('rejects malformed, weakened, or extended CSP directives', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(null, 'null.json'),
+    ).toThrow(/null\.json.*not an object/)
+
+    const host_permissions = [
+      'http://localhost:11434/*',
+      'http://127.0.0.1:11434/*',
+    ]
+    const csp = createProductionExtensionCsp(3)
+
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: csp.replace(
+              "object-src 'none'",
+              "object-src 'self'",
+            ),
+          },
+          host_permissions,
+        },
+        'object-src.json',
+      ),
+    ).toThrow(/object-src\.json.*object-src/)
+
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: csp.replace(
+              "script-src 'self' 'wasm-unsafe-eval'",
+              "script-src 'self'",
+            ),
+          },
+          host_permissions,
+        },
+        'script-src.json',
+      ),
+    ).toThrow(/script-src\.json.*script-src/)
+
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: `${csp}; report-uri https://example.com/csp`,
+          },
+          host_permissions,
+        },
+        'extra-directive.json',
+      ),
+    ).toThrow(/extra-directive\.json.*unexpected directives/)
+  })
+
+  it('rejects duplicate CSP directives instead of applying last-write-wins parsing', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: `connect-src *; ${createProductionExtensionCsp(3)}`,
+          },
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+        },
+        'duplicate-csp.json',
+      ),
+    ).toThrow(/duplicate-csp\.json.*duplicate.*connect-src/)
+  })
+
+  it('allows empty optional host permissions', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: createProductionExtensionCsp(3),
+          },
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+          optional_host_permissions: [],
+        },
+        'empty-optional.json',
+      ),
+    ).not.toThrow()
+  })
+})

--- a/tools/scripts/production-network-policy.ts
+++ b/tools/scripts/production-network-policy.ts
@@ -1,0 +1,622 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import {
+  PRODUCTION_OUTBOUND_ALLOWED_ORIGINS,
+  PRODUCTION_OUTBOUND_HOST_PERMISSIONS,
+  createProductionExtensionCsp,
+} from '#production-network-policy'
+import ts from 'typescript'
+
+export type NetworkCallsiteKind =
+  | 'network-client-import'
+  | 'fetch'
+  | 'xml-http-request'
+  | 'websocket'
+  | 'event-source'
+  | 'send-beacon'
+
+export type NetworkCallsite = {
+  detail?: string
+  kind: NetworkCallsiteKind
+  line: number
+  path: string
+}
+
+export type NormalizedNetworkCallsite = Omit<NetworkCallsite, 'line'>
+
+type AliasScope = {
+  bindings: Map<string, NetworkCallsiteKind | null>
+  type: 'block' | 'function' | 'source'
+}
+
+const NETWORK_CLIENT_MODULES = new Set([
+  'ai-sdk-ollama',
+  'axios',
+  'cross-fetch',
+  'got',
+  'http',
+  'https',
+  'ky',
+  'node-fetch',
+  'node:http',
+  'node:https',
+  'openai',
+  'socket.io-client',
+  'superagent',
+  'undici',
+])
+
+const GLOBAL_OBJECT_NAMES = new Set(['globalThis', 'self', 'window'])
+
+export const PRODUCTION_NETWORK_CALLSITE_INVENTORY: readonly NormalizedNetworkCallsite[] =
+  [
+    {
+      detail: 'ai-sdk-ollama',
+      kind: 'network-client-import',
+      path: 'src/lib/background/ai-chat.ts',
+    },
+    {
+      kind: 'fetch',
+      path: 'src/components/ai-elements/prompt-input.tsx',
+    },
+  ]
+
+const callsiteKindOrder: readonly NetworkCallsiteKind[] = [
+  'network-client-import',
+  'fetch',
+  'xml-http-request',
+  'websocket',
+  'event-source',
+  'send-beacon',
+]
+
+const compareCallsites = (left: NetworkCallsite, right: NetworkCallsite) =>
+  callsiteKindOrder.indexOf(left.kind) -
+    callsiteKindOrder.indexOf(right.kind) ||
+  left.path.localeCompare(right.path) ||
+  (left.detail ?? '').localeCompare(right.detail ?? '') ||
+  left.line - right.line
+
+const isNetworkClientModule = (moduleName: string): boolean =>
+  NETWORK_CLIENT_MODULES.has(moduleName) || moduleName.startsWith('@ai-sdk/')
+
+const directGlobalKinds = new Map<string, NetworkCallsiteKind>([
+  ['fetch', 'fetch'],
+  ['XMLHttpRequest', 'xml-http-request'],
+  ['WebSocket', 'websocket'],
+  ['EventSource', 'event-source'],
+])
+
+const getAccessedPropertyName = (node: ts.Node): string | null => {
+  if (ts.isPropertyAccessExpression(node)) {
+    return node.name.text
+  }
+  if (
+    ts.isElementAccessExpression(node) &&
+    ts.isStringLiteralLike(node.argumentExpression)
+  ) {
+    return node.argumentExpression.text
+  }
+  return null
+}
+
+const getAccessReceiver = (node: ts.Node): ts.Expression | null =>
+  ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)
+    ? node.expression
+    : null
+
+const isNamedGlobalObject = (node: ts.Node, name: string): boolean =>
+  (ts.isIdentifier(node) && node.text === name) ||
+  ((ts.isPropertyAccessExpression(node) ||
+    ts.isElementAccessExpression(node)) &&
+    ts.isIdentifier(node.expression) &&
+    GLOBAL_OBJECT_NAMES.has(node.expression.text) &&
+    getAccessedPropertyName(node) === name)
+
+const getBindingPropertyName = (element: ts.BindingElement): string | null => {
+  if (element.propertyName === undefined) {
+    return ts.isIdentifier(element.name) ? element.name.text : null
+  }
+  return ts.isIdentifier(element.propertyName) ||
+    ts.isStringLiteralLike(element.propertyName)
+    ? element.propertyName.text
+    : null
+}
+
+const resolveDestructuredNetworkKind = (
+  initializer: ts.Expression,
+  propertyName: string | null,
+): NetworkCallsiteKind | null => {
+  if (propertyName === null) {
+    return null
+  }
+  if (
+    ts.isIdentifier(initializer) &&
+    GLOBAL_OBJECT_NAMES.has(initializer.text)
+  ) {
+    return directGlobalKinds.get(propertyName) ?? null
+  }
+  if (
+    propertyName === 'sendBeacon' &&
+    isNamedGlobalObject(initializer, 'navigator')
+  ) {
+    return 'send-beacon'
+  }
+  return null
+}
+
+const getLine = (source: ts.SourceFile, node: ts.Node): number =>
+  source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1
+
+const collectBindingIdentifiers = (name: ts.BindingName): string[] => {
+  if (ts.isIdentifier(name)) {
+    return [name.text]
+  }
+  return name.elements.flatMap((element) =>
+    ts.isOmittedExpression(element)
+      ? []
+      : collectBindingIdentifiers(element.name),
+  )
+}
+
+export const normalizeNetworkCallsite = (
+  callsite: NetworkCallsite,
+): NormalizedNetworkCallsite => {
+  const { line: _line, ...normalized } = callsite
+  return normalized
+}
+
+export const collectSourceNetworkCallsites = (
+  relativePath: string,
+  sourceText: string,
+): NetworkCallsite[] => {
+  const scriptKind = relativePath.endsWith('.tsx')
+    ? ts.ScriptKind.TSX
+    : ts.ScriptKind.TS
+  const source = ts.createSourceFile(
+    relativePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  )
+  const callsites: NetworkCallsite[] = []
+  const sourceScope: AliasScope = { bindings: new Map(), type: 'source' }
+  const scopes: AliasScope[] = [sourceScope]
+  const getCurrentScope = (): AliasScope => scopes.at(-1) ?? sourceScope
+
+  const add = (
+    kind: NetworkCallsiteKind,
+    node: ts.Node,
+    detail?: string,
+  ): void => {
+    callsites.push({
+      ...(detail === undefined ? {} : { detail }),
+      kind,
+      line: getLine(source, node),
+      path: relativePath,
+    })
+  }
+
+  const resolveNetworkReference = (
+    node: ts.Node,
+  ): NetworkCallsiteKind | null => {
+    if (ts.isIdentifier(node)) {
+      for (let index = scopes.length - 1; index >= 0; index -= 1) {
+        const scope = scopes[index]
+        if (scope.bindings.has(node.text)) {
+          return scope.bindings.get(node.text) ?? null
+        }
+      }
+      return directGlobalKinds.get(node.text) ?? null
+    }
+    const propertyName = getAccessedPropertyName(node)
+    const receiver = getAccessReceiver(node)
+    if (propertyName === null || receiver === null) {
+      return null
+    }
+    if (ts.isIdentifier(receiver) && GLOBAL_OBJECT_NAMES.has(receiver.text)) {
+      return directGlobalKinds.get(propertyName) ?? null
+    }
+    if (
+      propertyName === 'sendBeacon' &&
+      isNamedGlobalObject(receiver, 'navigator')
+    ) {
+      return 'send-beacon'
+    }
+    return null
+  }
+
+  const resolveAliasSource = (
+    node: ts.Expression,
+  ): NetworkCallsiteKind | null => {
+    const directKind = resolveNetworkReference(node)
+    if (directKind !== null) {
+      return directKind
+    }
+    if (!ts.isCallExpression(node)) {
+      return null
+    }
+    const method = getAccessedPropertyName(node.expression)
+    const receiver = getAccessReceiver(node.expression)
+    return method === 'bind' && receiver !== null
+      ? resolveNetworkReference(receiver)
+      : null
+  }
+
+  const declareAlias = (
+    name: string,
+    kind: NetworkCallsiteKind | null,
+    scope: AliasScope = getCurrentScope(),
+  ): void => {
+    scope.bindings.set(name, kind)
+  }
+
+  const updateAlias = (
+    name: string,
+    kind: NetworkCallsiteKind | null,
+  ): void => {
+    for (let index = scopes.length - 1; index >= 0; index -= 1) {
+      const scope = scopes[index]
+      if (scope.bindings.has(name)) {
+        scope.bindings.set(name, kind)
+        return
+      }
+    }
+    declareAlias(name, kind)
+  }
+
+  const getVariableDeclarationScope = (
+    node: ts.VariableDeclaration,
+  ): AliasScope => {
+    const declarationList = ts.isVariableDeclarationList(node.parent)
+      ? node.parent
+      : null
+    if (
+      declarationList !== null &&
+      (declarationList.flags & ts.NodeFlags.BlockScoped) !== 0
+    ) {
+      return getCurrentScope()
+    }
+    return (
+      scopes.findLast(
+        (scope) => scope.type === 'function' || scope.type === 'source',
+      ) ?? scopes[0]
+    )
+  }
+
+  const registerVariableAliases = (node: ts.VariableDeclaration): void => {
+    const declarationScope = getVariableDeclarationScope(node)
+    if (node.initializer === undefined) {
+      for (const name of collectBindingIdentifiers(node.name)) {
+        declareAlias(name, null, declarationScope)
+      }
+      return
+    }
+    if (ts.isIdentifier(node.name)) {
+      declareAlias(
+        node.name.text,
+        resolveAliasSource(node.initializer),
+        declarationScope,
+      )
+      return
+    }
+    if (!ts.isObjectBindingPattern(node.name)) {
+      for (const name of collectBindingIdentifiers(node.name)) {
+        declareAlias(name, null, declarationScope)
+      }
+      return
+    }
+    for (const element of node.name.elements) {
+      if (!ts.isIdentifier(element.name)) {
+        continue
+      }
+      const kind = resolveDestructuredNetworkKind(
+        node.initializer,
+        getBindingPropertyName(element),
+      )
+      declareAlias(element.name.text, kind, declarationScope)
+    }
+  }
+
+  const registerAssignmentAlias = (node: ts.BinaryExpression): void => {
+    if (
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left)
+    ) {
+      updateAlias(node.left.text, resolveAliasSource(node.right))
+    }
+  }
+
+  const resolveInvokedNetworkReference = (
+    node: ts.CallExpression,
+  ): NetworkCallsiteKind | null => {
+    const directKind = resolveNetworkReference(node.expression)
+    if (directKind !== null) {
+      return directKind
+    }
+    const method = getAccessedPropertyName(node.expression)
+    const receiver = getAccessReceiver(node.expression)
+    return (method === 'call' || method === 'apply') && receiver !== null
+      ? resolveNetworkReference(receiver)
+      : null
+  }
+
+  const enterNodeScope = (node: ts.Node): boolean => {
+    if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
+      declareAlias(node.name.text, null)
+    }
+    if (ts.isFunctionLike(node)) {
+      scopes.push({ bindings: new Map(), type: 'function' })
+      for (const parameter of node.parameters) {
+        for (const name of collectBindingIdentifiers(parameter.name)) {
+          declareAlias(name, null)
+        }
+      }
+      return true
+    }
+    if (ts.isBlock(node)) {
+      scopes.push({ bindings: new Map(), type: 'block' })
+      return true
+    }
+    return false
+  }
+
+  const registerNodeAliases = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node)) {
+      registerVariableAliases(node)
+    } else if (ts.isBinaryExpression(node)) {
+      registerAssignmentAlias(node)
+    }
+  }
+
+  const recordNetworkCallsite = (node: ts.Node): void => {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      isNetworkClientModule(node.moduleSpecifier.text)
+    ) {
+      add('network-client-import', node, node.moduleSpecifier.text)
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteralLike(node.arguments[0]) &&
+      isNetworkClientModule(node.arguments[0].text)
+    ) {
+      add('network-client-import', node, node.arguments[0].text)
+    } else if (ts.isCallExpression(node)) {
+      const kind = resolveInvokedNetworkReference(node)
+      if (kind !== null) {
+        add(kind, node)
+      }
+    } else if (ts.isNewExpression(node)) {
+      const kind = resolveNetworkReference(node.expression)
+      if (kind !== null) {
+        add(kind, node)
+      }
+    }
+  }
+
+  const visit = (node: ts.Node): void => {
+    const createdScope = enterNodeScope(node)
+    registerNodeAliases(node)
+    recordNetworkCallsite(node)
+    ts.forEachChild(node, visit)
+    if (createdScope) {
+      scopes.pop()
+    }
+  }
+
+  visit(source)
+  return callsites.toSorted(compareCallsites)
+}
+
+const isProductionSource = (filePath: string): boolean =>
+  /\.(?:ts|tsx)$/u.test(filePath) &&
+  !/\.(?:test|spec|stories?)\.(?:ts|tsx)$/u.test(filePath) &&
+  !filePath.includes(`${path.sep}test${path.sep}`)
+
+const collectFiles = (root: string): string[] => {
+  const files: string[] = []
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name)
+      if (entry.isDirectory()) {
+        visit(entryPath)
+      } else if (entry.isFile() && isProductionSource(entryPath)) {
+        files.push(entryPath)
+      }
+    }
+  }
+  visit(root)
+  return files
+}
+
+export const collectProductionNetworkCallsites = (
+  projectRoot: string,
+): NetworkCallsite[] => {
+  const sourceRoot = path.join(projectRoot, 'src')
+  return collectFiles(sourceRoot)
+    .flatMap((filePath) =>
+      collectSourceNetworkCallsites(
+        path.relative(projectRoot, filePath),
+        readFileSync(filePath, 'utf8'),
+      ),
+    )
+    .toSorted(compareCallsites)
+}
+
+const formatCallsite = (callsite: NetworkCallsite): string =>
+  `${callsite.path}:${callsite.line} ${callsite.kind}${callsite.detail === undefined ? '' : ` (${callsite.detail})`}`
+
+export const assertProductionNetworkCallsiteInventory = (
+  callsites: readonly NetworkCallsite[],
+): void => {
+  const actual = callsites.map(normalizeNetworkCallsite)
+  if (
+    JSON.stringify(actual) ===
+    JSON.stringify(PRODUCTION_NETWORK_CALLSITE_INVENTORY)
+  ) {
+    return
+  }
+  throw new Error(
+    `Production network call-site inventory changed. Review every added or removed call site and update the security policy deliberately.\n${callsites.map(formatCallsite).join('\n')}`,
+  )
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const readStringArray = (
+  manifest: Record<string, unknown>,
+  property: string,
+  label: string,
+): string[] => {
+  const value = manifest[property]
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === 'string')
+  ) {
+    throw new TypeError(`${label} ${property} is missing or not a string array`)
+  }
+  return value
+}
+
+const readExtensionPagesCsp = (
+  manifest: Record<string, unknown>,
+  label: string,
+): string => {
+  const value = manifest.content_security_policy
+  if (typeof value === 'string') {
+    return value
+  }
+  if (isRecord(value) && typeof value.extension_pages === 'string') {
+    return value.extension_pages
+  }
+  throw new TypeError(
+    `${label} content_security_policy is missing an extension policy`,
+  )
+}
+
+const parseCspDirectives = (
+  csp: string,
+  label: string,
+): Map<string, string[]> => {
+  const directives = new Map<string, string[]>()
+  const sections = csp
+    .split(';')
+    .map((section) => section.trim())
+    .filter((section) => section !== '')
+  for (const section of sections) {
+    const [directive, ...values] = section.split(/\s+/u)
+    if (directives.has(directive)) {
+      throw new Error(
+        `${label} content_security_policy contains duplicate directive ${directive}`,
+      )
+    }
+    directives.set(directive, values)
+  }
+  return directives
+}
+
+const assertExtensionCspMatchesProductionNetworkPolicy = (
+  manifest: Record<string, unknown>,
+  label: string,
+): void => {
+  const directives = parseCspDirectives(
+    readExtensionPagesCsp(manifest, label),
+    label,
+  )
+  const expectedConnectSources = [
+    "'self'",
+    'blob:',
+    ...PRODUCTION_OUTBOUND_ALLOWED_ORIGINS,
+  ].toSorted()
+  const actualConnectSources = directives.get('connect-src')?.toSorted()
+  if (
+    actualConnectSources === undefined ||
+    JSON.stringify(actualConnectSources) !==
+      JSON.stringify(expectedConnectSources)
+  ) {
+    throw new Error(
+      `${label} connect-src does not match the production allowlist: ${JSON.stringify(actualConnectSources)}; expected ${JSON.stringify(expectedConnectSources)}`,
+    )
+  }
+  for (const directive of ['object-src', 'frame-src', 'form-action']) {
+    if (
+      JSON.stringify(directives.get(directive)) !== JSON.stringify(["'none'"])
+    ) {
+      throw new Error(`${label} ${directive} must be 'none'`)
+    }
+  }
+  const manifestVersion = manifest.manifest_version === 2 ? 2 : 3
+  const expectedDirectives = parseCspDirectives(
+    createProductionExtensionCsp(manifestVersion),
+    'production network policy',
+  )
+  for (const [directive, expectedValues] of expectedDirectives) {
+    if (directive === 'connect-src') {
+      continue
+    }
+    const actualValues = directives.get(directive)
+    if (
+      actualValues === undefined ||
+      JSON.stringify(actualValues.toSorted()) !==
+        JSON.stringify(expectedValues.toSorted())
+    ) {
+      throw new Error(
+        `${label} ${directive} does not match the production policy`,
+      )
+    }
+  }
+  const unexpectedDirectives = [...directives.keys()].filter(
+    (directive) => !expectedDirectives.has(directive),
+  )
+  if (unexpectedDirectives.length !== 0) {
+    throw new Error(
+      `${label} content_security_policy contains unexpected directives: ${unexpectedDirectives.join(', ')}`,
+    )
+  }
+}
+
+export const assertManifestMatchesProductionNetworkPolicy = (
+  manifest: unknown,
+  label: string,
+): void => {
+  if (!isRecord(manifest)) {
+    throw new TypeError(`${label} manifest is not an object`)
+  }
+  const isManifestV2 = manifest.manifest_version === 2
+  const hostPermissionProperty = isManifestV2
+    ? 'permissions'
+    : 'host_permissions'
+  const optionalHostPermissionProperty = isManifestV2
+    ? 'optional_permissions'
+    : 'optional_host_permissions'
+  const isHostPermission = (permission: string): boolean =>
+    permission === '<all_urls>' || permission.includes('://')
+  const actual = readStringArray(manifest, hostPermissionProperty, label)
+    .filter(isHostPermission)
+    .toSorted()
+  const expected = [...PRODUCTION_OUTBOUND_HOST_PERMISSIONS].toSorted()
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `${label} ${hostPermissionProperty} host patterns do not match the production allowlist: ${JSON.stringify(actual)}; expected ${JSON.stringify(expected)}`,
+    )
+  }
+  if (optionalHostPermissionProperty in manifest) {
+    const optionalPermissions = readStringArray(
+      manifest,
+      optionalHostPermissionProperty,
+      label,
+    ).filter(isHostPermission)
+    if (optionalPermissions.length !== 0) {
+      throw new Error(
+        `${label} ${optionalHostPermissionProperty} host patterns must be empty: ${JSON.stringify(optionalPermissions)}`,
+      )
+    }
+  }
+  assertExtensionCspMatchesProductionNetworkPolicy(manifest, label)
+}

--- a/tools/scripts/production-network-policy.ts
+++ b/tools/scripts/production-network-policy.ts
@@ -8,6 +8,16 @@ import {
 } from '#production-network-policy'
 import ts from 'typescript'
 
+import { collectPotentialNetworkAliasKinds } from './production-network-policy-aliases'
+import type { PotentialAliasSummary } from './production-network-policy-aliases'
+import {
+  NetworkAstTraverser,
+  cloneAliasScopes as cloneScopes,
+  collectBindingIdentifiers,
+  mergeAliasScopeStates as mergeScopeStates,
+} from './production-network-policy-ast'
+import type { AliasScope } from './production-network-policy-ast'
+
 export type NetworkCallsiteKind =
   | 'network-client-import'
   | 'fetch'
@@ -24,11 +34,6 @@ export type NetworkCallsite = {
 }
 
 export type NormalizedNetworkCallsite = Omit<NetworkCallsite, 'line'>
-
-type AliasScope = {
-  bindings: Map<string, NetworkCallsiteKind | null>
-  type: 'block' | 'function' | 'source'
-}
 
 const NETWORK_CLIENT_MODULES = new Set([
   'ai-sdk-ollama',
@@ -114,6 +119,28 @@ const isNamedGlobalObject = (node: ts.Node, name: string): boolean =>
     GLOBAL_OBJECT_NAMES.has(node.expression.text) &&
     getAccessedPropertyName(node) === name)
 
+const resolveDirectNetworkReferences = (
+  node: ts.Node,
+): ReadonlySet<NetworkCallsiteKind> => {
+  if (ts.isIdentifier(node)) {
+    const kind = directGlobalKinds.get(node.text)
+    return kind === undefined ? new Set() : new Set([kind])
+  }
+  const propertyName = getAccessedPropertyName(node)
+  const receiver = getAccessReceiver(node)
+  if (propertyName === null || receiver === null) {
+    return new Set()
+  }
+  if (ts.isIdentifier(receiver) && GLOBAL_OBJECT_NAMES.has(receiver.text)) {
+    const kind = directGlobalKinds.get(propertyName)
+    return kind === undefined ? new Set() : new Set([kind])
+  }
+  return propertyName === 'sendBeacon' &&
+    isNamedGlobalObject(receiver, 'navigator')
+    ? new Set(['send-beacon'])
+    : new Set()
+}
+
 const getBindingPropertyName = (element: ts.BindingElement): string | null => {
   if (element.propertyName === undefined) {
     return ts.isIdentifier(element.name) ? element.name.text : null
@@ -146,19 +173,71 @@ const resolveDestructuredNetworkKind = (
   return null
 }
 
+const resolveIdentifierNetworkReferences = (
+  name: string,
+  scopes: readonly AliasScope[],
+): ReadonlySet<NetworkCallsiteKind> => {
+  const currentFunctionScopeIndex = scopes.findLastIndex(
+    (scope) => scope.type === 'function',
+  )
+  for (let index = scopes.length - 1; index >= 0; index -= 1) {
+    const scope = scopes[index]
+    if (!scope.bindings.has(name)) {
+      continue
+    }
+    const currentKinds = scope.bindings.get(name) ?? new Set()
+    return currentFunctionScopeIndex > index
+      ? new Set([
+          ...currentKinds,
+          ...(scope.potentialBindings.get(name) ?? []),
+          ...(scopes[currentFunctionScopeIndex]?.potentialBindings.get(name) ??
+            []),
+        ])
+      : new Set([...currentKinds, ...(scope.capturedBindings.get(name) ?? [])])
+  }
+  const directKind = directGlobalKinds.get(name)
+  return directKind === undefined ? new Set() : new Set([directKind])
+}
+
+const resolveAliasNetworkReferences = (
+  node: ts.Expression,
+  resolveReferences: (node: ts.Node) => ReadonlySet<NetworkCallsiteKind>,
+): ReadonlySet<NetworkCallsiteKind> => {
+  const directKinds = resolveReferences(node)
+  if (directKinds.size > 0) {
+    return directKinds
+  }
+  if (ts.isConditionalExpression(node)) {
+    return new Set([
+      ...resolveAliasNetworkReferences(node.whenTrue, resolveReferences),
+      ...resolveAliasNetworkReferences(node.whenFalse, resolveReferences),
+    ])
+  }
+  if (
+    ts.isBinaryExpression(node) &&
+    [
+      ts.SyntaxKind.AmpersandAmpersandToken,
+      ts.SyntaxKind.BarBarToken,
+      ts.SyntaxKind.QuestionQuestionToken,
+    ].includes(node.operatorToken.kind)
+  ) {
+    return new Set([
+      ...resolveAliasNetworkReferences(node.left, resolveReferences),
+      ...resolveAliasNetworkReferences(node.right, resolveReferences),
+    ])
+  }
+  if (!ts.isCallExpression(node)) {
+    return new Set()
+  }
+  const method = getAccessedPropertyName(node.expression)
+  const receiver = getAccessReceiver(node.expression)
+  return method === 'bind' && receiver !== null
+    ? resolveReferences(receiver)
+    : new Set()
+}
+
 const getLine = (source: ts.SourceFile, node: ts.Node): number =>
   source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1
-
-const collectBindingIdentifiers = (name: ts.BindingName): string[] => {
-  if (ts.isIdentifier(name)) {
-    return [name.text]
-  }
-  return name.elements.flatMap((element) =>
-    ts.isOmittedExpression(element)
-      ? []
-      : collectBindingIdentifiers(element.name),
-  )
-}
 
 export const normalizeNetworkCallsite = (
   callsite: NetworkCallsite,
@@ -166,6 +245,62 @@ export const normalizeNetworkCallsite = (
   const { line: _line, ...normalized } = callsite
   return normalized
 }
+
+type NetworkCallsiteRecorder = {
+  add: (kind: NetworkCallsiteKind, node: ts.Node, detail?: string) => void
+  resolveInvokedReferences: (
+    node: ts.CallExpression,
+  ) => ReadonlySet<NetworkCallsiteKind>
+  resolveReferences: (node: ts.Node) => ReadonlySet<NetworkCallsiteKind>
+}
+
+const recordNetworkCallsite = (
+  node: ts.Node,
+  recorder: NetworkCallsiteRecorder,
+): void => {
+  if (
+    ts.isImportDeclaration(node) &&
+    ts.isStringLiteral(node.moduleSpecifier) &&
+    isNetworkClientModule(node.moduleSpecifier.text)
+  ) {
+    recorder.add('network-client-import', node, node.moduleSpecifier.text)
+    return
+  }
+  if (
+    ts.isCallExpression(node) &&
+    node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+    node.arguments.length === 1 &&
+    ts.isStringLiteralLike(node.arguments[0]) &&
+    isNetworkClientModule(node.arguments[0].text)
+  ) {
+    recorder.add('network-client-import', node, node.arguments[0].text)
+    return
+  }
+  if (ts.isCallExpression(node)) {
+    for (const kind of recorder.resolveInvokedReferences(node)) {
+      recorder.add(kind, node)
+    }
+  } else if (ts.isNewExpression(node)) {
+    for (const kind of recorder.resolveReferences(node.expression)) {
+      recorder.add(kind, node)
+    }
+  }
+}
+
+const createAliasScope = (
+  type: AliasScope['type'],
+  node: ts.Node,
+  potentialAliases: WeakMap<ts.Node, PotentialAliasSummary>,
+  bindings: Map<string, ReadonlySet<NetworkCallsiteKind>> = new Map<
+    string,
+    ReadonlySet<NetworkCallsiteKind>
+  >(),
+): AliasScope => ({
+  bindings,
+  capturedBindings: potentialAliases.get(node)?.capturedBindings ?? new Map(),
+  potentialBindings: potentialAliases.get(node)?.bindings ?? new Map(),
+  type,
+})
 
 export const collectSourceNetworkCallsites = (
   relativePath: string,
@@ -182,15 +317,49 @@ export const collectSourceNetworkCallsites = (
     scriptKind,
   )
   const callsites: NetworkCallsite[] = []
-  const sourceScope: AliasScope = { bindings: new Map(), type: 'source' }
-  const scopes: AliasScope[] = [sourceScope]
+  const recordedCallsites = new Set<string>()
+  const potentialAliasKinds = collectPotentialNetworkAliasKinds(
+    source,
+    resolveDirectNetworkReferences,
+  )
+  const sourceScope = createAliasScope(
+    'source',
+    source,
+    potentialAliasKinds,
+    new Map(
+      [...directGlobalKinds].map(([name, kind]) => [name, new Set([kind])]),
+    ),
+  )
+  let scopes: AliasScope[] = [sourceScope]
   const getCurrentScope = (): AliasScope => scopes.at(-1) ?? sourceScope
+
+  const createNetworkReference = (
+    kind: NetworkCallsiteKind | null,
+  ): ReadonlySet<NetworkCallsiteKind> =>
+    kind === null ? new Set() : new Set([kind])
+
+  const traverseFromClonedState = (
+    initialScopes: readonly AliasScope[],
+    traverse: () => void,
+  ): AliasScope[] => {
+    const previousScopes = scopes
+    scopes = cloneScopes(initialScopes)
+    traverse()
+    const result = scopes
+    scopes = previousScopes
+    return result
+  }
 
   const add = (
     kind: NetworkCallsiteKind,
     node: ts.Node,
     detail?: string,
   ): void => {
+    const key = `${kind}:${node.pos}:${detail ?? ''}`
+    if (recordedCallsites.has(key)) {
+      return
+    }
+    recordedCallsites.add(key)
     callsites.push({
       ...(detail === undefined ? {} : { detail }),
       kind,
@@ -199,77 +368,69 @@ export const collectSourceNetworkCallsites = (
     })
   }
 
-  const resolveNetworkReference = (
+  const resolveNetworkReferences = (
     node: ts.Node,
-  ): NetworkCallsiteKind | null => {
+  ): ReadonlySet<NetworkCallsiteKind> => {
     if (ts.isIdentifier(node)) {
-      for (let index = scopes.length - 1; index >= 0; index -= 1) {
-        const scope = scopes[index]
-        if (scope.bindings.has(node.text)) {
-          return scope.bindings.get(node.text) ?? null
-        }
-      }
-      return directGlobalKinds.get(node.text) ?? null
+      return resolveIdentifierNetworkReferences(node.text, scopes)
     }
     const propertyName = getAccessedPropertyName(node)
     const receiver = getAccessReceiver(node)
     if (propertyName === null || receiver === null) {
-      return null
+      return new Set()
     }
     if (ts.isIdentifier(receiver) && GLOBAL_OBJECT_NAMES.has(receiver.text)) {
-      return directGlobalKinds.get(propertyName) ?? null
+      return createNetworkReference(directGlobalKinds.get(propertyName) ?? null)
     }
     if (
       propertyName === 'sendBeacon' &&
       isNamedGlobalObject(receiver, 'navigator')
     ) {
-      return 'send-beacon'
+      return createNetworkReference('send-beacon')
     }
-    return null
+    return new Set()
   }
 
-  const resolveAliasSource = (
+  const resolveAliasReferences = (
     node: ts.Expression,
-  ): NetworkCallsiteKind | null => {
-    const directKind = resolveNetworkReference(node)
-    if (directKind !== null) {
-      return directKind
-    }
-    if (!ts.isCallExpression(node)) {
-      return null
-    }
-    const method = getAccessedPropertyName(node.expression)
-    const receiver = getAccessReceiver(node.expression)
-    return method === 'bind' && receiver !== null
-      ? resolveNetworkReference(receiver)
-      : null
-  }
+  ): ReadonlySet<NetworkCallsiteKind> =>
+    resolveAliasNetworkReferences(node, resolveNetworkReferences)
 
   const declareAlias = (
     name: string,
-    kind: NetworkCallsiteKind | null,
+    kinds: ReadonlySet<NetworkCallsiteKind>,
     scope: AliasScope = getCurrentScope(),
   ): void => {
-    scope.bindings.set(name, kind)
+    scope.bindings.set(name, new Set(kinds))
   }
 
   const updateAlias = (
     name: string,
-    kind: NetworkCallsiteKind | null,
+    kinds: ReadonlySet<NetworkCallsiteKind>,
   ): void => {
+    const currentFunctionScopeIndex = scopes.findLastIndex(
+      (scope) => scope.type === 'function',
+    )
     for (let index = scopes.length - 1; index >= 0; index -= 1) {
       const scope = scopes[index]
       if (scope.bindings.has(name)) {
-        scope.bindings.set(name, kind)
+        if (currentFunctionScopeIndex > index) {
+          declareAlias(name, kinds, scopes[currentFunctionScopeIndex])
+          return
+        }
+        scope.bindings.set(name, new Set(kinds))
         return
       }
     }
-    declareAlias(name, kind)
+    declareAlias(name, kinds)
   }
 
   const getVariableDeclarationScope = (
     node: ts.VariableDeclaration,
   ): AliasScope => {
+    if (ts.isCatchClause(node.parent)) {
+      return getCurrentScope()
+    }
     const declarationList = ts.isVariableDeclarationList(node.parent)
       ? node.parent
       : null
@@ -290,21 +451,21 @@ export const collectSourceNetworkCallsites = (
     const declarationScope = getVariableDeclarationScope(node)
     if (node.initializer === undefined) {
       for (const name of collectBindingIdentifiers(node.name)) {
-        declareAlias(name, null, declarationScope)
+        declareAlias(name, new Set(), declarationScope)
       }
       return
     }
     if (ts.isIdentifier(node.name)) {
       declareAlias(
         node.name.text,
-        resolveAliasSource(node.initializer),
+        resolveAliasReferences(node.initializer),
         declarationScope,
       )
       return
     }
     if (!ts.isObjectBindingPattern(node.name)) {
       for (const name of collectBindingIdentifiers(node.name)) {
-        declareAlias(name, null, declarationScope)
+        declareAlias(name, new Set(), declarationScope)
       }
       return
     }
@@ -316,7 +477,11 @@ export const collectSourceNetworkCallsites = (
         node.initializer,
         getBindingPropertyName(element),
       )
-      declareAlias(element.name.text, kind, declarationScope)
+      declareAlias(
+        element.name.text,
+        createNetworkReference(kind),
+        declarationScope,
+      )
     }
   }
 
@@ -325,39 +490,33 @@ export const collectSourceNetworkCallsites = (
       node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
       ts.isIdentifier(node.left)
     ) {
-      updateAlias(node.left.text, resolveAliasSource(node.right))
+      updateAlias(node.left.text, resolveAliasReferences(node.right))
     }
   }
 
-  const resolveInvokedNetworkReference = (
+  const resolveInvokedNetworkReferences = (
     node: ts.CallExpression,
-  ): NetworkCallsiteKind | null => {
-    const directKind = resolveNetworkReference(node.expression)
-    if (directKind !== null) {
-      return directKind
+  ): ReadonlySet<NetworkCallsiteKind> => {
+    const directKinds = resolveNetworkReferences(node.expression)
+    if (directKinds.size > 0) {
+      return directKinds
     }
     const method = getAccessedPropertyName(node.expression)
     const receiver = getAccessReceiver(node.expression)
     return (method === 'call' || method === 'apply') && receiver !== null
-      ? resolveNetworkReference(receiver)
-      : null
+      ? resolveNetworkReferences(receiver)
+      : new Set()
   }
 
   const enterNodeScope = (node: ts.Node): boolean => {
-    if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
-      declareAlias(node.name.text, null)
-    }
-    if (ts.isFunctionLike(node)) {
-      scopes.push({ bindings: new Map(), type: 'function' })
-      for (const parameter of node.parameters) {
-        for (const name of collectBindingIdentifiers(parameter.name)) {
-          declareAlias(name, null)
-        }
-      }
-      return true
-    }
-    if (ts.isBlock(node)) {
-      scopes.push({ bindings: new Map(), type: 'block' })
+    if (
+      ts.isBlock(node) ||
+      ts.isForStatement(node) ||
+      ts.isForInStatement(node) ||
+      ts.isForOfStatement(node) ||
+      ts.isSwitchStatement(node)
+    ) {
+      scopes.push(createAliasScope('block', node, potentialAliasKinds))
       return true
     }
     return false
@@ -371,45 +530,30 @@ export const collectSourceNetworkCallsites = (
     }
   }
 
-  const recordNetworkCallsite = (node: ts.Node): void => {
-    if (
-      ts.isImportDeclaration(node) &&
-      ts.isStringLiteral(node.moduleSpecifier) &&
-      isNetworkClientModule(node.moduleSpecifier.text)
-    ) {
-      add('network-client-import', node, node.moduleSpecifier.text)
-    } else if (
-      ts.isCallExpression(node) &&
-      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
-      node.arguments.length === 1 &&
-      ts.isStringLiteralLike(node.arguments[0]) &&
-      isNetworkClientModule(node.arguments[0].text)
-    ) {
-      add('network-client-import', node, node.arguments[0].text)
-    } else if (ts.isCallExpression(node)) {
-      const kind = resolveInvokedNetworkReference(node)
-      if (kind !== null) {
-        add(kind, node)
-      }
-    } else if (ts.isNewExpression(node)) {
-      const kind = resolveNetworkReference(node.expression)
-      if (kind !== null) {
-        add(kind, node)
-      }
-    }
-  }
-
-  const visit = (node: ts.Node): void => {
-    const createdScope = enterNodeScope(node)
-    registerNodeAliases(node)
-    recordNetworkCallsite(node)
-    ts.forEachChild(node, visit)
-    if (createdScope) {
-      scopes.pop()
-    }
-  }
-
-  visit(source)
+  const traverser = new NetworkAstTraverser({
+    cloneScopes,
+    createScope: (type, node) =>
+      createAliasScope(type, node, potentialAliasKinds),
+    declareAlias: (name, kinds) => {
+      declareAlias(name, kinds)
+    },
+    enterNodeScope,
+    getScopes: () => scopes,
+    mergeScopeStates,
+    recordNetworkCallsite: (node) => {
+      recordNetworkCallsite(node, {
+        add,
+        resolveInvokedReferences: resolveInvokedNetworkReferences,
+        resolveReferences: resolveNetworkReferences,
+      })
+    },
+    registerNodeAliases,
+    setScopes: (nextScopes) => {
+      scopes = nextScopes
+    },
+    traverseFromClonedState,
+  })
+  traverser.traverse(source)
   return callsites.toSorted(compareCallsites)
 }
 
@@ -524,6 +668,7 @@ const parseCspDirectives = (
 const assertExtensionCspMatchesProductionNetworkPolicy = (
   manifest: Record<string, unknown>,
   label: string,
+  manifestVersion: 2 | 3,
 ): void => {
   const directives = parseCspDirectives(
     readExtensionPagesCsp(manifest, label),
@@ -551,7 +696,6 @@ const assertExtensionCspMatchesProductionNetworkPolicy = (
       throw new Error(`${label} ${directive} must be 'none'`)
     }
   }
-  const manifestVersion = manifest.manifest_version === 2 ? 2 : 3
   const expectedDirectives = parseCspDirectives(
     createProductionExtensionCsp(manifestVersion),
     'production network policy',
@@ -588,7 +732,11 @@ export const assertManifestMatchesProductionNetworkPolicy = (
   if (!isRecord(manifest)) {
     throw new TypeError(`${label} manifest is not an object`)
   }
-  const isManifestV2 = manifest.manifest_version === 2
+  const manifestVersion = manifest.manifest_version
+  if (manifestVersion !== 2 && manifestVersion !== 3) {
+    throw new TypeError(`${label} manifest_version must be numeric 2 or 3`)
+  }
+  const isManifestV2 = manifestVersion === 2
   const hostPermissionProperty = isManifestV2
     ? 'permissions'
     : 'host_permissions'
@@ -618,5 +766,9 @@ export const assertManifestMatchesProductionNetworkPolicy = (
       )
     }
   }
-  assertExtensionCspMatchesProductionNetworkPolicy(manifest, label)
+  assertExtensionCspMatchesProductionNetworkPolicy(
+    manifest,
+    label,
+    manifestVersion,
+  )
 }

--- a/tools/scripts/verify-production-network-policy.ts
+++ b/tools/scripts/verify-production-network-policy.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import {
+  assertManifestMatchesProductionNetworkPolicy,
+  assertProductionNetworkCallsiteInventory,
+  collectProductionNetworkCallsites,
+} from './production-network-policy.ts'
+
+const projectRoot = path.resolve(import.meta.dirname, '..', '..')
+const manifestPaths = [
+  path.join(projectRoot, '.output', 'chrome-mv3', 'manifest.json'),
+  path.join(projectRoot, '.output', 'firefox-mv2', 'manifest.json'),
+]
+
+const callsites = collectProductionNetworkCallsites(projectRoot)
+assertProductionNetworkCallsiteInventory(callsites)
+
+for (const manifestPath of manifestPaths) {
+  const manifest: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'))
+  assertManifestMatchesProductionNetworkPolicy(manifest, manifestPath)
+}
+
+console.log(
+  `production network policy verified (${callsites.length} inventoried call sites, ${manifestPaths.length} manifests)`,
+)

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,6 +6,11 @@ import { type WxtViteConfig, defineConfig } from 'wxt' // eslint-disable-line
 
 import '@wxt-dev/module-react' // eslint-disable-line
 
+import {
+  PRODUCTION_OUTBOUND_HOST_PERMISSIONS,
+  createProductionExtensionCsp,
+} from './src/constants/productionNetworkPolicy'
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null
 
@@ -36,7 +41,10 @@ export default defineConfig({
     name: '__MSG_extensionName__',
     description: '__MSG_extensionDescription__',
     version: APP_VERSION,
-    host_permissions: ['http://localhost:11434/*', 'http://127.0.0.1:11434/*'],
+    content_security_policy: {
+      extension_pages: createProductionExtensionCsp(env.manifestVersion),
+    },
+    host_permissions: PRODUCTION_OUTBOUND_HOST_PERMISSIONS,
     permissions: ['alarms', 'tabs', 'storage', 'contextMenus', 'notifications'],
     action: {
       default_title: '__MSG_extensionName__',


### PR DESCRIPTION
## 変更内容

Closes #721

### 問題の原因

production build の outbound 通信先が manifest の host permission、CSP、実装内の endpoint 定義に分散しており、新しい通信 API や endpoint が追加されても一貫した allowlist として検証する仕組みがありませんでした。また、主要 flow の E2E でも extension 起点の予期しない外部 request を検出していませんでした。

### 採用した解決方法

production outbound policy を共有 source of truth に集約し、localhost / 127.0.0.1 の Ollama endpoint だけを許可します。その policy から manifest の host permission と CSP を生成し、source の network callsite inventory と Chrome MV3 / Firefox MV2 の生成 manifest を同じ verifier で照合します。さらに Playwright の persistent extension context で request を開始直後から監視し、allowlist 外通信を teardown 時に失敗させます。

### 主要な変更内容

- local Ollama origin、host permission、extension CSP、request 判定を `productionNetworkPolicy.ts` に集約
- TypeScript AST で fetch / XHR / WebSocket / EventSource / AI SDK / 明示的 client と alias・bind/call/apply・動的 import を inventory
- Chrome MV3 / Firefox MV2 の generated manifest に対して host permission と CSP を厳密検証
- verifier を CI と `release:check` に追加
- E2E fixture に extension 起点 outbound request guard を追加
- endpoint inventory、送信データ、追加時の security checklist、検証方法を文書化

### Regression risk と確認内容

- 既存 Ollama 通信: shared `OLLAMA_BASE_URL` を利用し、従来の localhost endpoint を維持
- browser 差異: Chrome MV3 と Firefox MV2 をそれぞれ production build し、生成 manifest を検証
- false negative: alias、再代入、destructuring、computed property、bind/call/apply、lexical shadowing を regression test で検証
- runtime request: 全 Playwright flow で extension request を監視し 17/17 pass
- CSP: Chrome で extension load を確認し、MV3 で禁止される `worker-src blob:` は許可していません

### 実行した test / quality command

- `bun run quality:check` ✅（この repository の broad quality gate。`quality` script は未定義）
- `bun run release:check` ✅
- `bun run test:coverage` ✅（318 files / 3450 tests、全体 statements 97.25%、新規 policy source 100%）
- `bun run e2e` ✅（17 passed）
- `bun run verify:production-network-policy` ✅（2 callsites / 2 manifests）
- `bun run test:node` ✅（188 files / 2548 tests、fresh-context evaluator 再実行）

### Acceptance criteria 対応

- production 通信先の棚卸し: AST inventory と security document で fetch / XHR / WebSocket / EventSource / AI SDK / client を対象化
- allowlist の明文化: local Ollama の2 originと送信データを文書化
- generated manifest 検証: Chrome MV3 / Firefox MV2 の permission と CSP を verifier で厳密照合
- CI / review gate: CI と `release:check` に verifier を追加
- 主要 flow の予期しない request 検出: Playwright persistent context の request guard を追加
- endpoint 追加時の security review: checklist と verifier test 手順を文書化
- 既存 Ollama flow: endpoint を shared policy に移し、E2E・build・全 test で回帰確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a production-only outbound network allowlist limited to the local Ollama service.
  - Enforced fail-closed extension CSP/connect behavior for Chrome and Firefox.
  - Added Playwright-based end-to-end detection and reporting of unexpected extension outbound requests.
  - Introduced automated verification in release checks for the network policy and manifests.
- **Bug Fixes**
  - Standardized the Ollama base URL usage across the extension.
- **Documentation**
  - Added comprehensive design, implementation, and security docs for the production network policy.
- **Tests**
  - Added extensive unit, inventory, manifest, and end-to-end request interception tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->