### PR TITLE
axe ベースの accessibility 自動検査を主要画面に追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,3 +151,34 @@ jobs:
 
       - name: Run unit tests (shard 2/2)
         run: bun run test --shard=2/2
+
+  e2e-accessibility:
+    name: E2E Accessibility (axe)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.node-version'
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: '.bun-version'
+
+      - name: Verify toolchain versions
+        run: bun run verify:toolchain-versions
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run axe accessibility E2E tests
+        run: bun run e2e:a11y

--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@chromatic-com/storybook": "^5.2.1",
         "@cyclonedx/cyclonedx-library": "^10.1.0",
         "@eslint-react/eslint-plugin": "^5.10.3",
@@ -150,6 +151,8 @@
     "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.12.1", "", { "dependencies": { "axe-core": "~4.12.1" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw=="],
 
     "@azu/format-text": ["@azu/format-text@1.0.2", "", {}, "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg=="],
 
@@ -1178,6 +1181,8 @@
     "attr-accept": ["attr-accept@2.2.5", "", {}, "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ=="],
 
     "autoprefixer": ["autoprefixer@10.5.2", "", { "dependencies": { "browserslist": "^4.28.4", "caniuse-lite": "^1.0.30001799", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q=="],
+
+    "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 

--- a/e2e/helpers/axe.ts
+++ b/e2e/helpers/axe.ts
@@ -1,0 +1,81 @@
+import { AxeBuilder } from '@axe-core/playwright'
+import type { Page } from '@playwright/test'
+
+import { expect } from './extension'
+
+/**
+ * axe-core による accessibility 自動検査の smoke-test helper。
+ *
+ * ## 方針
+ *
+ * - デフォルトで axe-core の全ルールを適用する (WCAG 2.0/2.1 A・AA)。
+ * - violation が 0 件であることを assert する。
+ * - false positive が発生した場合は、ルールを disable するのではなく
+ *   まずコード側で根本原因を修正することを試みる。
+ *   やむを得ず disable する場合は `disabledRules` に追加し、
+ *   その理由をコメントで明記する。
+ *
+ * ## 今後の拡張
+ *
+ * - ai-chat / analytics など他画面への展開は各画面の
+ *   `*.a11y.extension.spec.ts` を追加することで行う。
+ * - キーボード操作など自動検査で拾えない項目は別途 E2E で補う。
+ */
+
+/**
+ * 現在 disable しているルール。
+ *
+ * - なし: 全ルールが通過している。
+ *
+ * 今後追加する場合は以下の形式で理由を併記すること:
+ *   'rule-id': 'reason ...',
+ */
+const disabledRules: Record<string, string> = {}
+
+/**
+ * AxeBuilder を構築する。
+ * 共通設定 (disable rules, tags) をここに集約する。
+ */
+const createAxeBuilder = (page: Page): AxeBuilder => {
+  const builder = new AxeBuilder({ page }).withTags([
+    'wcag2a',
+    'wcag2aa',
+    'wcag21a',
+    'wcag21aa',
+  ])
+
+  const ruleIds = Object.keys(disabledRules)
+  if (ruleIds.length > 0) {
+    builder.disableRules(ruleIds)
+  }
+
+  return builder
+}
+
+/**
+ * ページに対して axe 検査を実行し、violation が 0 件であることを assert する。
+ *
+ * @param page - 検査対象の Playwright Page
+ * @param label - テスト出力で識別しやすいよう violation の詳細に添えるラベル
+ */
+export const assertNoAxeViolations = async (
+  page: Page,
+  label: string,
+): Promise<void> => {
+  const results = await createAxeBuilder(page).analyze()
+
+  if (results.violations.length > 0) {
+    const summary = results.violations
+      .map(
+        (v) =>
+          `  - ${v.id} (${v.impact ?? 'unknown'}): ${v.help} — ${v.nodes.length} node(s)`,
+      )
+      .join('\n')
+
+    throw new Error(
+      `axe accessibility violations on "${label}" (${results.violations.length} rule(s)):\n${summary}`,
+    )
+  }
+
+  expect(results.violations).toHaveLength(0)
+}

--- a/e2e/options.a11y.extension.spec.ts
+++ b/e2e/options.a11y.extension.spec.ts
@@ -1,0 +1,62 @@
+import { assertNoAxeViolations } from './helpers/axe'
+import {
+  createBaseSeed,
+  defaultUserSettings,
+  expect,
+  getExtensionUrl,
+  seedStorage,
+  test,
+} from './helpers/extension'
+
+const now = Date.now()
+
+/**
+ * options 画面の axe accessibility smoke test。
+ *
+ * 検査内容:
+ * - 設定画面が表示された状態で
+ *   WCAG 2.0/2.1 A・AA の violation が 0 件であることを確認する。
+ *
+ * 補足:
+ * - カラーピッカーなどのカスタムコントロールは
+ *   今後の拡張で個別にキーボード操作を確認する。
+ */
+test.describe('options accessibility', () => {
+  test('設定画面で axe violation がない', async ({
+    extensionId,
+    page,
+    serviceWorker,
+  }) => {
+    await seedStorage(
+      serviceWorker,
+      createBaseSeed({
+        savedTabs: [
+          {
+            domain: 'example.com',
+            id: 'group-example',
+            urlIds: ['url-example'],
+          },
+        ],
+        urls: [
+          {
+            id: 'url-example',
+            savedAt: now,
+            title: 'Example Home',
+            url: 'https://example.com/',
+          },
+        ],
+        userSettings: {
+          ...defaultUserSettings,
+          clickBehavior: 'saveCurrentTab',
+        },
+      }),
+    )
+
+    await page.goto(getExtensionUrl(extensionId, 'app.html#/options'))
+
+    // ページ内容が描画完了したことを確認してから検査する
+    await expect(page.getByRole('button', { name: /export/i })).toBeVisible()
+
+    await assertNoAxeViolations(page, 'options')
+  })
+})

--- a/e2e/saved-tabs.a11y.extension.spec.ts
+++ b/e2e/saved-tabs.a11y.extension.spec.ts
@@ -1,0 +1,64 @@
+import { assertNoAxeViolations } from './helpers/axe'
+import {
+  createBaseSeed,
+  defaultUserSettings,
+  expect,
+  getExtensionUrl,
+  seedStorage,
+  test,
+} from './helpers/extension'
+
+const now = Date.now()
+
+/**
+ * saved-tabs 画面の axe accessibility smoke test。
+ *
+ * 検査内容:
+ * - ドメインモードで保存済みタブが表示された状態で
+ *   WCAG 2.0/2.1 A・AA の violation が 0 件であることを確認する。
+ *
+ * 補足:
+ * - D&D や resize handle など手動操作が必要な項目は
+ *   この自動検査の対象外。
+ */
+test.describe('saved-tabs accessibility', () => {
+  test('ドメインモードで axe violation がない', async ({
+    extensionId,
+    page,
+    serviceWorker,
+  }) => {
+    await seedStorage(
+      serviceWorker,
+      createBaseSeed({
+        savedTabs: [
+          {
+            domain: 'example.com',
+            id: 'group-example',
+            urlIds: ['url-example'],
+          },
+        ],
+        urls: [
+          {
+            id: 'url-example',
+            savedAt: now,
+            title: 'Example Home',
+            url: 'https://example.com/',
+          },
+        ],
+        userSettings: {
+          ...defaultUserSettings,
+          clickBehavior: 'saveCurrentTab',
+        },
+      }),
+    )
+
+    await page.goto(
+      getExtensionUrl(extensionId, 'app.html#/saved-tabs?mode=domain'),
+    )
+
+    // ページ内容が描画完了したことを確認してから検査する
+    await expect(page.getByText('Example Home')).toBeVisible()
+
+    await assertNoAxeViolations(page, 'saved-tabs (domain mode)')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "storybook": "BROWSER=none storybook dev -p 6006",
     "build-storybook": "storybook build",
     "e2e": "playwright test e2e",
+    "e2e:a11y": "playwright test e2e --project=extension --grep 'accessibility'",
     "knip": "knip",
     "doctor": "react-doctor",
     "verify:app-version": "bun tools/scripts/verify-app-version.ts",
@@ -127,6 +128,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@chromatic-com/storybook": "^5.2.1",
     "@cyclonedx/cyclonedx-library": "^10.1.0",
     "@eslint-react/eslint-plugin": "^5.10.3",

--- a/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
+++ b/src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx
@@ -518,6 +518,7 @@ const useSavedTabsAppView = ({
             : 'container mx-auto min-h-screen py-2'
         }
       >
+        <h1 className='sr-only'>{t('sidebar.tabList')}</h1>
         <Header
           tabGroups={tabGroups}
           filteredTabGroups={headerFilteredTabGroups}

--- a/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx
@@ -221,10 +221,15 @@ const ProjectUrlItemComponent = ({
         <div
           {...attributes}
           {...listeners}
+          aria-label={t('savedTabs.url.dragHandleAria')}
           className='cursor-grab p-1 active:cursor-grabbing'
           data-testid='project-url-drag-handle'
         >
-          <GripVertical size={16} className='text-muted-foreground' />
+          <GripVertical
+            size={16}
+            aria-hidden='true'
+            className='text-muted-foreground'
+          />
         </div>
         {/* タイトル＋バッジ部 */}
         <div className='flex min-w-0 flex-1 items-center'>

--- a/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx
+++ b/src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx
@@ -221,7 +221,9 @@ const ProjectUrlItemComponent = ({
         <div
           {...attributes}
           {...listeners}
-          aria-label={t('savedTabs.url.dragHandleAria')}
+          aria-label={t('savedTabs.url.dragHandleAria', undefined, {
+            name: item.title || originalUrl,
+          })}
           className='cursor-grab p-1 active:cursor-grabbing'
           data-testid='project-url-drag-handle'
         >

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsContent.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsContent.tsx
@@ -132,6 +132,7 @@ export const SortableCategorySection = ({
             data-testid='draggable-category-handle'
             {...attributes}
             {...listeners}
+            aria-label={t('savedTabs.category.dragHandleAria')}
           >
             <div className='mr-2 text-muted-foreground'>
               <GripVertical size={16} aria-hidden='true' />

--- a/src/contexts/saved-tabs/presentation/components/SavedTabsContent.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SavedTabsContent.tsx
@@ -132,7 +132,9 @@ export const SortableCategorySection = ({
             data-testid='draggable-category-handle'
             {...attributes}
             {...listeners}
-            aria-label={t('savedTabs.category.dragHandleAria')}
+            aria-label={t('savedTabs.category.dragHandleAria', undefined, {
+              name: categoryDisplayName,
+            })}
           >
             <div className='mr-2 text-muted-foreground'>
               <GripVertical size={16} aria-hidden='true' />

--- a/src/contexts/saved-tabs/presentation/components/SortableCategorySection.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableCategorySection.tsx
@@ -335,6 +335,7 @@ const useSortableCategorySectionView = ({
             className={`flex grow items-center gap-2 ${isDragging ? 'cursor-grabbing' : 'cursor-grab hover:cursor-grab active:cursor-grabbing'}`}
             {...attributes}
             {...listeners}
+            aria-label={t('savedTabs.category.dragHandleAria')}
           >
             <div className='text-muted-foreground'>
               <GripVertical size={16} aria-hidden='true' />

--- a/src/contexts/saved-tabs/presentation/components/SortableCategorySection.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableCategorySection.tsx
@@ -335,7 +335,9 @@ const useSortableCategorySectionView = ({
             className={`flex grow items-center gap-2 ${isDragging ? 'cursor-grabbing' : 'cursor-grab hover:cursor-grab active:cursor-grabbing'}`}
             {...attributes}
             {...listeners}
-            aria-label={t('savedTabs.category.dragHandleAria')}
+            aria-label={t('savedTabs.category.dragHandleAria', undefined, {
+              name: displayedCategoryName,
+            })}
           >
             <div className='text-muted-foreground'>
               <GripVertical size={16} aria-hidden='true' />

--- a/src/contexts/saved-tabs/presentation/components/SortableUrlItem.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableUrlItem.tsx
@@ -216,6 +216,7 @@ export const SortableUrlItem = ({
           className='z-10 shrink-0 cursor-grab px-2.5 text-muted-foreground hover:cursor-grab active:cursor-grabbing'
           {...attributes}
           {...listeners}
+          aria-label={t('savedTabs.url.dragHandleAria')}
         >
           <GripVertical size={16} aria-hidden='true' />
         </div>

--- a/src/contexts/saved-tabs/presentation/components/SortableUrlItem.tsx
+++ b/src/contexts/saved-tabs/presentation/components/SortableUrlItem.tsx
@@ -216,7 +216,9 @@ export const SortableUrlItem = ({
           className='z-10 shrink-0 cursor-grab px-2.5 text-muted-foreground hover:cursor-grab active:cursor-grabbing'
           {...attributes}
           {...listeners}
-          aria-label={t('savedTabs.url.dragHandleAria')}
+          aria-label={t('savedTabs.url.dragHandleAria', undefined, {
+            name: title,
+          })}
         >
           <GripVertical size={16} aria-hidden='true' />
         </div>

--- a/src/entrypoints/app/index.html
+++ b/src/entrypoints/app/index.html
@@ -7,7 +7,7 @@
     <title>TABBIN App</title>
   </head>
   <body>
-    <main id="app" data-entrypoint="app-shell"></main>
+    <div id="app" data-entrypoint="app-shell"></div>
     <script type="module" src="./main.tsx" data-bootstrap="app"></script>
   </body>
 </html>

--- a/src/features/i18n/messages.ts
+++ b/src/features/i18n/messages.ts
@@ -516,7 +516,7 @@ const messages = {
     'options.title': 'Options',
     'periodicExecution.title': 'Scheduled tasks',
     'savedTabs.addProject': 'Add project',
-    'savedTabs.category.dragHandleAria': 'Drag to reorder category',
+    'savedTabs.category.dragHandleAria': 'Drag to reorder category "{{name}}"',
     'savedTabs.category.deleteAllItemName': 'domains in this category',
     'savedTabs.category.deleteAllWarning':
       'Delete all domains in this category. This action cannot be undone.',
@@ -817,7 +817,7 @@ const messages = {
       'Removed {{count}} opened tabs from saved data',
     'savedTabs.undo.restoreError': 'Could not restore saved data',
     'savedTabs.undo.restored': 'Restored saved data',
-    'savedTabs.url.dragHandleAria': 'Drag to reorder tab',
+    'savedTabs.url.dragHandleAria': 'Drag to reorder tab "{{name}}"',
     'savedTabs.url.deleteAria': 'Delete tab',
     'savedTabs.url.deleteConfirmDescription':
       'Delete this tab. This action cannot be undone.',
@@ -1361,7 +1361,8 @@ const messages = {
     'options.title': 'オプション',
     'periodicExecution.title': '定期実行',
     'savedTabs.addProject': 'プロジェクト追加',
-    'savedTabs.category.dragHandleAria': 'ドラッグしてカテゴリを並べ替える',
+    'savedTabs.category.dragHandleAria':
+      'ドラッグしてカテゴリ「{{name}}」を並べ替える',
     'savedTabs.category.deleteAllItemName': 'このカテゴリのドメイン',
     'savedTabs.category.deleteAllWarning':
       'カテゴリ内のすべてのドメインを削除します。この操作は元に戻せません。',
@@ -1659,7 +1660,7 @@ const messages = {
       '開いた{{count}}件のタブを保存データから削除しました',
     'savedTabs.undo.restoreError': '保存データを復元できませんでした',
     'savedTabs.undo.restored': '保存データを復元しました',
-    'savedTabs.url.dragHandleAria': 'ドラッグしてタブを並べ替える',
+    'savedTabs.url.dragHandleAria': 'ドラッグしてタブ「{{name}}」を並べ替える',
     'savedTabs.url.deleteAria': 'タブを削除',
     'savedTabs.url.deleteConfirmDescription':
       'このタブを削除します。この操作は元に戻せません。',

--- a/src/features/i18n/messages.ts
+++ b/src/features/i18n/messages.ts
@@ -516,6 +516,7 @@ const messages = {
     'options.title': 'Options',
     'periodicExecution.title': 'Scheduled tasks',
     'savedTabs.addProject': 'Add project',
+    'savedTabs.category.dragHandleAria': 'Drag to reorder category',
     'savedTabs.category.deleteAllItemName': 'domains in this category',
     'savedTabs.category.deleteAllWarning':
       'Delete all domains in this category. This action cannot be undone.',
@@ -816,6 +817,7 @@ const messages = {
       'Removed {{count}} opened tabs from saved data',
     'savedTabs.undo.restoreError': 'Could not restore saved data',
     'savedTabs.undo.restored': 'Restored saved data',
+    'savedTabs.url.dragHandleAria': 'Drag to reorder tab',
     'savedTabs.url.deleteAria': 'Delete tab',
     'savedTabs.url.deleteConfirmDescription':
       'Delete this tab. This action cannot be undone.',
@@ -1359,6 +1361,7 @@ const messages = {
     'options.title': 'オプション',
     'periodicExecution.title': '定期実行',
     'savedTabs.addProject': 'プロジェクト追加',
+    'savedTabs.category.dragHandleAria': 'ドラッグしてカテゴリを並べ替える',
     'savedTabs.category.deleteAllItemName': 'このカテゴリのドメイン',
     'savedTabs.category.deleteAllWarning':
       'カテゴリ内のすべてのドメインを削除します。この操作は元に戻せません。',
@@ -1656,6 +1659,7 @@ const messages = {
       '開いた{{count}}件のタブを保存データから削除しました',
     'savedTabs.undo.restoreError': '保存データを復元できませんでした',
     'savedTabs.undo.restored': '保存データを復元しました',
+    'savedTabs.url.dragHandleAria': 'ドラッグしてタブを並べ替える',
     'savedTabs.url.deleteAria': 'タブを削除',
     'savedTabs.url.deleteConfirmDescription':
       'このタブを削除します。この操作は元に戻せません。',

--- a/tools/renovate-policy.test.ts
+++ b/tools/renovate-policy.test.ts
@@ -225,7 +225,7 @@ describe('Renovate dependency update policy', () => {
         .map((section) => section.split('\n      - ')[0]),
     )
 
-    expect(checkoutSteps).toHaveLength(5)
+    expect(checkoutSteps).toHaveLength(6)
     for (const checkoutStep of checkoutSteps) {
       expect(checkoutStep).toContain('persist-credentials: false')
     }


### PR DESCRIPTION
## 変更内容

- `@axe-core/playwright` を導入し、saved-tabs / options の E2E accessibility smoke test を追加
- axe 検査で発見した 4 件の a11y 違反を根本修正
- E2E accessibility テストを CI に追加 (`e2e-accessibility` job)

## 問題の原因

axe 検査 (WCAG 2.0/2.1 A・AA) を saved-tabs と options で実行したところ、以下 4 件の違反を検出した。

1. **landmark-main-is-top-level / landmark-no-duplicate-main / landmark-unique** — `src/entrypoints/app/index.html` が `<main id="app">` をマウントポイントとして使用しており、`SidebarInset` が描画する `<main>` と重複していた。内側の `<main>` が外側の `<main>` にネストされ、ランドマーク階層が不正になっていた。
2. **page-has-heading-one** — saved-tabs 画面に h1 见出しが存在しなかった。options 画面には h1 があったが、重複 `<main>` の影響で axe が正しく検出できていなかった。
3. **aria-command-name** — `@dnd-kit/sortable` の `attributes` が付与する `role="button"` を持つドラッグハンドル (SortableUrlItem, ProjectUrlItem, SortableCategorySection, SavedTabsContent) に accessible name がなかった。GripVertical アイコンは `aria-hidden` で、テキストコンテンツもないため名前解決できていなかった。

## 採用した解決方法

- **重複 main ランドマーク**: `app/index.html` の `<main id="app">` を `<div id="app">` に変更。`SidebarInset` の `<main>` が唯一の main ランドマークとなる。他の entrypoint HTML はすでに `<div>` を使用しているため、これと一致する。
- **h1 欠落**: `SavedTabsApp` に `<h1 className='sr-only'>` を追加し、`t('sidebar.tabList')` を見出しとして設定。視覚的デザインは変更せず、スクリーンリーダー向けのセマンティック見出しを提供。
- **aria-command-name**: 4 つのドラッグハンドルに `aria-label` を追加。i18n キー `savedTabs.url.dragHandleAria` / `savedTabs.category.dragHandleAria` を en/ja 両方に追加。`ProjectUrlItem` の GripVertical に `aria-hidden='true'` を追加 (他のコンポーネントと一致)。
- **axe テストインフラ**: `e2e/helpers/axe.ts` に `assertNoAxeViolations` helper を作成。WCAG 2.0/2.1 A・AA タグで検査し、violation 0 件を assert する。false positive が発生した場合は `disabledRules` に理由付きで記録する方針をコメントで明記。
- **CI 統合**: `e2e-accessibility` job を `ci.yml` に追加し、`bun run e2e:a11y` を CI で実行。Playwright ブラウザのインストールと global setup による拡張機能ビルドを含む。

## 主要な変更内容

| ファイル | 変更 |
|---------|------|
| `src/entrypoints/app/index.html` | `<main id="app">` → `<div id="app">` |
| `src/contexts/saved-tabs/presentation/app/SavedTabsApp.tsx` | `<h1 className='sr-only'>` 追加 |
| `src/contexts/saved-tabs/presentation/components/SortableUrlItem.tsx` | ドラッグハンドルに `aria-label` 追加 |
| `src/contexts/saved-tabs/presentation/components/ProjectUrlItem.tsx` | ドラッグハンドルに `aria-label` + `aria-hidden` 追加 |
| `src/contexts/saved-tabs/presentation/components/SortableCategorySection.tsx` | ドラッグハンドルに `aria-label` 追加 |
| `src/contexts/saved-tabs/presentation/components/SavedTabsContent.tsx` | ドラッグハンドルに `aria-label` 追加 |
| `src/features/i18n/messages.ts` | `savedTabs.url.dragHandleAria` / `savedTabs.category.dragHandleAria` 追加 (en/ja) |
| `e2e/helpers/axe.ts` | axe helper 新規作成 |
| `e2e/saved-tabs.a11y.extension.spec.ts` | saved-tabs axe smoke test 新規作成 |
| `e2e/options.a11y.extension.spec.ts` | options axe smoke test 新規作成 |
| `package.json` | `@axe-core/playwright` devDependency, `e2e:a11y` script 追加 |
| `.github/workflows/ci.yml` | `e2e-accessibility` CI job 追加 |
| `tools/renovate-policy.test.ts` | checkout step 数の期待値を 5 → 6 に更新 |

## regression risk と確認内容

- **`<main>` → `<div>` 変更**: `mountToElement` は `document.querySelector('#app')` で要素を検索するため、要素型に依存しない。他の entrypoint HTML (`saved-tabs/index.html`, `changelog/index.html`) はすでに `<div id="app">` を使用しており、今回の変更で一致する。
- **ドラッグハンドルの `aria-label`**: `@dnd-kit/sortable` の `attributes` に含まれないプロパティであるため、D&D 機能への影響はない。既存の E2E テスト (saved-tabs.extension.spec.ts) でドラッグ操作が正常に動作することを確認済み。
- **i18n key 追加**: `messages-parity.test.ts` が en/ja の key セット一致を検証しており、テストが通過することを確認済み。
- **CI job 追加**: `renovate-policy.test.ts` の checkout step 数期待値を更新し、テストが通過することを確認済み。
- **既存テストへの影響**: 3474 個の unit/integration テストが全て通過。E2E a11y テスト 2 件が通過。既存の E2E 拡張機能テスト 7/8 件が通過 (1 件は develop ブランチでも失敗する pre-existing の flaky test)。

## 実行した test / quality command

- `bun run quality:check` — PASSED (format, compile, lint, validate:html, test, knip, duplication, secretlint, arch:check)
- `bun run build` — PASSED
- `bun run build:firefox` — PASSED
- `bun run verify:production-logging` — PASSED
- `bun run verify:app-version` — PASSED
- `bun run verify:production-network-policy` — PASSED
- `bun run e2e:a11y` — PASSED (2 tests)
- `bun run e2e` (saved-tabs + options extension specs) — 7 passed, 1 pre-existing failure

## Issue の acceptance criteria

- [x] axe ベースの accessibility 検査を導入する — `@axe-core/playwright` を devDependency に追加し、`e2e/helpers/axe.ts` で WCAG 2.0/2.1 A・AA 検査 helper を実装
- [x] saved-tabs の最低限の検査がある — `e2e/saved-tabs.a11y.extension.spec.ts` でドメインモードの smoke test を追加
- [x] options の最低限の検査がある — `e2e/options.a11y.extension.spec.ts` で設定画面の smoke test を追加
- [x] false positive の扱いが明確になっている — `e2e/helpers/axe.ts` に false positive 対応方針をコメントで明記 (ルール disable ではなく根本修正を優先、やむを得ない場合は `disabledRules` に理由付きで記録)
- [x] CI 実行に含めるか、手動 script にするか決める — CI に含める決定し、`e2e-accessibility` job を `ci.yml` に追加。`bun run e2e:a11y` でローカル実行も可能。
- [x] 関連テストが通る — 全 unit/integration テスト (3474件) + E2E a11y テスト (2件) が通過

closes #681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **アクセシビリティ改善**
  - 保存済みタブ画面のドラッグハンドルに、スクリーンリーダー向けの多言語ARIAラベルを追加しました。
  - 読み上げ向けの見出し（構造）を追加し、ページのナビゲーション性を改善しました。
  - オプション画面と保存済みタブ画面のアクセシビリティを強化しました。
- **テスト**
  - WCAG準拠を確認する自動E2Eアクセシビリティテスト（axe）を追加しました。
  - CIでアクセシビリティテストを実行するようにしました。
  - `e2e:a11y` スクリプトを追加し、対象テストのみ実行できるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->