### PR TITLE
i18n messages の ja/en key parity test を追加する

### DIFF
--- a/src/features/i18n/lib/messages-parity.test.ts
+++ b/src/features/i18n/lib/messages-parity.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest' // eslint-disable-line
+
+import { getMessages } from '@/features/i18n/messages'
+
+/**
+ * ja / en の message key parity と placeholder token parity を検証する。
+ * fallback があるからといって欠落を見逃さないための安全網。
+ */
+
+const extractTokens = (message: string): string[] =>
+  Array.from(
+    message.matchAll(/\{\{(\w+)\}\}/g),
+    ([, token]) => token,
+  ).toSorted()
+
+// 意図的に片方にのみ存在させる key がある場合はここに記録する
+const ALLOWED_MISSING_IN_JA = new Set<string>()
+const ALLOWED_MISSING_IN_EN = new Set<string>()
+
+// 意図的に placeholder token 差分を許容する key がある場合はここに記録する
+const ALLOWED_TOKEN_MISMATCH = new Set<string>()
+
+describe('i18n message parity', () => {
+  it('ja と en の key set が一致する', () => {
+    const enKeys = Object.keys(getMessages('en')).toSorted()
+    const jaKeys = Object.keys(getMessages('ja')).toSorted()
+
+    const enSet = new Set(enKeys)
+    const jaSet = new Set(jaKeys)
+
+    const missingInJa = enKeys.filter((k) => !jaSet.has(k))
+    const missingInEn = jaKeys.filter((k) => !enSet.has(k))
+
+    const unexpectedMissingInJa = missingInJa.filter(
+      (k) => !ALLOWED_MISSING_IN_JA.has(k),
+    )
+    const unexpectedMissingInEn = missingInEn.filter(
+      (k) => !ALLOWED_MISSING_IN_EN.has(k),
+    )
+
+    if (unexpectedMissingInJa.length > 0 || unexpectedMissingInEn.length > 0) {
+      let msg = 'Message key parity mismatch detected:\n'
+      if (unexpectedMissingInJa.length > 0) {
+        msg += `  Missing in ja: ${JSON.stringify(unexpectedMissingInJa)}\n`
+      }
+      if (unexpectedMissingInEn.length > 0) {
+        msg += `  Missing in en: ${JSON.stringify(unexpectedMissingInEn)}\n`
+      }
+      msg +=
+        '  Add the missing translation or add the key to the allowlist if intentional.'
+      throw new Error(msg)
+    }
+
+    expect(unexpectedMissingInJa).toEqual([])
+    expect(unexpectedMissingInEn).toEqual([])
+  })
+
+  it('ja と en の placeholder token が一致する', () => {
+    const enMessages = getMessages('en') as Record<string, string>
+    const jaMessages = getMessages('ja') as Record<string, string>
+    const keys = Object.keys(enMessages)
+
+    const mismatches: string[] = []
+
+    for (const key of keys) {
+      if (ALLOWED_TOKEN_MISMATCH.has(key)) {
+        continue
+      }
+
+      const enValue = enMessages[key]
+      const jaValue = jaMessages[key]
+
+      // key parity test で検出されるため、片方にない key は skip
+      if (enValue === undefined || jaValue === undefined) {
+        continue
+      }
+
+      const enTokens = extractTokens(enValue)
+      const jaTokens = extractTokens(jaValue)
+
+      if (JSON.stringify(enTokens) !== JSON.stringify(jaTokens)) {
+        mismatches.push(
+          `  ${key}: en=${JSON.stringify(enTokens)} ja=${JSON.stringify(jaTokens)}`,
+        )
+      }
+    }
+
+    if (mismatches.length > 0) {
+      throw new Error(
+        `Placeholder token mismatch detected:\n${mismatches.join('\n')}`,
+      )
+    }
+
+    expect(mismatches).toEqual([])
+  })
+})

--- a/src/features/i18n/messages.ts
+++ b/src/features/i18n/messages.ts
@@ -1323,6 +1323,7 @@ const messages = {
     'options.importExport.mergeWarning':
       'マージの際、同じIDのデータは更新されます。',
     'options.importExport.placeholderUrlTitle': '復元データ（元URL欠損）',
+    'options.importExport.previewAiChat': 'AIチャット履歴: {{hasAiChat}}',
     'options.importExport.previewAiChatLabel': 'AIチャット履歴',
     'options.importExport.previewAnalytics': '分析ビュー: {{hasAnalytics}}',
     'options.importExport.previewCategoriesLabel': 'カテゴリ数',


### PR DESCRIPTION
## 変更内容

- `src/features/i18n/messages.ts` に欠落していた ja key `options.importExport.previewAiChat` を追加
- `src/features/i18n/lib/messages-parity.test.ts` を新規作成し、ja/en の key parity と placeholder token parity を検証するテストを追加

## 問題の原因

`getMessage` は指定言語に key がない場合、英語 → fallback → key 自体の順にフォールバックする設計のため、ja/en のどちらかに key が欠けていても runtime error が発生せず、気づきにくい状態だった。実際に `options.importExport.previewAiChat` が en にのみ存在し ja に欠落していた。

## 採用した解決方法

- 欠落していた ja key を追加して key parity を解消
- ja/en の key set と placeholder token (`{{count}}` 等) の差分を検出するテストを追加
- 意図的な例外が必要な場合は allowlist (`ALLOWED_MISSING_IN_JA`, `ALLOWED_MISSING_IN_EN`, `ALLOWED_TOKEN_MISMATCH`) で管理できる構造にした

## 主要な変更内容

- `messages.ts`: ja ブロックに `'options.importExport.previewAiChat': 'AIチャット履歴: {{hasAiChat}}'` を追加
- `messages-parity.test.ts`: 2 つのテストケースを追加
  - `ja と en の key set が一致する` — key 差分を検出
  - `ja と en の placeholder token が一致する` — `{{token}}` の差分を検出

## regression risk と確認内容

- `messages.ts` の変更は ja key 1 件の追加のみで、既存 key の値は変更していないため、既存 UI 表示への影響はない
- 新規テストファイルの追加のみで、既存テストへの影響はない
- `bun run quality:check` および `bun run release:check` で full test suite / lint / type check / build を確認

## 実行した test / quality command

- `bun run compile` — type check pass
- `bun run lint` — lint pass
- `bun run test:node` — node project 全テスト pass (191 files / 2572 tests)
- `bun run quality:check` — format / lint / compile / test / knip / duplication / secretlint / arch:check 全て pass
- `bun run release:check` — build (chrome / firefox) / production logging / app version / network policy 全て pass

## acceptance criteria に対する確認

- [x] ja/en の key 差分を検出するテストがある → `ja と en の key set が一致する` テスト
- [x] placeholder token 差分を検出するテストがある → `ja と en の placeholder token が一致する` テスト
- [x] 意図的な例外が必要な場合は allowlist 化されている → `ALLOWED_MISSING_IN_JA` / `ALLOWED_MISSING_IN_EN` / `ALLOWED_TOKEN_MISMATCH`
- [x] fallback があるから欠落してもよい、という状態にならない → parity test が fail することで差分を検出
- [x] 既存テストが通る → `quality:check` / `release:check` で確認

closes #674