### PR TITLE
Oxlint no-restricted-imports で context 内部実装の direct import を制限する

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -193,7 +193,11 @@
     "import/unambiguous": "off",
     "import/no-cycle": [
       "error",
-      { "ignoreTypes": true, "ignoreExternal": true, "maxDepth": 10 }
+      {
+        "ignoreTypes": true,
+        "ignoreExternal": true,
+        "maxDepth": 10
+      }
     ],
     "promise/always-return": "off",
     "promise/avoid-new": "off",
@@ -466,7 +470,23 @@
     "react-hooks-compiler/set-state-in-render": "error",
     "react-hooks-compiler/unsupported-syntax": "error",
     "react-hooks-compiler/config": "error",
-    "react-hooks-compiler/gating": "error"
+    "react-hooks-compiler/gating": "error",
+    "eslint/no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          {
+            "group": [
+              "@/contexts/*/domain/**",
+              "@/contexts/*/application/**",
+              "@/contexts/*/infrastructure/**",
+              "@/contexts/*/presentation/**"
+            ],
+            "message": "別 context の内部実装を直接 import しないでください。@/contexts/<context>/public-api 経由にしてください。"
+          }
+        ]
+      }
+    ]
   },
   "overrides": [
     {
@@ -1224,6 +1244,24 @@
         "vitest/prefer-expect-resolves": "off",
         "vitest/require-top-level-describe": "off",
         "typescript/no-dynamic-delete": "off"
+      }
+    },
+    {
+      "files": ["src/contexts/**/*.{ts,tsx}"],
+      "rules": {
+        "eslint/no-restricted-imports": "off"
+      }
+    },
+    {
+      "files": ["src/app/composition/**/*.{ts,tsx}"],
+      "rules": {
+        "eslint/no-restricted-imports": "off"
+      }
+    },
+    {
+      "files": ["src/lib/storybook/**/*.{ts,tsx}"],
+      "rules": {
+        "eslint/no-restricted-imports": "off"
       }
     }
   ]

--- a/src/contexts/saved-tabs/public-api.ts
+++ b/src/contexts/saved-tabs/public-api.ts
@@ -13,3 +13,10 @@
  */
 
 export { normalizeDomainString } from './domain/value-objects/DomainName'
+
+// issue #639: settings defaults を public API 経由で提供する
+export { savedTabsActionSettingsDefaults } from './domain/services/SavedTabsActionSettingsPolicy'
+export {
+  DEFAULT_EXCLUDE_PATTERNS,
+  mergeStoredUserSettingsDefaults,
+} from './domain/services/userSettingsDefaultsMerge'

--- a/src/lib/storage/settings.ts
+++ b/src/lib/storage/settings.ts
@@ -1,9 +1,9 @@
 import { DEFAULT_FONT_SIZE_PERCENT } from '@/constants/fontSize'
-import { savedTabsActionSettingsDefaults } from '@/contexts/saved-tabs/domain/services/SavedTabsActionSettingsPolicy'
 import {
   DEFAULT_EXCLUDE_PATTERNS,
   mergeStoredUserSettingsDefaults,
-} from '@/contexts/saved-tabs/domain/services/userSettingsDefaultsMerge'
+  savedTabsActionSettingsDefaults,
+} from '@/contexts/saved-tabs/public-api'
 import {
   DEFAULT_AI_SYSTEM_PROMPT_PRESET_ID,
   DEFAULT_AI_SYSTEM_PROMPT_TEMPLATE,


### PR DESCRIPTION
## 背景

別 context の `domain` / `application` / `infrastructure` / `presentation` 配下の内部実装を直接 import できる状態だと、context 境界が崩れやすい。dependency-cruiser で制御しているが、Oxlint の `eslint/no-restricted-imports` でも public API 経由の利用を促す制約を追加したい (issue #639)。

## 原因

`eslint/no-restricted-imports` が未定義で、日常 lint で別 context 内部への direct import を早期検出できなかった。`src/lib/storage/settings.ts` が `saved-tabs` context の domain services を直接 import していた。

## 主要変更

- `.oxlintrc.json` に `eslint/no-restricted-imports` 規則を追加。`@/contexts/*/domain/**`, `@/contexts/*/application/**`, `@/contexts/*/infrastructure/**`, `@/contexts/*/presentation/**` の直接 import を `error` で禁止する
- 同一 context 内の内部 import は正当なため、`src/contexts/**` の override で `off` に設定（交差 context の制約は dependency-cruiser が管理）
- `src/app/composition/**` は wiring layer として正当に内部実装を参照するため override で除外
- `src/lib/storybook/**` は stories ファイルを import する test utility のため override で除外
- `src/lib/storage/settings.ts` の違反を修正: `savedTabsActionSettingsDefaults`, `DEFAULT_EXCLUDE_PATTERNS`, `mergeStoredUserSettingsDefaults` を `public-api.ts` に追加し、public API 経由に変更

## dependency-cruiser との役割分担

- **dependency-cruiser**: context / layer 間の詳細な依存制約（交差 context、layer 方向、infrastructure 構築位置など）を管理
- **no-restricted-imports**: 明らかに禁止したい import path（別 context の内部実装 direct import）を日常 lint で早期検出

`no-restricted-imports` で複雑な DDD 制約をすべて表現せず、dependency-cruiser との重複を最小限にしている。

## 受け入れ条件の対応

- [x] 現在の context 間 import 方針が確認されている — dependency-cruiser の `noCrossContextRules` と既存 override を確認
- [x] `eslint/no-restricted-imports` で禁止する path pattern が定義されている — `@/contexts/*/{domain,application,infrastructure,presentation}/**`
- [x] 同一 context 内の必要な内部 import を誤って禁止していない — `src/contexts/**` override で `off`
- [x] 別 context の内部実装 direct import が検出される — `src/lib/storage/settings.ts` の 2 件を検出
- [x] 検出された import は `public-api.ts` 経由に置き換えられている — settings.ts を public-api 経由に修正
- [x] `public-api.ts` に公開すべきでない実装を安易に export していない — 純粋関数・不変値のみ追加（方針通り）
- [x] dependency-cruiser との役割分担が PR に記載されている — 上記「dependency-cruiser との役割分担」参照
- [x] `bun run lint` が通る
- [x] `bun run arch:check` が通る
- [x] `bun run quality:check` が通る

## 検証結果

- `bun run lint`: PASS
- `bun run arch:check`: PASS (1025 modules, 4627 dependencies, no violations)
- `bun run compile`: PASS
- `bun run test`: PASS (323 files, 3524 tests)
- `bun run quality:check`: PASS (format, lint, compile, test, knip, duplication, secretlint, arch:check)
- `bun run test:coverage`: PASS (3524 tests, coverage 報告)

## Risk

- 新しい context 追加時は override の `src/contexts/**` pattern が自動的に適用されるため、追加作業は不要
- `src/app/composition/**` と `src/lib/storybook/**` の override は、これらのディレクトリが正当な wiring / test utility であることが dep-cruiser と一致しているため安全
- oxfmt が `.oxlintrc.json` の既存の `import/no-cycle` 行もフォーマット修正した（pre-existing の formatting issue）

Closes #639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 保存タブ設定のデフォルト値や除外パターンを、公開APIから利用できるようになりました。

* **改善**
  * 設定の取得・保存処理で、保存タブ関連の共通設定を一貫して利用するよう改善しました。
  * 内部実装への直接アクセスを制限し、構成の保守性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->