### PR TITLE
Vitest coverage threshold を設定し重要領域のテスト抜けを検出する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,34 @@ jobs:
       - name: Run unit tests (shard 2/2)
         run: bun run test --shard=2/2
 
+  coverage:
+    name: Coverage Thresholds
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.node-version'
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: '.bun-version'
+
+      - name: Verify toolchain versions
+        run: bun run verify:toolchain-versions
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run coverage with thresholds
+        run: bun run test:coverage
+
   e2e-accessibility:
     name: E2E Accessibility (axe)
     runs-on: ubuntu-latest

--- a/docs/testing/coverage-thresholds.md
+++ b/docs/testing/coverage-thresholds.md
@@ -1,0 +1,62 @@
+# Coverage Thresholds
+
+TABBIN uses Vitest coverage thresholds to detect test coverage regressions
+before they reach `develop`. The configuration lives in
+`vitest.ci.config.ts` and is enforced by the `coverage` job in
+`.github/workflows/ci.yml`.
+
+## Design decisions
+
+### CI-only, not in `quality:check`
+
+Coverage runs only in CI (`bun run test:coverage`), not in the local
+`bun run quality:check` gate. Rationale:
+
+- `quality:check` already runs the full test suite (~18 s). Adding coverage
+  would add ~27 s (total ~45 s), making the pre-commit cycle noticeably
+  slower.
+- Coverage thresholds guard long-term trends, not individual commits.
+  Running them in CI is sufficient for that purpose.
+- Developers who want local coverage can still run `bun run test:coverage`
+  on demand.
+
+### Global floor
+
+The global threshold is set below current coverage to allow normal
+fluctuation while catching significant erosion:
+
+| Metric     | Threshold | Baseline |
+| ---------- | --------- | -------- |
+| Statements | 90 %      | ~97 %    |
+| Branches   | 85 %      | ~92 %    |
+| Functions  | 90 %      | ~98 %    |
+| Lines      | 90 %      | ~97 %    |
+
+### Per-glob thresholds for critical domains
+
+Important areas have tighter per-glob thresholds so a drop in those areas
+is detected even when global coverage stays above the floor:
+
+| Area                                        | Stmts | Branches | Funcs | Lines |
+| ------------------------------------------- | ----- | -------- | ----- | ----- |
+| `src/lib/storage/**`                        | 95    | 88       | 90    | 95    |
+| `src/lib/background/**`                     | 95    | 90       | 95    | 95    |
+| `src/features/options/lib/import-export/**` | 95    | 90       | 95    | 95    |
+| `src/features/ai-chat/lib/**`               | 95    | 85       | 95    | 95    |
+| `src/features/i18n/**`                      | 90    | 75       | 95    | 90    |
+
+### Calibration
+
+Thresholds were calibrated from the coverage baseline measured in #679.
+Each per-glob threshold is set a few percentage points below the area's
+current coverage to give a small buffer. When coverage improves, the
+thresholds should be revisited and raised.
+
+### What not to do
+
+- Do not raise thresholds to chase a number — coverage is a signal, not a
+  goal.
+- Do not lower thresholds to make a failing build pass without
+  understanding why coverage dropped.
+- Do not exclude files from coverage to avoid threshold failures; add
+  tests instead.

--- a/tools/renovate-policy.test.ts
+++ b/tools/renovate-policy.test.ts
@@ -225,7 +225,7 @@ describe('Renovate dependency update policy', () => {
         .map((section) => section.split('\n      - ')[0]),
     )
 
-    expect(checkoutSteps).toHaveLength(6)
+    expect(checkoutSteps).toHaveLength(7)
     for (const checkoutStep of checkoutSteps) {
       expect(checkoutStep).toContain('persist-credentials: false')
     }

--- a/vitest.ci.config.ts
+++ b/vitest.ci.config.ts
@@ -44,6 +44,60 @@ export default defineConfig({
   },
   test: {
     coverage: {
+      // Coverage thresholds — see docs/testing/coverage-thresholds.md
+      //
+      // Global thresholds are set deliberately below current coverage (~97%
+      // statements/lines, ~92% branches, ~98% functions) to give a buffer for
+      // normal fluctuation while catching significant regressions.
+      //
+      // Per-glob thresholds protect critical domains (storage, background,
+      // import-export, ai-chat, i18n) with tighter floors so a drop in these
+      // areas is detected even when global coverage stays above the floor.
+      // Thresholds were calibrated from the coverage baseline measured in #679
+      // and should be revisited when coverage improves.
+      thresholds: {
+        // Global floor — catches project-wide coverage erosion.
+        statements: 90,
+        branches: 85,
+        functions: 90,
+        lines: 90,
+
+        // Critical storage layer — tab/URL/project persistence.
+        'src/lib/storage/**': {
+          statements: 95,
+          branches: 88,
+          functions: 90,
+          lines: 95,
+        },
+        // Background service logic — alarms, notifications, expired tabs.
+        'src/lib/background/**': {
+          statements: 95,
+          branches: 90,
+          functions: 95,
+          lines: 95,
+        },
+        // Import/export flows — user data round-trip integrity.
+        'src/features/options/lib/import-export/**': {
+          statements: 95,
+          branches: 90,
+          functions: 95,
+          lines: 95,
+        },
+        // AI chat core logic — route parsing, history management.
+        'src/features/ai-chat/lib/**': {
+          statements: 95,
+          branches: 85,
+          functions: 95,
+          lines: 95,
+        },
+        // i18n — language detection, provider, translation utils.
+        'src/features/i18n/**': {
+          statements: 90,
+          branches: 75,
+          functions: 95,
+          lines: 90,
+        },
+      },
       exclude: [
         '.storybook/**',
         '**/*.stories.ts',


### PR DESCRIPTION
## 原因

`test:coverage` script は存在するが coverage threshold が未設定で、coverage が
大きく下がっても CI で検出できなかった (Issue #679)。

## 主要変更

- **`vitest.ci.config.ts`**: global threshold (statements 90%, branches 85%, functions 90%, lines 90%) と重要領域別 per-glob threshold を追加
  - `src/lib/storage/**`: stmt 95%, branch 88%, func 90%, lines 95%
  - `src/lib/background/**`: stmt 95%, branch 90%, func 95%, lines 95%
  - `src/features/options/lib/import-export/**`: stmt 95%, branch 90%, func 95%, lines 95%
  - `src/features/ai-chat/lib/**`: stmt 95%, branch 85%, func 95%, lines 95%
  - `src/features/i18n/**`: stmt 90%, branch 75%, func 95%, lines 90%
- **`.github/workflows/ci.yml`**: `coverage` job を追加し `bun run test:coverage` を実行
- **`docs/testing/coverage-thresholds.md`**: 設計意図、threshold 一覧、運用方針を記録
- **`tools/renovate-policy.test.ts`**: checkout step 数を 6 → 7 へ更新 (coverage job 追加による)

## 設計判断

- **CI 専用**: `quality:check` には含めない。coverage は長期トレンド監視が目的で、`quality:check` が ~27s 遅くなるのを避けた。開発者は必要時に `bun run test:coverage` を個別実行できる。
- **低めの global threshold**: 現在の coverage (~97%) に対して 90% を設定し、通常の変動を許容しつつ大きな低下を検出する。
- **重要領域の per-glob threshold**: storage / background / import-export / ai-chat / i18n に現coverage より数ポイント低い floor を設定し、global が合格しても重要領域の低下を検出する。

## Acceptance criteria 対応

- [x] 現在の coverage を確認する — 97.28% stmt / 92.45% branch / 97.96% func / 97.29% lines
- [x] global coverage threshold を設定する — statements 90, branches 85, functions 90, lines 90
- [x] 重要領域の個別 threshold を検討する — 5 領域に per-glob threshold を設定
- [x] `quality` に含めるか CI 専用にするか決める — CI 専用 (docs に記録)
- [x] coverage threshold の意図をコメントまたは docs に残す — `docs/testing/coverage-thresholds.md` および config 内コメント
- [x] `bun run test:coverage` が成功する — 全 3529 test pass, threshold 合格
- [x] 既存テストが通る — 全 3529 test pass

## 検証結果

- `bun run test:coverage`: 全 3529 test pass, coverage threshold 合格 (exit 0)
- `bun run format:check`: pass
- `bun run lint`: pass
- `bun run compile`: pass
- `bun run arch:check`: pass
- `bun run knip`: pass (pre-existing hints only)
- `bun run secretlint`: pass
- `bun run release:check`: pass (version 2.0.7)

## Risk

- threshold が低すぎる可能性がある。coverage が改善されたら見直す必要がある。
- per-glob threshold の glob path が coverage exclude と重複しないことを確認済み。

Closes #679