### PR TITLE
[Persistence v2] incognitoデータ境界をnormal-onlyに固定

### DIFF
--- a/docs/architecture/persistence-model-v2.md
+++ b/docs/architecture/persistence-model-v2.md
@@ -350,6 +350,72 @@ entrypoints; new rows must be classified before #726 is finalized.
 No raw current key is a second authority after its logical cutover. Backup V2
 contains the logical model, not both legacy and v2 representations.
 
+## Incognito data boundary
+
+TABBIN does not support incognito/private-browsing persistence. Domain data and
+every control plane that governs it are normal-context-only. Both generated
+manifests declare:
+
+```json
+{
+  "incognito": "not_allowed"
+}
+```
+
+### Current behavior inventory and compatibility
+
+Before this decision, the current manifests omit `incognito` and therefore use
+the browser default `spanning` mode. There is no `tab.incognito` guard in the
+current writer inventory, so private-tab events are processed by the same
+background paths as normal tabs when a user grants private access.
+
+- Chrome runs the default spanning extension in one shared process and sends
+  incognito events to it. Chrome shares `chrome.storage.local` between regular
+  and incognito processes.
+- Firefox requires user opt-in for private browsing access. Its default
+  `spanning` mode also exposes private and non-private tab/window events to the
+  extension, distinguished only by the `incognito` property.
+- Both browsers support `not_allowed`; declaring it removes the user opt-in
+  surface and prevents private events from entering TABBIN persistence paths.
+
+This is a deliberate compatibility break for users who previously enabled
+private access. Existing private URLs were written into shared normal storage
+without provenance, so this change neither migrates nor guesses which existing
+records came from private browsing. Removing records without provenance would
+risk deleting normal user data.
+
+The browser behavior evidence is maintained against the official
+[Chrome incognito manifest](https://developer.chrome.com/docs/extensions/reference/manifest/incognito),
+[Chrome incognito access](https://developer.chrome.com/docs/extensions/develop/concepts/declare-permissions),
+and
+[Firefox incognito manifest](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/incognito)
+documentation.
+
+### Normal-only scope
+
+- PersistenceBootstrap state, migration lock, migration ownership, source
+  snapshot, target database identity, and cleanup eligibility are
+  normal-context-only.
+- Persistence v2 has one normal-context IndexedDB database identity. It does not
+  create a private database, private migration marker, or private bootstrap
+  state.
+- Migration coordination is acquired and verified only for the normal context.
+  If an unsupported private context reaches bootstrap in a development or
+  side-loaded build, it fails closed with `MIGRATION_COORDINATION_UNAVAILABLE`;
+  it must not read, write, cut over, or clean up either persistence source.
+- Backup V2 exports and imports normal-context data only. There is no private
+  backup envelope or implicit merge into a normal backup.
+- Analytics and AI saved-URL context builders consume normal-context data only.
+  They must not infer inclusion merely because a storage engine exposes a
+  record.
+- Migration notices, dismissal state, settings, recovery snapshots, and legacy
+  cleanup all use the normal-context control plane.
+
+Supporting private browsing later requires a dedicated product decision and
+separate migration, backup, analytics, AI, cleanup, and browser-compatibility
+contracts. Changing only the manifest mode or IndexedDB database name is not a
+supported rollout.
+
 ## JSON-safe persistence boundary
 
 The shared logical contract is:

--- a/docs/security/permissions.md
+++ b/docs/security/permissions.md
@@ -179,6 +179,10 @@ checks, per manifest:
   permits the approved resources. The verifier pins resource paths; the
   `matches` / `extension_ids` exposure scope is part of the security review and
   must be justified in this document before an entry is approved.
+- `incognito` is exactly `not_allowed`, keeping private browsing events and data
+  outside TABBIN's persistence, backup, analytics, and AI boundaries. The
+  authoritative downstream scope is documented in
+  [`persistence-model-v2.md`](../architecture/persistence-model-v2.md#incognito-data-boundary).
 
 The `assertChromeFirefoxManifestDelta` verifier checks that Chrome MV3 and
 Firefox MV2 differ only on the expected manifest-version-driven structure.
@@ -189,8 +193,9 @@ manifest. `action` / `browser_action`, `background`, and
 (allowed action fields, `service_worker` -> `scripts`, the expected Firefox
 gecko data-collection structure) and compared, so an unexpected
 browser-specific change inside those keys fails verification instead of being
-skipped. Any other key divergence fails verification, so a change that only
-lands on one browser is detected.
+skipped. The shared `incognito` key must be `not_allowed` on both browsers. Any
+other key divergence fails verification, so a change that only lands on one
+browser is detected.
 
 ## Adding a new permission or privileged surface
 

--- a/src/lib/architecture/persistenceModelV2Policy.test.ts
+++ b/src/lib/architecture/persistenceModelV2Policy.test.ts
@@ -331,6 +331,7 @@ describe('Persistence Model v2 architecture contract', () => {
       '## Timestamp semantics',
       '## Current to v2 mapping',
       '## Storage Placement Matrix',
+      '## Incognito data boundary',
       '## JSON-safe persistence boundary',
       '## Migration recoverability',
       '## Invariants for #712',
@@ -371,6 +372,23 @@ describe('Persistence Model v2 architecture contract', () => {
       "DynamicToolUIPart['output']",
     ]) {
       expect(modelDocument).toContain(guardrail)
+    }
+  })
+
+  it('defines one normal-only scope for every private browsing boundary', () => {
+    const normalizedModelDocument = normalizeProse(modelDocument)
+
+    for (const contract of [
+      /current manifests omit `incognito` and therefore use the browser default `spanning` mode/i,
+      /Chrome shares `chrome\.storage\.local` between regular and incognito processes/i,
+      /Firefox requires user opt-in for private browsing access/i,
+      /"incognito": "not_allowed"/i,
+      /PersistenceBootstrap state, migration lock, migration ownership, source snapshot, target database identity, and cleanup eligibility are normal-context-only/i,
+      /Backup V2 exports and imports normal-context data only/i,
+      /Analytics and AI saved-URL context builders consume normal-context data only/i,
+      /MIGRATION_COORDINATION_UNAVAILABLE/i,
+    ]) {
+      expect(normalizedModelDocument).toMatch(contract)
     }
   })
 

--- a/tools/scripts/manifestSecurityInvariants.ts
+++ b/tools/scripts/manifestSecurityInvariants.ts
@@ -240,6 +240,7 @@ export const assertGeneratedManifestSecurityInvariants = (
     label,
     APPROVED_WEB_ACCESSIBLE_RESOURCES,
   )
+  assertManifestIncognitoPolicy(manifest, label)
 }
 
 const readOptionalRecord = (

--- a/tools/scripts/manifestSecurityInvariants.ts
+++ b/tools/scripts/manifestSecurityInvariants.ts
@@ -138,6 +138,17 @@ const canonicalJson = (value: unknown): string => {
   return JSON.stringify(value)
 }
 
+const assertManifestIncognitoPolicy = (
+  manifest: Record<string, unknown>,
+  label: string,
+): void => {
+  if (manifest.incognito !== 'not_allowed') {
+    throw new Error(
+      `${label} incognito must be "not_allowed"; found ${JSON.stringify(manifest.incognito)}`,
+    )
+  }
+}
+
 export const extractWebAccessibleResourcePaths = (
   manifest: Record<string, unknown>,
   label: string,
@@ -394,6 +405,9 @@ export const assertChromeFirefoxManifestDelta = (
       `${firefoxLabel} manifest_version must be 2, got ${JSON.stringify(firefoxManifest.manifest_version)}`,
     )
   }
+
+  assertManifestIncognitoPolicy(chromeManifest, chromeLabel)
+  assertManifestIncognitoPolicy(firefoxManifest, firefoxLabel)
 
   const chromeApiPermissions = readStringArray(
     chromeManifest,

--- a/tools/scripts/production-network-policy.test.ts
+++ b/tools/scripts/production-network-policy.test.ts
@@ -497,6 +497,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             'http://127.0.0.1:11434/*',
             'http://localhost:11434/*',
           ],
+          incognito: 'not_allowed',
           manifest_version: 3,
           permissions: [
             'alarms',
@@ -512,11 +513,44 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
     ).not.toThrow()
   })
 
+  it.each([
+    ['missing', undefined],
+    ['unsupported', 'spanning'],
+  ])('rejects %s incognito policy', (label, incognito) => {
+    expect(() =>
+      assertManifestMatchesProductionNetworkPolicy(
+        {
+          content_security_policy: {
+            extension_pages: createProductionExtensionCsp(3),
+          },
+          host_permissions: [
+            'http://127.0.0.1:11434/*',
+            'http://localhost:11434/*',
+          ],
+          ...(incognito === undefined ? {} : { incognito }),
+          manifest_version: 3,
+          permissions: [
+            'alarms',
+            'tabs',
+            'storage',
+            'contextMenus',
+            'notifications',
+            'unlimitedStorage',
+          ],
+        },
+        `${label}-incognito.json`,
+      ),
+    ).toThrow(
+      new RegExp(`${label}-incognito\\.json.*incognito must be "not_allowed"`),
+    )
+  })
+
   it('extracts host patterns from Firefox MV2 permissions', () => {
     expect(() =>
       assertManifestMatchesProductionNetworkPolicy(
         {
           content_security_policy: createProductionExtensionCsp(2),
+          incognito: 'not_allowed',
           manifest_version: 2,
           permissions: [
             'alarms',
@@ -786,6 +820,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             'http://localhost:11434/*',
             'http://127.0.0.1:11434/*',
           ],
+          incognito: 'not_allowed',
           manifest_version: 3,
           optional_host_permissions: [],
           permissions: [
@@ -927,6 +962,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
             'http://localhost:11434/*',
             'http://127.0.0.1:11434/*',
           ],
+          incognito: 'not_allowed',
           manifest_version: 3,
           permissions: [
             'alarms',

--- a/tools/scripts/production-network-policy.test.ts
+++ b/tools/scripts/production-network-policy.test.ts
@@ -1121,6 +1121,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
         'http://localhost:11434/*',
         'http://127.0.0.1:11434/*',
       ],
+      incognito: 'not_allowed',
       manifest_version: 3,
       name: 'TABBIN',
       permissions: [
@@ -1139,6 +1140,7 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
         gecko: { data_collection_permissions: { required: ['none'] } },
       },
       content_security_policy: createProductionExtensionCsp(2),
+      incognito: 'not_allowed',
       manifest_version: 2,
       name: 'TABBIN',
       permissions: [
@@ -1164,6 +1166,20 @@ describe('assertManifestMatchesProductionNetworkPolicy', () => {
         ),
       ).not.toThrow()
     })
+
+    it.each(['spanning', 'split'])(
+      'rejects the shared %s incognito policy',
+      (incognito) => {
+        expect(() =>
+          assertChromeFirefoxManifestDelta(
+            { ...chromeBase, incognito },
+            { ...firefoxBase, incognito },
+            'chrome.json',
+            'firefox.json',
+          ),
+        ).toThrow(/incognito must be "not_allowed"/)
+      },
+    )
 
     it('rejects divergent API permissions between Chrome and Firefox', () => {
       expect(() =>

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
     name: '__MSG_extensionName__',
     description: '__MSG_extensionDescription__',
     version: APP_VERSION,
+    incognito: 'not_allowed',
     content_security_policy: {
       extension_pages: createProductionExtensionCsp(env.manifestVersion),
     },


### PR DESCRIPTION
## 概要
- Chrome MV3 / Firefox MV2 の manifest を incognito 非対応に固定
- Persistence v2 の normal-only data boundary を migration、IndexedDB identity、Backup V2、Analytics、AI まで明文化
- 生成 manifest と architecture contract の回帰テストを追加

## 原因
現行 manifest は incognito を省略して browser default の spanning mode に依存していました。ユーザーが private access を許可すると、private tab event が normal background path と共有 chrome.storage.local に入り、IndexedDB migration 後の authority や database scope が未定義になる状態でした。

## 変更
- wxt.config.ts に incognito: not_allowed を追加
- Chrome / Firefox の生成 manifest が両方 not_allowed でなければ verifier を失敗させる
- current behavior、互換性、normal-only bootstrap / migration / lock / DB / cleanup scope を記録
- Backup V2、Analytics、AI saved-URL context を normal-only に固定
- unsupported private context は MIGRATION_COORDINATION_UNAVAILABLE で fail closed と定義

## 受け入れ条件
Issue の 11 条件を architecture policy、manifest、generated-artifact verifier、回帰テストへ対応付けています。Fresh-context Harness Evaluator は approved、blocking finding なしです。

## 検証
- bun run test:node -- tools/scripts/production-network-policy.test.ts src/lib/architecture/persistenceModelV2Policy.test.ts
  - RED: 4 expected failures
  - GREEN: 73 tests passed
- bun run test:coverage
  - 336 files / 3712 tests passed
  - statements 97.31%, branches 92.64%, functions 98.01%, lines 97.32%
- bun run quality:check
- bun run build
- bun run build:firefox
- bun run verify:production-network-policy
- bun run release:check
- bun run harness:validate
- bun run harness:audit

## リスク
以前 private access を有効化していた利用者は更新後に利用できません。既存 private 由来 URL は provenance がなく通常 URL と安全に区別できないため、自動削除や推測 migration は行いません。

Closes #736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **仕様変更**
  - シークレット／プライベートブラウジングでの拡張機能利用とデータ取扱いを対象外とし、通常コンテキストのみで動作する方針を明確化しました。
  - `incognito` は常に `not_allowed` に固定され、逸脱した場合は処理を停止します。
- **ドキュメント**
  - プライベート境界（インコグニート境界）と制御範囲を追記・整理しました。
- **テスト**
  - Chrome・Firefox間で `incognito` 方針が一致し、必須・許容値が妥当であることを検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->