### PR TITLE
GitHub Issue skillをPR作成まで拡張する

### DIFF
--- a/.apm/skills/commit-push-pr/SKILL.md
+++ b/.apm/skills/commit-push-pr/SKILL.md
@@ -30,8 +30,10 @@ harness checkpoint、または同等の証拠と対応付けられる場合だ�
 
 **REQUIRED SUB-SKILL:** Use `github-issue-implementation`.
 
-1. sub-skill に Issue URL と baseline 証跡を渡し、Issue 本文、コメント、関連 Issue / PR、
-   現在の repository を acceptance contract として調査させます。
+1. sub-skill に `caller_mode: commit-push-pr`、Issue URL、baseline 証跡を渡し、Issue 本文、
+   コメント、関連 Issue / PR、現在の repository を acceptance contract として調査させます。
+   この flag により sub-skill は commit、push、PR 作成を重複実行せず、implementation phase の
+   結果を caller へ返します。
 2. sub-skill の worktree / branch で根本原因の修正と検証を完了させます。
 3. sub-skill が返す原因、変更、acceptance criteria 対応、検証証跡を受け取ります。
 4. そのまま下記 Publish phase を続行します。publish を別依頼に分けません。

--- a/.apm/skills/github-issue-implementation/SKILL.md
+++ b/.apm/skills/github-issue-implementation/SKILL.md
@@ -1,26 +1,69 @@
 ---
 name: github-issue-implementation
-description: Use when a GitHub Issue URL or number is the implementation contract and the repository, worktree, root cause, tests, or related Issue and pull request context must be investigated before publication.
+description: Use when a GitHub Issue URL or number is the implementation contract and live intake, authentication or network recovery, repository, worktree, root cause, tests, implementation, verification, commit, push, and Open pull request creation must be completed.
 ---
 
 # GitHub Issue Implementation
 
 GitHub Issue を live contract として intake し、隔離された branch / worktree で根本原因を
-修正して検証する implementation phase です。commit、push、PR 作成は行わず、caller が
-publish を安全に続けられる構造化された結果を返します。
+修正して検証します。standalone で呼ばれた場合は commit、push、`develop` 向け Open PR 作成まで
+完了します。`commit-push-pr` の implementation phase として呼ばれた場合だけ、publish を重複
+実行せず、caller が安全に続けられる構造化された結果を返します。
 
 ## Input contract
 
-必要な入力は Issue URL または `<owner>/<repo>#<number>` と、その repository を読める
-GitHub CLI 認証です。caller がすでに branch、worktree、既存変更を持つ場合は、開始時の
-`HEAD`、branch、status、staged / unstaged path を含む baseline 証跡も受け取ります。
+必要な入力は Issue URL または `<owner>/<repo>#<number>` です。GitHub CLI 認証は intake
+transport の一つであり、GitHub connector、許可済み fetch tool、browser などで live Issue を
+読める場合は必須ではありません。caller がすでに branch、worktree、既存変更を持つ場合は、
+開始時の `HEAD`、branch、status、staged / unstaged path を含む baseline 証跡も受け取ります。
 
 Issue を取得できない、URL が別 repository を指す、Issue が要求する repository を特定
 できない場合は、実装を推測せず停止します。
 
+## 実行 mode を固定する
+
+開始時に次の二つから一つを選び、途中で変更しません。
+
+- caller が明示的に `caller_mode: commit-push-pr` を渡した場合は **implementation phase**。
+  実装と対象検証を完了し、`ready_for_publish: true` を caller へ返します。この skill 自身は
+  commit、push、PR 作成をしません。
+- それ以外は **standalone end-to-end mode**。ユーザーが PR 作成を繰り返し指定しなくても、
+  Issue intake、実装、検証、commit、push、Open PR 作成までを既定の完了条件にします。
+
+Issue URL が会話にあることや `commit-push-pr` skill が利用可能なことだけで caller mode を
+推測しません。親 skill が flag を渡していなければ standalone として publish まで進めます。
+
 ## 1. Issue を live intake する
 
-`gh issue view` で少なくとも title、body、state、labels、comments、URL を取得します。
+repository instructions と実際に利用可能な tool を先に確認し、次の recovery ladder を上から
+順に進めます。ある段が利用不可なら、その事実を記録して次へ進みます。
+
+1. repository が network command の routing tool を指定している場合は、それを使います。
+   TABBIN で context-mode が利用可能なら、plain shell ではなく `ctx_batch_execute` 内で
+   `rtk gh issue view <number> --repo <owner>/<repo>
+   --json title,body,state,labels,comments,url` を実行します。
+2. routing 指定がなければ、purpose-built GitHub connector / MCP が利用可能ならそれを使い、
+   Issue 本文と comments を取得します。
+3. `gh` が利用可能なら、`gh auth status` を前提 gate にせず、上記の `gh issue view` を直接
+   実行します。read command の成功が認証と network の実証です。
+4. `gh` が認証 error になった場合、環境変数が keyring の有効な認証を shadow していないか
+   を診断します。token を表示せず、同じ command を `GH_TOKEN` / `GITHUB_TOKEN` を除いた
+   process environment で一度だけ再試行します。その後に `gh auth status` を診断情報として
+   使えますが、失敗だけで intake 全体を停止しません。
+5. `Could not resolve host`、`network disabled`、timeout など sandbox 内の network error が
+   出た場合は、host 全体の network failure と判定しません。実行 tool に escalation / network
+   approval があるなら、同じ read command を必要な permission 付きで直ちに一度再実行します。
+   approval tool を呼べる場合、ユーザーへ手動 command を案内する前に agent 自身が approval
+   request を発行します。
+6. CLI 経路が使えず Issue が public なら、許可された fetch / browser tool で公式 GitHub の
+   Issue page または REST API の Issue と comments を取得します。TABBIN では raw
+   `curl` / `wget` を使わず、`ctx_fetch_and_index` と `ctx_search` を使います。
+
+一つの `gh auth status` 失敗、sandbox 内の DNS failure、credential helper の空結果は、単独では
+blocker ではありません。利用可能な network-capable transport または escalated retry を最低一つ
+実行するまで「環境自体の network が遮断されている」と結論しません。
+
+取得には少なくとも title、body、state、labels、comments、URL を含めます。
 本文やコメントが参照する関連 Issue、PR、ADR、CI failure、外部仕様を必要な範囲で確認します。
 関連 PR の review が要件に影響する場合は、flat comment だけでなく live review thread 状態を
 確認します。
@@ -32,12 +75,23 @@ Issue から次を明示します。
 - 明示された制約、非目標、関連 decision
 - Issue の解決案と、検証が必要な仮説
 
-GitHub 認証や network が必要な command は、利用環境で必要なら escalated permission を
-使い、intake 前に `gh auth status` を確認します。未認証でも git credential helper が
-利用できる場合は、token を file や stdout に出さず、同じ shell invocation 内だけの
-`GH_TOKEN` で read command を再試行します。利用可能な認証を確立できなければ、取得できない
-contract と試した command を具体的な blocker として返します。取得に失敗したまま repository
-調査や実装へ進みません。
+すべての適用可能な transport が失敗した場合だけ停止します。その際は、利用可能だった tool、
+direct read、sanitized environment retry、escalated / network-capable retry、alternate transport
+の各結果を短く列挙し、最後に欠けている authority または capability を一つに絞ります。token を
+chat へ貼るよう求めず、network/tool approval、host 側の GitHub 認証、または Issue 本文と
+comments の貼り付けという最小の user action を案内します。取得に失敗したまま repository 調査や
+実装へ進みません。
+
+### Ollama / custom model provider での実行
+
+Ollama、GLM、その他の custom model provider は LLM endpoint の選択です。shell、MCP、browser、
+keyring、sandbox、network permission は Codex など host agent 側の capability なので、provider
+名だけを理由に利用不可と判定したり、処理を分岐したりしません。現在の tool 一覧と実際の tool
+result を根拠に上の recovery ladder を逐次実行します。
+
+特に local / custom provider では暗黙の fallback を期待せず、各段で「使う tool」「一回の
+action」「成功条件」を固定します。approval を要求できる tool がある場合は approval request を
+実際に発行し、`gh auth login` や PAT 設定を最初の user action にしません。
 
 ## 2. Workspace を隔離する
 
@@ -99,11 +153,37 @@ rollback を検討します。重大な仕様判断が必要な場合だけ bloc
 caller が `commit-push-pr` の場合、publish 前に必要な repository-wide gate は caller が実行します。
 この phase でも、変更に直結する regression test と runtime behavior の証拠を省略しません。
 
+## 6. standalone では Open PR まで公開する
+
+standalone end-to-end mode では、対象検証後に `commit-push-pr` の Publish phase と同じ安全条件で
+公開します。`ready_for_publish: true` を返して停止するだけでは未完了です。
+
+1. Issue-owned path だけが差分であることを baseline と照合します。`.apm/**` を変更した場合は
+   repository の source-of-truth sync command を使い、TABBIN では `bun run apm:sync` と
+   `bun run apm:check` を実行します。生成先だけを直接編集しません。
+2. repository-wide gate を実行します。TABBIN では `bun run test:coverage` と
+   `bun run quality:check` を実行し、結果を記録します。
+3. Issue-owned path だけを stage し、簡潔な commit message で commit します。commit 後の clean
+   tree で、release-sensitive な repository では `bun run release:check` を実行します。
+4. branch を通常 push します。force-push はユーザーが明示しない限り行いません。
+5. 同じ repository / head branch の PR を全 state で確認します。今回の Issue と同じ Open PR
+   だけを再利用し、該当がなければ必ず base `develop`、Open（非 Draft）で作成します。
+6. PR 本文に原因、主要変更、acceptance criteria 対応、検証結果、risk、
+   `Closes #<issue-number>` を含めます。
+7. PR が `OPEN`、`isDraft: false`、base `develop` であり、local branch と origin が同期済みで
+   あることを live に確認します。
+
+git / GitHub write が sandbox や network で失敗した場合も、Issue intake と同様に利用可能な
+escalation / approval を agent 自身が発行して再試行します。認証済み write transport をすべて
+試しても publish できない場合だけ、試した action と不足 authority を具体的な blocker として
+返します。
+
 ## Return contract
 
-caller へ次を返します。
+implementation phase では caller へ次を返します。
 
 - Issue number、title、URL、acceptance criteria
+- Issue intake に成功した transport と、失敗後に recovery した場合の retry 証跡
 - worktree path と branch 名
 - 開始 baseline と、そこから生じた Issue-owned path / commit の対応
 - 特定した根本原因
@@ -117,4 +197,7 @@ acceptance criteria が既に満たされ差分が不要な場合は、根拠と
 `already_satisfied: true` を返し、empty commit / PR を要求しません。
 
 `commit-push-pr` から呼ばれた場合は publish skill を再帰的に呼ばず、caller へ戻ります。
-standalone で使われた場合も、publish を要求されていなければ実装と検証の結果だけを返します。
+
+standalone end-to-end mode では、上記に加えて commit hash、push した branch、Open PR URL、base、
+Draft 状態、branch 同期結果と `published: true` を返します。publish 成功を live に確認する前に
+完了と報告しません。


### PR DESCRIPTION
## 概要

- github-issue-implementation の単独起動を、実装・検証で停止せず commit、push、Open PR 作成まで進める既定動作へ変更
- commit-push-pr から呼ぶ場合は caller_mode を明示し、重複 publish や再帰呼び出しを防止
- Ollama / GLM 5.2 向けの認証・sandbox・network recovery ladder を維持したまま、publish 時の escalation も明文化

## 検証

- bun run apm:sync
- bun run apm:check
- GLM 5.2 pressure test: standalone は publish、caller_mode 付きは return を選択
- bun run test:coverage: 323 files / 3,524 tests passed、coverage 97.28%
- bun run quality:check
- bun run release:check

## リスク

- production code の変更なし
- APM source と生成された agent skills の byte equality を確認済み


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * GitHub Issue の調査から修正・検証・公開までの手順を明確化しました。
  * Issue 情報の取得方法を拡充し、認証・ネットワーク障害時の再試行や代替手段を追加しました。
  * 実行環境に応じたツール利用と安全な承認フローの注意事項を追加しました。
  * 公開時のコミット、プッシュ、プルリクエスト作成結果を確認する基準を明確化しました。
  * 実行結果や不足している権限・操作を、より具体的に報告できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->