### PR TITLE
UserSettings を Zod schema で runtime validation する

### DIFF
--- a/src/contexts/saved-tabs/domain/services/UserSettingsDefaults.test.ts
+++ b/src/contexts/saved-tabs/domain/services/UserSettingsDefaults.test.ts
@@ -148,10 +148,17 @@ describe('normalizeUserSettings', () => {
     expect(result.normalized.openUrlInBackground).toBe(true)
   })
 
-  it('aiSystemPrompts の空 id preset を含む場合は default に fallback する', () => {
+  it('aiSystemPrompts は無効要素だけ除外し、有効な preset を保持する', () => {
     const result = normalizeUserSettings({
       userSettings: {
         aiSystemPrompts: [
+          {
+            id: 'valid',
+            name: 'Valid',
+            template: 't',
+            createdAt: 0,
+            updatedAt: 0,
+          },
           { id: '', name: 'Empty', template: 't', createdAt: 0, updatedAt: 0 },
         ],
       },
@@ -159,5 +166,6 @@ describe('normalizeUserSettings', () => {
 
     expect(result.normalized.aiSystemPrompts).toBeDefined()
     expect(result.normalized.aiSystemPrompts).toHaveLength(1)
+    expect(result.normalized.aiSystemPrompts?.[0].id).toBe('valid')
   })
 })

--- a/src/contexts/saved-tabs/domain/services/UserSettingsDefaults.test.ts
+++ b/src/contexts/saved-tabs/domain/services/UserSettingsDefaults.test.ts
@@ -115,4 +115,49 @@ describe('normalizeUserSettings', () => {
     expect(result.normalized.aiSystemPrompts).not.toBe(aiSystemPrompts)
     expect(result.normalized.aiSystemPrompts?.[0]).not.toBe(aiSystemPrompts[0])
   })
+
+  it('clickBehavior が enum 外れなら default に fallback する', () => {
+    const result = normalizeUserSettings({
+      userSettings: {
+        clickBehavior: 'invalid-behavior',
+      },
+    })
+
+    expect(result.normalized.clickBehavior).toBe('saveSameDomainTabs')
+  })
+
+  it('autoDeletePeriod が enum 外れなら default に fallback する', () => {
+    const result = normalizeUserSettings({
+      userSettings: {
+        autoDeletePeriod: 'invalid-period',
+      },
+    })
+
+    expect(result.normalized.autoDeletePeriod).toBe('never')
+  })
+
+  it('boolean field が型不正なら default に fallback する', () => {
+    const result = normalizeUserSettings({
+      userSettings: {
+        excludePinnedTabs: 'not-boolean',
+        openUrlInBackground: 1,
+      },
+    })
+
+    expect(result.normalized.excludePinnedTabs).toBe(true)
+    expect(result.normalized.openUrlInBackground).toBe(true)
+  })
+
+  it('aiSystemPrompts の空 id preset を含む場合は default に fallback する', () => {
+    const result = normalizeUserSettings({
+      userSettings: {
+        aiSystemPrompts: [
+          { id: '', name: 'Empty', template: 't', createdAt: 0, updatedAt: 0 },
+        ],
+      },
+    })
+
+    expect(result.normalized.aiSystemPrompts).toBeDefined()
+    expect(result.normalized.aiSystemPrompts).toHaveLength(1)
+  })
 })

--- a/src/contexts/saved-tabs/domain/services/UserSettingsDefaults.ts
+++ b/src/contexts/saved-tabs/domain/services/UserSettingsDefaults.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_AI_SYSTEM_PROMPT_TEMPLATE,
   normalizeAiSystemPromptSettings,
 } from '@/features/ai-chat/lib/systemPromptPresets'
+import { parseStoredUserSettings } from '@/lib/storage/zod-storage'
 
 /**
  * `UserSettingsDto` の domain 既定値。repository / use-case 初期値や未保存状態
@@ -129,7 +130,9 @@ export const normalizeUserSettings = (
 } => {
   if (isStrippableSettings(stored) && stored.userSettings) {
     const raw = stored.userSettings
-    const sanitizedStoredSettings = stripLegacyUserSettings(raw)
+    const sanitizedStoredSettings = parseStoredUserSettings(
+      stripLegacyUserSettings(raw),
+    )
     const mergedStoredSettings = mergeStoredUserSettings(
       sanitizedStoredSettings,
     )

--- a/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageSchema.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/chrome-storage/savedTabsStorageSchema.ts
@@ -73,6 +73,19 @@ export const DomainCategorySettingsRawSchema = z.object({
   categoryKeywords: z.array(subCategoryKeywordSchema),
 })
 
+const AUTO_DELETE_PERIOD_VALUES = new Set([
+  'never',
+  '30sec',
+  '1min',
+  '1hour',
+  '1day',
+  '7days',
+  '14days',
+  '30days',
+  '180days',
+  '365days',
+])
+
 export const UserSettingsRawSchema = z.object({
   language: z
     .union([z.literal('system'), z.literal('ja'), z.literal('en')])
@@ -81,7 +94,12 @@ export const UserSettingsRawSchema = z.object({
   removeTabAfterExternalDrop: z.boolean(),
   excludePatterns: z.array(z.string()),
   enableCategories: z.boolean(),
-  autoDeletePeriod: z.string().optional(),
+  autoDeletePeriod: z
+    .string()
+    .refine((val) => AUTO_DELETE_PERIOD_VALUES.has(val), {
+      message: 'Invalid auto delete period',
+    })
+    .optional(),
   showSavedTime: z.boolean(),
   clickBehavior: z.enum([
     'saveCurrentTab',
@@ -100,8 +118,8 @@ export const UserSettingsRawSchema = z.object({
   aiSystemPrompts: z
     .array(
       z.object({
-        id: z.string(),
-        name: z.string(),
+        id: z.string().min(1),
+        name: z.string().min(1),
         template: z.string(),
         createdAt: z.number(),
         updatedAt: z.number(),

--- a/src/features/options/lib/import-export/schemas.test.ts
+++ b/src/features/options/lib/import-export/schemas.test.ts
@@ -532,4 +532,60 @@ describe('backupDataSchema - safeParse', () => {
     const result = backupDataSchema.safeParse(data)
     expect(result.success).toBe(false)
   })
+
+  it('userSettings の clickBehavior が enum 外れでもパースは成功し、該当 field は undefined になる', () => {
+    const data = {
+      ...baseBackup(),
+      userSettings: {
+        ...buildFullUserSettings(),
+        clickBehavior: 'invalid-behavior',
+      },
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+    expect(result?.userSettings.clickBehavior).toBeUndefined()
+  })
+
+  it('userSettings の autoDeletePeriod が enum 外れでもパースは成功し、該当 field は undefined になる', () => {
+    const data = {
+      ...baseBackup(),
+      userSettings: {
+        ...buildFullUserSettings(),
+        autoDeletePeriod: 'invalid-period',
+      },
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+    expect(result?.userSettings.autoDeletePeriod).toBeUndefined()
+  })
+
+  it('userSettings の boolean field が型不正でもパースは成功し、該当 field は undefined になる', () => {
+    const data = {
+      ...baseBackup(),
+      userSettings: {
+        ...buildFullUserSettings(),
+        excludePinnedTabs: 'not-boolean',
+      },
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+    expect(result?.userSettings.excludePinnedTabs).toBeUndefined()
+  })
+
+  it('userSettings の必須 field が欠損していてもパースは成功する (storedUserSettingsSchema は全 field optional)', () => {
+    const data = {
+      ...baseBackup(),
+      userSettings: {
+        language: 'ja',
+      },
+    }
+
+    const result = parseBackupData(JSON.stringify(data))
+    expect(result).not.toBeNull()
+    expect(result?.userSettings.language).toBe('ja')
+    expect(result?.userSettings.clickBehavior).toBeUndefined()
+  })
 })

--- a/src/features/options/lib/import-export/schemas.ts
+++ b/src/features/options/lib/import-export/schemas.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 import type { AiChatConversation } from '@/features/ai-chat/types'
 import type { SavedAnalyticsView } from '@/lib/storage/analytics'
+import { storedUserSettingsSchema } from '@/lib/storage/zod-storage'
 import { isValidUrl } from '@/lib/url-filter'
 import type { ParentCategory, UserSettings } from '@/types/storage'
 
@@ -288,41 +289,7 @@ const aiChatConversationSchema = z.object({
 const backupDataSchema: z.ZodType<BackupData> = z.object({
   version: z.string(),
   timestamp: z.string(),
-  userSettings: z.object({
-    activeAiSystemPromptId: z.string().optional(),
-    aiSystemPrompts: z
-      .array(
-        z.object({
-          id: z.string(),
-          name: z.string(),
-          template: z.string(),
-          createdAt: z.number(),
-          updatedAt: z.number(),
-        }),
-      )
-      .optional(),
-    autoDeletePeriod: z.string().optional(),
-    clickBehavior: z.enum([
-      'saveCurrentTab',
-      'saveWindowTabs',
-      'saveSameDomainTabs',
-      'saveAllWindowsTabs',
-    ]),
-    enableCategories: z.boolean(),
-    excludePatterns: z.array(z.string()),
-    excludePinnedTabs: z.boolean().optional(),
-    openUrlInBackground: z.boolean().optional(),
-    openAllInNewWindow: z.boolean().optional(),
-    confirmDeleteAll: z.boolean().optional(),
-    confirmDeleteEach: z.boolean().optional(),
-    fontSizePercent: z.number().optional(),
-    colors: z.record(z.string(), z.string()).optional(),
-    language: z.enum(['system', 'ja', 'en']).optional(),
-    ollamaModel: z.string().optional(),
-    removeTabAfterExternalDrop: z.boolean().optional(),
-    removeTabAfterOpen: z.boolean(),
-    showSavedTime: z.boolean(),
-  }),
+  userSettings: storedUserSettingsSchema,
   parentCategories: z.array(
     z.object({
       id: z.string(),

--- a/src/lib/storage/settings.test.ts
+++ b/src/lib/storage/settings.test.ts
@@ -356,11 +356,18 @@ describe('settings storage', () => {
     expect(settings.openUrlInBackground).toBe(true)
   })
 
-  it('aiSystemPrompts の空 id preset を含む場合は default に fallback する', async () => {
+  it('aiSystemPrompts は無効要素だけ除外し、有効な preset を保持する', async () => {
     const storageLocal = {
       get: vi.fn(async () => ({
         userSettings: {
           aiSystemPrompts: [
+            {
+              id: 'valid',
+              name: 'Valid',
+              template: 't',
+              createdAt: 0,
+              updatedAt: 0,
+            },
             {
               id: '',
               name: 'Empty',
@@ -379,7 +386,7 @@ describe('settings storage', () => {
 
     const settings = await getUserSettings()
     expect(settings.aiSystemPrompts).toHaveLength(1)
-    expect(settings.aiSystemPrompts?.[0].id).toBe('default-id')
+    expect(settings.aiSystemPrompts?.[0].id).toBe('valid')
   })
 
   it('saveUserSettings は未正規化の clickBehavior を default に正規化して保存する', async () => {

--- a/src/lib/storage/settings.test.ts
+++ b/src/lib/storage/settings.test.ts
@@ -301,4 +301,124 @@ describe('settings storage', () => {
     )
     expect(errorSpy).toHaveBeenCalled()
   })
+
+  it('clickBehavior が enum 外れなら default に fallback する', async () => {
+    const storageLocal = {
+      get: vi.fn(async () => ({
+        userSettings: {
+          clickBehavior: 'invalid-behavior',
+          language: 'system',
+        },
+      })),
+      set: vi.fn(async () => undefined),
+    }
+    mocks.getChromeStorageLocal.mockReturnValue(storageLocal)
+
+    const { getUserSettings } = await loadModule()
+
+    const settings = await getUserSettings()
+    expect(settings.clickBehavior).toBe('saveSameDomainTabs')
+  })
+
+  it('autoDeletePeriod が enum 外れなら default に fallback する', async () => {
+    const storageLocal = {
+      get: vi.fn(async () => ({
+        userSettings: {
+          autoDeletePeriod: 'invalid-period',
+        },
+      })),
+      set: vi.fn(async () => undefined),
+    }
+    mocks.getChromeStorageLocal.mockReturnValue(storageLocal)
+
+    const { getUserSettings } = await loadModule()
+
+    const settings = await getUserSettings()
+    expect(settings.autoDeletePeriod).toBe('never')
+  })
+
+  it('boolean field が型不正なら default に fallback する', async () => {
+    const storageLocal = {
+      get: vi.fn(async () => ({
+        userSettings: {
+          excludePinnedTabs: 'not-boolean',
+          openUrlInBackground: 1,
+        },
+      })),
+      set: vi.fn(async () => undefined),
+    }
+    mocks.getChromeStorageLocal.mockReturnValue(storageLocal)
+
+    const { getUserSettings } = await loadModule()
+
+    const settings = await getUserSettings()
+    expect(settings.excludePinnedTabs).toBe(true)
+    expect(settings.openUrlInBackground).toBe(true)
+  })
+
+  it('aiSystemPrompts の空 id preset を含む場合は default に fallback する', async () => {
+    const storageLocal = {
+      get: vi.fn(async () => ({
+        userSettings: {
+          aiSystemPrompts: [
+            {
+              id: '',
+              name: 'Empty',
+              template: 't',
+              createdAt: 0,
+              updatedAt: 0,
+            },
+          ],
+        },
+      })),
+      set: vi.fn(async () => undefined),
+    }
+    mocks.getChromeStorageLocal.mockReturnValue(storageLocal)
+
+    const { getUserSettings } = await loadModule()
+
+    const settings = await getUserSettings()
+    expect(settings.aiSystemPrompts).toHaveLength(1)
+    expect(settings.aiSystemPrompts?.[0].id).toBe('default-id')
+  })
+
+  it('saveUserSettings は未正規化の clickBehavior を default に正規化して保存する', async () => {
+    const storageLocal = {
+      set: vi.fn(async () => undefined),
+    }
+    mocks.getChromeStorageLocal.mockReturnValue(storageLocal)
+
+    const { defaultSettings, saveUserSettings } = await loadModule()
+
+    await saveUserSettings({
+      ...defaultSettings,
+      clickBehavior: 'invalid-behavior' as never,
+    })
+
+    expect(storageLocal.set).toHaveBeenCalledWith({
+      userSettings: expect.objectContaining({
+        clickBehavior: 'saveSameDomainTabs',
+      }),
+    })
+  })
+
+  it('saveUserSettings は未正規化の autoDeletePeriod を default に正規化して保存する', async () => {
+    const storageLocal = {
+      set: vi.fn(async () => undefined),
+    }
+    mocks.getChromeStorageLocal.mockReturnValue(storageLocal)
+
+    const { defaultSettings, saveUserSettings } = await loadModule()
+
+    await saveUserSettings({
+      ...defaultSettings,
+      autoDeletePeriod: 'invalid-period' as never,
+    })
+
+    expect(storageLocal.set).toHaveBeenCalledWith({
+      userSettings: expect.objectContaining({
+        autoDeletePeriod: 'never',
+      }),
+    })
+  })
 })

--- a/src/lib/storage/settings.ts
+++ b/src/lib/storage/settings.ts
@@ -13,6 +13,7 @@ import {
   getChromeStorageLocal,
   warnMissingChromeStorage,
 } from '@/lib/browser/chrome-storage'
+import { parseStoredUserSettings } from '@/lib/storage/zod-storage'
 import type { UserSettings } from '@/types/storage'
 
 const stripLegacyUserSettings = (settings: unknown): Partial<UserSettings> => {
@@ -84,7 +85,9 @@ export const getUserSettings = async (): Promise<UserSettings> => {
     console.log('取得した設定データ:', data)
     if (Object.hasOwn(data, 'userSettings')) {
       console.log('保存された設定を使用:', data.userSettings)
-      const sanitizedStoredSettings = stripLegacyUserSettings(data.userSettings)
+      const sanitizedStoredSettings = parseStoredUserSettings(
+        stripLegacyUserSettings(data.userSettings),
+      )
       const mergedStoredSettings = mergeStoredUserSettings(
         sanitizedStoredSettings,
       )
@@ -123,8 +126,9 @@ export const saveUserSettings = async (
   settings: UserSettings,
 ): Promise<void> => {
   try {
+    const validatedSettings = parseStoredUserSettings(settings)
     const normalizedSettings = normalizeAiSystemPromptSettings(
-      mergeStoredUserSettings(settings),
+      mergeStoredUserSettings(validatedSettings),
     )
     console.log('ユーザー設定を保存:', normalizedSettings)
     const storageLocal = getChromeStorageLocal()

--- a/src/lib/storage/zod-storage.test.ts
+++ b/src/lib/storage/zod-storage.test.ts
@@ -3,9 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-
 import { z } from 'zod'
 
 import {
+  aiSystemPromptPresetSchema,
   fromStorageChange,
+  parseStoredUserSettings,
   safeParseArrayFromStorage,
+  storedUserSettingsSchema,
   TabGroupSchema,
+  UserSettingsSchema,
 } from './zod-storage'
 
 const ItemSchema = z.object({
@@ -88,6 +92,212 @@ describe('zod-storage helpers', () => {
       expect(result[0]).toStrictEqual(valid)
       expect(result[1]).toStrictEqual(valid)
       expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('UserSettingsSchema', () => {
+    it('autoDeletePeriod の enum 外れ値を拒否する', () => {
+      const result = UserSettingsSchema.safeParse({
+        removeTabAfterOpen: true,
+        removeTabAfterExternalDrop: false,
+        excludePatterns: [],
+        enableCategories: true,
+        showSavedTime: false,
+        clickBehavior: 'saveSameDomainTabs',
+        excludePinnedTabs: true,
+        openUrlInBackground: true,
+        openAllInNewWindow: false,
+        confirmDeleteAll: false,
+        confirmDeleteEach: false,
+        autoDeletePeriod: 'invalid-period',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('autoDeletePeriod の有効値を受け付ける', () => {
+      const result = UserSettingsSchema.safeParse({
+        removeTabAfterOpen: true,
+        removeTabAfterExternalDrop: false,
+        excludePatterns: [],
+        enableCategories: true,
+        showSavedTime: false,
+        clickBehavior: 'saveSameDomainTabs',
+        excludePinnedTabs: true,
+        openUrlInBackground: true,
+        openAllInNewWindow: false,
+        confirmDeleteAll: false,
+        confirmDeleteEach: false,
+        autoDeletePeriod: '30days',
+      })
+      expect(result.success).toBe(true)
+      if (!result.success) {
+        return
+      }
+      expect(result.data.autoDeletePeriod).toBe('30days')
+    })
+  })
+
+  describe('aiSystemPromptPresetSchema', () => {
+    it('id が空文字なら拒否する', () => {
+      const result = aiSystemPromptPresetSchema.safeParse({
+        id: '',
+        name: 'preset',
+        template: 'template',
+        createdAt: 0,
+        updatedAt: 0,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('name が空文字なら拒否する', () => {
+      const result = aiSystemPromptPresetSchema.safeParse({
+        id: 'preset-1',
+        name: '',
+        template: 'template',
+        createdAt: 0,
+        updatedAt: 0,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('有効な preset を受け付ける', () => {
+      const result = aiSystemPromptPresetSchema.safeParse({
+        id: 'preset-1',
+        name: 'My Preset',
+        template: 'You are helpful.',
+        createdAt: 1,
+        updatedAt: 2,
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('parseStoredUserSettings', () => {
+    it('有効な設定はそのまま返す', () => {
+      const result = parseStoredUserSettings({
+        language: 'en',
+        removeTabAfterOpen: false,
+        excludePatterns: ['chrome://'],
+        enableCategories: false,
+        showSavedTime: true,
+        clickBehavior: 'saveCurrentTab',
+        excludePinnedTabs: false,
+        openUrlInBackground: false,
+        openAllInNewWindow: true,
+        confirmDeleteAll: true,
+        confirmDeleteEach: true,
+        autoDeletePeriod: '7days',
+      })
+      expect(result.language).toBe('en')
+      expect(result.removeTabAfterOpen).toBe(false)
+      expect(result.clickBehavior).toBe('saveCurrentTab')
+      expect(result.autoDeletePeriod).toBe('7days')
+    })
+
+    it('型不正の boolean field は除外される', () => {
+      const result = parseStoredUserSettings({
+        removeTabAfterOpen: 'not-boolean',
+        clickBehavior: 'saveSameDomainTabs',
+      })
+      expect(result.removeTabAfterOpen).toBeUndefined()
+      expect(result.clickBehavior).toBe('saveSameDomainTabs')
+    })
+
+    it('enum 外れの clickBehavior は除外される', () => {
+      const result = parseStoredUserSettings({
+        clickBehavior: 'invalid-behavior',
+      })
+      expect(result.clickBehavior).toBeUndefined()
+    })
+
+    it('enum 外れの autoDeletePeriod は除外される', () => {
+      const result = parseStoredUserSettings({
+        autoDeletePeriod: 'invalid-period',
+      })
+      expect(result.autoDeletePeriod).toBeUndefined()
+    })
+
+    it('enum 外れの language は除外される', () => {
+      const result = parseStoredUserSettings({
+        language: 'fr',
+      })
+      expect(result.language).toBeUndefined()
+    })
+
+    it('excludePatterns 内の非文字列要素は除外され、文字列は保持される', () => {
+      const result = parseStoredUserSettings({
+        excludePatterns: ['custom', 123, null, 'chrome://'],
+      })
+      expect(result.excludePatterns).toStrictEqual(['custom', 'chrome://'])
+    })
+
+    it('excludePatterns が配列でなければ除外される', () => {
+      const result = parseStoredUserSettings({
+        excludePatterns: 'not-an-array',
+      })
+      expect(result.excludePatterns).toBeUndefined()
+    })
+
+    it('aiSystemPrompts 内の空 id preset を含む場合は配列全体が除外される', () => {
+      const result = parseStoredUserSettings({
+        aiSystemPrompts: [
+          {
+            id: 'valid',
+            name: 'Valid',
+            template: 't',
+            createdAt: 0,
+            updatedAt: 0,
+          },
+          { id: '', name: 'Empty', template: 't', createdAt: 0, updatedAt: 0 },
+        ],
+      })
+      expect(result.aiSystemPrompts).toBeUndefined()
+    })
+
+    it('colors の値が文字列でなければ除外される', () => {
+      const result = parseStoredUserSettings({
+        colors: { bg: 123 },
+      })
+      expect(result.colors).toBeUndefined()
+    })
+
+    it('fontSizePercent が数値でなければ除外される', () => {
+      const result = parseStoredUserSettings({
+        fontSizePercent: '100',
+      })
+      expect(result.fontSizePercent).toBeUndefined()
+    })
+
+    it('入力がオブジェクトでなければ空 object を返す', () => {
+      expect(parseStoredUserSettings('not-object')).toStrictEqual({})
+      expect(parseStoredUserSettings(null)).toStrictEqual({})
+      expect(parseStoredUserSettings(123)).toStrictEqual({})
+    })
+
+    it('全 field が不正な場合は空 object を返す', () => {
+      const result = parseStoredUserSettings({
+        language: 123,
+        removeTabAfterOpen: 'bad',
+        clickBehavior: 'bad',
+        autoDeletePeriod: 'bad',
+        fontSizePercent: 'bad',
+        colors: 'bad',
+        aiSystemPrompts: 'bad',
+      })
+      expect(result).toStrictEqual({})
+    })
+  })
+
+  describe('storedUserSettingsSchema', () => {
+    it('全 field optional で部分設定を受け付ける', () => {
+      const result = storedUserSettingsSchema.safeParse({
+        language: 'ja',
+      })
+      expect(result.success).toBe(true)
+      if (!result.success) {
+        return
+      }
+      expect(result.data.language).toBe('ja')
     })
   })
 })

--- a/src/lib/storage/zod-storage.test.ts
+++ b/src/lib/storage/zod-storage.test.ts
@@ -238,7 +238,7 @@ describe('zod-storage helpers', () => {
       expect(result.excludePatterns).toBeUndefined()
     })
 
-    it('aiSystemPrompts 内の空 id preset を含む場合は配列全体が除外される', () => {
+    it('aiSystemPrompts は無効要素だけ除外し、有効な preset は保持される', () => {
       const result = parseStoredUserSettings({
         aiSystemPrompts: [
           {
@@ -248,6 +248,16 @@ describe('zod-storage helpers', () => {
             createdAt: 0,
             updatedAt: 0,
           },
+          { id: '', name: 'Empty', template: 't', createdAt: 0, updatedAt: 0 },
+        ],
+      })
+      expect(result.aiSystemPrompts).toHaveLength(1)
+      expect(result.aiSystemPrompts?.[0].id).toBe('valid')
+    })
+
+    it('aiSystemPrompts が全て無効な場合は配列全体が除外される', () => {
+      const result = parseStoredUserSettings({
+        aiSystemPrompts: [
           { id: '', name: 'Empty', template: 't', createdAt: 0, updatedAt: 0 },
         ],
       })

--- a/src/lib/storage/zod-storage.ts
+++ b/src/lib/storage/zod-storage.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod'
 
-const AiSystemPromptPresetSchema = z.object({
-  id: z.string(),
-  name: z.string(),
+export const aiSystemPromptPresetSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
   template: z.string(),
   createdAt: z.number(),
   updatedAt: z.number(),
@@ -106,13 +106,40 @@ export const CustomProjectSchema = z.object({
   updatedAt: z.number().optional(),
 })
 
+const AUTO_DELETE_PERIOD_VALUES = new Set([
+  'never',
+  '30sec',
+  '1min',
+  '1hour',
+  '1day',
+  '7days',
+  '14days',
+  '30days',
+  '180days',
+  '365days',
+])
+
+const autoDeletePeriodField = z
+  .string()
+  .refine((val) => AUTO_DELETE_PERIOD_VALUES.has(val), {
+    message: 'Invalid auto delete period',
+  })
+  .optional()
+
+/**
+ * `UserSettings` の canonical Zod schema。
+ *
+ * 各 field の型・enum を検証する。`autoDeletePeriod` は有効な値のみ許可し、
+ * `aiSystemPrompts` の各 preset は id / name が空文字でないことを確認する。
+ * 出力型は `UserSettings` と構造完全一致するため、`z.infer` で型を導出できる。
+ */
 export const UserSettingsSchema = z.object({
   language: z.enum(['system', 'ja', 'en']).optional(),
   removeTabAfterOpen: z.boolean(),
   removeTabAfterExternalDrop: z.boolean(),
   excludePatterns: z.array(z.string()),
   enableCategories: z.boolean(),
-  autoDeletePeriod: z.string().optional(),
+  autoDeletePeriod: autoDeletePeriodField,
   showSavedTime: z.boolean(),
   clickBehavior: z.enum([
     'saveCurrentTab',
@@ -128,9 +155,89 @@ export const UserSettingsSchema = z.object({
   fontSizePercent: z.number().optional(),
   colors: z.record(z.string(), z.string()).optional(),
   ollamaModel: z.string().optional(),
-  aiSystemPrompts: z.array(AiSystemPromptPresetSchema).optional(),
+  aiSystemPrompts: z.array(aiSystemPromptPresetSchema).optional(),
   activeAiSystemPromptId: z.string().optional(),
 })
+
+/**
+ * `chrome.storage.local` / import から読み込んだ unknown 値を安全に検証する
+ * stored variant。全 field を optional + `.catch(undefined)` とし、
+ * 型不正や enum 外れの値は undefined へ fallback する。
+ *
+ * `parseStoredUserSettings` が undefined 値を取り除いて `Partial<UserSettings>`
+ * を返すため、merge 先の default が上書きされない。
+ */
+/* eslint-disable unicorn/prefer-top-level-await -- Zod .catch() not Promise .catch() */
+export const storedUserSettingsSchema = z.object({
+  language: z.enum(['system', 'ja', 'en']).optional().catch(undefined),
+  removeTabAfterOpen: z.boolean().optional().catch(undefined),
+  removeTabAfterExternalDrop: z.boolean().optional().catch(undefined),
+  excludePatterns: z
+    .preprocess(
+      (val) =>
+        Array.isArray(val)
+          ? val.filter((v): v is string => typeof v === 'string')
+          : undefined,
+      z.array(z.string()).optional(),
+    )
+    .catch(undefined),
+  enableCategories: z.boolean().optional().catch(undefined),
+  autoDeletePeriod: autoDeletePeriodField.catch(undefined),
+  showSavedTime: z.boolean().optional().catch(undefined),
+  clickBehavior: z
+    .enum([
+      'saveCurrentTab',
+      'saveWindowTabs',
+      'saveSameDomainTabs',
+      'saveAllWindowsTabs',
+    ])
+    .optional()
+    .catch(undefined),
+  excludePinnedTabs: z.boolean().optional().catch(undefined),
+  openUrlInBackground: z.boolean().optional().catch(undefined),
+  openAllInNewWindow: z.boolean().optional().catch(undefined),
+  confirmDeleteAll: z.boolean().optional().catch(undefined),
+  confirmDeleteEach: z.boolean().optional().catch(undefined),
+  fontSizePercent: z.number().optional().catch(undefined),
+  colors: z.record(z.string(), z.string()).optional().catch(undefined),
+  ollamaModel: z.string().optional().catch(undefined),
+  aiSystemPrompts: z
+    .array(aiSystemPromptPresetSchema)
+    .optional()
+    .catch(undefined),
+  activeAiSystemPromptId: z.string().optional().catch(undefined),
+})
+/* eslint-enable unicorn/prefer-top-level-await */
+
+/**
+ * unknown 値を `storedUserSettingsSchema` で safeParse し、
+ * 有効な field だけを抽出した `Partial<UserSettings>` を返す。
+ *
+ * 型不正・enum 外れの field は除外され、呼び出し側で default と merge される。
+ * parse 全体が失敗した場合は空 object を返す。
+ */
+export const parseStoredUserSettings = (
+  input: unknown,
+): Partial<z.infer<typeof UserSettingsSchema>> => {
+  if (typeof input !== 'object' || input === null) {
+    return {}
+  }
+  let data: z.infer<typeof storedUserSettingsSchema>
+  try {
+    data = storedUserSettingsSchema.parse(input)
+  } catch {
+    return {}
+  }
+  const filtered: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(data)) {
+    // eslint-disable-next-line typescript/no-unnecessary-condition -- .catch(undefined) が undefined を含むため実行時に必要
+    if (value !== undefined) {
+      filtered[key] = value
+    }
+  }
+  // eslint-disable-next-line typescript/no-unnecessary-type-assertion, typescript/consistent-type-assertions -- Zod 検証済みの Record を Partial<UserSettings> へ変換
+  return filtered as Partial<z.infer<typeof UserSettingsSchema>>
+}
 
 export const ParentCategorySchema = z.object({
   id: z.string(),

--- a/src/lib/storage/zod-storage.ts
+++ b/src/lib/storage/zod-storage.ts
@@ -202,8 +202,16 @@ export const storedUserSettingsSchema = z.object({
   colors: z.record(z.string(), z.string()).optional().catch(undefined),
   ollamaModel: z.string().optional().catch(undefined),
   aiSystemPrompts: z
-    .array(aiSystemPromptPresetSchema)
-    .optional()
+    .preprocess((val) => {
+      if (!Array.isArray(val)) {
+        return undefined
+      }
+      const filtered = val.filter(
+        (item): item is z.infer<typeof aiSystemPromptPresetSchema> =>
+          aiSystemPromptPresetSchema.safeParse(item).success,
+      )
+      return filtered.length > 0 ? filtered : undefined
+    }, z.array(aiSystemPromptPresetSchema).optional())
     .catch(undefined),
   activeAiSystemPromptId: z.string().optional().catch(undefined),
 })

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -1,3 +1,10 @@
+import type { z } from 'zod'
+
+import type {
+  UserSettingsSchema,
+  aiSystemPromptPresetSchema,
+} from '@/lib/storage/zod-storage'
+
 // URLレコードのインターフェース（共通URL管理用）
 export type UrlRecord = {
   id: string
@@ -50,30 +57,13 @@ export type TabGroup = {
   savedAt?: number // グループ全体の保存時刻を追加
 }
 
-export type UserSettings = {
-  language?: 'system' | 'ja' | 'en'
-  removeTabAfterOpen: boolean
-  removeTabAfterExternalDrop: boolean
-  excludePatterns: string[]
-  enableCategories: boolean // カテゴリ機能の有効/無効
-  autoDeletePeriod?: string // Never, 1hour, 1day, 7days, 14days, 30days, 180days, 365days
-  showSavedTime: boolean // 保存日時を表示するかどうか
-  clickBehavior:
-    | 'saveCurrentTab'
-    | 'saveWindowTabs'
-    | 'saveSameDomainTabs'
-    | 'saveAllWindowsTabs' // 新しいオプション: クリック時の挙動
-  excludePinnedTabs: boolean // 固定タブ（ピン留め）を除外するかどうか
-  openUrlInBackground: boolean // URLクリック時に別タブで開くかどうか
-  openAllInNewWindow: boolean // 「すべてのタブを開く」を別ウィンドウで開くかどうか
-  confirmDeleteAll: boolean // すべて削除前に確認するかどうか
-  confirmDeleteEach: boolean // URL削除前に個別確認するかどうか
-  fontSizePercent?: number
-  colors?: Record<string, string> // ユーザー設定: カラー設定まとめ
-  ollamaModel?: string
-  aiSystemPrompts?: AiSystemPromptPreset[]
-  activeAiSystemPromptId?: string
-}
+/**
+ * `UserSettings` の runtime schema から導出する型 (issue #672)。
+ *
+ * `z.infer<typeof UserSettingsSchema>` と構造一致するため、schema と
+ * TypeScript interface の二重管理を回避できる。
+ */
+export type UserSettings = z.infer<typeof UserSettingsSchema>
 
 // ドメイン別のカテゴリ設定を保存するためのインターフェース
 export type DomainCategorySettings = {
@@ -117,13 +107,10 @@ export type CustomProject = {
   updatedAt: number
 }
 
-export type AiSystemPromptPreset = {
-  id: string
-  name: string
-  template: string
-  createdAt: number
-  updatedAt: number
-}
+/**
+ * AI system prompt preset の runtime schema から導出する型 (issue #672)。
+ */
+export type AiSystemPromptPreset = z.infer<typeof aiSystemPromptPresetSchema>
 
 // ビューモード（表示モード）の型定義
 export type ViewMode = 'domain' | 'custom'


### PR DESCRIPTION
## 変更内容

- `UserSettingsSchema` に `autoDeletePeriod` の enum 検証と `aiSystemPrompts` preset の id/name 空文字検証を追加
- `storedUserSettingsSchema` と `parseStoredUserSettings` を追加し、chrome.storage.local / import からの unknown 値を per-field で安全に検証
- `getUserSettings` / `saveUserSettings` / `normalizeUserSettings` (DDD path) で `parseStoredUserSettings` を通してから default と merge するよう変更
- `backupDataSchema` の inline userSettings schema を `storedUserSettingsSchema` に統一し、validation 方針を統合
- `UserSettingsRawSchema` (DDD infrastructure) にも enum 検証を追加
- `UserSettings` / `AiSystemPromptPreset` 型を `z.infer<typeof UserSettingsSchema>` から導出し、schema と TypeScript interface の二重管理を解消

## 問題の原因

`UserSettings` は TypeScript interface として定義されていたが、`chrome.storage.local` や import/export から読み込む値は runtime では unknown だった。保存済み settings を default と merge する処理はあったが、各 field の型・enum・配列内容を schema で検証する仕組みがなかった。そのため、型不正の値 (例: `clickBehavior: "invalid"`、`excludePinnedTabs: "not-boolean"`) がそのまま merge されて保存される可能性があった。

## 採用した解決方法

1. `UserSettingsSchema` を canonical Zod schema として強化し、`autoDeletePeriod` は有効な enum 値のみ許可、`aiSystemPrompts` の各 preset は id/name が空文字でないことを確認
2. `storedUserSettingsSchema` を全 field optional + `.catch(undefined)` で定義し、型不正・enum 外れの値は per-field で undefined へ fallback する
3. `parseStoredUserSettings` が undefined 値を取り除いた `Partial<UserSettings>` を返すことで、merge 先の default が上書きされない
4. `excludePatterns` は preprocess で非文字列要素を filter し、既存の `mergeExcludePatterns` による trim・重複除去と整合する
5. `UserSettings` 型を `z.infer<typeof UserSettingsSchema>` から導出し、schema と型定義の二重管理を解消

## 主要な変更内容

| ファイル | 変更 |
|---------|------|
| `src/lib/storage/zod-storage.ts` | `UserSettingsSchema` 強化、`storedUserSettingsSchema` / `parseStoredUserSettings` / `aiSystemPromptPresetSchema` 追加 |
| `src/types/storage.ts` | `UserSettings` / `AiSystemPromptPreset` を `z.infer` から導出 |
| `src/lib/storage/settings.ts` | `getUserSettings` / `saveUserSettings` で `parseStoredUserSettings` を使用 |
| `src/contexts/saved-tabs/domain/services/UserSettingsDefaults.ts` | `normalizeUserSettings` で `parseStoredUserSettings` を使用 |
| `src/features/options/lib/import-export/schemas.ts` | `backupDataSchema` の inline schema を `storedUserSettingsSchema` に置換 |
| `src/contexts/saved-tabs/infrastructure/.../savedTabsStorageSchema.ts` | `UserSettingsRawSchema` に enum 検証を追加 |

## regression risk と確認内容

- **既存ユーザーデータ互換性**: `parseStoredUserSettings` は invalid field を undefined (default fallback) に寄せるため、有効な field は保持される。`excludePatterns` は非文字列要素のみ filter し、有効な文字列は保持される
- **import/export 互換性**: `backupDataSchema` が `storedUserSettingsSchema` (全 field optional) を使うようになったため、必須 field が欠損した旧バックアップも import 可能になった (従来は必須 field 欠損で import 失敗)
- **storage change listener**: `UserSettingsSchema` の強化 (autoDeletePeriod enum, preset name) は既存の `fromStorageChange` にも適用されるが、保存済みデータは `saveUserSettings` で正規化済みのため実影響はない

## 実行した test / quality command

- `bun run compile` (tsgo --noEmit) — pass
- `bun run lint` (oxlint) — pass
- `bun run format:check` (oxfmt) — pass
- `bun run test` (vitest, 322 files / 3509 tests) — pass
- `bun run knip` — pass
- `bun run check:duplication` — pass
- `bun run arch:check` (depcruise) — pass
- `bun run secretlint` — pass
- `bun run release:check` (quality:check + build + build:firefox + verify scripts) — pass

## Issue acceptance criteria の確認

- [x] `UserSettings` の runtime schema がある → `UserSettingsSchema` を強化、`z.infer` から型を導出
- [x] `getUserSettings` が保存済み settings を schema validation してから返す → `parseStoredUserSettings` を `stripLegacyUserSettings` の後に適用
- [x] 想定外の field value は default / normalized value に fallback する → `storedUserSettingsSchema` の per-field `.catch(undefined)` で実現
- [x] `saveUserSettings` が未正規化の settings をそのまま保存しない → `parseStoredUserSettings` で検証後に merge / normalize して保存
- [x] import/export の settings merge と validation 方針が統一されている → `backupDataSchema` が `storedUserSettingsSchema` を使用
- [x] storage 値の validation テストを追加 → `zod-storage.test.ts` / `settings.test.ts` / `UserSettingsDefaults.test.ts` / `schemas.test.ts` に追加
- [x] 既存テストが通る → 全 3509 test pass

closes #672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 設定の読み込み・保存時に バリデーション と 正規化 を行い、不正値は既定値へフォールバック
  - 設定バックアップの取り込みでも enum / boolean の不正や欠損があっても、 有効な項目のみ復元
  - AI システムプロンプトから 空の ID / 名前 を含む要素を除外
- **テスト**
  - 設定スキーマとバックアップパースの受理・拒否ケースを追加で検証
<!-- end of auto-generated comment: release notes by coderabbit.ai -->