### PR TITLE
Oxlint で import/no-cycle を有効化して循環依存を検出する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -191,6 +191,10 @@
     "import/max-dependencies": "off",
     "import/no-commonjs": "off",
     "import/unambiguous": "off",
+    "import/no-cycle": [
+      "error",
+      { "ignoreTypes": true, "ignoreExternal": true, "maxDepth": 10 }
+    ],
     "promise/always-return": "off",
     "promise/avoid-new": "off",
     "promise/no-callback-in-promise": "off",

--- a/src/lib/architecture/dependencyCruiserConfig.test.ts
+++ b/src/lib/architecture/dependencyCruiserConfig.test.ts
@@ -532,10 +532,15 @@ describe('dependency-cruiser architecture rules', () => {
     expect(readFileSync(configPath, 'utf8')).toContain('module.exports')
   })
 
-  it('keeps circular dependency enforcement out of oxlint', () => {
-    expect(readFileSync(oxlintConfigPath, 'utf8')).not.toContain(
-      'import/no-cycle',
-    )
+  it('enables import/no-cycle in oxlint as early lint detection', () => {
+    const oxlintConfig = JSON.parse(readFileSync(oxlintConfigPath, 'utf8')) as {
+      rules: Record<string, unknown>
+    }
+
+    expect(oxlintConfig.rules['import/no-cycle']).toEqual([
+      'error',
+      { ignoreTypes: true, ignoreExternal: true, maxDepth: 10 },
+    ])
   })
 
   it('runs the architecture check in CI', () => {


### PR DESCRIPTION
## 概要

Issue #638 に対応し、Oxlint に `import/no-cycle` ルールを追加して import graph 上の循環依存を日常 lint で早期検出できるようにします。

## 変更内容

### `.oxlintrc.json`

`import/no-cycle` を `error` で追加:

```json
"import/no-cycle": [
  "error",
  { "ignoreTypes": true, "ignoreExternal": true, "maxDepth": 10 }
]
```

各設定値の意図:

- `ignoreTypes: true` — 型 import の循環は runtime に影響しないケースがあるため、まず runtime import の循環を優先検出する。`import type` への寄せは `typescript/consistent-type-imports`（既に `error`）と連動する。
- `ignoreExternal: true` — 外部 package 内の循環や package boundary の解析に引っ張られないようにする。まずは repository 内の実装に集中する。
- `maxDepth: 10` — 無制限にすると lint コストや検出ノイズが増えるため、まずは depth 10 で検証する。

### `src/lib/architecture/dependencyCruiserConfig.test.ts`

既存の architecture test が「oxlint に `import/no-cycle` が無いこと」を検証していたのを、「`import/no-cycle` が正しい設定値で有効化されていること」へ更新しました。

## dependency-cruiser との役割分担

- **dependency-cruiser**: 層・コンテキスト間の依存方向（architectural constraint）を制御する
- **`import/no-cycle`**: 日常 lint で import graph 上の循環を早期検出する

どちらか片方で代替せず、検出観点を分けます。

## 検証

- [x] `bun run lint` — 通過
- [x] `bun run arch:check` — 通過（1025 modules, 4626 dependencies）
- [x] `bun run quality:check` — 通過（format, lint, test 3524 passed, knip, duplication, secretlint, arch:check）
- [x] 既存コードに循環依存なし — rule 追加後も lint が clean

Closes #638