### PR TITLE
Vitest isolate:false の影響を検証しテスト状態汚染を防ぐ

### DIFF
--- a/src/features/navigation/app/AppRouter.test.tsx
+++ b/src/features/navigation/app/AppRouter.test.tsx
@@ -93,6 +93,9 @@ import { AppRouter } from './AppRouter'
 
 describe('AppRouter', () => {
   beforeEach(() => {
+    // The lazy route-module load counter is module-level and accumulates
+    // across tests; reset it so load-count assertions are order-independent.
+    routeModuleLoads.aiChat = 0
     window.history.replaceState({}, '', '/')
   })
 

--- a/src/lib/react/render-root.test.tsx
+++ b/src/lib/react/render-root.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest' // eslint-disable-line
+import { beforeEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
 
 import { getOrCreateRoot, mountToElement, renderToRoot } from './render-root'
 
@@ -14,6 +14,12 @@ vi.mock('react-dom/client', () => ({
 }))
 
 describe('render-root', () => {
+  beforeEach(() => {
+    // createRoot is a module-level mock shared across both tests; clear call
+    // history so absolute call-count assertions stay order-independent.
+    rootMocks.createRoot.mockClear()
+  })
+
   it('同じ container では root を再利用して render する', () => {
     const container = document.createElement('div')
 

--- a/src/test/setup-global-state.ts
+++ b/src/test/setup-global-state.ts
@@ -1,0 +1,59 @@
+import { afterEach, vi } from 'vitest'
+
+/**
+ * Shared safety net for `isolate: false` (vitest.ci.config.ts).
+ *
+ * `isolate: false` keeps a single module registry per thread for speed
+ * (~18s vs ~36s with `isolate: true`).  That means module singletons, the
+ * fake `chrome` global, and Web Storage can leak across test files when a
+ * file forgets to clean up after itself.
+ *
+ * This setup file provides defence-in-depth: after every test we reset the
+ * globals that are most prone to cross-file leakage.  Test files are still
+ * expected to clean up their own module-level state, but this prevents one
+ * file's leftover `globalThis.chrome` or Web Storage from poisoning the
+ * next file.
+ *
+ * Verified safe: `bun run test` and `--sequence.shuffle.files` both stay
+ * green with this hook active (see issue #668).
+ *
+ * Module-level cache reset strategy
+ * ---------------------------------
+ * Under `isolate: false` a single module registry is shared across every
+ * test file in a thread, so module singletons that hold mutable state can
+ * leak between files.  The reset strategy (in order of preference):
+ *
+ * 1. Prefer a dedicated reset helper exported by the owning module — e.g.
+ *    `invalidateUrlCache` from `src/lib/storage/urls.ts` — when you only
+ *    need to clear the cache without re-evaluating dependents.
+ * 2. Use `vi.resetModules()` followed by a fresh dynamic `import()` when a
+ *    test needs a fully fresh singleton (fresh `urlRecordsCache`, fresh
+ *    WeakMap of React roots, etc.).  This is the pattern already used in
+ *    `src/lib/storage/urls.test.ts` (`loadUrlsModule`) and
+ *    `src/lib/storage/projects.test.ts` (`loadModule`).
+ * 3. Pure, deterministic caches (`Intl.DateTimeFormat` formatters in
+ *    `src/utils/localDateTime.ts`, the shiki `highlighterCache` /
+ *    `tokensCache` in `src/components/ai-elements/code-block.tsx`) are keyed
+ *    by immutable inputs and never need reset.
+ */
+afterEach(() => {
+  // There is no real `chrome` in the test environment.  Resetting to
+  // undefined prevents a file that sets `globalThis.chrome` without an
+  // afterEach restore from leaking it into the next file under
+  // `isolate: false`.  Files that need chrome re-create it in their own
+  // beforeEach, which runs before each test body.
+  delete (globalThis as { chrome?: unknown }).chrome
+
+  // Clear Web Storage so DOM tests don't inherit leftover keys.
+  if (typeof localStorage !== 'undefined') {
+    localStorage.clear()
+  }
+
+  if (typeof sessionStorage !== 'undefined') {
+    sessionStorage.clear()
+  }
+
+  // Restore globals stubbed via vi.stubGlobal (e.g. fetch, matchMedia) so a
+  // stub from one file does not persist into the next.
+  vi.unstubAllGlobals()
+})

--- a/vitest.ci.config.ts
+++ b/vitest.ci.config.ts
@@ -20,7 +20,23 @@ const sharedExclude = [
   '**/.{idea,git,cache,output,temp}/**',
 ]
 
-const sharedSetupFiles = ['./src/test/setup-console.ts']
+// `isolate: false` is retained deliberately for CI speed: a single module
+// registry per thread runs the full suite in ~18s vs ~36s with `isolate: true`.
+// Verified safe under issue #668:
+//   - `isolate: true` passes all 3529 tests (no hidden module dependency).
+//   - `--sequence.shuffle.files` passes under `isolate: false` (no cross-file
+//     order dependency).
+// Defence-in-depth is provided by `src/test/setup-global-state.ts`, which
+// resets `globalThis.chrome`, Web Storage, and stubbed globals after every
+// test so a file that forgets to clean up cannot poison the next.
+// Module-level singleton cache reset strategy is documented in
+// `src/test/setup-global-state.ts` (prefer the owning module's reset
+// helper such as `invalidateUrlCache`, or `vi.resetModules()` + fresh
+// dynamic import for a fully fresh singleton).
+const sharedSetupFiles = [
+  './src/test/setup-console.ts',
+  './src/test/setup-global-state.ts',
+]
 
 export default defineConfig({
   resolve: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,7 +29,10 @@ export default defineConfig({
       'src/utils/**/*.test.ts',
       'src/utils/**/*.test.tsx',
     ],
-    setupFiles: ['./src/test/setup-console.ts'],
+    setupFiles: [
+      './src/test/setup-console.ts',
+      './src/test/setup-global-state.ts',
+    ],
     typecheck: {
       enabled: false,
     },


### PR DESCRIPTION
Closes #668

## 原因・背景

`vitest.ci.config.ts` で `isolate: false` が設定されており、module singleton・global mock・storage cache などの状態がテスト間で漏れるリスクがあった。

## 検証結果

- **`isolate: true` で全 3529 テストが成功** — 隠れた module 依存がないことを確認
- **`--sequence.shuffle.files` (file order shuffle) が `isolate: false` で複数 seed (42, 777, 12345) で成功** — cross-file の状態汚染がないことを証明

## 主な変更

- **`src/test/setup-global-state.ts`** (新規): `afterEach` で `globalThis.chrome`・`localStorage`・`sessionStorage`・stubbed globals を reset する防護網。`isolate: false` で cleanup を忘れたファイルが次のファイルへ状態を漏らさないようにする。
- **`vitest.ci.config.ts` / `vitest.config.ts`**: setup-global-state.ts を setupFiles に登録。config に `isolate: false` 維持理由と module-level cache reset 方針 (`invalidateUrlCache` / `vi.resetModules()` + dynamic import) を明記。
- **`render-root.test.tsx`**: `beforeEach` で `createRoot` mock の call history を clear し、絶対 call-count assertion が test 順に依存しないよう修正。
- **`AppRouter.test.tsx`**: `beforeEach` で lazy route-module load counter を reset し、load-count assertion が test 順に依存しないよう修正。

## 受け入れ条件の対応

- [x] `isolate: true` でテストが通るか検証する — 全 3529 テスト成功
- [x] `isolate: false` を維持する場合、その理由がコメントで明記されている — vitest.ci.config.ts に明記
- [x] test setup で主要な global mock が `afterEach` で reset される — setup-global-state.ts
- [x] storage cache など module-level cache の reset 方針がある — setup-global-state.ts のコメント + 既存 `invalidateUrlCache` / `vi.resetModules` pattern
- [x] テスト順を変えても失敗しないことを確認する — `--sequence.shuffle.files` 複数 seed で成功
- [x] `bun run test` が成功する — 3529/3529

## 残存事項 (follow-up)

`SavedTabsApp.test.tsx` (4500行) には `isolate` 設定に関係ない既存の intra-file test-order 依存が残存する (`isolate: true` でも `--sequence.shuffle.tests` で失敗する)。persistent mock implementation (`mockResolvedValue` / `mockRejectedValue` の非 Once 利用) が `vi.clearAllMocks` で reset されないことが主因。本 PR では `isolate: false` の cross-file 汚染対策に集中し、別 issue で対応する。

## 検証コマンド

- `bun run test` — 3529 passed
- `bun run quality:check` — passed (format, lint, compile, test, knip, duplication, secretlint, arch)
- `bun run release:check` — passed
- `bunx vitest run --config vitest.ci.config.ts --sequence.shuffle.files --sequence.seed 42` — 3529 passed

## リスク

- test infrastructure のみ変更 (production code は未変更)
- setup-global-state.ts の afterEach は全テストで実行されるが overhead は無視できる程度 (<0.5s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * テスト間でモックやグローバル状態が引き継がれないようになり、実行順序に依存しにくくなりました。
  * ルートの遅延読み込み回数やルート作成処理の検証が、より安定して実行されるようになりました。
* **設定**
  * 通常のテストとCIテストで、テスト後のグローバル状態を自動的にリセットする共通設定を適用しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->