### PR TITLE
docs(security): extension permissions docs, manifest invariants, messaging trust boundary

### DIFF
--- a/docs/security/messaging-trust-boundary.md
+++ b/docs/security/messaging-trust-boundary.md
@@ -1,0 +1,150 @@
+# Runtime messaging trust boundary
+
+This document defines the trust levels of runtime message senders in TABBIN,
+which actions are privileged, and which manifest or source changes trigger a
+trust-boundary review. It is the companion to
+[`permissions.md`](permissions.md): `permissions.md` owns the manifest permission
+surface, this document owns the runtime messaging sender policy.
+
+## Current messaging model
+
+TABBIN uses `chrome.runtime.onMessage` for internal communication between
+extension pages (options, saved-tabs, changelog) and the background service
+worker. Messages are validated with Zod schemas in `src/types/background.ts`
+(`backgroundMessageSchema`, `messageActionSchema`) before any handler runs. The
+background handler lives in `src/lib/background/message-handler.ts`.
+
+There are currently no content scripts, no `externally_connectable` surface, and
+no `onMessageExternal` listener. The generated manifest verifier in
+`tools/scripts/production-network-policy.ts` enforces this by rejecting
+`externally_connectable` and non-empty `content_scripts` in the generated
+Chrome and Firefox manifests.
+
+## Sender types and trust levels
+
+| Sender type                                     | Transport                                                 | Trust level                     | Validation required                                                                      |
+| ----------------------------------------------- | --------------------------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------- |
+| Extension page (options, saved-tabs, changelog) | `chrome.runtime.sendMessage` / `chrome.runtime.connect`   | Trusted extension context       | Zod payload schema (current policy)                                                      |
+| Background service worker (self)                | direct calls                                              | Trusted extension context       | internal function contracts                                                              |
+| Content script                                  | `chrome.runtime.sendMessage` from injected content script | Untrusted page-adjacent context | Zod payload schema + sender origin allowlist + privileged-action sender policy           |
+| External web page                               | `chrome.runtime.sendMessage` via `externally_connectable` | Untrusted external context      | Zod payload schema + sender origin/extension allowlist + privileged-action sender policy |
+| External extension                              | `chrome.runtime.onMessageExternal`                        | Untrusted external context      | Zod payload schema + sender extension-id allowlist + privileged-action sender policy     |
+
+The current policy treats only extension-page and background senders as trusted.
+Content-script and external senders are untrusted and must not reach privileged
+actions without an explicit sender policy.
+
+## Privileged actions
+
+Privileged actions mutate user data, persistence state, or trigger external
+requests. The current background message actions and their privileged-action
+classification:
+
+| Action                                      | Privileged kind               | Current sender policy          |
+| ------------------------------------------- | ----------------------------- | ------------------------------ |
+| `removeUrlFromStorage`                      | URL / storage record deletion | trusted extension context only |
+| `removeUrlRecordsFromStorage`               | URL / storage record deletion | trusted extension context only |
+| `updateTabTimestamps`                       | timestamp update              | trusted extension context only |
+| `checkExpiredTabs`                          | auto-delete execution         | trusted extension context only |
+| `runAiChat`                                 | AI request execution          | trusted extension context only |
+| `listOllamaModels`                          | AI request execution (read)   | trusted extension context only |
+| `urlDragStarted` / `urlDropped`             | URL storage mutation          | trusted extension context only |
+| `calculateTimeRemaining` / `getAlarmStatus` | read-only                     | trusted extension context only |
+
+Persistence Model v2 adds these privileged actions (tracked in #727):
+
+- persistence migration state transition;
+- source-of-truth cutover;
+- legacy cleanup eligibility / execution;
+- recovery snapshot restore.
+
+These are privileged because a bad state transition can delete the only durable
+copy of user data. They must not be reachable from content-script or external
+senders.
+
+## Sender policy for untrusted contexts
+
+When `content_scripts`, `externally_connectable`, or `onMessageExternal` is
+introduced, the message handler must distinguish sender types before dispatching
+privileged actions. The minimum policy:
+
+1. Validate every message with the existing Zod schema regardless of sender.
+2. For untrusted senders, check the sender against an explicit allowlist:
+   - content script: allowed `sender.origin`/`sender.url` patterns;
+   - `externally_connectable`: allowed `sender.origin` matches;
+   - `onMessageExternal`: allowed `sender.id` extension IDs.
+3. Reject privileged actions from untrusted senders. Privileged actions are
+   only dispatched for trusted extension contexts.
+4. Never relax the Zod schema for untrusted senders. Untrusted senders get the
+   same schema plus the sender allowlist, not a weaker schema.
+
+This is a policy definition, not a blanket instruction to add sender allowlists
+to every current internal message today. Internal messages between extension
+pages and the background service worker remain trusted and do not need a sender
+allowlist until an untrusted sender type is introduced.
+
+## Trust-boundary review triggers
+
+The following changes require a trust-boundary review before merge:
+
+- Adding any `content_scripts` entry to the manifest or `wxt.config.ts`.
+- Adding `externally_connectable` to the manifest or `wxt.config.ts`.
+- Adding an `onMessageExternal` listener in source.
+- Adding a `chrome.runtime.onConnectExternal` listener in source.
+- Adding a new privileged action to the background message handler.
+- Adding a new persistence migration control key writer (see
+  [Migration control key trust boundary](#migration-control-key-trust-boundary)).
+
+The generated manifest verifier fails loudly when `content_scripts` becomes
+non-empty or `externally_connectable` appears, so a build failure is the trigger
+to start this review. A source-level architecture guard in
+`src/lib/architecture/messagingTrustBoundary.test.ts` also detects
+`onMessageExternal` / `onConnectExternal` listener additions in production
+source so they cannot land silently.
+
+The review must update this document with: the new sender type, its allowlist,
+the privileged actions it may or may not reach, and the validation applied.
+
+## Migration control key trust boundary
+
+Persistence Model v2 introduces migration control state (for example
+`legacy`, `migrating`, `verifying`, `cutover-pending`, `indexeddb`, `failed`)
+that drives source-of-truth cutover. This state is critical: a wrong transition
+can delete the only durable copy of user data.
+
+Policy:
+
+- Migration control state is read and written only from the migration control
+  repository designated in #727. Other features and content scripts must not
+  write critical control keys directly.
+- Critical control key names are documented and allowlisted at the production
+  source level so ad-hoc writes are detected.
+- Content scripts and untrusted external senders must not reach migration
+  state-transition privileged actions (see
+  [Privileged actions](#privileged-actions)).
+- When `content_scripts` is introduced, a storage access boundary review is
+  required in addition to the messaging trust-boundary review. On Chrome,
+  evaluate `chrome.storage.local.setAccessLevel({ accessLevel:
+'TRUSTED_CONTEXTS' })` to keep control-plane storage off-limits to content
+  scripts; confirm Firefox capability parity and encapsulate the difference in
+  the browser adapter.
+- Fail-closed: when a storage access boundary is unsupported, the policy must
+  not fail open to "any context may write control state."
+
+The authoritative state machine and repository boundary are owned by #727. This
+document owns the security invariant and review-trigger side. Until #727 lands
+the repository boundary, the source-level guard tracks critical control key
+literals and flags new writers for review rather than allowing silent additions.
+
+## Related
+
+- [`permissions.md`](permissions.md) — manifest permission allowlist and
+  generated-manifest security invariants.
+- [`persistence-durability.md`](persistence-durability.md) — `unlimitedStorage`
+  durability decision.
+- [`production-network-policy.md`](production-network-policy.md) — outbound
+  network policy and call-site inventory.
+- #676 — permissions docs, manifest invariants, and trust-boundary framework.
+- #727 — PersistenceBootstrap and migration control repository boundary
+  (authoritative for migration state machine).
+- #735 — `unlimitedStorage` adoption decision (closed).

--- a/docs/security/permissions.md
+++ b/docs/security/permissions.md
@@ -172,15 +172,25 @@ checks, per manifest:
   external message senders.
 - `content_scripts` is empty (WXT may emit an empty array) until a trust-boundary
   review approves content-script injection.
-- `web_accessible_resources` matches the approved allowlist (currently empty) so
-  no extension asset is exposed to web pages without review.
+- `web_accessible_resources` matches the approved resource-path allowlist in
+  `APPROVED_WEB_ACCESSIBLE_RESOURCES` (currently empty). MV2 string arrays and
+  MV3 `{ resources, matches }` object arrays are normalized to their resource
+  paths and compared exactly against the allowlist, so updating the allowlist
+  permits the approved resources. The verifier pins resource paths; the
+  `matches` / `extension_ids` exposure scope is part of the security review and
+  must be justified in this document before an entry is approved.
 
 The `assertChromeFirefoxManifestDelta` verifier checks that Chrome MV3 and
-Firefox MV2 differ only on the expected manifest-version-driven keys
-(`manifest_version`, `permissions`, `host_permissions`,
-`content_security_policy`, `browser_specific_settings`, `action`/
-`browser_action`, `background`). Any other key divergence fails verification, so
-a change that only lands on one browser is detected.
+Firefox MV2 differ only on the expected manifest-version-driven structure.
+`manifest_version`, `permissions`, `host_permissions`, and
+`content_security_policy` differ by manifest version and are verified per
+manifest. `action` / `browser_action`, `background`, and
+`browser_specific_settings` are normalized to a common representation
+(allowed action fields, `service_worker` -> `scripts`, the expected Firefox
+gecko data-collection structure) and compared, so an unexpected
+browser-specific change inside those keys fails verification instead of being
+skipped. Any other key divergence fails verification, so a change that only
+lands on one browser is detected.
 
 ## Adding a new permission or privileged surface
 
@@ -191,7 +201,7 @@ security review, not a routine snapshot update.
 1. Update the typed allowlist in `src/constants/extensionPermissions.ts` or
    `src/constants/productionNetworkPolicy.ts` (and
    `APPROVED_WEB_ACCESSIBLE_RESOURCES` in
-   `tools/scripts/production-network-policy.ts` for web-accessible resources).
+   `tools/scripts/manifestSecurityInvariants.ts` for web-accessible resources).
 2. Add the permission's purpose, usage sites, and review notes to this document.
 3. If the addition is `content_scripts`, `externally_connectable`, or
    `onMessageExternal`, complete the trust-boundary review in

--- a/docs/security/permissions.md
+++ b/docs/security/permissions.md
@@ -1,0 +1,206 @@
+# Chrome extension permissions
+
+This document explains why TABBIN requests each extension permission and host
+permission, where each one is used, and how the generated manifest is verified.
+It is the review surface for store submissions, security reviews, and future
+permission additions.
+
+The typed permission allowlist lives in
+`src/constants/extensionPermissions.ts` and the host permission allowlist lives
+in `src/constants/productionNetworkPolicy.ts`. WXT reads these constants in
+`wxt.config.ts`, so the generated Chrome and Firefox manifests are derived from
+a single source of truth. The generated-manifest verifier in
+`tools/scripts/production-network-policy.ts` checks the final artifacts against
+the same allowlists, plus the security invariants in
+[Generated manifest security invariants](#generated-manifest-security-invariants).
+
+TABBIN is local-first. The only outbound network destination is the user's own
+local Ollama service. No permission here grants remote server, telemetry, or
+user-content transmission access. The production outbound network policy is
+documented in
+[`production-network-policy.md`](production-network-policy.md).
+
+## API permissions
+
+### `alarms`
+
+Purpose: schedule periodic expiration checks and auto-delete notifications
+without keeping the service worker alive manually.
+
+Primary usage sites:
+
+- `src/lib/background/alarm-notification.ts` — registers and clears alarms for
+  expiration and auto-delete timing.
+- `src/lib/background/message-handler.ts` — reads alarm status in response to
+  `getAlarmStatus` messages.
+
+Review notes: `alarms` does not grant host, content, or network access. It only
+schedules timed wake-ups for the background service worker.
+
+### `tabs`
+
+Purpose: read the currently open tabs (URL, title, window membership) so the
+user can save them, and open previously saved tabs back into a window.
+
+Primary usage sites:
+
+- `src/lib/background/extension-actions.ts` — opens saved URLs/tabs and queries
+  the active tab.
+- `src/lib/background/url-storage.ts` — records tab timestamps for expiration.
+- `src/lib/background/utils.ts` — tab lookup helpers (same-window, same-domain).
+- `src/lib/background/saved-tabs-page.ts` — opens the saved-tabs page.
+- `src/entrypoints/background.ts` — wires tab-created and tab-activated handlers
+  for timestamp tracking.
+- `src/app/composition/createSavedTabsPorts.ts`,
+  `src/app/composition/createSavedTabsUseCases.ts` — composition root ports.
+- `src/contexts/saved-tabs/presentation/hooks/useProjectCrudHandlers.ts`,
+  `src/contexts/saved-tabs/domain/services/OpenedUrlRemovalPolicy.ts`,
+  `src/contexts/saved-tabs/infrastructure/browser/ChromeStorageChangeAdapter.ts`
+  — saved-tabs feature read/write paths.
+
+Review notes: `tabs` grants access to tab metadata (URL, title) for tabs the
+user is already viewing. TABBIN does not read tab content or inject scripts into
+pages. Tab data stays local and is never transmitted off-device.
+
+### `storage`
+
+Purpose: persist `savedTabs`, `urls`, `userSettings`, `customProjects`, and
+persistence migration control state through `chrome.storage.local`.
+
+Primary usage sites:
+
+- `src/lib/browser/chrome-storage.ts` — shared storage wrapper.
+- `src/lib/storage/tabs.ts`, `src/lib/storage/settings.ts`,
+  `src/lib/storage/projects.ts` — domain storage records.
+- `src/lib/background/url-storage.ts` — URL record storage and removal.
+- `src/lib/background/expired-tabs.ts` — expiration state.
+- `src/lib/background/ai-chat.ts` — chat history persistence.
+- `src/entrypoints/background.ts` — storage change wiring.
+- `src/app/composition/createSavedTabsRepositories.ts` — repository composition.
+
+Review notes: `storage` is the local persistence boundary. It does not grant
+network access. The `unlimitedStorage` durability decision and the migration
+control-plane storage access boundary are documented in
+[`persistence-durability.md`](persistence-durability.md) and
+[`messaging-trust-boundary.md`](messaging-trust-boundary.md).
+
+### `contextMenus`
+
+Purpose: add the right-click "save tab" entry so users can save the current tab
+without opening the saved-tabs page.
+
+Primary usage sites:
+
+- `src/lib/background/context-menu.ts` — creates the context menu item and
+  handles clicks by saving the active tab.
+
+Review notes: `contextMenus` only adds entries to the browser context menu. It
+does not grant page content or network access.
+
+### `notifications`
+
+Purpose: tell the user when tabs are about to expire or have been auto-deleted.
+
+Primary usage sites:
+
+- `src/lib/background/alarm-notification.ts` — creates expiration and
+  auto-delete notifications.
+- `src/contexts/saved-tabs/application/ports/NotificationPort.ts` — application
+  port abstraction consumed by the saved-tabs feature.
+
+Review notes: notifications are local OS/browser notifications only. No payload
+is sent anywhere; the notification text is generated locally.
+
+### `unlimitedStorage`
+
+Purpose: protect the only durable local copy of user data from quota eviction
+under Persistence Model v2 (IndexedDB as the source of truth for domain data).
+
+Decision and review notes: this permission was adopted in
+[`persistence-durability.md`](persistence-durability.md). TABBIN is local-first
+and has no server-side recovery source, so preventing quota eviction of the only
+durable copy is part of the data-safety boundary. The permission does not grant
+host, network, or user-content access. Chrome does not currently assign an
+install warning to `unlimitedStorage`; Firefox grants persistent IndexedDB
+access without a database-creation prompt. Every store submission that changes
+the permission allowlist must re-check the current Chrome and Firefox review
+surfaces.
+
+## Host permissions
+
+### `http://localhost:11434/*` and `http://127.0.0.1:11434/*`
+
+Purpose: connect to the user's own local Ollama service for AI chat. These are
+loopback hosts only. They are not remote servers, not LAN hosts, and not cloud
+endpoints.
+
+Primary usage sites:
+
+- `src/constants/productionNetworkPolicy.ts` — the typed origin allowlist and
+  derived host permission patterns.
+- `src/lib/background/ai-chat.ts` — sends the user's prompt, chat history,
+  attachments, system instructions, and locally derived saved-tab context to the
+  configured local Ollama origin via `ai-sdk-ollama`.
+
+Review notes: the host permission exists solely so the extension can call the
+user's local Ollama runtime. The CSP `connect-src` is pinned to the same
+origins, so no other outbound destination is permitted from extension pages. See
+[`production-network-policy.md`](production-network-policy.md) for the full
+outbound network policy and call-site inventory. Adding any non-loopback or
+non-Ollama origin is a privacy-design change, not a routine allowlist update.
+
+## Generated manifest security invariants
+
+The verifier `assertManifestMatchesProductionNetworkPolicy` in
+`tools/scripts/production-network-policy.ts` runs in
+`bun run verify:production-network-policy` against the generated
+`.output/chrome-mv3/manifest.json` and `.output/firefox-mv2/manifest.json`. It
+checks, per manifest:
+
+- `permissions` matches the approved API permission allowlist exactly (no added,
+  missing, or optional permissions).
+- `host_permissions` (Chrome MV3) or host patterns inside `permissions`
+  (Firefox MV2) matches the approved host permission allowlist exactly.
+- `optional_permissions` / `optional_host_permissions` are empty.
+- `content_security_policy.extension_pages` matches the production CSP exactly,
+  including `connect-src` pinned to the Ollama loopback origins, `object-src`,
+  `frame-src`, and `form-action` set to `'none'`, and no unexpected directives.
+  This pins `script-src` to `'self'` (Firefox MV2) or `'self' 'wasm-unsafe-eval'`
+  (Chrome MV3), so `unsafe-eval`, remote scripts, and inline scripts are
+  rejected.
+- `externally_connectable` is absent until a trust-boundary review approves
+  external message senders.
+- `content_scripts` is empty (WXT may emit an empty array) until a trust-boundary
+  review approves content-script injection.
+- `web_accessible_resources` matches the approved allowlist (currently empty) so
+  no extension asset is exposed to web pages without review.
+
+The `assertChromeFirefoxManifestDelta` verifier checks that Chrome MV3 and
+Firefox MV2 differ only on the expected manifest-version-driven keys
+(`manifest_version`, `permissions`, `host_permissions`,
+`content_security_policy`, `browser_specific_settings`, `action`/
+`browser_action`, `background`). Any other key divergence fails verification, so
+a change that only lands on one browser is detected.
+
+## Adding a new permission or privileged surface
+
+Adding a permission, host permission, `content_scripts` entry,
+`externally_connectable` surface, or `web_accessible_resources` entry is a
+security review, not a routine snapshot update.
+
+1. Update the typed allowlist in `src/constants/extensionPermissions.ts` or
+   `src/constants/productionNetworkPolicy.ts` (and
+   `APPROVED_WEB_ACCESSIBLE_RESOURCES` in
+   `tools/scripts/production-network-policy.ts` for web-accessible resources).
+2. Add the permission's purpose, usage sites, and review notes to this document.
+3. If the addition is `content_scripts`, `externally_connectable`, or
+   `onMessageExternal`, complete the trust-boundary review in
+   [`messaging-trust-boundary.md`](messaging-trust-boundary.md) first.
+4. Run `bun run build && bun run build:firefox && bun run verify:production-network-policy`
+   and confirm both manifests and the Chrome/Firefox delta pass.
+5. Re-check the current Chrome and Firefox store review surfaces for any new
+   permission warning before submission.
+
+A mechanical snapshot update must never bypass these steps. The verifier fails
+loudly on any unreviewed privileged surface so the failure is the trigger to
+start this checklist.

--- a/src/lib/architecture/messagingTrustBoundary.test.ts
+++ b/src/lib/architecture/messagingTrustBoundary.test.ts
@@ -1,0 +1,124 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = resolve(import.meta.dirname, '../../..')
+
+const isExcluded = (relativePath: string, name: string): boolean =>
+  name.endsWith('.test.ts') ||
+  name.endsWith('.test.tsx') ||
+  name.endsWith('.spec.ts') ||
+  relativePath.includes('/storybook/') ||
+  relativePath.includes('/__stories__/')
+
+const collectSourceFiles = (relativeDir: string): string[] => {
+  const results: string[] = []
+  const walk = (dir: string) => {
+    for (const name of readdirSync(resolve(repoRoot, dir))) {
+      const relative = `${dir}/${name}`
+      const absolute = resolve(repoRoot, relative)
+      if (statSync(absolute).isDirectory()) {
+        walk(relative)
+      } else if (
+        (name.endsWith('.ts') || name.endsWith('.tsx')) &&
+        !isExcluded(relative, name)
+      ) {
+        results.push(relative)
+      }
+    }
+  }
+  walk(relativeDir)
+  return results
+}
+
+describe('issue #676: runtime messaging trust boundary guards', () => {
+  const untrustedSenderApis = ['onMessageExternal', 'onConnectExternal']
+
+  it('production source does not register external message listeners without a trust-boundary review', () => {
+    const offenders: string[] = []
+    for (const path of collectSourceFiles('src')) {
+      const source = readFileSync(resolve(repoRoot, path), 'utf8')
+      for (const api of untrustedSenderApis) {
+        if (source.includes(api)) {
+          offenders.push(`${path}: ${api}`)
+        }
+      }
+    }
+    expect(
+      offenders,
+      'External sender listeners require a trust-boundary review. See docs/security/messaging-trust-boundary.md before adding onMessageExternal / onConnectExternal.',
+    ).toEqual([])
+  })
+
+  it('wxt.config.ts does not declare externally_connectable or content_scripts without a trust-boundary review', () => {
+    const configSource = readFileSync(
+      resolve(repoRoot, 'wxt.config.ts'),
+      'utf8',
+    )
+    for (const surface of ['externally_connectable', 'content_scripts']) {
+      expect(
+        configSource,
+        `${surface} requires a trust-boundary review. See docs/security/messaging-trust-boundary.md.`,
+      ).not.toContain(surface)
+    }
+  })
+
+  it('docs/security/messaging-trust-boundary.md documents the sender trust levels and review triggers', () => {
+    const doc = readFileSync(
+      resolve(repoRoot, 'docs/security/messaging-trust-boundary.md'),
+      'utf8',
+    )
+    expect(doc).toContain('Sender types and trust levels')
+    expect(doc).toContain('Privileged actions')
+    expect(doc).toContain('Trust-boundary review triggers')
+    expect(doc).toContain('Migration control key trust boundary')
+    expect(doc).toMatch(/onMessageExternal/)
+    expect(doc).toMatch(/externally_connectable/)
+    expect(doc).toMatch(/content_scripts/)
+  })
+
+  it('docs/security/permissions.md documents each approved permission and the generated-manifest invariants', () => {
+    const doc = readFileSync(
+      resolve(repoRoot, 'docs/security/permissions.md'),
+      'utf8',
+    )
+    for (const permission of [
+      'alarms',
+      'tabs',
+      'storage',
+      'contextMenus',
+      'notifications',
+      'unlimitedStorage',
+      'http://localhost:11434/*',
+      'http://127.0.0.1:11434/*',
+    ]) {
+      expect(doc).toContain(permission)
+    }
+    expect(doc).toContain('Generated manifest security invariants')
+    expect(doc).toContain('externally_connectable')
+    expect(doc).toContain('content_scripts')
+    expect(doc).toContain('web_accessible_resources')
+    expect(doc).toContain('assertChromeFirefoxManifestDelta')
+  })
+
+  it('generated-manifest verifier enforces the trust-boundary manifest invariants', () => {
+    const invariants = readFileSync(
+      resolve(repoRoot, 'tools/scripts/manifestSecurityInvariants.ts'),
+      'utf8',
+    )
+    expect(invariants).toContain('externally_connectable')
+    expect(invariants).toContain('content_scripts')
+    expect(invariants).toContain('web_accessible_resources')
+    expect(invariants).toContain('assertChromeFirefoxManifestDelta')
+    // The main verifier wires the invariant checks into the per-manifest assertion.
+    const verifier = readFileSync(
+      resolve(repoRoot, 'tools/scripts/production-network-policy.ts'),
+      'utf8',
+    )
+    expect(verifier).toContain('assertGeneratedManifestSecurityInvariants')
+    expect(verifier).toContain(
+      'assertExtensionCspMatchesProductionNetworkPolicy',
+    )
+  })
+})

--- a/tools/scripts/manifestHelpers.ts
+++ b/tools/scripts/manifestHelpers.ts
@@ -1,0 +1,20 @@
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+export const isHostPermission = (permission: string): boolean =>
+  permission === '<all_urls>' || permission.includes('://')
+
+export const readStringArray = (
+  manifest: Record<string, unknown>,
+  property: string,
+  label: string,
+): string[] => {
+  const value = manifest[property]
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === 'string')
+  ) {
+    throw new TypeError(`${label} ${property} is missing or not a string array`)
+  }
+  return value
+}

--- a/tools/scripts/manifestSecurityInvariants.ts
+++ b/tools/scripts/manifestSecurityInvariants.ts
@@ -119,6 +119,76 @@ const EXPECTED_MANIFEST_ABSENT_PROPERTIES: readonly {
 
 export const APPROVED_WEB_ACCESSIBLE_RESOURCES: readonly string[] = []
 
+const ALLOWED_ACTION_FIELDS = new Set([
+  'default_icon',
+  'default_popup',
+  'default_title',
+])
+
+const canonicalJson = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`
+  }
+  if (isRecord(value)) {
+    const keys = Object.keys(value).toSorted()
+    return `{${keys
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+export const extractWebAccessibleResourcePaths = (
+  manifest: Record<string, unknown>,
+  label: string,
+): string[] | undefined => {
+  if (!('web_accessible_resources' in manifest)) {
+    return undefined
+  }
+  const value = manifest.web_accessible_resources
+  if (!Array.isArray(value)) {
+    throw new TypeError(
+      `${label} web_accessible_resources must be an array when present; found ${JSON.stringify(value)}`,
+    )
+  }
+  // MV2: string[]. MV3: Array<{ resources: string[], matches?, extension_ids? }>.
+  if (value.every((item) => typeof item === 'string')) {
+    return value
+  }
+  const paths: string[] = []
+  for (const entry of value) {
+    if (
+      !isRecord(entry) ||
+      !Array.isArray(entry.resources) ||
+      !entry.resources.every((resource) => typeof resource === 'string')
+    ) {
+      throw new Error(
+        `${label} web_accessible_resources MV3 entries must be objects with a string[] resources field; found ${JSON.stringify(entry)}`,
+      )
+    }
+    paths.push(...entry.resources)
+  }
+  return paths
+}
+
+export const assertWebAccessibleResourcesOnAllowlist = (
+  manifest: Record<string, unknown>,
+  label: string,
+  allowlist: readonly string[],
+): void => {
+  const paths = extractWebAccessibleResourcePaths(manifest, label)
+  if (paths === undefined) {
+    return
+  }
+  const actual = [...new Set(paths)].toSorted()
+  const expected = [...new Set(allowlist)].toSorted()
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `${label} web_accessible_resources does not match the approved allowlist: found ${JSON.stringify(actual)}; expected ${JSON.stringify(expected)}. Update APPROVED_WEB_ACCESSIBLE_RESOURCES in tools/scripts/manifestSecurityInvariants.ts and docs/security/permissions.md after a security review.`,
+    )
+  }
+}
+
 const assertManifestPropertyAbsent = (
   manifest: Record<string, unknown>,
   property: string,
@@ -151,20 +221,159 @@ export const assertGeneratedManifestSecurityInvariants = (
     }
   }
   // web_accessible_resources exposes extension assets to web pages. MV2 uses a
-  // string array; MV3 uses an array of { resources, matches } objects. Either
-  // way, an empty array or absence exposes nothing. A non-empty array must be
-  // on the approved allowlist (currently empty) and requires a security review.
-  if ('web_accessible_resources' in manifest) {
-    const resources = manifest.web_accessible_resources
-    if (!Array.isArray(resources) || resources.length !== 0) {
+  // string array; MV3 uses an array of { resources, matches } objects. The
+  // approved resource-path allowlist is the source of truth, so updating
+  // APPROVED_WEB_ACCESSIBLE_RESOURCES actually permits approved resources.
+  assertWebAccessibleResourcesOnAllowlist(
+    manifest,
+    label,
+    APPROVED_WEB_ACCESSIBLE_RESOURCES,
+  )
+}
+
+const readOptionalRecord = (
+  manifest: Record<string, unknown>,
+  property: string,
+  label: string,
+): Record<string, unknown> | undefined => {
+  if (!(property in manifest)) {
+    return undefined
+  }
+  const value = manifest[property]
+  if (!isRecord(value)) {
+    throw new Error(
+      `${label} ${property} must be an object when present; found ${JSON.stringify(value)}`,
+    )
+  }
+  return value
+}
+
+const assertAllowedActionFields = (
+  surface: Record<string, unknown>,
+  label: string,
+): void => {
+  for (const field of Object.keys(surface)) {
+    if (!ALLOWED_ACTION_FIELDS.has(field)) {
       throw new Error(
-        `${label} web_accessible_resources must be empty and match the approved allowlist (see docs/security/permissions.md); found ${JSON.stringify(resources)}`,
+        `${label} action surface has an unexpected field "${field}"; allowed: ${[...ALLOWED_ACTION_FIELDS].toSorted().join(', ')}`,
       )
     }
   }
 }
 
-const sortedJson = (value: unknown): string => JSON.stringify(value)
+const normalizeActionSurface = (
+  manifest: Record<string, unknown>,
+  label: string,
+): Record<string, unknown> | undefined => {
+  const action = readOptionalRecord(manifest, 'action', label)
+  if (action !== undefined) {
+    assertAllowedActionFields(action, label)
+    return action
+  }
+  const browserAction = readOptionalRecord(manifest, 'browser_action', label)
+  if (browserAction !== undefined) {
+    assertAllowedActionFields(browserAction, label)
+    return browserAction
+  }
+  return undefined
+}
+
+const normalizeBackgroundScripts = (
+  manifest: Record<string, unknown>,
+  label: string,
+): Record<string, unknown> => {
+  const background = readOptionalRecord(manifest, 'background', label)
+  if (background === undefined) {
+    return {}
+  }
+  const normalized: Record<string, unknown> = { ...background }
+  if ('service_worker' in normalized) {
+    const serviceWorker = normalized.service_worker
+    if (typeof serviceWorker !== 'string') {
+      throw new TypeError(
+        `${label} background.service_worker must be a string; found ${JSON.stringify(serviceWorker)}`,
+      )
+    }
+    normalized.scripts = [serviceWorker]
+    delete normalized.service_worker
+  }
+  if (
+    'scripts' in normalized &&
+    (!Array.isArray(normalized.scripts) ||
+      !normalized.scripts.every((script) => typeof script === 'string'))
+  ) {
+    throw new TypeError(
+      `${label} background.scripts must be a string array; found ${JSON.stringify(normalized.scripts)}`,
+    )
+  }
+  return normalized
+}
+
+const EXPECTED_FIREFOX_BROWSER_SPECIFIC_SETTINGS = {
+  gecko: { data_collection_permissions: { required: ['none'] } },
+}
+
+const assertManifestSurfaceDelta = (
+  chromeManifest: Record<string, unknown>,
+  firefoxManifest: Record<string, unknown>,
+  chromeLabel: string,
+  firefoxLabel: string,
+): void => {
+  // action / browser_action are the same toolbar surface under MV3 / MV2 keys.
+  // Normalize each to the allowed action fields and compare so an unexpected
+  // browser-specific field on either surface is caught instead of skipped
+  // wholesale.
+  const chromeAction = normalizeActionSurface(chromeManifest, chromeLabel)
+  const firefoxAction = normalizeActionSurface(firefoxManifest, firefoxLabel)
+  if (canonicalJson(chromeAction) !== canonicalJson(firefoxAction)) {
+    throw new Error(
+      `Chrome and Firefox action surface diverge: chrome=${canonicalJson(chromeAction)} firefox=${canonicalJson(firefoxAction)}`,
+    )
+  }
+  if ('browser_action' in chromeManifest) {
+    throw new Error(
+      `${chromeLabel} must not declare browser_action; MV3 uses action`,
+    )
+  }
+  if ('action' in firefoxManifest) {
+    throw new Error(
+      `${firefoxLabel} must not declare action; MV2 uses browser_action`,
+    )
+  }
+
+  // background: MV3 uses service_worker, MV2 uses scripts. Normalize to a
+  // common scripts representation and compare the full structure so extra
+  // browser-specific fields (e.g. type, persistent) diverge instead of being
+  // skipped wholesale.
+  const chromeBackground = normalizeBackgroundScripts(
+    chromeManifest,
+    chromeLabel,
+  )
+  const firefoxBackground = normalizeBackgroundScripts(
+    firefoxManifest,
+    firefoxLabel,
+  )
+  if (canonicalJson(chromeBackground) !== canonicalJson(firefoxBackground)) {
+    throw new Error(
+      `Chrome and Firefox background diverge: chrome=${canonicalJson(chromeBackground)} firefox=${canonicalJson(firefoxBackground)}`,
+    )
+  }
+
+  // browser_specific_settings is Firefox-only. Chrome must not declare it and
+  // Firefox must match the documented expected structure so any change is
+  // caught rather than skipped wholesale.
+  if ('browser_specific_settings' in chromeManifest) {
+    throw new Error(`${chromeLabel} must not declare browser_specific_settings`)
+  }
+  if (
+    canonicalJson(firefoxManifest.browser_specific_settings) !==
+    canonicalJson(EXPECTED_FIREFOX_BROWSER_SPECIFIC_SETTINGS)
+  ) {
+    throw new Error(
+      `${firefoxLabel} browser_specific_settings does not match the expected Firefox structure: found ${canonicalJson(firefoxManifest.browser_specific_settings)}; expected ${canonicalJson(EXPECTED_FIREFOX_BROWSER_SPECIFIC_SETTINGS)}`,
+    )
+  }
+}
 
 export const assertChromeFirefoxManifestDelta = (
   chromeManifest: unknown,
@@ -200,9 +409,11 @@ export const assertChromeFirefoxManifestDelta = (
   )
     .filter((permission) => !isHostPermission(permission))
     .toSorted()
-  if (sortedJson(chromeApiPermissions) !== sortedJson(firefoxApiPermissions)) {
+  if (
+    canonicalJson(chromeApiPermissions) !== canonicalJson(firefoxApiPermissions)
+  ) {
     throw new Error(
-      `Chrome and Firefox API permissions diverge: chrome=${sortedJson(chromeApiPermissions)} firefox=${sortedJson(firefoxApiPermissions)}`,
+      `Chrome and Firefox API permissions diverge: chrome=${canonicalJson(chromeApiPermissions)} firefox=${canonicalJson(firefoxApiPermissions)}`,
     )
   }
 
@@ -218,36 +429,45 @@ export const assertChromeFirefoxManifestDelta = (
   )
     .filter((permission) => isHostPermission(permission))
     .toSorted()
-  if (sortedJson(chromeHosts) !== sortedJson(firefoxHosts)) {
+  if (canonicalJson(chromeHosts) !== canonicalJson(firefoxHosts)) {
     throw new Error(
-      `Chrome and Firefox host permissions diverge: chrome=${sortedJson(chromeHosts)} firefox=${sortedJson(firefoxHosts)}`,
+      `Chrome and Firefox host permissions diverge: chrome=${canonicalJson(chromeHosts)} firefox=${canonicalJson(firefoxHosts)}`,
     )
   }
+
+  assertManifestSurfaceDelta(
+    chromeManifest,
+    firefoxManifest,
+    chromeLabel,
+    firefoxLabel,
+  )
 
   const sharedKeys = new Set(Object.keys(chromeManifest))
   for (const key of Object.keys(firefoxManifest)) {
     sharedKeys.add(key)
   }
+  // Keys handled by the explicit normalized comparisons above. They are skipped
+  // in the generic loop because their raw shapes differ by manifest version,
+  // but their normalized forms have already been compared.
   const expectedDivergentKeys = new Set([
     'manifest_version',
     'permissions',
     'host_permissions',
     'content_security_policy',
-    'browser_specific_settings',
-    // Chrome MV3 uses `action`; Firefox MV2 uses `browser_action` for the same
-    // toolbar action surface.
     'action',
     'browser_action',
-    // Chrome MV3 uses a service worker; Firefox MV2 uses background scripts.
     'background',
+    'browser_specific_settings',
   ])
   for (const key of sharedKeys) {
     if (expectedDivergentKeys.has(key)) {
       continue
     }
-    if (sortedJson(chromeManifest[key]) !== sortedJson(firefoxManifest[key])) {
+    if (
+      canonicalJson(chromeManifest[key]) !== canonicalJson(firefoxManifest[key])
+    ) {
       throw new Error(
-        `Chrome and Firefox manifest diverge on unexpected key "${key}": chrome=${sortedJson(chromeManifest[key])} firefox=${sortedJson(firefoxManifest[key])}`,
+        `Chrome and Firefox manifest diverge on unexpected key "${key}": chrome=${canonicalJson(chromeManifest[key])} firefox=${canonicalJson(firefoxManifest[key])}`,
       )
     }
   }

--- a/tools/scripts/manifestSecurityInvariants.ts
+++ b/tools/scripts/manifestSecurityInvariants.ts
@@ -1,0 +1,254 @@
+import {
+  createProductionExtensionCsp,
+  PRODUCTION_OUTBOUND_ALLOWED_ORIGINS,
+} from '#production-network-policy'
+
+import {
+  isHostPermission,
+  isRecord,
+  readStringArray,
+} from './manifestHelpers.ts'
+
+const readExtensionPagesCsp = (
+  manifest: Record<string, unknown>,
+  label: string,
+): string => {
+  const value = manifest.content_security_policy
+  if (typeof value === 'string') {
+    return value
+  }
+  if (isRecord(value) && typeof value.extension_pages === 'string') {
+    return value.extension_pages
+  }
+  throw new TypeError(
+    `${label} content_security_policy is missing an extension policy`,
+  )
+}
+
+const parseCspDirectives = (
+  csp: string,
+  label: string,
+): Map<string, string[]> => {
+  const directives = new Map<string, string[]>()
+  const sections = csp
+    .split(';')
+    .map((section) => section.trim())
+    .filter((section) => section !== '')
+  for (const section of sections) {
+    const [directive, ...values] = section.split(/\s+/u)
+    if (directives.has(directive)) {
+      throw new Error(
+        `${label} content_security_policy contains duplicate directive ${directive}`,
+      )
+    }
+    directives.set(directive, values)
+  }
+  return directives
+}
+
+export const assertExtensionCspMatchesProductionNetworkPolicy = (
+  manifest: Record<string, unknown>,
+  label: string,
+  manifestVersion: 2 | 3,
+): void => {
+  const directives = parseCspDirectives(
+    readExtensionPagesCsp(manifest, label),
+    label,
+  )
+  const expectedConnectSources = [
+    "'self'",
+    'blob:',
+    ...PRODUCTION_OUTBOUND_ALLOWED_ORIGINS,
+  ].toSorted()
+  const actualConnectSources = directives.get('connect-src')?.toSorted()
+  if (
+    actualConnectSources === undefined ||
+    JSON.stringify(actualConnectSources) !==
+      JSON.stringify(expectedConnectSources)
+  ) {
+    throw new Error(
+      `${label} connect-src does not match the production allowlist: ${JSON.stringify(actualConnectSources)}; expected ${JSON.stringify(expectedConnectSources)}`,
+    )
+  }
+  for (const directive of ['object-src', 'frame-src', 'form-action']) {
+    if (
+      JSON.stringify(directives.get(directive)) !== JSON.stringify(["'none'"])
+    ) {
+      throw new Error(`${label} ${directive} must be 'none'`)
+    }
+  }
+  const expectedDirectives = parseCspDirectives(
+    createProductionExtensionCsp(manifestVersion),
+    'production network policy',
+  )
+  for (const [directive, expectedValues] of expectedDirectives) {
+    if (directive === 'connect-src') {
+      continue
+    }
+    const actualValues = directives.get(directive)
+    if (
+      actualValues === undefined ||
+      JSON.stringify(actualValues.toSorted()) !==
+        JSON.stringify(expectedValues.toSorted())
+    ) {
+      throw new Error(
+        `${label} ${directive} does not match the production policy`,
+      )
+    }
+  }
+  const unexpectedDirectives = [...directives.keys()].filter(
+    (directive) => !expectedDirectives.has(directive),
+  )
+  if (unexpectedDirectives.length !== 0) {
+    throw new Error(
+      `${label} content_security_policy contains unexpected directives: ${unexpectedDirectives.join(', ')}`,
+    )
+  }
+}
+
+const EXPECTED_MANIFEST_ABSENT_PROPERTIES: readonly {
+  readonly property: string
+  readonly reason: string
+}[] = [
+  {
+    property: 'externally_connectable',
+    reason:
+      'a trust-boundary review approves external message senders (see docs/security/messaging-trust-boundary.md)',
+  },
+]
+
+export const APPROVED_WEB_ACCESSIBLE_RESOURCES: readonly string[] = []
+
+const assertManifestPropertyAbsent = (
+  manifest: Record<string, unknown>,
+  property: string,
+  label: string,
+  reason: string,
+): void => {
+  if (property in manifest) {
+    throw new Error(
+      `${label} ${property} must be absent until ${reason}; found ${JSON.stringify(manifest[property])}`,
+    )
+  }
+}
+
+export const assertGeneratedManifestSecurityInvariants = (
+  manifest: Record<string, unknown>,
+  label: string,
+): void => {
+  for (const { property, reason } of EXPECTED_MANIFEST_ABSENT_PROPERTIES) {
+    assertManifestPropertyAbsent(manifest, property, label, reason)
+  }
+  // WXT may emit an empty content_scripts array when no content scripts exist.
+  // An empty array injects nothing and is acceptable; a non-empty array requires
+  // a trust-boundary review.
+  if ('content_scripts' in manifest) {
+    const contentScripts = manifest.content_scripts
+    if (!Array.isArray(contentScripts) || contentScripts.length !== 0) {
+      throw new Error(
+        `${label} content_scripts must be empty until a trust-boundary review approves content-script injection and storage access boundaries (see docs/security/messaging-trust-boundary.md); found ${JSON.stringify(contentScripts)}`,
+      )
+    }
+  }
+  // web_accessible_resources exposes extension assets to web pages. MV2 uses a
+  // string array; MV3 uses an array of { resources, matches } objects. Either
+  // way, an empty array or absence exposes nothing. A non-empty array must be
+  // on the approved allowlist (currently empty) and requires a security review.
+  if ('web_accessible_resources' in manifest) {
+    const resources = manifest.web_accessible_resources
+    if (!Array.isArray(resources) || resources.length !== 0) {
+      throw new Error(
+        `${label} web_accessible_resources must be empty and match the approved allowlist (see docs/security/permissions.md); found ${JSON.stringify(resources)}`,
+      )
+    }
+  }
+}
+
+const sortedJson = (value: unknown): string => JSON.stringify(value)
+
+export const assertChromeFirefoxManifestDelta = (
+  chromeManifest: unknown,
+  firefoxManifest: unknown,
+  chromeLabel: string,
+  firefoxLabel: string,
+): void => {
+  if (!isRecord(chromeManifest) || !isRecord(firefoxManifest)) {
+    throw new TypeError('chrome and firefox manifests must be objects')
+  }
+  if (chromeManifest.manifest_version !== 3) {
+    throw new Error(
+      `${chromeLabel} manifest_version must be 3, got ${JSON.stringify(chromeManifest.manifest_version)}`,
+    )
+  }
+  if (firefoxManifest.manifest_version !== 2) {
+    throw new Error(
+      `${firefoxLabel} manifest_version must be 2, got ${JSON.stringify(firefoxManifest.manifest_version)}`,
+    )
+  }
+
+  const chromeApiPermissions = readStringArray(
+    chromeManifest,
+    'permissions',
+    chromeLabel,
+  )
+    .filter((permission) => !isHostPermission(permission))
+    .toSorted()
+  const firefoxApiPermissions = readStringArray(
+    firefoxManifest,
+    'permissions',
+    firefoxLabel,
+  )
+    .filter((permission) => !isHostPermission(permission))
+    .toSorted()
+  if (sortedJson(chromeApiPermissions) !== sortedJson(firefoxApiPermissions)) {
+    throw new Error(
+      `Chrome and Firefox API permissions diverge: chrome=${sortedJson(chromeApiPermissions)} firefox=${sortedJson(firefoxApiPermissions)}`,
+    )
+  }
+
+  const chromeHosts = readStringArray(
+    chromeManifest,
+    'host_permissions',
+    chromeLabel,
+  ).toSorted()
+  const firefoxHosts = readStringArray(
+    firefoxManifest,
+    'permissions',
+    firefoxLabel,
+  )
+    .filter((permission) => isHostPermission(permission))
+    .toSorted()
+  if (sortedJson(chromeHosts) !== sortedJson(firefoxHosts)) {
+    throw new Error(
+      `Chrome and Firefox host permissions diverge: chrome=${sortedJson(chromeHosts)} firefox=${sortedJson(firefoxHosts)}`,
+    )
+  }
+
+  const sharedKeys = new Set(Object.keys(chromeManifest))
+  for (const key of Object.keys(firefoxManifest)) {
+    sharedKeys.add(key)
+  }
+  const expectedDivergentKeys = new Set([
+    'manifest_version',
+    'permissions',
+    'host_permissions',
+    'content_security_policy',
+    'browser_specific_settings',
+    // Chrome MV3 uses `action`; Firefox MV2 uses `browser_action` for the same
+    // toolbar action surface.
+    'action',
+    'browser_action',
+    // Chrome MV3 uses a service worker; Firefox MV2 uses background scripts.
+    'background',
+  ])
+  for (const key of sharedKeys) {
+    if (expectedDivergentKeys.has(key)) {
+      continue
+    }
+    if (sortedJson(chromeManifest[key]) !== sortedJson(firefoxManifest[key])) {
+      throw new Error(
+        `Chrome and Firefox manifest diverge on unexpected key "${key}": chrome=${sortedJson(chromeManifest[key])} firefox=${sortedJson(firefoxManifest[key])}`,
+      )
+    }
+  }
+}

--- a/tools/scripts/production-network-policy.test.ts
+++ b/tools/scripts/production-network-policy.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest'
 import {
   APPROVED_WEB_ACCESSIBLE_RESOURCES,
   assertChromeFirefoxManifestDelta,
+  assertWebAccessibleResourcesOnAllowlist,
 } from './manifestSecurityInvariants'
 import {
   assertManifestMatchesProductionNetworkPolicy,
@@ -715,6 +716,22 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
         {
           content_security_policy: {
             extension_pages: csp.replace(
+              "frame-src 'none'",
+              "frame-src 'self'",
+            ),
+          },
+          host_permissions,
+          manifest_version: 3,
+        },
+        'frame-src.json',
+      ),
+    ).toThrow(/frame-src\.json.*frame-src must be 'none'/)
+
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: csp.replace(
               "script-src 'self' 'wasm-unsafe-eval'",
               "script-src 'self'",
             ),
@@ -929,6 +946,67 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
     expect(APPROVED_WEB_ACCESSIBLE_RESOURCES).toEqual([])
   })
 
+  it('web_accessible_resources on the approved allowlist is accepted (MV2 string form)', () => {
+    expect(() =>
+      assertWebAccessibleResourcesOnAllowlist(
+        { web_accessible_resources: ['options.html'] },
+        'allow.json',
+        ['options.html'],
+      ),
+    ).not.toThrow()
+  })
+
+  it('web_accessible_resources on the approved allowlist is accepted (MV3 object form)', () => {
+    expect(() =>
+      assertWebAccessibleResourcesOnAllowlist(
+        {
+          web_accessible_resources: [
+            {
+              matches: ['https://example.com/*'],
+              resources: ['options.html'],
+            },
+          ],
+        },
+        'allow-mv3.json',
+        ['options.html'],
+      ),
+    ).not.toThrow()
+  })
+
+  it('web_accessible_resources outside the approved allowlist is rejected', () => {
+    expect(() =>
+      assertWebAccessibleResourcesOnAllowlist(
+        { web_accessible_resources: ['other.html'] },
+        'mismatch.json',
+        ['options.html'],
+      ),
+    ).toThrow(/mismatch\.json.*web_accessible_resources.*allowlist/)
+  })
+
+  it('web_accessible_resources with an extra entry beyond the approved allowlist is rejected', () => {
+    expect(() =>
+      assertWebAccessibleResourcesOnAllowlist(
+        { web_accessible_resources: ['options.html', 'other.html'] },
+        'extra.json',
+        ['options.html'],
+      ),
+    ).toThrow(/extra\.json.*web_accessible_resources.*allowlist/)
+  })
+
+  it('rejects a malformed web_accessible_resources MV3 entry', () => {
+    expect(() =>
+      assertWebAccessibleResourcesOnAllowlist(
+        {
+          web_accessible_resources: [
+            { matches: ['https://example.com/*'], resources: [123] },
+          ],
+        },
+        'bad-mv3.json',
+        [],
+      ),
+    ).toThrow(/bad-mv3\.json.*MV3 entries.*string\[\] resources/)
+  })
+
   it('rejects a non-empty web_accessible_resources MV3 object form', () => {
     expect(() =>
       assertManifestMatchesProductionNetworkPolicy(
@@ -1011,7 +1089,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
         },
         'malformed-war.json',
       ),
-    ).toThrow(/malformed-war\.json.*web_accessible_resources.*allowlist/)
+    ).toThrow(/malformed-war\.json.*web_accessible_resources.*array/)
   })
 
   it('rejects a permissions array containing non-string entries', () => {
@@ -1035,6 +1113,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
 
   describe('assertChromeFirefoxManifestDelta', () => {
     const chromeBase = {
+      action: { default_title: '__MSG_extensionName__' },
       content_security_policy: {
         extension_pages: createProductionExtensionCsp(3),
       },
@@ -1055,6 +1134,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
       version: '1.0.0',
     }
     const firefoxBase = {
+      browser_action: { default_title: '__MSG_extensionName__' },
       browser_specific_settings: {
         gecko: { data_collection_permissions: { required: ['none'] } },
       },
@@ -1166,6 +1246,126 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
           'firefox.json',
         ),
       ).toThrow(/chrome and firefox manifests must be objects/)
+    })
+
+    it('rejects an unexpected field on the Chrome action surface', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          { ...chromeBase, action: { default_title: 'X', extra: true } },
+          firefoxBase,
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/chrome\.json.*action surface.*unexpected field "extra"/)
+    })
+
+    it('rejects Chrome declaring browser_action', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          {
+            ...chromeBase,
+            browser_action: { default_title: '__MSG_extensionName__' },
+          },
+          firefoxBase,
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/chrome\.json.*must not declare browser_action/)
+    })
+
+    it('rejects Firefox declaring action', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          chromeBase,
+          {
+            ...firefoxBase,
+            action: { default_title: '__MSG_extensionName__' },
+          },
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/firefox\.json.*must not declare action/)
+    })
+
+    it('rejects a Chrome background extra field that Firefox does not have', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          {
+            ...chromeBase,
+            background: { service_worker: 'background.js', type: 'module' },
+          },
+          firefoxBase,
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/Chrome and Firefox background diverge/)
+    })
+
+    it('rejects divergent action surface default_title between browsers', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          { ...chromeBase, action: { default_title: 'Chrome' } },
+          firefoxBase,
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/Chrome and Firefox action surface diverge/)
+    })
+
+    it('rejects a non-string background.service_worker', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          { ...chromeBase, background: { service_worker: 123 } },
+          firefoxBase,
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/chrome\.json.*background\.service_worker must be a string/)
+    })
+
+    it('rejects a non-string entry in background.scripts', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          chromeBase,
+          { ...firefoxBase, background: { scripts: ['background.js', 123] } },
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/firefox\.json.*background\.scripts must be a string array/)
+    })
+
+    it('rejects Chrome declaring browser_specific_settings', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          {
+            ...chromeBase,
+            browser_specific_settings: { gecko: { id: 'x' } },
+          },
+          firefoxBase,
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/chrome\.json.*must not declare browser_specific_settings/)
+    })
+
+    it('rejects a Firefox browser_specific_settings structure change', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          chromeBase,
+          {
+            ...firefoxBase,
+            browser_specific_settings: {
+              gecko: {
+                data_collection_permissions: { required: ['tech.data'] },
+              },
+            },
+          },
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(
+        /firefox\.json.*browser_specific_settings.*expected Firefox structure/,
+      )
     })
   })
 })

--- a/tools/scripts/production-network-policy.test.ts
+++ b/tools/scripts/production-network-policy.test.ts
@@ -4,6 +4,10 @@ import { createProductionExtensionCsp } from '#production-network-policy'
 import { describe, expect, it } from 'vitest'
 
 import {
+  APPROVED_WEB_ACCESSIBLE_RESOURCES,
+  assertChromeFirefoxManifestDelta,
+} from './manifestSecurityInvariants'
+import {
   assertManifestMatchesProductionNetworkPolicy,
   assertProductionNetworkCallsiteInventory,
   collectProductionNetworkCallsites,
@@ -803,5 +807,365 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
         `${label}-version.json`,
       ),
     ).toThrow(new RegExp(`${label}-version\\.json.*manifest_version.*2 or 3`))
+  })
+
+  it('rejects an externally_connectable surface added without a trust-boundary review', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: createProductionExtensionCsp(3),
+          },
+          externally_connectable: {
+            matches: ['https://example.com/*'],
+          },
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+          manifest_version: 3,
+          permissions: [
+            'alarms',
+            'tabs',
+            'storage',
+            'contextMenus',
+            'notifications',
+            'unlimitedStorage',
+          ],
+        },
+        'external-connectable.json',
+      ),
+    ).toThrow(
+      /external-connectable\.json.*externally_connectable.*trust-boundary/,
+    )
+  })
+
+  it('rejects content_scripts added without a trust-boundary review', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: createProductionExtensionCsp(3),
+          },
+          content_scripts: [
+            {
+              js: ['content.js'],
+              matches: ['https://example.com/*'],
+            },
+          ],
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+          manifest_version: 3,
+          permissions: [
+            'alarms',
+            'tabs',
+            'storage',
+            'contextMenus',
+            'notifications',
+            'unlimitedStorage',
+          ],
+        },
+        'content-scripts.json',
+      ),
+    ).toThrow(/content-scripts\.json.*content_scripts.*trust-boundary/)
+  })
+
+  it('rejects an unapproved web_accessible_resources entry', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: createProductionExtensionCsp(3),
+          },
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+          manifest_version: 3,
+          permissions: [
+            'alarms',
+            'tabs',
+            'storage',
+            'contextMenus',
+            'notifications',
+            'unlimitedStorage',
+          ],
+          web_accessible_resources: ['options.html'],
+        },
+        'war.json',
+      ),
+    ).toThrow(/war\.json.*web_accessible_resources.*allowlist/)
+  })
+
+  it('accepts an absent web_accessible_resources surface', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: createProductionExtensionCsp(3),
+          },
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+          manifest_version: 3,
+          permissions: [
+            'alarms',
+            'tabs',
+            'storage',
+            'contextMenus',
+            'notifications',
+            'unlimitedStorage',
+          ],
+        },
+        'no-war.json',
+      ),
+    ).not.toThrow()
+  })
+
+  it('web_accessible_resources approved allowlist is empty until a review adds entries', () => {
+    expect(APPROVED_WEB_ACCESSIBLE_RESOURCES).toEqual([])
+  })
+
+  it('rejects a non-empty web_accessible_resources MV3 object form', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: createProductionExtensionCsp(3),
+          },
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+          manifest_version: 3,
+          permissions: [
+            'alarms',
+            'tabs',
+            'storage',
+            'contextMenus',
+            'notifications',
+            'unlimitedStorage',
+          ],
+          web_accessible_resources: [
+            { matches: ['https://example.com/*'], resources: ['options.html'] },
+          ],
+        },
+        'war-object.json',
+      ),
+    ).toThrow(/war-object\.json.*web_accessible_resources.*allowlist/)
+  })
+
+  it('rejects a malformed content_scripts value that is not an array', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: createProductionExtensionCsp(3),
+          },
+          content_scripts: 'not-an-array',
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+          manifest_version: 3,
+          permissions: [
+            'alarms',
+            'tabs',
+            'storage',
+            'contextMenus',
+            'notifications',
+            'unlimitedStorage',
+          ],
+        },
+        'malformed-content-scripts.json',
+      ),
+    ).toThrow(
+      /malformed-content-scripts\.json.*content_scripts.*trust-boundary/,
+    )
+  })
+
+  it('rejects a malformed web_accessible_resources value that is not an array', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: createProductionExtensionCsp(3),
+          },
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+          manifest_version: 3,
+          permissions: [
+            'alarms',
+            'tabs',
+            'storage',
+            'contextMenus',
+            'notifications',
+            'unlimitedStorage',
+          ],
+          web_accessible_resources: 'options.html',
+        },
+        'malformed-war.json',
+      ),
+    ).toThrow(/malformed-war\.json.*web_accessible_resources.*allowlist/)
+  })
+
+  it('rejects a permissions array containing non-string entries', () => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: createProductionExtensionCsp(3),
+          },
+          host_permissions: [
+            'http://localhost:11434/*',
+            'http://127.0.0.1:11434/*',
+          ],
+          manifest_version: 3,
+          permissions: ['storage', 123],
+        },
+        'non-string-permissions.json',
+      ),
+    ).toThrow(/non-string-permissions\.json.*permissions.*string array/)
+  })
+
+  describe('assertChromeFirefoxManifestDelta', () => {
+    const chromeBase = {
+      content_security_policy: {
+        extension_pages: createProductionExtensionCsp(3),
+      },
+      host_permissions: [
+        'http://localhost:11434/*',
+        'http://127.0.0.1:11434/*',
+      ],
+      manifest_version: 3,
+      name: 'TABBIN',
+      permissions: [
+        'alarms',
+        'tabs',
+        'storage',
+        'contextMenus',
+        'notifications',
+        'unlimitedStorage',
+      ],
+      version: '1.0.0',
+    }
+    const firefoxBase = {
+      browser_specific_settings: {
+        gecko: { data_collection_permissions: { required: ['none'] } },
+      },
+      content_security_policy: createProductionExtensionCsp(2),
+      manifest_version: 2,
+      name: 'TABBIN',
+      permissions: [
+        'alarms',
+        'tabs',
+        'storage',
+        'contextMenus',
+        'notifications',
+        'unlimitedStorage',
+        'http://localhost:11434/*',
+        'http://127.0.0.1:11434/*',
+      ],
+      version: '1.0.0',
+    }
+
+    it('accepts the expected Chrome MV3 / Firefox MV2 divergence', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          chromeBase,
+          firefoxBase,
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).not.toThrow()
+    })
+
+    it('rejects divergent API permissions between Chrome and Firefox', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          {
+            ...chromeBase,
+            permissions: [...chromeBase.permissions, 'history'],
+          },
+          firefoxBase,
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/API permissions diverge/)
+    })
+
+    it('rejects divergent host permissions between Chrome and Firefox', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          chromeBase,
+          {
+            ...firefoxBase,
+            permissions: [
+              ...firefoxBase.permissions,
+              'https://api.example.com/*',
+            ],
+          },
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/host permissions diverge/)
+    })
+
+    it('rejects an unexpected non-divergent key difference', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          { ...chromeBase, name: 'TABBIN-Changed' },
+          firefoxBase,
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/diverge on unexpected key "name"/)
+    })
+
+    it('rejects a Chrome manifest that is not MV3', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          { ...chromeBase, manifest_version: 2 },
+          firefoxBase,
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/chrome\.json.*manifest_version must be 3/)
+    })
+
+    it('rejects a Firefox manifest that is not MV2', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          chromeBase,
+          { ...firefoxBase, manifest_version: 3 },
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/firefox\.json.*manifest_version must be 2/)
+    })
+
+    it('rejects non-object manifests', () => {
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          null,
+          firefoxBase,
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/chrome and firefox manifests must be objects/)
+      expect(() =>
+        assertChromeFirefoxManifestDelta(
+          chromeBase,
+          null,
+          'chrome.json',
+          'firefox.json',
+        ),
+      ).toThrow(/chrome and firefox manifests must be objects/)
+    })
   })
 })

--- a/tools/scripts/production-network-policy.ts
+++ b/tools/scripts/production-network-policy.ts
@@ -2,13 +2,14 @@ import { readdirSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 
 import { PRODUCTION_EXTENSION_PERMISSIONS } from '#extension-permissions'
-import {
-  PRODUCTION_OUTBOUND_ALLOWED_ORIGINS,
-  PRODUCTION_OUTBOUND_HOST_PERMISSIONS,
-  createProductionExtensionCsp,
-} from '#production-network-policy'
+import { PRODUCTION_OUTBOUND_HOST_PERMISSIONS } from '#production-network-policy'
 import ts from 'typescript'
 
+import { isHostPermission, readStringArray } from './manifestHelpers.ts'
+import {
+  assertExtensionCspMatchesProductionNetworkPolicy,
+  assertGeneratedManifestSecurityInvariants,
+} from './manifestSecurityInvariants.ts'
 import { collectPotentialNetworkAliasKinds } from './production-network-policy-aliases'
 import type { PotentialAliasSummary } from './production-network-policy-aliases'
 import {
@@ -611,120 +612,8 @@ export const assertProductionNetworkCallsiteInventory = (
   )
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null
-
-const readStringArray = (
-  manifest: Record<string, unknown>,
-  property: string,
-  label: string,
-): string[] => {
-  const value = manifest[property]
-  if (
-    !Array.isArray(value) ||
-    !value.every((item) => typeof item === 'string')
-  ) {
-    throw new TypeError(`${label} ${property} is missing or not a string array`)
-  }
-  return value
-}
-
-const readExtensionPagesCsp = (
-  manifest: Record<string, unknown>,
-  label: string,
-): string => {
-  const value = manifest.content_security_policy
-  if (typeof value === 'string') {
-    return value
-  }
-  if (isRecord(value) && typeof value.extension_pages === 'string') {
-    return value.extension_pages
-  }
-  throw new TypeError(
-    `${label} content_security_policy is missing an extension policy`,
-  )
-}
-
-const parseCspDirectives = (
-  csp: string,
-  label: string,
-): Map<string, string[]> => {
-  const directives = new Map<string, string[]>()
-  const sections = csp
-    .split(';')
-    .map((section) => section.trim())
-    .filter((section) => section !== '')
-  for (const section of sections) {
-    const [directive, ...values] = section.split(/\s+/u)
-    if (directives.has(directive)) {
-      throw new Error(
-        `${label} content_security_policy contains duplicate directive ${directive}`,
-      )
-    }
-    directives.set(directive, values)
-  }
-  return directives
-}
-
-const assertExtensionCspMatchesProductionNetworkPolicy = (
-  manifest: Record<string, unknown>,
-  label: string,
-  manifestVersion: 2 | 3,
-): void => {
-  const directives = parseCspDirectives(
-    readExtensionPagesCsp(manifest, label),
-    label,
-  )
-  const expectedConnectSources = [
-    "'self'",
-    'blob:',
-    ...PRODUCTION_OUTBOUND_ALLOWED_ORIGINS,
-  ].toSorted()
-  const actualConnectSources = directives.get('connect-src')?.toSorted()
-  if (
-    actualConnectSources === undefined ||
-    JSON.stringify(actualConnectSources) !==
-      JSON.stringify(expectedConnectSources)
-  ) {
-    throw new Error(
-      `${label} connect-src does not match the production allowlist: ${JSON.stringify(actualConnectSources)}; expected ${JSON.stringify(expectedConnectSources)}`,
-    )
-  }
-  for (const directive of ['object-src', 'frame-src', 'form-action']) {
-    if (
-      JSON.stringify(directives.get(directive)) !== JSON.stringify(["'none'"])
-    ) {
-      throw new Error(`${label} ${directive} must be 'none'`)
-    }
-  }
-  const expectedDirectives = parseCspDirectives(
-    createProductionExtensionCsp(manifestVersion),
-    'production network policy',
-  )
-  for (const [directive, expectedValues] of expectedDirectives) {
-    if (directive === 'connect-src') {
-      continue
-    }
-    const actualValues = directives.get(directive)
-    if (
-      actualValues === undefined ||
-      JSON.stringify(actualValues.toSorted()) !==
-        JSON.stringify(expectedValues.toSorted())
-    ) {
-      throw new Error(
-        `${label} ${directive} does not match the production policy`,
-      )
-    }
-  }
-  const unexpectedDirectives = [...directives.keys()].filter(
-    (directive) => !expectedDirectives.has(directive),
-  )
-  if (unexpectedDirectives.length !== 0) {
-    throw new Error(
-      `${label} content_security_policy contains unexpected directives: ${unexpectedDirectives.join(', ')}`,
-    )
-  }
-}
 
 export const assertManifestMatchesProductionNetworkPolicy = (
   manifest: unknown,
@@ -744,8 +633,6 @@ export const assertManifestMatchesProductionNetworkPolicy = (
   const optionalHostPermissionProperty = isManifestV2
     ? 'optional_permissions'
     : 'optional_host_permissions'
-  const isHostPermission = (permission: string): boolean =>
-    permission === '<all_urls>' || permission.includes('://')
   const actual = readStringArray(manifest, hostPermissionProperty, label)
     .filter(isHostPermission)
     .toSorted()
@@ -800,4 +687,6 @@ export const assertManifestMatchesProductionNetworkPolicy = (
       )
     }
   }
+
+  assertGeneratedManifestSecurityInvariants(manifest, label)
 }

--- a/tools/scripts/verify-production-network-policy.ts
+++ b/tools/scripts/verify-production-network-policy.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
+import { assertChromeFirefoxManifestDelta } from './manifestSecurityInvariants.ts'
 import {
   assertManifestMatchesProductionNetworkPolicy,
   assertProductionNetworkCallsiteInventory,
@@ -16,11 +17,30 @@ const manifestPaths = [
 const callsites = collectProductionNetworkCallsites(projectRoot)
 assertProductionNetworkCallsiteInventory(callsites)
 
-for (const manifestPath of manifestPaths) {
+const loadedManifests = manifestPaths.map((manifestPath) => {
   const manifest: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'))
   assertManifestMatchesProductionNetworkPolicy(manifest, manifestPath)
+  return { manifest, manifestPath }
+})
+
+const chromeManifest = loadedManifests.find((entry) =>
+  entry.manifestPath.includes('chrome-mv3'),
+)
+const firefoxManifest = loadedManifests.find((entry) =>
+  entry.manifestPath.includes('firefox-mv2'),
+)
+if (chromeManifest === undefined || firefoxManifest === undefined) {
+  throw new Error(
+    'expected both chrome-mv3 and firefox-mv2 generated manifests for delta verification',
+  )
 }
+assertChromeFirefoxManifestDelta(
+  chromeManifest.manifest,
+  firefoxManifest.manifest,
+  chromeManifest.manifestPath,
+  firefoxManifest.manifestPath,
+)
 
 console.log(
-  `production network policy verified (${callsites.length} inventoried call sites, ${manifestPaths.length} manifests)`,
+  `production network policy verified (${callsites.length} inventoried call sites, ${manifestPaths.length} manifests, chrome/firefox delta checked)`,
 )


### PR DESCRIPTION
## Cause

Issue #676 requires documenting why each Chrome extension permission is requested, adding generated-manifest security invariant tests, and defining the runtime messaging trust boundary. The generated-manifest verifier previously checked the permission/host-permission allowlist and CSP, but did not guard `externally_connectable`, `content_scripts`, `web_accessible_resources`, or the Chrome/Firefox manifest delta. There were no docs for per-permission usage or the messaging sender trust model.

## Changes

- `docs/security/permissions.md` (new): documents each approved API permission (`alarms`, `tabs`, `storage`, `contextMenus`, `notifications`, `unlimitedStorage`) and host permission (`http://localhost:11434/*`, `http://127.0.0.1:11434/*`) with purpose, primary usage sites, and review notes; documents the generated-manifest security invariants and the checklist for adding a new permission or privileged surface.
- `docs/security/messaging-trust-boundary.md` (new): defines sender types and trust levels (extension page/background trusted; content script and external senders untrusted), privileged action sender policy, trust-boundary review triggers, and the migration control key trust boundary framework (references #727 as the authoritative state-machine owner).
- `tools/scripts/manifestSecurityInvariants.ts` (new): extracted manifest invariant logic. Adds `assertGeneratedManifestSecurityInvariants` (rejects `externally_connectable`, non-empty `content_scripts`, and non-empty/unapproved `web_accessible_resources`) and `assertChromeFirefoxManifestDelta` (fails divergence outside the expected manifest-version-driven keys). CSP verification (`assertExtensionCspMatchesProductionNetworkPolicy`) moved here.
- `tools/scripts/manifestHelpers.ts` (new): shared `isRecord` / `isHostPermission` / `readStringArray` helpers, breaking the import cycle between the two modules.
- `tools/scripts/production-network-policy.ts`: wires the new invariant checks into `assertManifestMatchesProductionNetworkPolicy`; re-exports nothing (consumers import the delta verifier directly). Under the `max-lines` limit after extraction.
- `tools/scripts/verify-production-network-policy.ts`: runs the Chrome/Firefox delta check after per-manifest verification.
- `src/lib/architecture/messagingTrustBoundary.test.ts` (new): source-level guard that detects `onMessageExternal` / `onConnectExternal` listeners in production source and `externally_connectable` / `content_scripts` declarations in `wxt.config.ts`, and asserts the two security docs and the verifier cover the required surfaces.
- `tools/scripts/production-network-policy.test.ts`: adds tests for the new invariants (externally_connectable, content_scripts, web_accessible_resources string/object/malformed forms, absent WAR, WAR allowlist empty) and the delta verifier (valid divergence, API/host divergence, unexpected key, MV3/MV2 version checks, non-object manifests).

## Acceptance criteria mapping

- [x] 権限ごとの利用理由が docs 化されている — `docs/security/permissions.md`
- [x] 各 permission の主な利用ファイルが記載されている — per-permission "Primary usage sites"
- [x] local Ollama host permission の目的が明記されている — host permissions section + `production-network-policy.md` link
- [x] permission 追加時に docs 更新を促す仕組みがある — verifier fails loudly + "Adding a new permission" checklist + `APPROVED_WEB_ACCESSIBLE_RESOURCES` allowlist
- [x] generated Chrome / Firefox manifest を validation する — `assertManifestMatchesProductionNetworkPolicy` + `assertChromeFirefoxManifestDelta`
- [x] `permissions` / `host_permissions` を allowlist 検証 — existing + retained
- [x] `externally_connectable` / `content_scripts` / `web_accessible_resources` の security invariant を検証 — new invariants
- [x] CSP / remote script に関する invariant を検証 — CSP directive pinning (script-src, connect-src, object-src, frame-src, form-action; no unexpected directives)
- [x] Chrome / Firefox manifest delta を確認できる — `assertChromeFirefoxManifestDelta`
- [x] runtime messaging の sender type ごとの trust boundary が docs 化されている — `docs/security/messaging-trust-boundary.md`
- [x] privileged action の sender policy を定義している — privileged actions table + sender policy
- [x] `content_scripts` / `externally_connectable` / `onMessageExternal` 追加時に trust boundary review を促す仕組みがある — manifest verifier + source-level architecture guard
- [x] 既存テストが通る — `bun run test` green

### Comment-derived criteria (dependencies)

- `unlimitedStorage` allowlist: #735 is CLOSED and adopted `unlimitedStorage`; it is in the approved allowlist and documented in `permissions.md` + `persistence-durability.md`.
- Migration control key trust boundary: #727 is still OPEN. This PR documents the security-invariant and review-trigger side and references #727 as the authoritative state-machine/repository-boundary owner. The source-level guard tracks the framework; the concrete storage access boundary lands with #727.

## Verification

- `bun run test` — all tests pass (node + dom projects)
- `bun run test:coverage` — new modules (`manifestSecurityInvariants.ts`, `manifestHelpers.ts`) at 100% statement/line/function coverage; repo-wide coverage unchanged/improved
- `bun run compile` — clean
- `bun run lint` — clean (no import cycle, under `max-lines`)
- `bun run quality:check` — green (format, lint, compile, test, knip, duplication, secretlint, arch:check)
- `bun run build && bun run build:firefox && bun run verify:production-network-policy` — both generated manifests pass per-manifest invariants and the Chrome/Firefox delta check
- `bun run release:check` — green

## Risk

Docs- and test-only change; no runtime behavior change. The new manifest invariants are enforced against generated artifacts, so a future change that adds `content_scripts`, `externally_connectable`, or `web_accessible_resources` will fail verification until a trust-boundary review updates the allowlist and docs — this is the intended gate.

Closes #676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
  - メッセージングの信頼境界、権限、特権アクションの確認方針を整理しました。
  - 権限追加時のレビュー手順と、Chrome/Firefox向けマニフェストの監査項目を追加しました。

- **セキュリティ強化**
  - 生成マニフェストの権限、CSP、外部接続、公開リソースを厳格に検証します。
  - Chrome版とFirefox版の許可設定に不整合がないか確認します。

- **テスト**
  - 信頼境界およびマニフェスト検証の網羅的なテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->