### PR TITLE
Persistence v2の整合性監査とrepair planを追加する

### DIFF
--- a/docs/architecture/persistence-model-v2.md
+++ b/docs/architecture/persistence-model-v2.md
@@ -449,6 +449,42 @@ The machine-readable code list is exported as
 The checker reports and classifies issues; repair remains a separate audit ->
 plan -> backup -> repair -> re-audit flow.
 
+### Pure checker boundary
+
+`checkPersistenceIntegrity(snapshot)` accepts only a logical
+`PersistenceV2Snapshot`. It does not import Chrome or IndexedDB APIs, normalize
+input, write storage, or repair the snapshot. It returns a deterministic
+`StorageIntegrityReport`; `isHealthy` is true only when the typed `issues` list
+is empty.
+
+Every code in `PERSISTENCE_V2_INVARIANT_CODES` has an exhaustive severity and
+repairability entry in `PERSISTENCE_V2_INVARIANT_POLICY`. The v2 checker emits
+only findings supported by the logical target snapshot. Source-only findings,
+including `URL_IDENTITY_COLLISION`, `URL_TITLE_CONFLICT`,
+`MISSING_TIMESTAMP_PROVENANCE`, and `INVALID_ACTIVE_CHAT_REFERENCE`, are kept in
+the shared typed contract for migration/import adapters and are not inferred
+without source evidence.
+
+Diagnostics include stable entity identifiers, field paths, occurrence counts,
+and type classes. They do not copy URL, title, domain, note, keyword, prompt, or
+other user content into the report.
+
+### Repair-plan boundary
+
+`createStorageRepairPlan(report)` is also pure. It converts only
+`automatic-safe` issues into typed dry-run operations and leaves every
+ambiguous or non-repairable issue in `unresolvedIssues`. Duplicate memberships
+produce `REMOVE_DUPLICATE_MEMBERSHIP` only when all non-key metadata is
+equivalent; conflicting category, note, ordering, or timestamp metadata requires
+review. An invalid active-chat selection can produce the non-destructive
+`RESET_ACTIVE_CHAT_REFERENCE` operation.
+
+`ORPHAN_URL` never produces an automatic deletion operation. The plan's
+`destructive` flag is derived from its operations, and executing those
+operations remains a caller-owned step after review and backup. Callers must
+re-run `checkPersistenceIntegrity` after any repair and must not cut over or
+clean up legacy storage while an `error` finding remains.
+
 ## Query and projection boundary
 
 Normalized stores are write models. UI, analytics, and AI features do not join

--- a/docs/plans/2026-07-17-persistence-integrity-checker-design.md
+++ b/docs/plans/2026-07-17-persistence-integrity-checker-design.md
@@ -1,0 +1,77 @@
+# Persistence Integrity Checker Design
+
+## Context
+
+Issue #712 requires a storage-engine-independent audit boundary for the
+Persistence Model v2 contract established by Issue #725. The same logical
+snapshot checker must be usable before or after IndexedDB writes without
+performing storage reads, writes, normalization, or repair itself.
+
+## Considered approaches
+
+### 1. Add checking functions to `PersistenceModelV2.ts`
+
+This keeps the types and invariants together, but turns the entity contract
+file into a growing service module and couples future repair planning to model
+declarations.
+
+### 2. Add separate domain services for audit and repair planning
+
+This keeps `PersistenceModelV2.ts` as the entity contract. A pure checker owns
+typed findings and invariant policy, while a second pure function converts
+only safely repairable findings into a dry-run plan. This is the selected
+approach because it enforces the Issue #712 audit/repair boundary structurally.
+
+### 3. Create a new cross-cutting persistence context
+
+This could eventually fit the IndexedDB transaction and repository work in
+Issue #726, but it would decide ownership before those contracts exist and
+would move the Issue #725 model away from its current saved-tabs boundary.
+
+## Selected design
+
+`checkPersistenceIntegrity(snapshot)` lives in the saved-tabs domain service
+layer. It accepts `PersistenceV2Snapshot` and returns a deterministic
+`StorageIntegrityReport`. Findings are a discriminated union keyed by the
+existing `PersistenceV2InvariantCode`; every code has a typed severity and
+repairability policy.
+
+The v2 checker detects duplicate identifiers and logical identities, dangling
+references, category/collection mismatches, invalid group references, orphaned
+entities, unsafe ordering ranks, duplicate domain collections, timestamp
+relations, and non-JSON-safe values. Source-only findings such as identity
+collisions, title conflicts, missing source timestamp provenance, and invalid
+active-chat selection remain valid typed codes for migration adapters, but the
+v2 snapshot checker does not invent them without source evidence.
+
+Diagnostics contain stable entity identifiers, field paths, counts, and type
+classes only. They do not copy raw URLs, titles, domains, notes, keywords, or
+other user content into reports.
+
+`createStorageRepairPlan(report)` is a separate pure function. It emits typed
+operations only for `automatic-safe` findings and returns all other findings as
+unresolved. Duplicate memberships produce an idempotent
+`REMOVE_DUPLICATE_MEMBERSHIP` dry-run operation only when their non-key metadata
+is equivalent. Metadata conflicts require review. Orphan URLs and ambiguous
+relations never become deletion operations automatically. Operations and the
+overall plan explicitly identify destructive behavior; neither function
+executes a repair.
+
+## Data flow
+
+```text
+logical PersistenceV2Snapshot
+  -> checkPersistenceIntegrity
+  -> typed StorageIntegrityReport
+  -> createStorageRepairPlan
+  -> dry-run StorageRepairPlan
+  -> caller-controlled review / backup / execution / re-audit
+```
+
+## Verification
+
+Reusable corrupted fixtures cover each Issue #712 relation and duplicate
+class. Tests first prove the absent checker and planner APIs fail, then verify a
+healthy snapshot, deterministic typed findings, safe diagnostics, repair-plan
+separation, and the no-orphan-deletion rule. Repository-wide coverage, quality,
+architecture, and release gates remain required before publication.

--- a/docs/plans/2026-07-17-persistence-integrity-checker.md
+++ b/docs/plans/2026-07-17-persistence-integrity-checker.md
@@ -1,0 +1,91 @@
+# Persistence Integrity Checker Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use test-driven-development to implement this plan task-by-task.
+
+**Goal:** Add a pure Persistence Model v2 integrity checker and a separate typed repair-plan generator for Issue #712.
+
+**Architecture:** Keep the Issue #725 entity contract in `PersistenceModelV2.ts`. Add two saved-tabs domain services: one for deterministic audit findings and one for dry-run repair planning. Export only pure functions, types, and invariant policy through the context public API.
+
+**Tech Stack:** TypeScript, Vitest node project, TABBIN saved-tabs DDD domain, oxfmt, Oxlint.
+
+---
+
+### Task 1: Define corrupted snapshot behavior
+
+**Files:**
+
+- Create: `src/contexts/saved-tabs/domain/testing/persistenceV2IntegrityFixtures.ts`
+- Create: `src/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker.test.ts`
+
+1. Add a healthy snapshot fixture and focused corruptions for duplicate URL ID,
+   duplicate normalized URL, dangling URL/collection/category/group relations,
+   category mismatch, duplicate membership, orphans, invalid ordering,
+   duplicate domain collection, timestamp relations, and non-JSON-safe data.
+2. Write tests for `checkPersistenceIntegrity`, typed severity/repairability,
+   deterministic finding order, and safe diagnostics.
+3. Run
+   `rtk bun run test:node -- src/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker.test.ts`
+   and verify RED because the checker module does not exist.
+
+### Task 2: Implement the pure checker
+
+**Files:**
+
+- Create: `src/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker.ts`
+- Test: `src/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker.test.ts`
+
+1. Define `IntegrityIssueSeverity`, `IntegrityRepairability`, the keyed finding
+   detail map, `StorageIntegrityIssue`, and `StorageIntegrityReport`.
+2. Define an exhaustive policy for every `PERSISTENCE_V2_INVARIANT_CODES`
+   member so additions fail type-checking until policy is selected.
+3. Implement index-building and each Issue #712 invariant as pure passes over
+   the logical snapshot. Never normalize or mutate input records.
+4. Run the focused node test and verify GREEN.
+5. Refactor only while the focused test remains green.
+
+### Task 3: Define and implement separated repair planning
+
+**Files:**
+
+- Create: `src/contexts/saved-tabs/domain/services/PersistenceRepairPlanner.test.ts`
+- Create: `src/contexts/saved-tabs/domain/services/PersistenceRepairPlanner.ts`
+
+1. Write failing tests proving metadata-equivalent duplicate membership creates
+   one typed, destructive dry-run operation; metadata conflicts and other
+   ambiguous findings remain unresolved; and orphan URLs never create removal
+   operations.
+2. Run the focused planner test and verify RED because the module is absent.
+3. Implement `StorageRepairOperation`, `StorageRepairPlan`, and
+   `createStorageRepairPlan` without executing or importing storage writes.
+4. Run both Issue #712 test files and verify GREEN.
+
+### Task 4: Publish the pure contract and document the handoff
+
+**Files:**
+
+- Modify: `src/contexts/saved-tabs/public-api.ts`
+- Modify: `docs/architecture/persistence-model-v2.md`
+- Test: `src/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker.test.ts`
+- Test: `src/contexts/saved-tabs/domain/services/PersistenceRepairPlanner.test.ts`
+
+1. Export checker/planner pure functions and public types from the saved-tabs
+   public API.
+2. Document the audit -> plan -> review/backup -> repair -> re-audit boundary,
+   safe diagnostics, and source-only adapter codes.
+3. Run `rtk bun run compile` and the Issue #712 node tests.
+
+### Task 5: Verify and publish
+
+**Files:**
+
+- Validate all Issue-owned paths.
+
+1. Run `rtk bun run test:node`.
+2. Run `rtk bun run test:coverage` and confirm 100% repository coverage.
+3. Run `rtk bun run quality:check`.
+4. Record harness checkpoints, run the fresh-context Evaluator, then run
+   `rtk bun run harness:validate` and `rtk bun run harness:audit`.
+5. Stage Issue-owned paths, commit in Japanese, and run the clean-tree
+   `rtk bun run release:check`.
+6. Push `codex/issue-712-persistence-integrity`, create an Open non-draft PR to
+   `develop` with `Closes #712`, and live-verify PR and branch synchronization.

--- a/src/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker.test.ts
+++ b/src/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { PERSISTENCE_V2_INVARIANT_CODES } from '@/contexts/saved-tabs/domain/entities/PersistenceModelV2'
+import {
+  createCorruptedPersistenceV2Snapshot,
+  createHealthyPersistenceV2Snapshot,
+} from '@/contexts/saved-tabs/domain/testing/persistenceV2IntegrityFixtures'
+
+import {
+  checkPersistenceIntegrity,
+  PERSISTENCE_V2_INVARIANT_POLICY,
+} from './PersistenceIntegrityChecker'
+
+describe('checkPersistenceIntegrity', () => {
+  it('reports a healthy logical snapshot without changing it', () => {
+    const snapshot = createHealthyPersistenceV2Snapshot()
+    const before = structuredClone(snapshot)
+
+    expect(checkPersistenceIntegrity(snapshot)).toStrictEqual({
+      isHealthy: true,
+      issues: [],
+    })
+    expect(snapshot).toStrictEqual(before)
+  })
+
+  it('detects the corrupted fixture invariants required by Issue #712', () => {
+    const report = checkPersistenceIntegrity(
+      createCorruptedPersistenceV2Snapshot(),
+    )
+
+    expect(report.isHealthy).toBe(false)
+    expect(new Set(report.issues.map(({ code }) => code))).toEqual(
+      new Set([
+        'CATEGORY_COLLECTION_MISMATCH',
+        'CATEGORY_MISSING',
+        'COLLECTION_MISSING',
+        'DUPLICATE_DOMAIN_COLLECTION',
+        'DUPLICATE_MEMBERSHIP',
+        'DUPLICATE_NORMALIZED_URL',
+        'DUPLICATE_URL_ID',
+        'GROUP_MISSING',
+        'INVALID_CATEGORY_ORDER',
+        'INVALID_COLLECTION_ORDER',
+        'INVALID_GROUP_ORDER',
+        'INVALID_MEMBERSHIP_ORDER',
+        'INVALID_TIMESTAMP_RELATION',
+        'NON_JSON_SAFE_VALUE',
+        'ORPHAN_CATEGORY',
+        'ORPHAN_URL',
+        'URL_MISSING',
+      ]),
+    )
+  })
+
+  it('returns review metadata for a conflicting duplicate membership', () => {
+    const report = checkPersistenceIntegrity(
+      createCorruptedPersistenceV2Snapshot(),
+    )
+
+    expect(
+      report.issues.find(
+        (issue) =>
+          issue.code === 'DUPLICATE_MEMBERSHIP' &&
+          issue.collectionId === 'collection-domain',
+      ),
+    ).toStrictEqual({
+      code: 'DUPLICATE_MEMBERSHIP',
+      collectionId: 'collection-domain',
+      occurrenceCount: 2,
+      repairability: 'requires-review',
+      severity: 'error',
+      urlId: 'url-alpha',
+    })
+  })
+
+  it('allows automatic repair for metadata-equivalent memberships', () => {
+    const snapshot = createHealthyPersistenceV2Snapshot()
+    const membership = snapshot.memberships[0]
+    const report = checkPersistenceIntegrity({
+      ...snapshot,
+      memberships: [...snapshot.memberships, { ...membership }],
+    })
+
+    expect(
+      report.issues.find(({ code }) => code === 'DUPLICATE_MEMBERSHIP'),
+    ).toEqual(
+      expect.objectContaining({
+        code: 'DUPLICATE_MEMBERSHIP',
+        repairability: 'automatic-safe',
+      }),
+    )
+  })
+
+  it('requires review when duplicate memberships have conflicting metadata', () => {
+    const snapshot = createHealthyPersistenceV2Snapshot()
+    const membership = snapshot.memberships[0]
+    const report = checkPersistenceIntegrity({
+      ...snapshot,
+      memberships: [
+        ...snapshot.memberships,
+        { ...membership, notes: 'different private note' },
+      ],
+    })
+
+    expect(
+      report.issues.find(({ code }) => code === 'DUPLICATE_MEMBERSHIP'),
+    ).toEqual(
+      expect.objectContaining({
+        code: 'DUPLICATE_MEMBERSHIP',
+        repairability: 'requires-review',
+      }),
+    )
+  })
+
+  it('does not depend on locale-sensitive comparison for finding order', () => {
+    const localeCompare = vi
+      .spyOn(String.prototype, 'localeCompare')
+      .mockImplementation(() => {
+        throw new Error('locale-sensitive comparison must not be used')
+      })
+
+    try {
+      expect(() =>
+        checkPersistenceIntegrity(createCorruptedPersistenceV2Snapshot()),
+      ).not.toThrow()
+    } finally {
+      localeCompare.mockRestore()
+    }
+  })
+
+  it('keeps identical findings stable while sorting', () => {
+    const snapshot = createHealthyPersistenceV2Snapshot()
+    const missingMembership = {
+      ...snapshot.memberships[0],
+      collectionId: 'collection-missing',
+      urlId: 'url-missing',
+    }
+    const report = checkPersistenceIntegrity({
+      ...snapshot,
+      memberships: [missingMembership, { ...missingMembership }],
+    })
+
+    expect(
+      report.issues.filter(({ code }) => code === 'COLLECTION_MISSING'),
+    ).toHaveLength(2)
+  })
+
+  it('defines severity and repairability for every Issue #725 code', () => {
+    expect(Object.keys(PERSISTENCE_V2_INVARIANT_POLICY)).toStrictEqual([
+      ...PERSISTENCE_V2_INVARIANT_CODES,
+    ])
+  })
+
+  it('returns deterministic findings without leaking user content', () => {
+    const snapshot = createCorruptedPersistenceV2Snapshot()
+    const first = checkPersistenceIntegrity(snapshot)
+    const second = checkPersistenceIntegrity(snapshot)
+    const serialized = JSON.stringify(first)
+
+    expect(first).toStrictEqual(second)
+    expect(serialized).not.toContain('private-path')
+    expect(serialized).not.toContain('Private ')
+    expect(serialized).not.toContain('private membership note')
+    expect(serialized).not.toContain('alpha.test')
+  })
+
+  it.each([
+    [1n, 'bigint'],
+    [() => 'not persisted', 'function'],
+    [Number.NaN, 'non-finite-number'],
+    [-0, 'negative-zero'],
+    [new Date(0), 'object'],
+    [Symbol('not persisted'), 'symbol'],
+    [[undefined], 'array'],
+    [undefined, 'undefined'],
+  ])(
+    'classifies a non-JSON-safe field without copying it',
+    (value, typeClass) => {
+      const snapshot = createHealthyPersistenceV2Snapshot()
+      Object.defineProperty(snapshot.urls[0], 'title', {
+        configurable: true,
+        enumerable: true,
+        value,
+      })
+
+      expect(
+        checkPersistenceIntegrity(snapshot).issues.find(
+          ({ code }) => code === 'NON_JSON_SAFE_VALUE',
+        ),
+      ).toStrictEqual({
+        code: 'NON_JSON_SAFE_VALUE',
+        path: 'urls[0].title',
+        repairability: 'not-repairable',
+        severity: 'error',
+        typeClass,
+      })
+    },
+  )
+
+  it('reports a non-plain record without exposing its fields', () => {
+    const snapshot = createHealthyPersistenceV2Snapshot()
+    Object.setPrototypeOf(snapshot.urls[0], Date.prototype)
+
+    expect(
+      checkPersistenceIntegrity(snapshot).issues.find(
+        ({ code }) => code === 'NON_JSON_SAFE_VALUE',
+      ),
+    ).toStrictEqual({
+      code: 'NON_JSON_SAFE_VALUE',
+      path: 'urls[0]',
+      repairability: 'not-repairable',
+      severity: 'error',
+      typeClass: 'object',
+    })
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker.ts
+++ b/src/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker.ts
@@ -1,0 +1,681 @@
+import { PERSISTENCE_V2_INVARIANT_CODES } from '@/contexts/saved-tabs/domain/entities/PersistenceModelV2'
+import type {
+  PersistenceV2Collection,
+  PersistenceV2CollectionMembership,
+  PersistenceV2InvariantCode,
+  PersistenceV2Snapshot,
+} from '@/contexts/saved-tabs/domain/entities/PersistenceModelV2'
+import { isJsonValue } from '@/lib/persistence/jsonValue'
+
+export type IntegrityIssueSeverity = 'error' | 'warning'
+
+export type IntegrityRepairability =
+  | 'automatic-safe'
+  | 'not-repairable'
+  | 'requires-review'
+
+type IntegrityIssuePolicy = {
+  readonly repairability: IntegrityRepairability
+  readonly severity: IntegrityIssueSeverity
+}
+
+export const PERSISTENCE_V2_INVARIANT_POLICY = {
+  DUPLICATE_URL_ID: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  DUPLICATE_NORMALIZED_URL: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  URL_IDENTITY_COLLISION: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  URL_TITLE_CONFLICT: {
+    repairability: 'requires-review',
+    severity: 'warning',
+  },
+  COLLECTION_MISSING: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  URL_MISSING: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  CATEGORY_MISSING: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  CATEGORY_COLLECTION_MISMATCH: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  GROUP_MISSING: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  DUPLICATE_MEMBERSHIP: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  ORPHAN_URL: {
+    repairability: 'requires-review',
+    severity: 'warning',
+  },
+  ORPHAN_CATEGORY: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  INVALID_MEMBERSHIP_ORDER: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  INVALID_CATEGORY_ORDER: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  INVALID_COLLECTION_ORDER: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  INVALID_GROUP_ORDER: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  DUPLICATE_DOMAIN_COLLECTION: {
+    repairability: 'requires-review',
+    severity: 'error',
+  },
+  INVALID_TIMESTAMP_RELATION: {
+    repairability: 'not-repairable',
+    severity: 'error',
+  },
+  MISSING_TIMESTAMP_PROVENANCE: {
+    repairability: 'not-repairable',
+    severity: 'warning',
+  },
+  NON_JSON_SAFE_VALUE: {
+    repairability: 'not-repairable',
+    severity: 'error',
+  },
+  INVALID_ACTIVE_CHAT_REFERENCE: {
+    repairability: 'automatic-safe',
+    severity: 'warning',
+  },
+} as const satisfies Readonly<
+  Record<PersistenceV2InvariantCode, IntegrityIssuePolicy>
+>
+
+type TimestampEntityType =
+  | 'category'
+  | 'collection'
+  | 'group'
+  | 'membership'
+  | 'url'
+
+type NonJsonValueType =
+  | 'array'
+  | 'bigint'
+  | 'boolean'
+  | 'function'
+  | 'negative-zero'
+  | 'non-finite-number'
+  | 'object'
+  | 'string'
+  | 'symbol'
+  | 'undefined'
+
+type PersistenceV2DomainCollection = PersistenceV2Collection & {
+  readonly definition: Extract<
+    PersistenceV2Collection['definition'],
+    { readonly type: 'domain' }
+  >
+}
+
+export type StorageIntegrityIssueDetails = {
+  readonly CATEGORY_COLLECTION_MISMATCH: {
+    readonly categoryCollectionId: string
+    readonly categoryId: string
+    readonly collectionId: string
+    readonly urlId: string
+  }
+  readonly CATEGORY_MISSING: {
+    readonly categoryId: string
+    readonly collectionId: string
+    readonly urlId: string
+  }
+  readonly COLLECTION_MISSING: {
+    readonly collectionId: string
+    readonly urlId: string
+  }
+  readonly DUPLICATE_DOMAIN_COLLECTION: {
+    readonly collectionIds: readonly string[]
+  }
+  readonly DUPLICATE_MEMBERSHIP: {
+    readonly collectionId: string
+    readonly occurrenceCount: number
+    readonly urlId: string
+  }
+  readonly DUPLICATE_NORMALIZED_URL: {
+    readonly occurrenceCount: number
+    readonly urlIds: readonly string[]
+  }
+  readonly DUPLICATE_URL_ID: {
+    readonly occurrenceCount: number
+    readonly urlId: string
+  }
+  readonly GROUP_MISSING: {
+    readonly collectionId: string
+    readonly groupId: string
+  }
+  readonly INVALID_ACTIVE_CHAT_REFERENCE: {
+    readonly conversationId: string
+  }
+  readonly INVALID_CATEGORY_ORDER: {
+    readonly categoryId: string
+  }
+  readonly INVALID_COLLECTION_ORDER: {
+    readonly collectionId: string
+  }
+  readonly INVALID_GROUP_ORDER: {
+    readonly groupId: string
+  }
+  readonly INVALID_MEMBERSHIP_ORDER: {
+    readonly collectionId: string
+    readonly urlId: string
+  }
+  readonly INVALID_TIMESTAMP_RELATION: {
+    readonly earlierField: string
+    readonly entityId: string
+    readonly entityType: TimestampEntityType
+    readonly laterField: string
+  }
+  readonly MISSING_TIMESTAMP_PROVENANCE: {
+    readonly entityId: string
+    readonly entityType: TimestampEntityType
+    readonly field: string
+  }
+  readonly NON_JSON_SAFE_VALUE: {
+    readonly path: string
+    readonly typeClass: NonJsonValueType
+  }
+  readonly ORPHAN_CATEGORY: {
+    readonly categoryId: string
+    readonly collectionId: string
+  }
+  readonly ORPHAN_URL: {
+    readonly urlId: string
+  }
+  readonly URL_IDENTITY_COLLISION: {
+    readonly occurrenceCount: number
+    readonly sourceRecordIds: readonly string[]
+  }
+  readonly URL_MISSING: {
+    readonly collectionId: string
+    readonly urlId: string
+  }
+  readonly URL_TITLE_CONFLICT: {
+    readonly urlIds: readonly string[]
+  }
+}
+
+type StorageIntegrityIssueBase<Code extends PersistenceV2InvariantCode> = {
+  readonly code: Code
+  readonly repairability: IntegrityRepairability
+  readonly severity: IntegrityIssueSeverity
+}
+
+type StorageIntegrityIssueFor<Code extends PersistenceV2InvariantCode> =
+  StorageIntegrityIssueBase<Code> & StorageIntegrityIssueDetails[Code]
+
+export type StorageIntegrityIssue<
+  Code extends PersistenceV2InvariantCode = PersistenceV2InvariantCode,
+> = {
+  readonly [CurrentCode in Code]: StorageIntegrityIssueFor<CurrentCode>
+}[Code]
+
+export type StorageIntegrityReport = {
+  readonly isHealthy: boolean
+  readonly issues: readonly StorageIntegrityIssue[]
+}
+
+const createIssue = <Code extends PersistenceV2InvariantCode>(
+  code: Code,
+  details: StorageIntegrityIssueDetails[Code],
+  repairability?: IntegrityRepairability,
+): StorageIntegrityIssueFor<Code> => {
+  const policy: IntegrityIssuePolicy = PERSISTENCE_V2_INVARIANT_POLICY[code]
+  return {
+    code,
+    repairability: repairability ?? policy.repairability,
+    severity: policy.severity,
+    ...details,
+  }
+}
+
+const groupBy = <Value>(
+  values: readonly Value[],
+  getKey: (value: Value) => string,
+): Map<string, Value[]> => {
+  const groups = new Map<string, Value[]>()
+  for (const value of values) {
+    const key = getKey(value)
+    const group = groups.get(key)
+    if (group) {
+      group.push(value)
+    } else {
+      groups.set(key, [value])
+    }
+  }
+  return groups
+}
+
+const isValidOrder = (value: number): boolean => Number.isSafeInteger(value)
+
+const NON_JSON_PRIMITIVE_TYPE_CLASSES = {
+  bigint: 'bigint',
+  boolean: 'boolean',
+  function: 'function',
+  string: 'string',
+  symbol: 'symbol',
+  undefined: 'undefined',
+} as const
+
+const classifyNonJsonValue = (value: unknown): NonJsonValueType => {
+  const valueType = typeof value
+  if (valueType === 'number') {
+    return Object.is(value, -0) ? 'negative-zero' : 'non-finite-number'
+  }
+  if (valueType === 'object') {
+    return Array.isArray(value) ? 'array' : 'object'
+  }
+  return NON_JSON_PRIMITIVE_TYPE_CLASSES[valueType]
+}
+
+const findNonJsonIssues = (
+  snapshot: PersistenceV2Snapshot,
+): readonly StorageIntegrityIssue<'NON_JSON_SAFE_VALUE'>[] => {
+  const issues: StorageIntegrityIssue<'NON_JSON_SAFE_VALUE'>[] = []
+  const collections = [
+    ['categories', snapshot.categories],
+    ['collections', snapshot.collections],
+    ['groups', snapshot.groups],
+    ['memberships', snapshot.memberships],
+    ['urls', snapshot.urls],
+  ] as const
+
+  for (const [collectionName, records] of collections) {
+    records.forEach((record, index) => {
+      if (isJsonValue(record)) {
+        return
+      }
+      const invalidFields = Object.entries(record).filter(
+        ([, value]) => !isJsonValue(value),
+      )
+      if (invalidFields.length === 0) {
+        issues.push(
+          createIssue('NON_JSON_SAFE_VALUE', {
+            path: `${collectionName}[${index}]`,
+            typeClass: 'object',
+          }),
+        )
+        return
+      }
+      for (const [field, value] of invalidFields) {
+        issues.push(
+          createIssue('NON_JSON_SAFE_VALUE', {
+            path: `${collectionName}[${index}].${field}`,
+            typeClass: classifyNonJsonValue(value),
+          }),
+        )
+      }
+    })
+  }
+
+  return issues
+}
+
+const compareIssues = (
+  left: StorageIntegrityIssue,
+  right: StorageIntegrityIssue,
+): number => {
+  const codeOrder =
+    PERSISTENCE_V2_INVARIANT_CODES.indexOf(left.code) -
+    PERSISTENCE_V2_INVARIANT_CODES.indexOf(right.code)
+  if (codeOrder !== 0) {
+    return codeOrder
+  }
+  const leftSerialized = JSON.stringify(left)
+  const rightSerialized = JSON.stringify(right)
+  if (leftSerialized === rightSerialized) {
+    return 0
+  }
+  return leftSerialized < rightSerialized ? -1 : 1
+}
+
+const findUrlIdentityIssues = (
+  snapshot: PersistenceV2Snapshot,
+): readonly StorageIntegrityIssue[] => {
+  const issues: StorageIntegrityIssue[] = []
+  const urlsById = groupBy(snapshot.urls, ({ id }) => id)
+  const urlsByNormalizedUrl = groupBy(
+    snapshot.urls,
+    ({ normalizedUrl }) => normalizedUrl,
+  )
+
+  for (const [urlId, urls] of urlsById) {
+    if (urls.length > 1) {
+      issues.push(
+        createIssue('DUPLICATE_URL_ID', {
+          occurrenceCount: urls.length,
+          urlId,
+        }),
+      )
+    }
+  }
+  for (const urls of urlsByNormalizedUrl.values()) {
+    if (urls.length > 1) {
+      issues.push(
+        createIssue('DUPLICATE_NORMALIZED_URL', {
+          occurrenceCount: urls.length,
+          urlIds: urls.map(({ id }) => id).toSorted(),
+        }),
+      )
+    }
+  }
+  return issues
+}
+
+type MembershipGroups = Map<
+  string,
+  Map<string, PersistenceV2CollectionMembership[]>
+>
+
+const addMembership = (
+  groups: MembershipGroups,
+  membership: PersistenceV2CollectionMembership,
+): void => {
+  const groupsByUrl =
+    groups.get(membership.collectionId) ??
+    new Map<string, PersistenceV2CollectionMembership[]>()
+  const memberships = groupsByUrl.get(membership.urlId) ?? []
+  memberships.push(membership)
+  groupsByUrl.set(membership.urlId, memberships)
+  groups.set(membership.collectionId, groupsByUrl)
+}
+
+const hasSameMembershipMetadata = (
+  left: PersistenceV2CollectionMembership,
+  right: PersistenceV2CollectionMembership,
+): boolean =>
+  left.addedAt === right.addedAt &&
+  left.categoryId === right.categoryId &&
+  left.notes === right.notes &&
+  left.sortOrder === right.sortOrder &&
+  left.updatedAt === right.updatedAt
+
+const hasConflictingMembershipMetadata = (
+  memberships: readonly PersistenceV2CollectionMembership[],
+): boolean => {
+  const first = memberships[0]
+  return memberships.some(
+    (membership) => !hasSameMembershipMetadata(first, membership),
+  )
+}
+
+const findDuplicateMembershipIssues = (
+  groups: ReadonlyMap<
+    string,
+    ReadonlyMap<string, readonly PersistenceV2CollectionMembership[]>
+  >,
+): readonly StorageIntegrityIssue[] => {
+  const issues: StorageIntegrityIssue[] = []
+  for (const [collectionId, groupsByUrl] of groups) {
+    for (const [urlId, memberships] of groupsByUrl) {
+      if (memberships.length > 1) {
+        issues.push(
+          createIssue(
+            'DUPLICATE_MEMBERSHIP',
+            {
+              collectionId,
+              occurrenceCount: memberships.length,
+              urlId,
+            },
+            hasConflictingMembershipMetadata(memberships)
+              ? 'requires-review'
+              : 'automatic-safe',
+          ),
+        )
+      }
+    }
+  }
+  return issues
+}
+
+const findMembershipIssues = (
+  snapshot: PersistenceV2Snapshot,
+): readonly StorageIntegrityIssue[] => {
+  const issues: StorageIntegrityIssue[] = []
+  const collectionIds = new Set(snapshot.collections.map(({ id }) => id))
+  const urlIds = new Set(snapshot.urls.map(({ id }) => id))
+  const categoryById = new Map(
+    snapshot.categories.map((category) => [category.id, category]),
+  )
+  const membershipGroups: MembershipGroups = new Map()
+
+  for (const membership of snapshot.memberships) {
+    if (!collectionIds.has(membership.collectionId)) {
+      issues.push(
+        createIssue('COLLECTION_MISSING', {
+          collectionId: membership.collectionId,
+          urlId: membership.urlId,
+        }),
+      )
+    }
+    if (!urlIds.has(membership.urlId)) {
+      issues.push(
+        createIssue('URL_MISSING', {
+          collectionId: membership.collectionId,
+          urlId: membership.urlId,
+        }),
+      )
+    }
+    if (membership.categoryId) {
+      const category = categoryById.get(membership.categoryId)
+      if (!category) {
+        issues.push(
+          createIssue('CATEGORY_MISSING', {
+            categoryId: membership.categoryId,
+            collectionId: membership.collectionId,
+            urlId: membership.urlId,
+          }),
+        )
+      } else if (category.collectionId !== membership.collectionId) {
+        issues.push(
+          createIssue('CATEGORY_COLLECTION_MISMATCH', {
+            categoryCollectionId: category.collectionId,
+            categoryId: category.id,
+            collectionId: membership.collectionId,
+            urlId: membership.urlId,
+          }),
+        )
+      }
+    }
+    addMembership(membershipGroups, membership)
+    if (!isValidOrder(membership.sortOrder)) {
+      issues.push(
+        createIssue('INVALID_MEMBERSHIP_ORDER', {
+          collectionId: membership.collectionId,
+          urlId: membership.urlId,
+        }),
+      )
+    }
+    if (membership.addedAt > membership.updatedAt) {
+      issues.push(
+        createIssue('INVALID_TIMESTAMP_RELATION', {
+          earlierField: 'addedAt',
+          entityId: `${membership.collectionId}:${membership.urlId}`,
+          entityType: 'membership',
+          laterField: 'updatedAt',
+        }),
+      )
+    }
+  }
+  issues.push(...findDuplicateMembershipIssues(membershipGroups))
+  return issues
+}
+
+const findUrlIssues = (
+  snapshot: PersistenceV2Snapshot,
+): readonly StorageIntegrityIssue[] => {
+  const issues: StorageIntegrityIssue[] = []
+  const referencedUrlIds = new Set(
+    snapshot.memberships.map(({ urlId }) => urlId),
+  )
+  for (const url of snapshot.urls) {
+    if (!referencedUrlIds.has(url.id)) {
+      issues.push(createIssue('ORPHAN_URL', { urlId: url.id }))
+    }
+    if (url.firstSavedAt > url.lastSavedAt) {
+      issues.push(
+        createIssue('INVALID_TIMESTAMP_RELATION', {
+          earlierField: 'firstSavedAt',
+          entityId: url.id,
+          entityType: 'url',
+          laterField: 'lastSavedAt',
+        }),
+      )
+    }
+  }
+  return issues
+}
+
+const findCollectionIssues = (
+  snapshot: PersistenceV2Snapshot,
+): readonly StorageIntegrityIssue[] => {
+  const issues: StorageIntegrityIssue[] = []
+  const groupIds = new Set(snapshot.groups.map(({ id }) => id))
+  const domainCollections = groupBy(
+    snapshot.collections.filter(
+      (collection): collection is PersistenceV2DomainCollection =>
+        collection.definition.type === 'domain',
+    ),
+    ({ definition }) => definition.domain,
+  )
+
+  for (const collections of domainCollections.values()) {
+    if (collections.length > 1) {
+      issues.push(
+        createIssue('DUPLICATE_DOMAIN_COLLECTION', {
+          collectionIds: collections.map(({ id }) => id).toSorted(),
+        }),
+      )
+    }
+  }
+  for (const collection of snapshot.collections) {
+    if (collection.groupId && !groupIds.has(collection.groupId)) {
+      issues.push(
+        createIssue('GROUP_MISSING', {
+          collectionId: collection.id,
+          groupId: collection.groupId,
+        }),
+      )
+    }
+    if (!isValidOrder(collection.sortOrder)) {
+      issues.push(
+        createIssue('INVALID_COLLECTION_ORDER', {
+          collectionId: collection.id,
+        }),
+      )
+    }
+    if (collection.createdAt > collection.updatedAt) {
+      issues.push(
+        createIssue('INVALID_TIMESTAMP_RELATION', {
+          earlierField: 'createdAt',
+          entityId: collection.id,
+          entityType: 'collection',
+          laterField: 'updatedAt',
+        }),
+      )
+    }
+  }
+  return issues
+}
+
+const findCategoryIssues = (
+  snapshot: PersistenceV2Snapshot,
+): readonly StorageIntegrityIssue[] => {
+  const issues: StorageIntegrityIssue[] = []
+  const collectionIds = new Set(snapshot.collections.map(({ id }) => id))
+  for (const category of snapshot.categories) {
+    if (!collectionIds.has(category.collectionId)) {
+      issues.push(
+        createIssue('ORPHAN_CATEGORY', {
+          categoryId: category.id,
+          collectionId: category.collectionId,
+        }),
+      )
+    }
+    if (!isValidOrder(category.sortOrder)) {
+      issues.push(
+        createIssue('INVALID_CATEGORY_ORDER', {
+          categoryId: category.id,
+        }),
+      )
+    }
+    if (category.createdAt > category.updatedAt) {
+      issues.push(
+        createIssue('INVALID_TIMESTAMP_RELATION', {
+          earlierField: 'createdAt',
+          entityId: category.id,
+          entityType: 'category',
+          laterField: 'updatedAt',
+        }),
+      )
+    }
+  }
+  return issues
+}
+
+const findGroupIssues = (
+  snapshot: PersistenceV2Snapshot,
+): readonly StorageIntegrityIssue[] => {
+  const issues: StorageIntegrityIssue[] = []
+  for (const group of snapshot.groups) {
+    if (!isValidOrder(group.sortOrder)) {
+      issues.push(createIssue('INVALID_GROUP_ORDER', { groupId: group.id }))
+    }
+    if (group.createdAt > group.updatedAt) {
+      issues.push(
+        createIssue('INVALID_TIMESTAMP_RELATION', {
+          earlierField: 'createdAt',
+          entityId: group.id,
+          entityType: 'group',
+          laterField: 'updatedAt',
+        }),
+      )
+    }
+  }
+  return issues
+}
+
+export const checkPersistenceIntegrity = (
+  snapshot: PersistenceV2Snapshot,
+): StorageIntegrityReport => {
+  const issues = [
+    ...findUrlIdentityIssues(snapshot),
+    ...findMembershipIssues(snapshot),
+    ...findUrlIssues(snapshot),
+    ...findCollectionIssues(snapshot),
+    ...findCategoryIssues(snapshot),
+    ...findGroupIssues(snapshot),
+    ...findNonJsonIssues(snapshot),
+  ].toSorted(compareIssues)
+
+  return {
+    isHealthy: issues.length === 0,
+    issues,
+  }
+}

--- a/src/contexts/saved-tabs/domain/services/PersistenceRepairPlanner.test.ts
+++ b/src/contexts/saved-tabs/domain/services/PersistenceRepairPlanner.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createCorruptedPersistenceV2Snapshot,
+  createHealthyPersistenceV2Snapshot,
+} from '@/contexts/saved-tabs/domain/testing/persistenceV2IntegrityFixtures'
+
+import { checkPersistenceIntegrity } from './PersistenceIntegrityChecker'
+import type { StorageIntegrityReport } from './PersistenceIntegrityChecker'
+import { createStorageRepairPlan } from './PersistenceRepairPlanner'
+
+describe('createStorageRepairPlan', () => {
+  it('creates a destructive dry-run operation for an equivalent duplicate', () => {
+    const snapshot = createHealthyPersistenceV2Snapshot()
+    const membership = snapshot.memberships[0]
+    const report = checkPersistenceIntegrity({
+      ...snapshot,
+      memberships: [...snapshot.memberships, { ...membership }],
+    })
+
+    const plan = createStorageRepairPlan(report)
+
+    expect(plan.destructive).toBe(true)
+    expect(plan.operations).toEqual(
+      expect.arrayContaining([
+        {
+          collectionId: 'collection-domain',
+          destructive: true,
+          removeCount: 1,
+          type: 'REMOVE_DUPLICATE_MEMBERSHIP',
+          urlId: 'url-alpha',
+        },
+      ]),
+    )
+    expect(plan.unresolvedIssues).not.toContainEqual(
+      expect.objectContaining({ code: 'DUPLICATE_MEMBERSHIP' }),
+    )
+  })
+
+  it('never turns an orphan URL into a removal operation', () => {
+    const plan = createStorageRepairPlan(
+      checkPersistenceIntegrity(createCorruptedPersistenceV2Snapshot()),
+    )
+
+    expect(plan.operations).not.toContainEqual(
+      expect.objectContaining({ type: 'REMOVE_ORPHAN_URL' }),
+    )
+    expect(plan.unresolvedIssues).toContainEqual(
+      expect.objectContaining({ code: 'ORPHAN_URL' }),
+    )
+  })
+
+  it('leaves conflicting duplicate memberships unresolved', () => {
+    const snapshot = createHealthyPersistenceV2Snapshot()
+    const membership = snapshot.memberships[0]
+    const report = checkPersistenceIntegrity({
+      ...snapshot,
+      memberships: [
+        ...snapshot.memberships,
+        { ...membership, sortOrder: membership.sortOrder + 1 },
+      ],
+    })
+
+    const plan = createStorageRepairPlan(report)
+
+    expect(plan.operations).not.toContainEqual(
+      expect.objectContaining({ type: 'REMOVE_DUPLICATE_MEMBERSHIP' }),
+    )
+    expect(plan.unresolvedIssues).toContainEqual(
+      expect.objectContaining({
+        code: 'DUPLICATE_MEMBERSHIP',
+        repairability: 'requires-review',
+      }),
+    )
+  })
+
+  it('distinguishes a non-destructive active selection reset', () => {
+    const report = {
+      isHealthy: false,
+      issues: [
+        {
+          code: 'INVALID_ACTIVE_CHAT_REFERENCE',
+          conversationId: 'conversation-missing',
+          repairability: 'automatic-safe',
+          severity: 'warning',
+        },
+      ],
+    } satisfies StorageIntegrityReport
+
+    expect(createStorageRepairPlan(report)).toStrictEqual({
+      destructive: false,
+      operations: [
+        {
+          conversationId: 'conversation-missing',
+          destructive: false,
+          type: 'RESET_ACTIVE_CHAT_REFERENCE',
+        },
+      ],
+      unresolvedIssues: [],
+    })
+  })
+
+  it('returns an empty non-destructive plan for a healthy report', () => {
+    expect(
+      createStorageRepairPlan({ isHealthy: true, issues: [] }),
+    ).toStrictEqual({
+      destructive: false,
+      operations: [],
+      unresolvedIssues: [],
+    })
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/PersistenceRepairPlanner.ts
+++ b/src/contexts/saved-tabs/domain/services/PersistenceRepairPlanner.ts
@@ -1,0 +1,81 @@
+import type {
+  StorageIntegrityIssue,
+  StorageIntegrityReport,
+} from './PersistenceIntegrityChecker'
+
+type AutomaticSafeInvariantCode =
+  | 'DUPLICATE_MEMBERSHIP'
+  | 'INVALID_ACTIVE_CHAT_REFERENCE'
+
+type RemoveDuplicateMembershipOperation = {
+  readonly collectionId: string
+  readonly destructive: true
+  readonly removeCount: number
+  readonly type: 'REMOVE_DUPLICATE_MEMBERSHIP'
+  readonly urlId: string
+}
+
+type ResetActiveChatReferenceOperation = {
+  readonly conversationId: string
+  readonly destructive: false
+  readonly type: 'RESET_ACTIVE_CHAT_REFERENCE'
+}
+
+export type StorageRepairOperation =
+  | RemoveDuplicateMembershipOperation
+  | ResetActiveChatReferenceOperation
+
+export type StorageRepairPlan = {
+  readonly destructive: boolean
+  readonly operations: readonly StorageRepairOperation[]
+  readonly unresolvedIssues: readonly StorageIntegrityIssue[]
+}
+
+type AutomaticSafeIssue = StorageIntegrityIssue<AutomaticSafeInvariantCode>
+
+const isAutomaticSafeIssue = (
+  issue: StorageIntegrityIssue,
+): issue is AutomaticSafeIssue =>
+  issue.repairability === 'automatic-safe' &&
+  (issue.code === 'DUPLICATE_MEMBERSHIP' ||
+    issue.code === 'INVALID_ACTIVE_CHAT_REFERENCE')
+
+const createRepairOperation = (
+  issue: AutomaticSafeIssue,
+): StorageRepairOperation => {
+  if (issue.code === 'DUPLICATE_MEMBERSHIP') {
+    return {
+      collectionId: issue.collectionId,
+      destructive: true,
+      removeCount: issue.occurrenceCount - 1,
+      type: 'REMOVE_DUPLICATE_MEMBERSHIP',
+      urlId: issue.urlId,
+    }
+  }
+  return {
+    conversationId: issue.conversationId,
+    destructive: false,
+    type: 'RESET_ACTIVE_CHAT_REFERENCE',
+  }
+}
+
+export const createStorageRepairPlan = (
+  report: StorageIntegrityReport,
+): StorageRepairPlan => {
+  const operations: StorageRepairOperation[] = []
+  const unresolvedIssues: StorageIntegrityIssue[] = []
+
+  for (const issue of report.issues) {
+    if (isAutomaticSafeIssue(issue)) {
+      operations.push(createRepairOperation(issue))
+    } else {
+      unresolvedIssues.push(issue)
+    }
+  }
+
+  return {
+    destructive: operations.some(({ destructive }) => destructive),
+    operations,
+    unresolvedIssues,
+  }
+}

--- a/src/contexts/saved-tabs/domain/testing/persistenceV2IntegrityFixtures.ts
+++ b/src/contexts/saved-tabs/domain/testing/persistenceV2IntegrityFixtures.ts
@@ -1,0 +1,202 @@
+import type {
+  PersistenceV2Snapshot,
+  PersistenceV2Url,
+} from '@/contexts/saved-tabs/domain/entities/PersistenceModelV2'
+
+const unsafeRank = Number.MAX_SAFE_INTEGER + 1
+
+export const createHealthyPersistenceV2Snapshot =
+  (): PersistenceV2Snapshot => ({
+    categories: [
+      {
+        collectionId: 'collection-domain',
+        createdAt: 10,
+        id: 'category-domain',
+        keywords: ['reference'],
+        name: 'Reference',
+        sortOrder: 1024,
+        updatedAt: 20,
+      },
+    ],
+    collections: [
+      {
+        createdAt: 10,
+        definition: { domain: 'alpha.test', type: 'domain' },
+        groupId: 'group-main',
+        id: 'collection-domain',
+        name: 'Alpha',
+        sortOrder: 1024,
+        updatedAt: 20,
+      },
+      {
+        createdAt: 10,
+        definition: {
+          projectKeywords: {
+            domainKeywords: [],
+            titleKeywords: ['private-title-keyword'],
+            urlKeywords: [],
+          },
+          type: 'custom',
+        },
+        id: 'collection-custom',
+        name: 'Private custom collection',
+        sortOrder: 2048,
+        updatedAt: 20,
+      },
+    ],
+    groups: [
+      {
+        createdAt: 10,
+        id: 'group-main',
+        name: 'Main',
+        sortOrder: 1024,
+        updatedAt: 20,
+      },
+    ],
+    memberships: [
+      {
+        addedAt: 10,
+        categoryId: 'category-domain',
+        collectionId: 'collection-domain',
+        notes: 'private membership note',
+        sortOrder: 1024,
+        updatedAt: 20,
+        urlId: 'url-alpha',
+      },
+      {
+        addedAt: 10,
+        collectionId: 'collection-custom',
+        sortOrder: 1024,
+        updatedAt: 20,
+        urlId: 'url-beta',
+      },
+    ],
+    urls: [
+      {
+        firstSavedAt: 10,
+        id: 'url-alpha',
+        lastSavedAt: 20,
+        normalizedUrl: 'https://alpha.test/private-path',
+        title: 'Private Alpha Title',
+        updatedAt: 15,
+        url: 'https://alpha.test/private-path',
+      },
+      {
+        firstSavedAt: 10,
+        id: 'url-beta',
+        lastSavedAt: 20,
+        normalizedUrl: 'https://beta.test/private-path',
+        title: 'Private Beta Title',
+        updatedAt: 15,
+        url: 'https://beta.test/private-path',
+      },
+    ],
+  })
+
+export const createCorruptedPersistenceV2Snapshot =
+  (): PersistenceV2Snapshot => {
+    const healthy = createHealthyPersistenceV2Snapshot()
+    const [alphaUrl, betaUrl] = healthy.urls
+    const [domainCollection, customCollection] = healthy.collections
+    const [domainMembership, customMembership] = healthy.memberships
+    const [domainCategory] = healthy.categories
+    const [mainGroup] = healthy.groups
+
+    const nonJsonSafeAlphaUrl = {
+      ...alphaUrl,
+      favIconUrl: undefined,
+      firstSavedAt: 30,
+    } as PersistenceV2Url
+
+    return {
+      categories: [
+        { ...domainCategory, createdAt: 30, updatedAt: 20 },
+        {
+          collectionId: 'collection-missing-for-category',
+          createdAt: 10,
+          id: 'category-orphan',
+          keywords: [],
+          name: 'Orphan',
+          sortOrder: unsafeRank,
+          updatedAt: 20,
+        },
+      ],
+      collections: [
+        { ...domainCollection, createdAt: 30, updatedAt: 20 },
+        customCollection,
+        {
+          createdAt: 10,
+          definition: { domain: 'alpha.test', type: 'domain' },
+          groupId: 'group-missing',
+          id: 'collection-duplicate-domain',
+          name: 'Duplicate domain',
+          sortOrder: unsafeRank,
+          updatedAt: 20,
+        },
+      ],
+      groups: [
+        {
+          ...mainGroup,
+          createdAt: 30,
+          sortOrder: unsafeRank,
+          updatedAt: 20,
+        },
+      ],
+      memberships: [
+        { ...domainMembership, addedAt: 30, updatedAt: 20 },
+        customMembership,
+        { ...domainMembership },
+        {
+          addedAt: 10,
+          collectionId: 'collection-missing',
+          sortOrder: 1024,
+          updatedAt: 20,
+          urlId: 'url-alpha',
+        },
+        {
+          addedAt: 10,
+          collectionId: 'collection-domain',
+          sortOrder: 2048,
+          updatedAt: 20,
+          urlId: 'url-missing',
+        },
+        {
+          addedAt: 10,
+          categoryId: 'category-domain',
+          collectionId: 'collection-custom',
+          sortOrder: 2048,
+          updatedAt: 20,
+          urlId: 'url-beta',
+        },
+        {
+          addedAt: 10,
+          categoryId: 'category-missing',
+          collectionId: 'collection-custom',
+          sortOrder: unsafeRank,
+          updatedAt: 20,
+          urlId: 'url-duplicate-normalized',
+        },
+      ],
+      urls: [
+        nonJsonSafeAlphaUrl,
+        betaUrl,
+        {
+          ...alphaUrl,
+          normalizedUrl: 'https://duplicate-id.test/private-path',
+          title: 'Private duplicate identifier title',
+        },
+        {
+          ...betaUrl,
+          id: 'url-duplicate-normalized',
+          title: 'Private duplicate normalized title',
+        },
+        {
+          ...betaUrl,
+          id: 'url-orphan',
+          normalizedUrl: 'https://orphan.test/private-path',
+          title: 'Private orphan title',
+          url: 'https://orphan.test/private-path',
+        },
+      ],
+    }
+  }

--- a/src/contexts/saved-tabs/public-api.test.ts
+++ b/src/contexts/saved-tabs/public-api.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { createHealthyPersistenceV2Snapshot } from './domain/testing/persistenceV2IntegrityFixtures'
+import {
+  checkPersistenceIntegrity,
+  createStorageRepairPlan,
+} from './public-api'
+
+describe('saved-tabs public persistence integrity API', () => {
+  it('exposes the pure audit and repair-plan boundaries', () => {
+    const report = checkPersistenceIntegrity(
+      createHealthyPersistenceV2Snapshot(),
+    )
+
+    expect(report).toStrictEqual({ isHealthy: true, issues: [] })
+    expect(createStorageRepairPlan(report)).toStrictEqual({
+      destructive: false,
+      operations: [],
+      unresolvedIssues: [],
+    })
+  })
+})

--- a/src/contexts/saved-tabs/public-api.ts
+++ b/src/contexts/saved-tabs/public-api.ts
@@ -20,3 +20,35 @@ export {
   DEFAULT_EXCLUDE_PATTERNS,
   mergeStoredUserSettingsDefaults,
 } from './domain/services/userSettingsDefaultsMerge'
+
+export {
+  PERSISTENCE_V2_INVARIANT_CODES,
+  PERSISTENCE_V2_ORDERING_POLICY,
+} from './domain/entities/PersistenceModelV2'
+export type {
+  PersistenceV2Collection,
+  PersistenceV2CollectionCategory,
+  PersistenceV2CollectionDefinition,
+  PersistenceV2CollectionGroup,
+  PersistenceV2CollectionMembership,
+  PersistenceV2InvariantCode,
+  PersistenceV2ProjectKeywordSettings,
+  PersistenceV2Snapshot,
+  PersistenceV2Url,
+} from './domain/entities/PersistenceModelV2'
+export {
+  checkPersistenceIntegrity,
+  PERSISTENCE_V2_INVARIANT_POLICY,
+} from './domain/services/PersistenceIntegrityChecker'
+export type {
+  IntegrityIssueSeverity,
+  IntegrityRepairability,
+  StorageIntegrityIssue,
+  StorageIntegrityIssueDetails,
+  StorageIntegrityReport,
+} from './domain/services/PersistenceIntegrityChecker'
+export { createStorageRepairPlan } from './domain/services/PersistenceRepairPlanner'
+export type {
+  StorageRepairOperation,
+  StorageRepairPlan,
+} from './domain/services/PersistenceRepairPlanner'


### PR DESCRIPTION
## 概要

Persistence Model v2 の型と invariant code は定義済みでしたが、論理 snapshot を監査する実行可能な checker と、安全性を分類した repair plan がありませんでした。

Closes #712

## 変更内容

- Chrome / IndexedDB に依存しない pure な `checkPersistenceIntegrity` を追加
- Issue #725 の invariant code 全件に severity / repairability policy を定義
- 参照切れ、重複、orphan、order、timestamp、JSON-safe 境界を独立検査
- user content を診断へコピーせず、locale 非依存で finding を決定的に整列
- audit と storage write を分離した pure な `createStorageRepairPlan` を追加
- metadata が等価な duplicate membership だけを automatic-safe とし、競合は review-required のまま保持
- `ORPHAN_URL` は自動削除せず、曖昧・修復不能な finding を `unresolvedIssues` に保持
- corrupted fixture、公開 API、architecture / implementation docs を追加

## 検証

- focused: 3 files / 24 tests passed
- `bun run quality:check`: 332 files / 3651 tests passed
- `bun run test:coverage`: gate passed
  - `PersistenceIntegrityChecker.ts`: statements / branches / functions / lines 100%
  - `PersistenceRepairPlanner.ts`: statements / branches / functions / lines 100%
- `bun run release:check`: passed
- fresh-context Evaluator: approved

## 境界とリスク

- checker / planner は snapshot と report のみを扱い、storage write や repair 実行を行いません。
- source evidence が必要な collision / provenance / active-chat finding は migration/import adapter 側で再利用できる typed contract として残し、v2 logical checker では推測しません。
- repair 実行側は review / dry-run、backup、repair、re-audit の順序を維持する必要があります。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 永続化データの整合性を検査し、問題の種類・重大度・修復可能性を含むレポートを生成できるようになりました。
  * 安全に自動修復できる問題と、確認が必要な問題を分離した修復計画を作成できるようになりました。
  * 整合性チェックと修復計画のAPIを公開しました。

* **ドキュメント**
  * 整合性検査、修復計画、安全性、対象外となる問題の扱いを文書化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->