### PR TITLE
APM同期時の生成物ドリフトを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ web-ext.config.ts
 .opencode/
 .github/hooks/
 .github/instructions/
+.github/copilot-instructions.md
 .github/prompts/*.prompt.md
 .github/skills/
 

--- a/tools/scripts/sync-agent-config.test.ts
+++ b/tools/scripts/sync-agent-config.test.ts
@@ -277,6 +277,72 @@ describe('syncAgentConfig', () => {
     expect(() => validateRequiredAgentArtifacts(projectRoot)).not.toThrow()
   })
 
+  it('removes stale generated client artifacts before applying the verified deployment', () => {
+    const projectRoot = createProject()
+    const staleInstruction = path.join(
+      projectRoot,
+      '.github/instructions/removed.instructions.md',
+    )
+    const staleClientHooks = [
+      '.claude/hooks/TABBIN/scripts/stale.sh',
+      '.codex/hooks/TABBIN/scripts/stale.sh',
+      '.cursor/hooks/TABBIN/scripts/stale.sh',
+      '.gemini/hooks/TABBIN/scripts/stale.sh',
+    ].map((relativePath) => path.join(projectRoot, relativePath))
+    const preservedWorkflow = path.join(projectRoot, '.github/workflows/ci.yml')
+    const preservedIssueTemplate = path.join(
+      projectRoot,
+      '.github/ISSUE_TEMPLATE/bug_report.md',
+    )
+    const staleCopilotInstructions = path.join(
+      projectRoot,
+      '.github/copilot-instructions.md',
+    )
+    const harnessState = path.join(
+      projectRoot,
+      '.agents/harness/runtime-state.json',
+    )
+    mkdirSync(path.dirname(staleInstruction), { recursive: true })
+    for (const staleHook of staleClientHooks) {
+      mkdirSync(path.dirname(staleHook), { recursive: true })
+      writeFileSync(staleHook, '# stale generated hook\n')
+    }
+    mkdirSync(path.dirname(preservedWorkflow), { recursive: true })
+    mkdirSync(path.dirname(preservedIssueTemplate), { recursive: true })
+    mkdirSync(path.dirname(harnessState), { recursive: true })
+    writeFileSync(staleInstruction, '# Removed source\n')
+    writeFileSync(preservedWorkflow, 'name: CI\n')
+    writeFileSync(preservedIssueTemplate, '# Bug report\n')
+    writeFileSync(staleCopilotInstructions, '# stale generated instructions\n')
+    writeFileSync(harnessState, '{"status":"running"}\n')
+
+    let rootDeploymentSawClean = false
+    const runner: AgentConfigCommandRunner = (command, args, cwd) => {
+      if (
+        command === 'apm' &&
+        (args[0] !== 'compile' || !args.includes('--validate'))
+      ) {
+        if (cwd === projectRoot && !args.includes('--dry-run')) {
+          rootDeploymentSawClean =
+            !existsSync(staleInstruction) &&
+            !staleClientHooks.some((file) => existsSync(file)) &&
+            !existsSync(staleCopilotInstructions)
+        }
+        writeRequiredArtifacts(cwd)
+      }
+    }
+
+    syncAgentConfig({ projectRoot, runner })
+
+    expect(existsSync(staleInstruction)).toBe(false)
+    expect(staleClientHooks.some((file) => existsSync(file))).toBe(false)
+    expect(existsSync(staleCopilotInstructions)).toBe(false)
+    expect(rootDeploymentSawClean).toBe(true)
+    expect(readFileSync(preservedWorkflow, 'utf8')).toBe('name: CI\n')
+    expect(readFileSync(preservedIssueTemplate, 'utf8')).toBe('# Bug report\n')
+    expect(readFileSync(harnessState, 'utf8')).toBe('{"status":"running"}\n')
+  })
+
   it('fails apply mode when repository output diverges from verified scratch output', () => {
     const projectRoot = createProject()
     const runner: AgentConfigCommandRunner = (command, args, cwd) => {

--- a/tools/scripts/sync-agent-config.ts
+++ b/tools/scripts/sync-agent-config.ts
@@ -47,6 +47,31 @@ const TRACKED_SYNC_ARTIFACTS = [
   'apm.lock.yaml',
 ] as const
 
+const GENERATED_AGENT_ARTIFACT_PATHS = [
+  '.agents/skills',
+  '.claude/apm-hooks.json',
+  '.claude/commands',
+  '.claude/hooks/TABBIN',
+  '.claude/rules',
+  '.claude/settings.json',
+  '.claude/skills',
+  '.codex/hooks.json',
+  '.codex/hooks/TABBIN',
+  '.cursor/commands',
+  '.cursor/hooks.json',
+  '.cursor/hooks/TABBIN',
+  '.cursor/rules',
+  '.gemini/commands',
+  '.gemini/hooks/TABBIN',
+  '.gemini/settings.json',
+  '.github/copilot-instructions.md',
+  '.github/hooks',
+  '.github/instructions',
+  '.github/prompts',
+  '.github/skills',
+  '.opencode/commands',
+] as const
+
 type AgentConfigCommand = {
   args: readonly string[]
   command: string
@@ -181,6 +206,15 @@ const runDeployment = (
   }
 }
 
+const removeGeneratedAgentArtifacts = (projectRoot: string): void => {
+  for (const relativePath of GENERATED_AGENT_ARTIFACT_PATHS) {
+    rmSync(path.join(projectRoot, relativePath), {
+      force: true,
+      recursive: true,
+    })
+  }
+}
+
 const formatApmLockfile = (
   projectRoot: string,
   workingDirectory: string,
@@ -258,6 +292,7 @@ export const syncAgentConfig = ({
     if (checkOnly) {
       validateTrackedArtifactSync(projectRoot, scratchRoot)
     } else {
+      removeGeneratedAgentArtifacts(projectRoot)
       runDeployment(projectRoot, runner, true)
       formatApmLockfile(projectRoot, projectRoot, runner)
       validateRequiredAgentArtifacts(projectRoot)


### PR DESCRIPTION
## 概要

`bun run apm:sync` が、過去の APM 生成物（特に `.github/instructions` や各クライアントの `hooks/TABBIN`）を root 側へ再取り込みし、scratch 検証結果と `AGENTS.md` / `CLAUDE.md` が不一致になって失敗する問題を修正します。

## 原因

APM の dry-run / scratch 検証は現在の `.apm` source of truth から生成されますが、root の `apm install --force` は削除済みの生成先を完全には掃除しません。そのため、無視された stale artifact が root の再コンパイルへ混入し、idempotent な scratch 出力との差分として検出されていました。

## 対応

- root への verified deployment 前に、APM 管理下の生成先だけを明示的に削除
- Claude / Codex / Cursor / Gemini の `hooks/TABBIN` を cleanup 対象へ追加
- `.agents/harness`、`.github/workflows`、`.github/ISSUE_TEMPLATE` などのユーザー管理領域は保持
- stale instruction / hook / Copilot artifact の cleanup とデプロイ前実行順を回帰テストで固定

## 検証

- `bun run apm:sync`
- `bun run apm:check`
- 対象テスト: 14 tests passed
- `bun run test:coverage`: 323 files / 3524 tests passed（既存全体 coverage 97.28%）
- `bun run quality:check`: passed
- `bun run release:check`: passed（Chrome/Firefox build、production logging/network/version verifier を含む）

## リスク

cleanup 対象は APM が生成する既知のクライアント成果物に限定しています。ユーザー管理の GitHub workflow、Issue template、Harness runtime state は削除しません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * エージェント設定を再適用する際、古い生成済みの設定・コマンド・フックなどを事前に削除するよう改善しました。
  * 不要な古い成果物が残ることで、最新設定が正しく反映されない問題を防止します。
  * CI設定、Issueテンプレート、実行状態など、保持すべきファイルは削除されません。

* **テスト**
  * 古い成果物の削除と、保持対象ファイルが維持されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->