### PR TITLE
保存済みタブ削除ポリシーと確認導線を整理する

### DIFF
--- a/docs/adr/0001-saved-tabs-deletion-confirmation-policy.md
+++ b/docs/adr/0001-saved-tabs-deletion-confirmation-policy.md
@@ -1,0 +1,69 @@
+# ADR 0001: Saved Tabs deletion and confirmation policy
+
+## Status
+
+Accepted
+
+## Context
+
+Saved Tabs exposes several operations that remove saved data or change how tabs
+are opened. Their defaults were duplicated across domain and infrastructure,
+and the intended confirmation criteria were not recorded. Custom-project URL
+removal also cascaded into Domain mode even though its Undo snapshot covered
+only the Custom project.
+
+The reviewed operation inventory is:
+
+| Operation                                  | Guard                                    | Recovery / effect                                                                                            |
+| ------------------------------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Delete one saved URL                       | `confirmDeleteEach`                      | Full saved-tabs snapshot and Undo                                                                            |
+| Delete groups or multiple saved URLs       | `confirmDeleteAll`                       | Full saved-tabs snapshot and Undo                                                                            |
+| Remove URL(s) from a Custom project        | `confirmDeleteEach` / `confirmDeleteAll` | Custom-project snapshot and Undo; Domain URL is preserved                                                    |
+| Remove after opening                       | `removeTabAfterOpen`                     | Saved-tabs UI provides Undo; browser-tab drag creation is an explicit consume action without an in-app toast |
+| Remove after external drop                 | `removeTabAfterExternalDrop`             | No in-app confirmation or Undo                                                                               |
+| Delete project/category/parent/subcategory | Unconditional confirmation               | Organization changes; project/category flows preserve the URL records                                        |
+| Delete expired URLs                        | `autoDeletePeriod`                       | No runtime confirmation or Undo; default is `never`                                                          |
+| Open all in a new window                   | `openAllInNewWindow`                     | Changes window placement, not saved data                                                                     |
+
+## Decision
+
+The Saved Tabs domain is the source of truth for these defaults:
+
+- opening a saved URL removes it by default because this explicit consume flow
+  has Undo;
+- external-drop removal is disabled by default because it has neither an
+  in-app confirmation nor Undo;
+- opening all URLs uses the current window by default;
+- single and bulk URL deletion confirmation is opt-in because the actions are
+  explicit and recoverable with Undo.
+
+An explicit stored setting always overrides the default. No existing stored
+value is migrated.
+
+Confirmation is unconditional for deletion of a project, category,
+parent-category, or subcategory because these operations alter user-created
+organization. URL/group deletion uses `confirmDeleteEach` or
+`confirmDeleteAll`; open-after removal relies on Undo; external-drop removal is
+an explicit opt-in setting.
+
+Removing a URL from a Custom project removes only that project's reference and
+metadata. It does not delete the Domain-mode saved URL. Domain-mode deletion is
+the global saved-URL operation and remains responsible for removing references
+from all Custom projects.
+
+## Consequences
+
+New users and older partial settings objects no longer remove a saved URL after
+external drag-and-drop unless they opt in. Existing explicit preferences are
+preserved. Custom-project Undo now fully restores the mutation it represents,
+and the settings defaults cannot drift between domain and storage adapters.
+
+## Alternatives
+
+- Document the current behavior without code changes: rejected because policy
+  duplication and incomplete Undo would remain.
+- Confirm every deletion by default: rejected because recoverable explicit
+  actions do not justify changing existing stored behavior.
+- Preserve the cascade and add a larger compatibility snapshot: rejected
+  because it retains a surprising cross-mode side effect in a project-scoped
+  operation.

--- a/docs/plans/2026-07-13-saved-tabs-deletion-confirmation-policy-design.md
+++ b/docs/plans/2026-07-13-saved-tabs-deletion-confirmation-policy-design.md
@@ -1,0 +1,58 @@
+# Saved Tabs Deletion Confirmation Policy Design
+
+## Context
+
+Saved Tabs has five settings that govern actions which can change saved data or
+the window model. Their defaults are duplicated between the domain and the
+Chrome storage adapter, so the product policy can drift. The destructive flows
+also have two inconsistencies:
+
+- removing a URL from one Custom project silently removes the same saved URL
+  from Domain mode, although Undo restores only the Custom project snapshot;
+- project deletion performs a guaranteed-to-fail uncategorized-project delete
+  before the real delete and suppresses that error.
+
+## Decision
+
+The domain owns one exported default policy for the five action settings. Both
+the domain fallback and the storage adapter compose that policy into their full
+settings defaults.
+
+| Setting                      | Default | Reason                                                                                     |
+| ---------------------------- | ------- | ------------------------------------------------------------------------------------------ |
+| `removeTabAfterOpen`         | `true`  | Opening is an explicit consume action and the saved-tabs UI provides Undo.                 |
+| `removeTabAfterExternalDrop` | `false` | External drop removal has no in-app confirmation or Undo, so new users must opt in.        |
+| `openAllInNewWindow`         | `false` | Opening in the current window avoids an unexpected extra window.                           |
+| `confirmDeleteAll`           | `false` | Explicit URL/group deletion is recoverable through Undo; users can opt into confirmation.  |
+| `confirmDeleteEach`          | `false` | Explicit single-URL deletion is recoverable through Undo; users can opt into confirmation. |
+
+Existing stored values remain authoritative. The changed external-drop default
+only applies when the setting has never been stored or is absent from an older
+partial settings object.
+
+Custom-project URL removal is project-scoped: it removes only that project
+reference and metadata. The Domain-mode saved URL remains. Global saved-URL
+deletion continues to originate in Domain mode and removes stale references
+from all Custom projects. This makes the mutation match the operation name and
+makes the existing Custom-project snapshot sufficient for Undo.
+
+Project, category, parent-category, and subcategory deletion continue to show
+an unconditional confirmation because they alter user-created organization and
+are not governed by the URL deletion confirmation settings.
+
+## Alternatives considered
+
+- Documentation only was rejected because it would preserve duplicated policy
+  and the incomplete Undo behavior.
+- Enabling every confirmation by default was rejected because explicit URL
+  deletion already has Undo and there is no evidence that existing users should
+  receive a behavior migration.
+- Expanding Custom-project Undo to snapshot Domain mode was rejected because it
+  would preserve an unexpected cross-mode side effect instead of correcting the
+  project-scoped operation.
+
+## Verification
+
+Regression tests cover the canonical defaults, preservation of explicit stored
+values, project-scoped single and bulk deletion, and one-call project deletion.
+The repository quality, coverage, and release gates verify the wider flow.

--- a/docs/plans/2026-07-13-saved-tabs-deletion-confirmation-policy.md
+++ b/docs/plans/2026-07-13-saved-tabs-deletion-confirmation-policy.md
@@ -1,0 +1,70 @@
+# Saved Tabs Deletion Confirmation Policy Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make Saved Tabs destructive-action defaults explicit and consistent, and remove hidden deletion behavior that cannot be fully undone.
+
+**Architecture:** Define the five action defaults in the Saved Tabs domain and compose them into both domain and storage defaults. Keep Custom-project mutations project-scoped while retaining Domain-mode global deletion as the owner of cross-project cleanup.
+
+**Tech Stack:** TypeScript, React hooks, Vitest, Chrome storage adapter, WXT.
+
+---
+
+### Task 1: Lock the policy with failing tests
+
+**Files:**
+
+- Create: `src/contexts/saved-tabs/domain/services/SavedTabsActionSettingsPolicy.test.ts`
+- Modify: `src/contexts/saved-tabs/domain/services/UserSettingsDefaults.test.ts`
+
+1. Assert the exact five defaults, including opt-in external-drop removal.
+2. Assert missing settings receive defaults while explicit stored values win.
+3. Run the focused node tests and confirm the new contract fails first.
+
+### Task 2: Lock project-scoped deletion with failing tests
+
+**Files:**
+
+- Modify: `src/lib/storage/projects.test.ts`
+- Modify: `src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx`
+
+1. Change single and bulk Custom-project deletion expectations so Domain-mode
+   groups remain unchanged.
+2. Assert project deletion invokes the application use case exactly once.
+3. Run focused node and DOM tests and confirm the old behavior fails.
+
+### Task 3: Implement the domain policy and deletion correction
+
+**Files:**
+
+- Create: `src/contexts/saved-tabs/domain/services/SavedTabsActionSettingsPolicy.ts`
+- Modify: `src/contexts/saved-tabs/domain/services/UserSettingsDefaults.ts`
+- Modify: `src/lib/storage/settings.ts`
+- Modify: `src/lib/storage/projects.ts`
+- Modify: `src/contexts/saved-tabs/presentation/hooks/useProjectCrudHandlers.ts`
+
+1. Export a typed, documented five-setting policy from the domain.
+2. Compose it into both settings default objects.
+3. Remove Custom-project-to-Domain hidden cascade deletion and its swallowed
+   error path.
+4. Remove the synthetic uncategorized-project delete call.
+5. Run focused tests until green.
+
+### Task 4: Record the durable decision
+
+**Files:**
+
+- Create: `docs/adr/0001-saved-tabs-deletion-confirmation-policy.md`
+
+1. Record operation inventory, default intent, confirmation criteria, migration
+   effect, and Custom/Domain ownership.
+2. Verify documentation agrees with tests and runtime behavior.
+
+### Task 5: Verify and publish
+
+1. Run React Doctor for the hook change.
+2. Run focused tests, coverage, the requested quality command, the repository's
+   actual quality gate, and the release gate.
+3. Run the harness evaluator and resolve findings.
+4. Commit, push, and open a non-draft PR against `develop` referencing issue
+   #677.

--- a/src/contexts/saved-tabs/domain/services/SavedTabsActionSettingsPolicy.test.ts
+++ b/src/contexts/saved-tabs/domain/services/SavedTabsActionSettingsPolicy.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { savedTabsActionSettingsDefaults } from './SavedTabsActionSettingsPolicy'
+
+describe('savedTabsActionSettingsDefaults', () => {
+  it('データ変更とウィンドウ操作の既定ポリシーを一箇所で定義する', () => {
+    expect(savedTabsActionSettingsDefaults).toStrictEqual({
+      confirmDeleteAll: false,
+      confirmDeleteEach: false,
+      openAllInNewWindow: false,
+      removeTabAfterExternalDrop: false,
+      removeTabAfterOpen: true,
+    })
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/SavedTabsActionSettingsPolicy.ts
+++ b/src/contexts/saved-tabs/domain/services/SavedTabsActionSettingsPolicy.ts
@@ -1,0 +1,25 @@
+import type { UserSettingsDto } from '@/contexts/saved-tabs/domain/dto/UserSettingsDto'
+
+type SavedTabsActionSettings = Pick<
+  UserSettingsDto,
+  | 'confirmDeleteAll'
+  | 'confirmDeleteEach'
+  | 'openAllInNewWindow'
+  | 'removeTabAfterExternalDrop'
+  | 'removeTabAfterOpen'
+>
+
+/**
+ * Saved Tabs のデータ変更とウィンドウ操作に関する既定ポリシー。
+ *
+ * 明示的な削除と URL を開いた後の削除は Undo 可能なため確認を opt-in
+ * とする。外部ドロップ後の削除は確認も Undo もないため opt-in とする。
+ * 保存済みの明示値は settings merge で常にこの既定値より優先される。
+ */
+export const savedTabsActionSettingsDefaults = {
+  confirmDeleteAll: false,
+  confirmDeleteEach: false,
+  openAllInNewWindow: false,
+  removeTabAfterExternalDrop: false,
+  removeTabAfterOpen: true,
+} satisfies SavedTabsActionSettings

--- a/src/contexts/saved-tabs/domain/services/UserSettingsDefaults.test.ts
+++ b/src/contexts/saved-tabs/domain/services/UserSettingsDefaults.test.ts
@@ -44,6 +44,18 @@ describe('normalizeUserSettings', () => {
     expect(result.normalized).not.toHaveProperty('aiProvider')
   })
 
+  it('未保存の外部ドロップ削除は無効にし、明示的な保存値は維持する', () => {
+    expect(
+      normalizeUserSettings({ userSettings: {} }).normalized
+        .removeTabAfterExternalDrop,
+    ).toBe(false)
+    expect(
+      normalizeUserSettings({
+        userSettings: { removeTabAfterExternalDrop: true },
+      }).normalized.removeTabAfterExternalDrop,
+    ).toBe(true)
+  })
+
   it('除外パターンを trim・重複除去し、必須パターンを補う', () => {
     const result = normalizeUserSettings({
       userSettings: {

--- a/src/contexts/saved-tabs/domain/services/UserSettingsDefaults.ts
+++ b/src/contexts/saved-tabs/domain/services/UserSettingsDefaults.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_FONT_SIZE_PERCENT } from '@/constants/fontSize'
 import type { UserSettingsDto } from '@/contexts/saved-tabs/domain/dto/UserSettingsDto'
+import { savedTabsActionSettingsDefaults } from '@/contexts/saved-tabs/domain/services/SavedTabsActionSettingsPolicy'
 import {
   DEFAULT_EXCLUDE_PATTERNS,
   mergeStoredUserSettingsDefaults,
@@ -11,9 +12,9 @@ import {
 } from '@/features/ai-chat/lib/systemPromptPresets'
 
 /**
- * `UserSettingsDto` の domain 既定値。`src/lib/storage/settings.defaultSettings`
- * を DDD 側に再配置したもので、repository / use-case 初期値や未保存状態
- * のフォールバックとして利用する。
+ * `UserSettingsDto` の domain 既定値。repository / use-case 初期値や未保存状態
+ * のフォールバックとして利用する。データ変更とウィンドウ操作の既定値は
+ * `savedTabsActionSettingsDefaults` を source of truth とする。
  *
  * 旧 `lib/storage/settings` の正規化 (`normalizeAiSystemPromptSettings`)
  * 適用前の素の値なので、利用側で `normalizeAiSystemPromptSettings` を
@@ -24,8 +25,7 @@ import {
  */
 export const defaultUserSettings: UserSettingsDto = {
   language: 'system',
-  removeTabAfterOpen: true,
-  removeTabAfterExternalDrop: true,
+  ...savedTabsActionSettingsDefaults,
   excludePatterns: [...DEFAULT_EXCLUDE_PATTERNS],
   enableCategories: true,
   autoDeletePeriod: 'never',
@@ -33,9 +33,6 @@ export const defaultUserSettings: UserSettingsDto = {
   clickBehavior: 'saveSameDomainTabs',
   excludePinnedTabs: true,
   openUrlInBackground: true,
-  openAllInNewWindow: false,
-  confirmDeleteAll: false,
-  confirmDeleteEach: false,
   fontSizePercent: DEFAULT_FONT_SIZE_PERCENT,
   colors: {},
   ollamaModel: '',

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectCrudHandlers.ts
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectCrudHandlers.ts
@@ -2,7 +2,6 @@ import { useCallback } from 'react'
 import type { Dispatch, RefObject, SetStateAction } from 'react'
 import { toast } from 'sonner'
 
-import { savedTabsUncategorizedProjectId as UNCATEGORIZED_PROJECT_ID } from '@/contexts/saved-tabs/application/dto/SavedTabsPresentationDefaultsDto'
 import type {
   SavedTabsCustomProjectDto as CustomProject,
   SavedTabsProjectKeywordSettingsDto as ProjectKeywordSettings,
@@ -132,11 +131,6 @@ const useProjectCrudHandlers = ({
         if (!project) {
           return
         }
-        await refs.deleteCustomProjectUseCaseRef
-          .current({
-            projectId: UNCATEGORIZED_PROJECT_ID,
-          })
-          .catch(async () => {})
         await refs.deleteCustomProjectUseCaseRef.current({
           projectId,
         })

--- a/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx
+++ b/src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx
@@ -883,6 +883,7 @@ describe('useProjectManagement', () => {
     expect(projectManagementMocks.deleteCustomProject).toHaveBeenCalledWith({
       projectId: 'project-1',
     })
+    expect(projectManagementMocks.deleteCustomProject).toHaveBeenCalledTimes(1)
     expect(result.current.customProjects).toStrictEqual([untouchedProject])
   })
 

--- a/src/lib/storage/projects.test.ts
+++ b/src/lib/storage/projects.test.ts
@@ -366,7 +366,7 @@ describe('projects storage', () => {
     )
   })
 
-  it('removeUrlsFromCustomProject は URL ID 欠損と空グループ削除を扱う', async () => {
+  it('removeUrlsFromCustomProject は URL ID 欠損を扱いドメイン保存を維持する', async () => {
     const state: StorageState = {
       customProjects: [
         createProject({
@@ -414,7 +414,13 @@ describe('projects storage', () => {
 
     expect(state.customProjects?.[1]?.urlIds).toEqual([])
 
-    expect(state.savedTabs).toEqual([])
+    expect(state.savedTabs).toEqual([
+      {
+        id: 'domain-group',
+        domain: 'https://docs.example.com',
+        urlIds: ['url-1'],
+      },
+    ])
   })
 
   it('saveUrlsToCustomProjects は未分類から一致プロジェクトへURLを移す', async () => {
@@ -1529,7 +1535,7 @@ describe('projects storage', () => {
     ).rejects.toThrow('Project with ID missing not found')
   })
 
-  it('removeUrlFromCustomProject はURLとメタデータを消し空のドメイングループも削除する', async () => {
+  it('removeUrlFromCustomProject はプロジェクト内のURLとメタデータだけを削除する', async () => {
     const state: StorageState = {
       customProjects: [
         createProject({
@@ -1576,10 +1582,56 @@ describe('projects storage', () => {
       }),
     )
 
-    expect(state.savedTabs).toEqual([])
+    expect(state.savedTabs).toEqual([
+      {
+        domain: 'https://docs.example.com',
+        id: 'group-1',
+        urlIds: ['url-1'],
+      },
+    ])
   })
 
-  it('removeUrlFromCustomProject は存在しないプロジェクトを拒否し同期失敗は握りつぶす', async () => {
+  it('removeUrlFromCustomProject は URL IDs 未定義でもドメイン保存を維持する', async () => {
+    const state: StorageState = {
+      customProjects: [createProject({ id: 'target' })],
+      savedTabs: [
+        {
+          domain: 'https://docs.example.com',
+          id: 'group-1',
+          urlIds: ['url-1'],
+        },
+      ],
+      urls: [
+        {
+          id: 'url-1',
+          savedAt: 1,
+          title: 'Doc',
+          url: 'https://docs.example.com/a',
+        },
+      ],
+    }
+    delete state.customProjects?.[0]?.urlIds
+    globalThis.chrome = {
+      storage: {
+        local: createChromeStorageLocal(state),
+      },
+    } as unknown as typeof chrome
+
+    const { removeUrlFromCustomProject } = await loadModule()
+
+    await removeUrlFromCustomProject('target', 'https://docs.example.com/a')
+
+    expect(state.customProjects?.[0]?.urlIds).toEqual([])
+    expect(state.savedTabs).toEqual([
+      {
+        domain: 'https://docs.example.com',
+        id: 'group-1',
+        urlIds: ['url-1'],
+      },
+    ])
+  })
+
+  it('removeUrlFromCustomProject は存在しないプロジェクトを拒否しドメイン保存を維持する', async () => {
     const state: StorageState = {
       customProjects: [
         createProject({
@@ -1635,32 +1687,12 @@ describe('projects storage', () => {
       {
         domain: 'https://docs.example.com',
         id: 'group-with-ids',
-        urlIds: ['url-2'],
+        urlIds: ['url-1', 'url-2'],
       },
     ])
-
-    vi.mocked(chrome.storage.local.get)
-
-      .mockImplementationOnce(async (keys) => {
-        // eslint-disable-line
-        if (Array.isArray(keys)) {
-          return Object.fromEntries(
-            keys.map((key) => [key, state[key as keyof StorageState]]),
-          )
-        }
-        return {
-          [keys as unknown as string]:
-            state[keys as unknown as keyof StorageState],
-        }
-      })
-      .mockRejectedValueOnce(new Error('sync failed'))
-
-    await expect(
-      removeUrlFromCustomProject('target', 'https://docs.example.com/missing'),
-    ).resolves.toBeUndefined()
   })
 
-  it('bulk remove APIs はURL/ID指定でプロジェクトとドメインモードを同期削除する', async () => {
+  it('bulk remove APIs はURL/ID指定でプロジェクトだけを削除する', async () => {
     const state: StorageState = {
       customProjects: [
         createProject({
@@ -1738,12 +1770,12 @@ describe('projects storage', () => {
       {
         domain: 'https://docs.example.com',
         id: 'group-1',
-        urlIds: ['url-2', 'url-3'],
+        urlIds: ['url-1', 'url-2', 'url-3'],
       },
     ])
   })
 
-  it('bulk remove APIs は空入力・対象なし・同期エラーを扱う', async () => {
+  it('bulk remove APIs は空入力・対象なし・存在しないプロジェクトを扱う', async () => {
     const state: StorageState = {
       customProjects: [
         createProject({
@@ -1788,24 +1820,16 @@ describe('projects storage', () => {
 
     expect(state.customProjects?.[0]?.urlIds).toEqual(['url-1'])
 
-    vi.mocked(chrome.storage.local.get)
-
-      .mockImplementationOnce(async (keys) => {
-        // eslint-disable-line
-        if (Array.isArray(keys)) {
-          return Object.fromEntries(
-            keys.map((key) => [key, state[key as keyof StorageState]]),
-          )
-        }
-        return {
-          [keys as unknown as string]:
-            state[keys as unknown as keyof StorageState],
-        }
-      })
-      .mockRejectedValueOnce(new Error('storage failed'))
-    await expect(
-      removeUrlsFromCustomProject('target', ['https://docs.example.com/one']),
-    ).resolves.toBeUndefined()
+    await removeUrlsFromCustomProject('target', [
+      'https://docs.example.com/one',
+    ])
+    expect(state.customProjects?.[0]?.urlIds).toEqual([])
+    expect(state.savedTabs).toEqual([
+      {
+        domain: 'https://docs.example.com',
+        id: 'group-1',
+      },
+    ])
 
     await expect(
       removeUrlsFromCustomProject('missing', ['https://docs.example.com/one']),

--- a/src/lib/storage/projects.ts
+++ b/src/lib/storage/projects.ts
@@ -570,92 +570,6 @@ const removeUrlFromCustomProject = async (
   project.updatedAt = Date.now()
   projects[projectIndex] = project
   await saveCustomProjects(projects)
-
-  // ドメインモードからも同じURLを削除
-  try {
-    const { savedTabs = [] } = await chrome.storage.local.get<{
-      savedTabs?: TabGroup[]
-    }>('savedTabs')
-
-    // URLレコードを取得
-    const urlRecords = await getUrlRecordsByIds(
-      savedTabs.flatMap((group: TabGroup) => group.urlIds ?? []),
-    )
-    const urlRecord = urlRecords.find((record) => record.url === url)
-    if (urlRecord) {
-      const updatedGroups = savedTabs.reduce<TabGroup[]>((groups, group) => {
-        if (!group.urlIds) {
-          groups.push(group)
-          return groups
-        }
-
-        const updatedUrlIds = group.urlIds.filter((id) => id !== urlRecord.id)
-        if (updatedUrlIds.length > 0) {
-          groups.push({
-            ...group,
-            urlIds: updatedUrlIds,
-          })
-        }
-        return groups
-      }, [])
-      await chrome.storage.local.set({
-        savedTabs: updatedGroups,
-      })
-      console.log(
-        `URL ${redactUrlForLog(url)} はドメインモードからも削除されました`,
-      )
-    }
-  } catch (syncError) {
-    console.error('ドメインモードの同期中にエラーが発生しました:', syncError)
-    // エラーをスローしないで続行 - カスタムプロジェクトの削除は成功している
-  }
-}
-
-/**
- * ドメインモードからも指定されたURLを同期削除するヘルパー関数
- */
-const syncDeleteToDomainMode = async (
-  targetUrlsSet: Set<string>,
-  urlsLength: number,
-): Promise<void> => {
-  try {
-    const { savedTabs = [] } = await chrome.storage.local.get<{
-      savedTabs?: TabGroup[]
-    }>('savedTabs')
-
-    const urlRecords = await getUrlRecordsByIds(
-      savedTabs.flatMap((g: TabGroup) => g.urlIds ?? []),
-    )
-    const recordsToDelete = urlRecords.filter((record) =>
-      targetUrlsSet.has(record.url),
-    )
-
-    if (recordsToDelete.length > 0) {
-      const idsToDelete = new Set(recordsToDelete.map((r) => r.id))
-      const updatedGroups = savedTabs.reduce<TabGroup[]>((groups, group) => {
-        if (!group.urlIds) {
-          groups.push(group)
-          return groups
-        }
-
-        const updatedUrlIds = group.urlIds.filter((id) => !idsToDelete.has(id))
-        if (updatedUrlIds.length > 0) {
-          groups.push({
-            ...group,
-            urlIds: updatedUrlIds,
-          })
-        }
-        return groups
-      }, [])
-
-      await chrome.storage.local.set({
-        savedTabs: updatedGroups,
-      })
-      console.log(`${urlsLength}件のURLはドメインモードからも削除されました`)
-    }
-  } catch (syncError) {
-    console.error('ドメインモードの同期中にエラーが発生しました:', syncError)
-  }
 }
 
 /**
@@ -721,9 +635,6 @@ const removeUrlsFromCustomProject = async (
       await saveCustomProjects(projects)
     }
   }
-
-  // ドメインモードからも同じURLを削除
-  await syncDeleteToDomainMode(targetUrlsSet, urls.length)
 }
 
 type DeleteSyncBehavior = {

--- a/src/lib/storage/settings.ts
+++ b/src/lib/storage/settings.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_FONT_SIZE_PERCENT } from '@/constants/fontSize'
+import { savedTabsActionSettingsDefaults } from '@/contexts/saved-tabs/domain/services/SavedTabsActionSettingsPolicy'
 import {
   DEFAULT_EXCLUDE_PATTERNS,
   mergeStoredUserSettingsDefaults,
@@ -39,8 +40,7 @@ const mergeStoredUserSettings = (
 // デフォルト設定
 export const defaultSettings: UserSettings = {
   language: 'system',
-  removeTabAfterOpen: true,
-  removeTabAfterExternalDrop: true,
+  ...savedTabsActionSettingsDefaults,
   excludePatterns: [...DEFAULT_EXCLUDE_PATTERNS],
   enableCategories: true,
   // デフォルトは有効
@@ -54,13 +54,7 @@ export const defaultSettings: UserSettings = {
   // デフォルトでは固定タブを除外する
   openUrlInBackground: true,
   // デフォルト: URLをバックグラウンドで開く
-  openAllInNewWindow: false,
-  // デフォルト: 「すべてのタブを開く」を現在のウィンドウで開く
-  confirmDeleteAll: false,
-  // デフォルト: 確認しない
-  confirmDeleteEach: false,
   fontSizePercent: DEFAULT_FONT_SIZE_PERCENT,
-  // デフォルト: 確認しない
   colors: {}, // デフォルト: カラー設定まとめ
   ollamaModel: '',
   activeAiSystemPromptId: DEFAULT_AI_SYSTEM_PROMPT_PRESET_ID,


### PR DESCRIPTION
## 変更内容

Closes #677

### 問題の原因

- Saved Tabs のデータ変更・ウィンドウ操作に関する 5 つの既定値が domain と Chrome storage adapter に重複定義され、判断根拠と source of truth がありませんでした。
- `removeTabAfterExternalDrop` は確認も Undo もない経路にもかかわらず既定で有効でした。
- Custom プロジェクト内の URL 削除が操作名と Undo snapshot の範囲を越えて Domain モードの URL まで暗黙に削除し、Domain 側は復元されず同期 error も握り潰されていました。
- プロジェクト削除 handler は未分類プロジェクトの削除を意図的に失敗させ、その error を握り潰していました。

### 採用した解決方法

- Saved Tabs domain に action settings の既定ポリシーを定義し、domain / storage の両方が共有します。
- 外部ドロップ後の削除を opt-in に変更しました。保存済みの明示的な `true` は維持します。
- Custom プロジェクトの URL 削除を project-scoped に戻しました。Domain モードからの global 削除は既存 use case により Custom 参照を引き続き掃除します。
- synthetic な未分類プロジェクト削除と error 握り潰しを削除しました。
- ADR に操作一覧、既定値の意図、確認基準、Undo / recovery、既存ユーザーへの影響を記録しました。

### 主要な変更内容

- `SavedTabsActionSettingsPolicy` と回帰テストを追加
- `defaultUserSettings` / `defaultSettings` の重複値を共通ポリシーへ集約
- `removeTabAfterExternalDrop` の未保存時 default を `false` へ変更
- Custom プロジェクト単体・一括 URL 削除から hidden Domain cascade を削除
- プロジェクト削除 use case の呼び出しを対象 project の 1 回だけに修正
- single / bulk / `urlIds` 欠損 / stored-value compatibility の regression test を追加・更新
- ADR と設計・実装計画を追加

### Regression risk と確認内容

- 明示的に保存済みの設定値は変更せず、新規・欠損設定にだけ新 default を適用します。
- Custom 削除後も Domain URL が残ることを single / bulk / `urlIds` 欠損で検証しました。
- Domain global deletion が Custom 参照を削除する既存 use case / test は維持されています。
- UI の新規視覚変更はなく、既存 options UI の設定導線を利用します。
- clean `develop` と変更後の coverage で、未到達数は statements 404 / branches 595 / functions 71 / lines 392 と同一でした。総 coverage 100% 未達は既存 baseline です。

### 実行した test / quality command

- `bun run test:node -- ...`: focused tests passed
- `bun run test:dom -- src/contexts/saved-tabs/presentation/hooks/useProjectManagement.test.tsx`: 16 tests passed
- `bun run compile`: passed
- `bun run format:check`: passed
- `bun run quality`: `package.json` に script がなく `Script not found quality`（変更前からの repository state）
- `bun run quality:check`: 320 test files / 3,472 tests passed。format / lint / type / architecture / unused / duplicate check を含む
- `bun run test:coverage`: passed。変更前 97.29% statements / 92.45% branches、変更後 97.28% / 92.43%。未到達数は同一、新規 policy は 100%
- `bun run release:check`: passed。Chrome / Firefox production build、manifest version、production network policy を確認
- `npx -y react-doctor@latest . --verbose --diff`: completed。今回変更外を含む既存 25 diagnostics、score 69/100

### Acceptance criteria との対応

- 操作の棚卸し: ADR の operation inventory
- 各 default の意図: domain policy、ADR、design document
- dialog 基準: single / bulk settings、構造削除の常時確認、自動操作の opt-in を ADR に記録
- UI / 設定 / test: 既存 UI 導線を維持し、external-drop default と Custom / Domain mutation scope を修正
- 変更不要箇所: Undo 可能な明示削除は confirmation を opt-in のまま、構造削除は常時確認を維持
- regression: 新規・更新 test と全体 quality / release gate で確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added explicit Saved Tabs action defaults for deletion confirmations, tab removal, and opening tabs in new windows.
  - Existing saved preferences continue to override defaults.

- **Bug Fixes**
  - Removing URLs from a Custom project now affects only that project and preserves Domain-mode saved URLs.
  - Domain-mode deletion remains responsible for global cleanup.
  - Project deletion no longer triggers unintended additional removals.
  - External drag-and-drop removal is disabled by default unless enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->