### PR TITLE
feat: Persistence v2 の容量・耐久性ポリシーを確定する (#735)

### DIFF
--- a/docs/architecture/persistence-model-v2.md
+++ b/docs/architecture/persistence-model-v2.md
@@ -11,6 +11,13 @@ identity examples are in `urlIdentityCorpus.ts`.
 This contract does not create IndexedDB stores, migrate current data, or switch
 the runtime source of truth. Those changes remain separate Issues and PRs.
 
+The quota, eviction, permission, capacity-preflight, typed failure, and recovery
+boundary is defined by
+[`docs/security/persistence-durability.md`](../security/persistence-durability.md)
+and the executable contract in `src/lib/persistence/capacity.ts`. IndexedDB and
+migration implementations must consume that boundary rather than reclassifying
+storage failures locally.
+
 ## Aggregate boundary
 
 The normalized saved-tabs aggregate consists of `Url`, `Collection`,

--- a/docs/plans/2026-07-17-issue-735-persistence-durability-design.md
+++ b/docs/plans/2026-07-17-issue-735-persistence-durability-design.md
@@ -1,0 +1,122 @@
+# Issue #735 persistence durability design
+
+## Scope
+
+Issue #735 is a Phase 0 durability contract for Persistence Model v2. It does
+not implement the IndexedDB schema, connection lifecycle, migration mapper, or
+source-of-truth cutover owned by #726, #727, and #728. It makes the capacity and
+failure boundary those later implementations must consume executable before
+any user data moves.
+
+The implementation covers four coupled surfaces:
+
+1. a shared capacity preflight and typed persistence failure contract;
+2. a migration failure outcome that forbids cutover and requires legacy-source
+   retention;
+3. a user-facing recovery component with backup and retry actions; and
+4. an exact generated-manifest permission invariant for Chrome and Firefox.
+
+## Durability permission decision
+
+TABBIN will add `unlimitedStorage` to the required extension permissions.
+TABBIN is local-first and has no server-side recovery authority for saved URLs,
+notes, AI conversations, attachments, or analytics data. Losing or silently
+evicting the only copy is therefore a higher product risk than the additional
+storage permission.
+
+The decision is based on current browser documentation:
+
+- Chrome states that `unlimitedStorage` applies to extension and web storage
+  APIs, removes normal quota restrictions, and exempts extension storage from
+  eviction. It also documents `navigator.storage.persist()` as an eviction-only
+  alternative: <https://developer.chrome.com/docs/extensions/develop/concepts/storage-and-cookies>
+- Firefox documents that `unlimitedStorage` permits a persistent IndexedDB
+  database without a creation-time permission prompt:
+  <https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#unlimited_storage>
+- `StorageManager.persist()` may be refused and is unavailable in Web Workers,
+  so it cannot be the sole MV3 background-service-worker durability mechanism:
+  <https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/persist>
+
+`unlimitedStorage` is not treated as proof that a disk write will succeed.
+Disk exhaustion, unavailable storage, transaction aborts, hardware failures,
+and explicit user deletion remain possible. Capacity preflight and typed write
+failure handling therefore remain mandatory.
+
+The permission grants no network, host, or user-content access. The production
+manifest verifier will compare all required API permissions against one typed
+allowlist for both generated manifests and reject missing, added, or optional
+permissions. This is the #676 security invariant for this change.
+
+## Capacity preflight
+
+The migration planner supplies values measured from its actual source reader
+and synthetic target fixture:
+
+- serialized legacy source bytes;
+- target expansion ratio;
+- minimum reserve bytes; and
+- reserve ratio.
+
+The shared policy computes:
+
+```text
+projected target bytes = ceil(source bytes * target expansion ratio)
+reserve bytes = max(minimum reserve, ceil(projected target bytes * reserve ratio))
+required headroom = projected target bytes + reserve bytes
+available bytes = estimated quota - estimated usage
+```
+
+The legacy source remains present while the target is written, so the required
+headroom is for the complete projected target plus reserve. A caller may not
+treat the source size alone as proof that migration fits. The target expansion
+ratio is explicit rather than a hidden constant so #728's representative
+fixture can replace the Phase 0 baseline without changing the policy boundary.
+
+`navigator.storage.estimate()` is advisory. MDN describes `usage` and `quota`
+as approximate and potentially obfuscated values:
+<https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/estimate>.
+Missing, non-finite, rejected, or internally inconsistent estimates block the
+preflight with `PERSISTENCE_CAPACITY_PREFLIGHT_FAILED`; they do not silently
+allow migration.
+
+Only counts and numeric sizes enter diagnostics. Raw URLs, titles, notes,
+prompts, attachments, or filesystem/browser error messages are excluded.
+
+## Failure and recovery contract
+
+The minimum error codes are:
+
+- `PERSISTENCE_QUOTA_EXCEEDED`;
+- `PERSISTENCE_DISK_WRITE_FAILED`;
+- `PERSISTENCE_STORAGE_UNAVAILABLE`; and
+- `PERSISTENCE_CAPACITY_PREFLIGHT_FAILED`.
+
+Quota and known storage-unavailable DOM exception names are classified
+explicitly. Other target-write failures remain typed disk-write failures rather
+than being collapsed into an empty result or generic persistence error.
+
+Every capacity/write failure produces the same safety outcome:
+
+```text
+control state = failed
+cutover allowed = false
+legacy source action = retain
+recovery actions = backup, retry
+```
+
+The recovery component explains that the update did not complete and that the
+previous data was retained. It exposes backup and retry callbacks and never
+accepts a raw browser error for rendering.
+
+## Verification
+
+- Node tests cover normal capacity, near-capacity rejection, invalid estimates,
+  typed error classification, source retention, and retry readiness.
+- DOM tests cover the recovery message and both actions without raw error
+  leakage.
+- Manifest policy tests cover exact Chrome MV3 and Firefox MV2 required API
+  permissions plus rejection of added, missing, and optional permissions.
+- Production builds and the generated-manifest verifier confirm Chrome and
+  Firefox artifacts.
+- Repository coverage, quality, security review, and release gates run before
+  publication.

--- a/docs/security/persistence-durability.md
+++ b/docs/security/persistence-durability.md
@@ -1,0 +1,136 @@
+# Persistence durability policy
+
+## Decision
+
+TABBIN requires the `unlimitedStorage` extension permission for Persistence
+Model v2. The product is local-first and does not have a server-side recovery
+authority for user data. Preventing quota eviction of the only durable copy is
+therefore part of the data-safety boundary.
+
+Chrome documents that `unlimitedStorage` applies to extension and web storage
+APIs, removes normal quota restrictions, and exempts extension storage from
+eviction. Firefox documents that it permits an extension to create a persistent
+IndexedDB database without a creation-time prompt.
+
+- Chrome: <https://developer.chrome.com/docs/extensions/develop/concepts/storage-and-cookies>
+- Firefox: <https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#unlimited_storage>
+
+The permission does not grant host, network, or user-content access. The typed
+allowlist in `src/constants/extensionPermissions.ts` is used by WXT and the
+generated-manifest verifier. Chrome MV3 and Firefox MV2 artifacts must contain
+exactly the reviewed API permissions. Added, missing, or optional permissions
+fail release verification.
+
+### User and store-review impact
+
+The benefit is that the browser may retain the only durable local copy beyond
+its normal quota and eviction policy. The cost is that TABBIN may consume more
+local disk space, while users and the browser can still remove extension data
+and a full or unavailable disk can still reject writes.
+
+Chrome's current permission-warning list does not assign an install warning to
+`unlimitedStorage`. Firefox grants persistent IndexedDB access without a
+database-creation prompt. These browser behaviors may change, so every store
+submission that changes the permission allowlist must re-check the current
+Chrome and Firefox review surfaces. The submission notes must justify
+`unlimitedStorage` as protection for local-only user data and must not claim
+that it guarantees successful writes. If a store begins showing a new warning,
+the release must explain the storage purpose to users before publication.
+
+- Chrome permission warnings: <https://developer.chrome.com/docs/extensions/reference/permissions-list>
+- Firefox permission behavior: <https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#unlimited_storage>
+
+`navigator.storage.persist()` is not the primary policy because a browser may
+refuse the request and the method is unavailable in Web Workers, including the
+MV3 background-service-worker execution model. It may be used later from a
+supported extension page as defense in depth, but refusal must not bypass
+capacity or write-failure handling.
+
+## Capacity preflight
+
+Before a migration target write, the migration planner must obtain:
+
+- the UTF-8 byte size of the serialized legacy source;
+- privacy-safe source entity counts;
+- `navigator.storage.estimate()` usage and quota when available;
+- a target expansion ratio measured by the migration's synthetic fixture;
+- a minimum reserve and reserve ratio.
+
+The shared contract in `src/lib/persistence/capacity.ts` computes:
+
+```text
+projected target bytes = ceil(source bytes * target expansion ratio)
+reserve bytes = max(minimum reserve, ceil(projected target bytes * reserve ratio))
+required headroom = projected target bytes + reserve bytes
+available bytes = estimated quota - estimated usage
+```
+
+The Phase 0 contract test uses a `1.5` synthetic target expansion ratio to
+exercise temporary duplication and reserve behavior. The actual #728 migration
+fixture must measure and supply its own ratio; production code does not hide an
+unverified default.
+
+The complete target plus reserve must fit while the legacy source is retained.
+Comparing source bytes with quota is insufficient. `StorageManager.estimate()`
+values are approximate, may be padded or obfuscated, and cannot prove that the
+underlying disk write will succeed:
+<https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/estimate>.
+
+Missing, rejected, non-finite, or inconsistent estimates block migration with
+`PERSISTENCE_CAPACITY_PREFLIGHT_FAILED`. `unlimitedStorage` never changes this
+fail-closed rule.
+
+## Typed failures and migration safety
+
+Persistence capacity and write failures use these codes:
+
+- `PERSISTENCE_QUOTA_EXCEEDED`;
+- `PERSISTENCE_DISK_WRITE_FAILED`;
+- `PERSISTENCE_STORAGE_UNAVAILABLE`;
+- `PERSISTENCE_CAPACITY_PREFLIGHT_FAILED`.
+
+`QuotaExceededError` maps to the quota code. Known unavailable storage states
+map to the unavailable code. Other target-write or transaction-abort errors
+remain typed disk-write failures. No path converts these failures to an empty
+data result or generic success.
+
+Every failure outcome has the following immutable safety semantics:
+
+- migration control state is `failed`;
+- cutover is forbidden;
+- the legacy source must be retained;
+- partial target data is not authoritative;
+- backup and retry are the available recovery actions.
+
+The concrete #727/#728 control state and migration executor must consume this
+outcome. #733 cleanup is not eligible until migration succeeds, source/target
+verification passes, and its separate retention period and integrity checks are
+satisfied.
+
+## Recovery UI and safe diagnostics
+
+`PersistenceCapacityRecovery` explains the typed reason, states that previous
+data was not deleted, and offers backup and retry. The component accepts no raw
+browser error, filesystem path, URL, title, note, prompt, or attachment data.
+
+Diagnostics may contain only:
+
+- fixed-kind entity counts;
+- approximate serialized source bytes;
+- estimated usage and quota;
+- failed stage; and
+- typed error code.
+
+Diagnostic data stays local under the existing production outbound-network
+policy. Adding capacity telemetry to an external request requires a separate
+privacy and security review and is not allowed by this policy.
+
+## Browser differences
+
+| Browser | `unlimitedStorage` effect used by TABBIN                                                                  | Remaining failure modes                                                |
+| ------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Chrome  | Exempts extension/web storage APIs from normal quota and eviction                                         | Disk exhaustion, unavailable storage, transaction abort, user deletion |
+| Firefox | Allows persistent IndexedDB without the creation-time permission prompt and removes `storage.local` quota | Disk exhaustion, unavailable storage, transaction abort, user deletion |
+
+Both generated manifests are built and checked during `release:check`. Browser
+differences do not change the typed error or recovery contract.

--- a/docs/security/production-network-policy.md
+++ b/docs/security/production-network-policy.md
@@ -14,6 +14,12 @@ custom Ollama endpoints, cloud AI endpoints, HTTPS, WebSocket, and EventSource
 origins are not currently allowed. Adding one is a privacy-design change, not a
 routine allowlist update.
 
+The same generated-manifest verification also checks the exact reviewed API
+permission allowlist from `src/constants/extensionPermissions.ts`. The
+`unlimitedStorage` durability decision and its non-network security boundary are
+documented in
+[`docs/security/persistence-durability.md`](persistence-durability.md).
+
 ## Production network inventory
 
 The automated AST inventory in

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "An extension for organizing and categorizing browser tabs so cluttered tab lists stay manageable.",
   "type": "module",
   "imports": {
+    "#extension-permissions": "./src/constants/extensionPermissions.ts",
     "#harness-state": "./tools/harness/state/index.ts",
     "#production-network-policy": "./src/constants/productionNetworkPolicy.ts"
   },

--- a/src/constants/extensionPermissions.test.ts
+++ b/src/constants/extensionPermissions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest' // eslint-disable-line
+
+import { PRODUCTION_EXTENSION_PERMISSIONS } from './extensionPermissions'
+
+describe('production extension permission policy', () => {
+  it('allows only the reviewed permissions including persistence durability', () => {
+    expect(PRODUCTION_EXTENSION_PERMISSIONS).toEqual([
+      'alarms',
+      'tabs',
+      'storage',
+      'contextMenus',
+      'notifications',
+      'unlimitedStorage',
+    ])
+    expect(new Set(PRODUCTION_EXTENSION_PERMISSIONS).size).toBe(
+      PRODUCTION_EXTENSION_PERMISSIONS.length,
+    )
+  })
+})

--- a/src/constants/extensionPermissions.ts
+++ b/src/constants/extensionPermissions.ts
@@ -1,0 +1,8 @@
+export const PRODUCTION_EXTENSION_PERMISSIONS = [
+  'alarms',
+  'tabs',
+  'storage',
+  'contextMenus',
+  'notifications',
+  'unlimitedStorage',
+] as const

--- a/src/features/i18n/messages.ts
+++ b/src/features/i18n/messages.ts
@@ -506,6 +506,19 @@ const messages = {
     'options.importExport.unresolvedWarning':
       ' (Warning: {{count}} domains were missing URL records, so {{placeholderCount}} replacement URLs were generated)',
     'options.importExport.uploadTitle': 'Import settings and tab data',
+    'options.persistenceRecovery.backup': 'Back up current data',
+    'options.persistenceRecovery.description':
+      'The update could not be completed. Your previous data has not been deleted.',
+    'options.persistenceRecovery.diskWriteFailed':
+      'Writing data to browser storage failed.',
+    'options.persistenceRecovery.preflightFailed':
+      'Available browser storage could not be confirmed.',
+    'options.persistenceRecovery.quotaExceeded':
+      'There is not enough browser storage to complete the update.',
+    'options.persistenceRecovery.retry': 'Retry',
+    'options.persistenceRecovery.storageUnavailable':
+      'Browser storage is currently unavailable.',
+    'options.persistenceRecovery.title': 'Storage recovery required',
     'options.previewColorCustomization': '(preview) Color customization',
     'options.previewColorCustomizationReset': 'Reset',
     'options.previewFontSizeCustomization': '(preview) Font size',
@@ -1351,6 +1364,19 @@ const messages = {
     'options.importExport.unresolvedWarning':
       '（注意: {{count}}個のドメインでURL実体が欠損していたため、{{placeholderCount}}件の代替URLを生成しました）',
     'options.importExport.uploadTitle': '設定とタブデータのインポート',
+    'options.persistenceRecovery.backup': '現在のデータをバックアップ',
+    'options.persistenceRecovery.description':
+      'データの更新を完了できませんでした。以前のデータは削除されていません。',
+    'options.persistenceRecovery.diskWriteFailed':
+      'ブラウザの保存領域への書き込みに失敗しました。',
+    'options.persistenceRecovery.preflightFailed':
+      '利用可能なブラウザの保存領域を確認できませんでした。',
+    'options.persistenceRecovery.quotaExceeded':
+      'データの更新に必要なブラウザの保存領域を確保できませんでした。',
+    'options.persistenceRecovery.retry': '再試行',
+    'options.persistenceRecovery.storageUnavailable':
+      'ブラウザの保存領域を現在利用できません。',
+    'options.persistenceRecovery.title': '保存領域の復旧が必要です',
     'options.previewColorCustomization': '(preview)カラーカスタマイズ',
     'options.previewColorCustomizationReset': 'リセット',
     'options.previewFontSizeCustomization': '(preview)フォントサイズ',

--- a/src/features/options/PersistenceCapacityRecovery.test.tsx
+++ b/src/features/options/PersistenceCapacityRecovery.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest' // eslint-disable-line
+
+import { PersistenceCapacityRecovery } from './PersistenceCapacityRecovery'
+
+vi.mock('@/features/i18n/context/I18nProvider', () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      const messages: Record<string, string> = {
+        'options.persistenceRecovery.backup': 'Back up current data',
+        'options.persistenceRecovery.description':
+          'The update could not be completed. Your previous data has not been deleted.',
+        'options.persistenceRecovery.diskWriteFailed':
+          'Writing data to browser storage failed.',
+        'options.persistenceRecovery.preflightFailed':
+          'Available browser storage could not be confirmed.',
+        'options.persistenceRecovery.quotaExceeded':
+          'There is not enough browser storage to complete the update.',
+        'options.persistenceRecovery.retry': 'Retry',
+        'options.persistenceRecovery.storageUnavailable':
+          'Browser storage is currently unavailable.',
+        'options.persistenceRecovery.title': 'Storage recovery required',
+      }
+      return messages[key] ?? key
+    },
+  }),
+}))
+
+describe('PersistenceCapacityRecovery', () => {
+  afterEach(cleanup)
+
+  it.each([
+    [
+      'PERSISTENCE_QUOTA_EXCEEDED',
+      'There is not enough browser storage to complete the update.',
+    ],
+    [
+      'PERSISTENCE_DISK_WRITE_FAILED',
+      'Writing data to browser storage failed.',
+    ],
+    [
+      'PERSISTENCE_STORAGE_UNAVAILABLE',
+      'Browser storage is currently unavailable.',
+    ],
+    [
+      'PERSISTENCE_CAPACITY_PREFLIGHT_FAILED',
+      'Available browser storage could not be confirmed.',
+    ],
+  ] as const)('renders a safe recovery reason for %s', (errorCode, reason) => {
+    render(
+      <PersistenceCapacityRecovery
+        errorCode={errorCode}
+        onBackup={vi.fn()}
+        onRetry={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole('alert')).toHaveTextContent(reason)
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Your previous data has not been deleted.',
+    )
+    expect(screen.queryByText('/private/profile/path')).toBeNull()
+  })
+
+  it('offers backup and retry actions', async () => {
+    const user = userEvent.setup()
+    const onBackup = vi.fn()
+    const onRetry = vi.fn()
+
+    render(
+      <PersistenceCapacityRecovery
+        errorCode='PERSISTENCE_QUOTA_EXCEEDED'
+        onBackup={onBackup}
+        onRetry={onRetry}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole('button', { name: 'Back up current data' }),
+    )
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+
+    expect(onBackup).toHaveBeenCalledTimes(1)
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/options/PersistenceCapacityRecovery.tsx
+++ b/src/features/options/PersistenceCapacityRecovery.tsx
@@ -1,0 +1,48 @@
+import { Download, HardDrive, RotateCcw } from 'lucide-react'
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { useI18n } from '@/features/i18n/context/I18nProvider'
+import type { PersistenceCapacityErrorCode } from '@/lib/persistence/capacity'
+
+type PersistenceCapacityRecoveryProps = {
+  errorCode: PersistenceCapacityErrorCode
+  onBackup: () => void
+  onRetry: () => void
+}
+
+const reasonKeyByErrorCode: Record<PersistenceCapacityErrorCode, string> = {
+  PERSISTENCE_CAPACITY_PREFLIGHT_FAILED:
+    'options.persistenceRecovery.preflightFailed',
+  PERSISTENCE_DISK_WRITE_FAILED: 'options.persistenceRecovery.diskWriteFailed',
+  PERSISTENCE_QUOTA_EXCEEDED: 'options.persistenceRecovery.quotaExceeded',
+  PERSISTENCE_STORAGE_UNAVAILABLE:
+    'options.persistenceRecovery.storageUnavailable',
+}
+
+export const PersistenceCapacityRecovery: React.FC<
+  PersistenceCapacityRecoveryProps
+> = ({ errorCode, onBackup, onRetry }) => {
+  const { t } = useI18n()
+
+  return (
+    <Alert variant='destructive'>
+      <HardDrive className='size-4' />
+      <AlertTitle>{t('options.persistenceRecovery.title')}</AlertTitle>
+      <AlertDescription className='space-y-3'>
+        <p>{t(reasonKeyByErrorCode[errorCode])}</p>
+        <p>{t('options.persistenceRecovery.description')}</p>
+        <div className='flex flex-wrap gap-2'>
+          <Button type='button' variant='outline' onClick={onBackup}>
+            <Download className='size-4' />
+            {t('options.persistenceRecovery.backup')}
+          </Button>
+          <Button type='button' onClick={onRetry}>
+            <RotateCcw className='size-4' />
+            {t('options.persistenceRecovery.retry')}
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/src/lib/persistence/capacity.test.ts
+++ b/src/lib/persistence/capacity.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest' // eslint-disable-line
+
+import {
+  assessPersistenceCapacity,
+  classifyPersistenceWriteFailure,
+  createPersistenceFailureOutcome,
+  measureSerializedBytes,
+  runPersistenceCapacityPreflight,
+} from './capacity'
+
+const plan = {
+  minimumReserveBytes: 200,
+  reserveRatio: 0.2,
+  sourceEntityCounts: {
+    collections: 4,
+    urls: 10,
+  },
+  sourceSerializedBytes: 1_000,
+  targetExpansionRatio: 1.5,
+} as const
+
+describe('persistence capacity policy', () => {
+  it('measures the UTF-8 byte size of the serialized legacy source', () => {
+    const source = {
+      title: '保存データ',
+      urls: ['https://example.com'],
+    }
+
+    expect(measureSerializedBytes(source)).toBe(
+      new TextEncoder().encode(JSON.stringify(source)).byteLength,
+    )
+    expect(() => measureSerializedBytes(undefined)).toThrow(/JSON-serializable/)
+  })
+
+  it('requires projected target bytes plus a reserve while source data remains', () => {
+    expect(
+      assessPersistenceCapacity(plan, {
+        quota: 10_000,
+        usage: 4_000,
+      }),
+    ).toEqual({
+      availableBytes: 6_000,
+      diagnostics: {
+        approximateSourceBytes: 1_000,
+        estimatedQuotaBytes: 10_000,
+        estimatedUsageBytes: 4_000,
+        sourceEntityCounts: {
+          collections: 4,
+          urls: 10,
+        },
+      },
+      projectedTargetBytes: 1_500,
+      requiredHeadroomBytes: 1_800,
+      reserveBytes: 300,
+      status: 'ready',
+    })
+  })
+
+  it('blocks near-capacity migration before the target write starts', () => {
+    expect(
+      assessPersistenceCapacity(plan, {
+        quota: 10_000,
+        usage: 8_500,
+      }),
+    ).toMatchObject({
+      availableBytes: 1_500,
+      errorCode: 'PERSISTENCE_QUOTA_EXCEEDED',
+      requiredHeadroomBytes: 1_800,
+      status: 'blocked',
+    })
+  })
+
+  it('blocks when the browser estimate is missing or internally invalid', () => {
+    expect(assessPersistenceCapacity(plan, {})).toMatchObject({
+      errorCode: 'PERSISTENCE_CAPACITY_PREFLIGHT_FAILED',
+      status: 'blocked',
+    })
+    expect(
+      assessPersistenceCapacity(plan, {
+        quota: 1_000,
+        usage: 2_000,
+      }),
+    ).toMatchObject({
+      errorCode: 'PERSISTENCE_CAPACITY_PREFLIGHT_FAILED',
+      status: 'blocked',
+    })
+  })
+
+  it('fails closed when plan math overflows or entity counts are invalid', () => {
+    expect(
+      assessPersistenceCapacity(
+        {
+          ...plan,
+          sourceSerializedBytes: Number.MAX_VALUE,
+          targetExpansionRatio: 2,
+        },
+        {
+          quota: Number.MAX_VALUE,
+          usage: 0,
+        },
+      ),
+    ).toMatchObject({
+      errorCode: 'PERSISTENCE_CAPACITY_PREFLIGHT_FAILED',
+      status: 'blocked',
+    })
+
+    expect(
+      assessPersistenceCapacity(
+        {
+          ...plan,
+          sourceEntityCounts: {
+            urls: -1,
+          },
+        },
+        {
+          quota: 10_000,
+          usage: 0,
+        },
+      ),
+    ).toMatchObject({
+      errorCode: 'PERSISTENCE_CAPACITY_PREFLIGHT_FAILED',
+      status: 'blocked',
+    })
+  })
+
+  it('turns a rejected estimate into a typed preflight failure', async () => {
+    const estimateStorage = vi
+      .fn()
+      .mockRejectedValue(new Error('/private/profile/path'))
+
+    await expect(
+      runPersistenceCapacityPreflight(plan, estimateStorage),
+    ).resolves.toMatchObject({
+      errorCode: 'PERSISTENCE_CAPACITY_PREFLIGHT_FAILED',
+      status: 'blocked',
+    })
+  })
+
+  it.each([
+    ['QuotaExceededError', 'PERSISTENCE_QUOTA_EXCEEDED'],
+    ['InvalidStateError', 'PERSISTENCE_STORAGE_UNAVAILABLE'],
+    ['SecurityError', 'PERSISTENCE_STORAGE_UNAVAILABLE'],
+    ['AbortError', 'PERSISTENCE_DISK_WRITE_FAILED'],
+  ] as const)(
+    'classifies %s without exposing the raw browser error',
+    (name, expectedCode) => {
+      expect(classifyPersistenceWriteFailure({ name })).toBe(expectedCode)
+    },
+  )
+
+  it.each([null, 'raw error', {}, { name: 1 }])(
+    'classifies an unrecognized write failure without inspecting raw content',
+    (error) => {
+      expect(classifyPersistenceWriteFailure(error)).toBe(
+        'PERSISTENCE_DISK_WRITE_FAILED',
+      )
+    },
+  )
+
+  it('retains the legacy source and forbids cutover on every capacity failure', () => {
+    expect(
+      createPersistenceFailureOutcome(
+        'PERSISTENCE_DISK_WRITE_FAILED',
+        'target-write',
+        {
+          approximateSourceBytes: 1_000,
+          estimatedQuotaBytes: 10_000,
+          estimatedUsageBytes: 8_500,
+          sourceEntityCounts: {
+            urls: 10,
+          },
+        },
+      ),
+    ).toEqual({
+      canCutover: false,
+      controlState: 'failed',
+      diagnostics: {
+        approximateSourceBytes: 1_000,
+        errorCode: 'PERSISTENCE_DISK_WRITE_FAILED',
+        estimatedQuotaBytes: 10_000,
+        estimatedUsageBytes: 8_500,
+        failedStage: 'target-write',
+        sourceEntityCounts: {
+          urls: 10,
+        },
+      },
+      legacySourceAction: 'retain',
+      recoveryActions: ['backup', 'retry'],
+    })
+  })
+})

--- a/src/lib/persistence/capacity.test.ts
+++ b/src/lib/persistence/capacity.test.ts
@@ -7,6 +7,7 @@ import {
   measureSerializedBytes,
   runPersistenceCapacityPreflight,
 } from './capacity'
+import type { PersistenceCapacityPlan } from './capacity'
 
 const plan = {
   minimumReserveBytes: 200,
@@ -120,6 +121,33 @@ describe('persistence capacity policy', () => {
     ).toMatchObject({
       errorCode: 'PERSISTENCE_CAPACITY_PREFLIGHT_FAILED',
       status: 'blocked',
+    })
+  })
+
+  it('blocks unknown entity kinds and excludes them from diagnostics', () => {
+    const rawUserContent = 'https://private.example/saved-tab'
+    const sourceEntityCounts = {
+      urls: 10,
+      [rawUserContent]: 1,
+    } as unknown as PersistenceCapacityPlan['sourceEntityCounts']
+
+    const assessment = assessPersistenceCapacity(
+      {
+        ...plan,
+        sourceEntityCounts,
+      },
+      {
+        quota: 10_000,
+        usage: 4_000,
+      },
+    )
+
+    expect(assessment).toMatchObject({
+      errorCode: 'PERSISTENCE_CAPACITY_PREFLIGHT_FAILED',
+      status: 'blocked',
+    })
+    expect(assessment.diagnostics.sourceEntityCounts).toEqual({
+      urls: 10,
     })
   })
 

--- a/src/lib/persistence/capacity.ts
+++ b/src/lib/persistence/capacity.ts
@@ -1,0 +1,230 @@
+import { isJsonValue } from './jsonValue'
+
+export type PersistenceCapacityErrorCode =
+  | 'PERSISTENCE_QUOTA_EXCEEDED'
+  | 'PERSISTENCE_DISK_WRITE_FAILED'
+  | 'PERSISTENCE_STORAGE_UNAVAILABLE'
+  | 'PERSISTENCE_CAPACITY_PREFLIGHT_FAILED'
+
+export type PersistenceFailureStage =
+  | 'capacity-preflight'
+  | 'target-write'
+  | 'transaction-abort'
+
+export type PersistenceSourceEntityKind =
+  | 'analyticsViews'
+  | 'attachments'
+  | 'categories'
+  | 'collections'
+  | 'conversations'
+  | 'groups'
+  | 'memberships'
+  | 'messages'
+  | 'settings'
+  | 'urls'
+
+export type PersistenceSourceEntityCounts = Readonly<
+  Partial<Record<PersistenceSourceEntityKind, number>>
+>
+
+export type PersistenceCapacityPlan = {
+  minimumReserveBytes: number
+  reserveRatio: number
+  sourceEntityCounts: PersistenceSourceEntityCounts
+  sourceSerializedBytes: number
+  targetExpansionRatio: number
+}
+
+export type PersistenceStorageEstimate = {
+  quota?: number
+  usage?: number
+}
+
+export type PersistenceCapacityDiagnostics = {
+  approximateSourceBytes: number
+  estimatedQuotaBytes?: number
+  estimatedUsageBytes?: number
+  sourceEntityCounts: PersistenceSourceEntityCounts
+}
+
+type PersistenceCapacityAssessmentBase = {
+  availableBytes: number
+  diagnostics: PersistenceCapacityDiagnostics
+  projectedTargetBytes: number
+  requiredHeadroomBytes: number
+  reserveBytes: number
+}
+
+export type PersistenceCapacityAssessment =
+  | (PersistenceCapacityAssessmentBase & {
+      status: 'ready'
+    })
+  | (PersistenceCapacityAssessmentBase & {
+      errorCode:
+        | 'PERSISTENCE_QUOTA_EXCEEDED'
+        | 'PERSISTENCE_CAPACITY_PREFLIGHT_FAILED'
+      status: 'blocked'
+    })
+
+export type PersistenceFailureOutcome = {
+  canCutover: false
+  controlState: 'failed'
+  diagnostics: PersistenceCapacityDiagnostics & {
+    errorCode: PersistenceCapacityErrorCode
+    failedStage: PersistenceFailureStage
+  }
+  legacySourceAction: 'retain'
+  recoveryActions: readonly ['backup', 'retry']
+}
+
+export type PersistenceStorageEstimatePort =
+  () => Promise<PersistenceStorageEstimate>
+
+const unavailableStorageErrorNames = new Set([
+  'InvalidStateError',
+  'NotFoundError',
+  'SecurityError',
+  'VersionError',
+])
+
+export const measureSerializedBytes = (value: unknown): number => {
+  if (!isJsonValue(value)) {
+    throw new TypeError('persistence source must be JSON-serializable')
+  }
+  const serialized = JSON.stringify(value)
+  return new TextEncoder().encode(serialized).byteLength
+}
+
+const isFiniteNonNegative = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0
+
+const isSafeNonNegativeInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+
+const isFinitePositive = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value) && value > 0
+
+const isValidPlan = (plan: PersistenceCapacityPlan): boolean =>
+  isSafeNonNegativeInteger(plan.minimumReserveBytes) &&
+  isFiniteNonNegative(plan.reserveRatio) &&
+  isSafeNonNegativeInteger(plan.sourceSerializedBytes) &&
+  isFinitePositive(plan.targetExpansionRatio) &&
+  Object.values(plan.sourceEntityCounts).every(isSafeNonNegativeInteger)
+
+const createDiagnostics = (
+  plan: PersistenceCapacityPlan,
+  estimate: PersistenceStorageEstimate,
+): PersistenceCapacityDiagnostics => ({
+  approximateSourceBytes: isSafeNonNegativeInteger(plan.sourceSerializedBytes)
+    ? plan.sourceSerializedBytes
+    : 0,
+  ...(isSafeNonNegativeInteger(estimate.quota)
+    ? { estimatedQuotaBytes: estimate.quota }
+    : {}),
+  ...(isSafeNonNegativeInteger(estimate.usage)
+    ? { estimatedUsageBytes: estimate.usage }
+    : {}),
+  sourceEntityCounts: { ...plan.sourceEntityCounts },
+})
+
+export const assessPersistenceCapacity = (
+  plan: PersistenceCapacityPlan,
+  estimate: PersistenceStorageEstimate,
+): PersistenceCapacityAssessment => {
+  const planIsValid = isValidPlan(plan)
+  const projectedTargetBytes = planIsValid
+    ? Math.ceil(plan.sourceSerializedBytes * plan.targetExpansionRatio)
+    : 0
+  const reserveBytes = planIsValid
+    ? Math.max(
+        plan.minimumReserveBytes,
+        Math.ceil(projectedTargetBytes * plan.reserveRatio),
+      )
+    : 0
+  const requiredHeadroomBytes = projectedTargetBytes + reserveBytes
+  const requirementIsValid =
+    isSafeNonNegativeInteger(projectedTargetBytes) &&
+    isSafeNonNegativeInteger(reserveBytes) &&
+    isSafeNonNegativeInteger(requiredHeadroomBytes)
+  const { quota, usage } = estimate
+  const estimateIsValid =
+    isSafeNonNegativeInteger(quota) &&
+    isSafeNonNegativeInteger(usage) &&
+    usage <= quota
+  const availableBytes = estimateIsValid ? quota - usage : 0
+  const base = {
+    availableBytes,
+    diagnostics: createDiagnostics(plan, estimate),
+    projectedTargetBytes,
+    requiredHeadroomBytes,
+    reserveBytes,
+  }
+
+  if (!planIsValid || !requirementIsValid || !estimateIsValid) {
+    return {
+      ...base,
+      errorCode: 'PERSISTENCE_CAPACITY_PREFLIGHT_FAILED',
+      status: 'blocked',
+    }
+  }
+
+  if (availableBytes < requiredHeadroomBytes) {
+    return {
+      ...base,
+      errorCode: 'PERSISTENCE_QUOTA_EXCEEDED',
+      status: 'blocked',
+    }
+  }
+
+  return {
+    ...base,
+    status: 'ready',
+  }
+}
+
+export const runPersistenceCapacityPreflight = async (
+  plan: PersistenceCapacityPlan,
+  estimateStorage: PersistenceStorageEstimatePort,
+): Promise<PersistenceCapacityAssessment> => {
+  try {
+    return assessPersistenceCapacity(plan, await estimateStorage())
+  } catch {
+    return assessPersistenceCapacity(plan, {})
+  }
+}
+
+export const classifyPersistenceWriteFailure = (
+  error: unknown,
+): PersistenceCapacityErrorCode => {
+  const name =
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    typeof error.name === 'string'
+      ? error.name
+      : ''
+
+  if (name === 'QuotaExceededError') {
+    return 'PERSISTENCE_QUOTA_EXCEEDED'
+  }
+  if (unavailableStorageErrorNames.has(name)) {
+    return 'PERSISTENCE_STORAGE_UNAVAILABLE'
+  }
+  return 'PERSISTENCE_DISK_WRITE_FAILED'
+}
+
+export const createPersistenceFailureOutcome = (
+  errorCode: PersistenceCapacityErrorCode,
+  failedStage: PersistenceFailureStage,
+  diagnostics: PersistenceCapacityDiagnostics,
+): PersistenceFailureOutcome => ({
+  canCutover: false,
+  controlState: 'failed',
+  diagnostics: {
+    ...diagnostics,
+    errorCode,
+    failedStage,
+  },
+  legacySourceAction: 'retain',
+  recoveryActions: ['backup', 'retry'],
+})

--- a/src/lib/persistence/capacity.ts
+++ b/src/lib/persistence/capacity.ts
@@ -11,17 +11,21 @@ export type PersistenceFailureStage =
   | 'target-write'
   | 'transaction-abort'
 
+export const PERSISTENCE_SOURCE_ENTITY_KINDS = [
+  'analyticsViews',
+  'attachments',
+  'categories',
+  'collections',
+  'conversations',
+  'groups',
+  'memberships',
+  'messages',
+  'settings',
+  'urls',
+] as const
+
 export type PersistenceSourceEntityKind =
-  | 'analyticsViews'
-  | 'attachments'
-  | 'categories'
-  | 'collections'
-  | 'conversations'
-  | 'groups'
-  | 'memberships'
-  | 'messages'
-  | 'settings'
-  | 'urls'
+  (typeof PERSISTENCE_SOURCE_ENTITY_KINDS)[number]
 
 export type PersistenceSourceEntityCounts = Readonly<
   Partial<Record<PersistenceSourceEntityKind, number>>
@@ -86,6 +90,9 @@ const unavailableStorageErrorNames = new Set([
   'SecurityError',
   'VersionError',
 ])
+const persistenceSourceEntityKindSet = new Set<string>(
+  PERSISTENCE_SOURCE_ENTITY_KINDS,
+)
 
 export const measureSerializedBytes = (value: unknown): number => {
   if (!isJsonValue(value)) {
@@ -104,11 +111,32 @@ const isSafeNonNegativeInteger = (value: unknown): value is number =>
 const isFinitePositive = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value) && value > 0
 
+const hasOnlyKnownSourceEntityKinds = (
+  sourceEntityCounts: PersistenceSourceEntityCounts,
+): boolean =>
+  Object.keys(sourceEntityCounts).every((kind) =>
+    persistenceSourceEntityKindSet.has(kind),
+  )
+
+const createSafeSourceEntityCounts = (
+  sourceEntityCounts: PersistenceSourceEntityCounts,
+): PersistenceSourceEntityCounts => {
+  const safeCounts: Partial<Record<PersistenceSourceEntityKind, number>> = {}
+  for (const kind of PERSISTENCE_SOURCE_ENTITY_KINDS) {
+    const count = sourceEntityCounts[kind]
+    if (isSafeNonNegativeInteger(count)) {
+      safeCounts[kind] = count
+    }
+  }
+  return safeCounts
+}
+
 const isValidPlan = (plan: PersistenceCapacityPlan): boolean =>
   isSafeNonNegativeInteger(plan.minimumReserveBytes) &&
   isFiniteNonNegative(plan.reserveRatio) &&
   isSafeNonNegativeInteger(plan.sourceSerializedBytes) &&
   isFinitePositive(plan.targetExpansionRatio) &&
+  hasOnlyKnownSourceEntityKinds(plan.sourceEntityCounts) &&
   Object.values(plan.sourceEntityCounts).every(isSafeNonNegativeInteger)
 
 const createDiagnostics = (
@@ -124,7 +152,7 @@ const createDiagnostics = (
   ...(isSafeNonNegativeInteger(estimate.usage)
     ? { estimatedUsageBytes: estimate.usage }
     : {}),
-  sourceEntityCounts: { ...plan.sourceEntityCounts },
+  sourceEntityCounts: createSafeSourceEntityCounts(plan.sourceEntityCounts),
 })
 
 export const assessPersistenceCapacity = (

--- a/tools/scripts/production-network-policy.test.ts
+++ b/tools/scripts/production-network-policy.test.ts
@@ -493,6 +493,14 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             'http://localhost:11434/*',
           ],
           manifest_version: 3,
+          permissions: [
+            'alarms',
+            'tabs',
+            'storage',
+            'contextMenus',
+            'notifications',
+            'unlimitedStorage',
+          ],
         },
         'manifest.json',
       ),
@@ -506,7 +514,12 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
           content_security_policy: createProductionExtensionCsp(2),
           manifest_version: 2,
           permissions: [
+            'alarms',
+            'tabs',
             'storage',
+            'contextMenus',
+            'notifications',
+            'unlimitedStorage',
             'http://127.0.0.1:11434/*',
             'http://localhost:11434/*',
           ],
@@ -529,6 +542,60 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
         'firefox-optional.json',
       ),
     ).toThrow(/firefox-optional\.json.*optional_permissions/)
+  })
+
+  it('rejects missing, added, or optional API permissions', () => {
+    const manifest = {
+      content_security_policy: {
+        extension_pages: createProductionExtensionCsp(3),
+      },
+      host_permissions: [
+        'http://127.0.0.1:11434/*',
+        'http://localhost:11434/*',
+      ],
+      manifest_version: 3,
+    }
+    const requiredPermissions = [
+      'alarms',
+      'tabs',
+      'storage',
+      'contextMenus',
+      'notifications',
+      'unlimitedStorage',
+    ]
+
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          ...manifest,
+          permissions: requiredPermissions.filter(
+            (permission) => permission !== 'unlimitedStorage',
+          ),
+        },
+        'missing-api-permission.json',
+      ),
+    ).toThrow(/missing-api-permission\.json.*permissions/)
+
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          ...manifest,
+          permissions: [...requiredPermissions, 'history'],
+        },
+        'added-api-permission.json',
+      ),
+    ).toThrow(/added-api-permission\.json.*permissions/)
+
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          ...manifest,
+          optional_permissions: ['downloads'],
+          permissions: requiredPermissions,
+        },
+        'optional-api-permission.json',
+      ),
+    ).toThrow(/optional-api-permission\.json.*optional_permissions/)
   })
 
   it('rejects added, missing, optional, or malformed host permissions', () => {
@@ -700,6 +767,14 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
           ],
           manifest_version: 3,
           optional_host_permissions: [],
+          permissions: [
+            'alarms',
+            'tabs',
+            'storage',
+            'contextMenus',
+            'notifications',
+            'unlimitedStorage',
+          ],
         },
         'empty-optional.json',
       ),

--- a/tools/scripts/production-network-policy.ts
+++ b/tools/scripts/production-network-policy.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 
+import { PRODUCTION_EXTENSION_PERMISSIONS } from '#extension-permissions'
 import {
   PRODUCTION_OUTBOUND_ALLOWED_ORIGINS,
   PRODUCTION_OUTBOUND_HOST_PERMISSIONS,
@@ -771,4 +772,32 @@ export const assertManifestMatchesProductionNetworkPolicy = (
     label,
     manifestVersion,
   )
+
+  const actualApiPermissions = readStringArray(manifest, 'permissions', label)
+    .filter((permission) => !isHostPermission(permission))
+    .toSorted()
+  const expectedApiPermissions = [
+    ...PRODUCTION_EXTENSION_PERMISSIONS,
+  ].toSorted()
+  if (
+    JSON.stringify(actualApiPermissions) !==
+    JSON.stringify(expectedApiPermissions)
+  ) {
+    throw new Error(
+      `${label} permissions do not match the approved extension permission allowlist: ${JSON.stringify(actualApiPermissions)}; expected ${JSON.stringify(expectedApiPermissions)}`,
+    )
+  }
+
+  if ('optional_permissions' in manifest) {
+    const optionalApiPermissions = readStringArray(
+      manifest,
+      'optional_permissions',
+      label,
+    ).filter((permission) => !isHostPermission(permission))
+    if (optionalApiPermissions.length !== 0) {
+      throw new Error(
+        `${label} optional_permissions API permissions must be empty: ${JSON.stringify(optionalApiPermissions)}`,
+      )
+    }
+  }
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -6,6 +6,7 @@ import { type WxtViteConfig, defineConfig } from 'wxt' // eslint-disable-line
 
 import '@wxt-dev/module-react' // eslint-disable-line
 
+import { PRODUCTION_EXTENSION_PERMISSIONS } from './src/constants/extensionPermissions'
 import {
   PRODUCTION_OUTBOUND_HOST_PERMISSIONS,
   createProductionExtensionCsp,
@@ -45,7 +46,7 @@ export default defineConfig({
       extension_pages: createProductionExtensionCsp(env.manifestVersion),
     },
     host_permissions: PRODUCTION_OUTBOUND_HOST_PERMISSIONS,
-    permissions: ['alarms', 'tabs', 'storage', 'contextMenus', 'notifications'],
+    permissions: [...PRODUCTION_EXTENSION_PERMISSIONS],
     action: {
       default_title: '__MSG_extensionName__',
     },


### PR DESCRIPTION
## 概要

Persistence Model v2 の Phase 0 として、IndexedDB 移行前に必要な quota・eviction・durability contract を確定します。

- 一時二重保持と reserve を含む fail-closed capacity preflight を追加
- quota / disk write / storage unavailable / preflight failure を typed error として固定
- failure 時の cutover 禁止・legacy source 保持・backup / retry recovery UI を追加
- `unlimitedStorage` を採用し、Chrome MV3 / Firefox MV2 の生成 manifest を exact allowlist で検証
- browser 差分、store review / user-facing impact、安全な診断項目を文書化

## スコープ

Issue #735 の順序に従い、#726 の IndexedDB schema や #727/#728 の migration executor / cutover は先取りしていません。後続 Issue が消費する実行可能な durability contract を提供します。

## 受け入れ条件との対応

- quota / eviction risk と一時二重保持 headroom: `docs/security/persistence-durability.md` と `src/lib/persistence/capacity.ts`
- `unlimitedStorage` の採否・理由・browser / store impact: durability policy と generated-manifest verifier
- typed failure、cutover 禁止、legacy 保持: capacity failure outcome
- recovery UI: previous data retention、backup、retry の EN / JA 表示
- quota regression: capacity / manifest / verifier / recovery component tests

## 検証

- `bun run test:coverage` — 335 files / 3669 tests passed（新しい capacity contract は statements / functions / lines 100%）
- targeted regression — 4 files / 54 tests passed
- `bun run quality:check` — 335 files / 3673 tests passed
- `bun run release:check` — Chrome MV3 / Firefox MV2 build、production verifiers、clean-tree check を含めて passed
- React Doctor — 100 / 100、changed scope に issue なし
- fresh-context Harness Evaluator — approved、findings 0

Closes #735


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 保存領域の容量を事前確認し、容量不足や利用不可を安全に検知できるようになりました。
  * 復旧画面で問題の理由を確認し、「現在のデータをバックアップ」または「再試行」を選択できます。
  * 失敗時は既存データを保持し、意図しない切り替えを防止します。
  * 拡張機能の本番用ストレージ権限を統一しました。

* **ドキュメント**
  * 永続化、容量管理、権限、復旧時の安全な動作に関する仕様を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->