### PR TITLE
feat: backup schema versioning pipeline を導入

### DIFF
--- a/docs/architecture/backup-schema-versioning.md
+++ b/docs/architecture/backup-schema-versioning.md
@@ -1,0 +1,167 @@
+# Backup Schema Versioning
+
+Status: public migration-kernel contract for Issue #713  
+Parent: Issue #724  
+Production Backup V2 owner: Issue #730
+
+## Version domains
+
+TABBIN keeps three version domains independent:
+
+| Version           | Meaning                                       | Owner                         |
+| ----------------- | --------------------------------------------- | ----------------------------- |
+| `appVersion`      | Extension release provenance                  | Manifest / release process    |
+| `schemaVersion`   | Public backup import and export data contract | Backup schema registry        |
+| `databaseVersion` | IndexedDB object stores and indexes           | IndexedDB upgrade transaction |
+
+`appVersion` is diagnostic metadata. It never selects a backup parser or
+migration, and semver comparison is not a compatibility rule.
+
+`schemaVersion` selects a public backup schema and its ordered migration path.
+It is independent of how the logical data is stored.
+
+`databaseVersion` changes when the physical IndexedDB schema changes. It does
+not appear in `BackupEnvelope`, and an object-store dump is not a backup format.
+
+## Backup envelope
+
+Versioned backup input has this generic envelope:
+
+```ts
+type BackupEnvelope<TData> = {
+  readonly schemaVersion: number
+  readonly appVersion: string
+  readonly exportedAt: string
+  readonly data: TData
+}
+```
+
+The concrete current `data` schema and production current version belong to
+#730. Components and mappers consume the caller-owned schema registry; they do
+not duplicate a schema-version magic number.
+
+Backup V2 is a logical, JSON-safe projection selected by the Storage Placement
+Matrix. It is never an IndexedDB database, object-store, index, cache, migration
+metadata, or transaction log dump.
+
+## Format detection boundary
+
+Unknown JSON is classified before version-specific parsing:
+
+```text
+unknown JSON
+  -> object with positive integer schemaVersion: versioned
+  -> object without schemaVersion: legacy candidate
+  -> malformed object or invalid schemaVersion: INVALID_SCHEMA
+```
+
+Legacy classification is routing information only. The versioned pipeline does
+not parse, migrate, or accept pre-IndexedDB data.
+
+## Sequential migration registry
+
+The caller supplies a positive integer current version, the complete current
+envelope schema, and one registered step for each supported source version.
+Every step advances exactly one version:
+
+```ts
+type BackupMigration<TFrom, TTo> = (input: TFrom) => TTo
+```
+
+```text
+parse schemaVersion N
+  -> input validation for N
+  -> pure migration N to N+1
+  -> output validation for N+1
+  -> repeat until current
+  -> current schema validation
+```
+
+The registry rejects gaps and steps that skip a version. A migration function
+receives parsed source data, performs no I/O, and returns only the next envelope
+shape. There is no giant migration that maps every historical version directly
+to current.
+
+Input and output schemas are both required even when adjacent shapes look
+similar. This prevents a migration from sending malformed data into the next
+step and makes the failure boundary deterministic.
+
+## Typed rejection
+
+The public failure codes are:
+
+- `UNSUPPORTED_FUTURE_SCHEMA`: `schemaVersion` is greater than the caller's
+  current version.
+- `UNSUPPORTED_SCHEMA_VERSION`: the version is older than the supported range
+  or has no registered step.
+- `INVALID_SCHEMA`: envelope detection, step input validation, step output
+  validation, or final current validation failed.
+
+A future version is never best-effort parsed as current. Error messages carry
+only safe version diagnostics and never include backup payloads, Zod issues, URL
+values, notes, prompts, attachments, or other user content.
+
+## Current-schema idempotence
+
+When input already declares the current version, the pipeline validates it with
+the current schema and invokes no migration function.
+
+```text
+migrateToCurrent(current) preserves current logical semantics
+```
+
+Object identity is not required because runtime validation may clone the value.
+Issue #718 can extend this semantic invariant with deterministic property-based
+tests once #730 provides the concrete current Backup V2 data generator.
+
+## Adding a schema version
+
+To add one supported version:
+
+1. Define the next immutable envelope schema without changing the previous
+   schema.
+2. Add one pure `N -> N+1` migration.
+3. Register the source schema, migration, and target schema under version `N`.
+4. Set the caller-owned current version and current schema to `N+1`.
+5. Add golden fixtures for the new current, previous current, future, and
+   malformed shapes.
+6. Prove input validation, output validation, sequential call order, future
+   rejection, and current-schema idempotence.
+7. Update the supported range in user-facing compatibility documentation.
+
+Do not rewrite old schemas to match the new shape. Do not add application-semver
+branches or direct old-to-current shortcuts.
+
+## Pre-IndexedDB compatibility lifecycle
+
+Schema-less backups with the legacy `version` field are not members of the
+versioned registry. #730 owns a dedicated temporary legacy importer and maps a
+validated legacy backup to current logical backup data before current-schema
+validation.
+
+The target support policy is:
+
+- legacy pre-IndexedDB backup import is available through `2026-08-31`;
+- #734 removes the legacy parser, mapper, detector branch, fixtures, deadline
+  constants, and temporary UI branch from `2026-09-01`;
+- the parent policy still requires at least 30 days after the production notice
+  release, so a late notice release postpones the cutoff consistently across
+  #724, #730, #731, #734, docs, i18n, constants, and tests.
+
+The live installed-data `chrome.storage.local` to IndexedDB migration has a
+separate lifecycle and is not deleted by the backup cutoff.
+
+## Validation and review checklist
+
+- `appVersion`, `schemaVersion`, and `databaseVersion` remain separate.
+- Every supported older version has exactly one sequential step.
+- Every step performs input validation and output validation.
+- Current input performs validation but no migration.
+- Future input is rejected with `UNSUPPORTED_FUTURE_SCHEMA`.
+- Unsupported old input is rejected with `UNSUPPORTED_SCHEMA_VERSION`.
+- Invalid data is rejected with `INVALID_SCHEMA`.
+- Legacy detection does not import or migrate legacy data.
+- Golden fixtures cover each supported version, current, future, and invalid
+  data.
+- The public backup remains a logical JSON-safe contract rather than an
+  IndexedDB dump.

--- a/docs/architecture/backup-schema-versioning.md
+++ b/docs/architecture/backup-schema-versioning.md
@@ -1,8 +1,8 @@
 # Backup Schema Versioning
 
-Status: public migration-kernel contract for Issue #713  
-Parent: Issue #724  
-Production Backup V2 owner: Issue #730
+- Status: public migration-kernel contract for Issue #713
+- Parent: Issue #724
+- Production Backup V2 owner: Issue #730
 
 ## Version domains
 

--- a/docs/architecture/persistence-model-v2.md
+++ b/docs/architecture/persistence-model-v2.md
@@ -466,6 +466,11 @@ not the user content itself.
 
 ## Backup V2 resource and round-trip envelope
 
+The public envelope and migration lifecycle follow the
+[backup schema versioning](./backup-schema-versioning.md) contract. The backup
+`schemaVersion` remains independent of the IndexedDB physical version and the
+extension release version.
+
 The executable resource policy is
 `src/lib/persistence/backupResourcePolicy.ts`. A supported production state is a
 logical snapshot that is healthy under #712, contains only the logical data

--- a/docs/plans/2026-07-18-issue-713-backup-schema-versioning-design.md
+++ b/docs/plans/2026-07-18-issue-713-backup-schema-versioning-design.md
@@ -1,0 +1,209 @@
+# Issue #713 Backup Schema Versioning Design
+
+## Context
+
+The current options backup stores the extension manifest version in
+`BackupData.version`. Import validates that legacy shape directly, so the
+application release version and the public backup schema version are the same
+field in practice.
+
+Persistence Model v2 requires three independent version domains:
+
+- `appVersion`: extension release version used for diagnostics and provenance.
+- `schemaVersion`: public import/export contract version used for dispatch.
+- IndexedDB `databaseVersion`: physical object-store and index upgrade version.
+
+Issue #730 owns the concrete Backup V2 logical data model and its production
+import/export integration. Issue #713 must therefore provide the reusable
+versioned envelope and migration mechanism without defining that logical model
+early or mixing the pre-IndexedDB compatibility importer into the current
+pipeline.
+
+## Goals
+
+- Define a generic immutable `BackupEnvelope` carrying `schemaVersion`,
+  `appVersion`, `exportedAt`, and logical `data`.
+- Detect a versioned envelope before parsing version-specific data.
+- Run supported migrations sequentially through a registry.
+- Validate each step's input and output schema.
+- Reject future, unsupported, and invalid schemas with typed error codes.
+- Treat current-schema input as an idempotent validation path with no migration.
+- Keep schema-less pre-IndexedDB backups outside the versioned migration
+  registry.
+- Provide deterministic golden fixtures proving V2 -> V3 -> current behavior.
+
+## Non-goals
+
+- Defining `BackupDataV2` or the complete production Backup V2 schema. That
+  remains Issue #730.
+- Connecting the current options import/export UI to the new envelope.
+- Migrating, importing, or deleting pre-IndexedDB backup formats.
+- Exposing IndexedDB object-store records as backup data.
+- Using semver comparison to decide backup compatibility.
+
+## Considered approaches
+
+### Generic migration kernel with a caller-owned schema registry
+
+The migration module owns only the envelope, dispatch, validation, errors, and
+sequential execution. A caller such as Issue #730 supplies the current version,
+current schema, and ordered migration steps.
+
+This keeps the public mechanism testable now while preserving #730 as the
+source of truth for the actual Backup V2 model. This is the selected approach.
+
+### Define Backup V2 in Issue #713
+
+This would allow immediate production integration, but duplicates #730's
+logical-model responsibility and risks defining the contract before the
+IndexedDB query and mapper boundaries exist.
+
+### Declare V4 as the production current schema
+
+This follows the illustrative V2 -> V3 -> V4 sequence literally, but conflicts
+with #730's explicit Backup V2 contract. The sequence belongs in golden tests,
+not in production version declarations.
+
+## Module boundaries
+
+The cross-cutting public contract lives in `src/lib/persistence/`, beside the
+JSON-safe and backup resource policies:
+
+- `backupSchema.ts`: envelope types, format detection, typed errors, and public
+  schema definitions for the version header.
+- `backupMigrationPipeline.ts`: registry types, construction-time invariants,
+  sequential migration, and current-schema validation.
+- `backupMigrationPipeline.test.ts`: behavior tests using the golden fixtures.
+- `__fixtures__/backup-schema/`: V2, V3, current, future, and invalid JSON.
+
+The production module does not import from `features/options`. The future
+legacy importer stays under the dedicated #730 boundary and may call the same
+current-schema validator only after it has produced current logical backup
+data.
+
+## Public contract
+
+```ts
+type BackupEnvelope<TData, TVersion extends number = number> = {
+  readonly schemaVersion: TVersion
+  readonly appVersion: string
+  readonly exportedAt: string
+  readonly data: TData
+}
+
+type BackupMigration<TFrom, TTo> = (input: TFrom) => TTo
+
+type BackupSchemaErrorCode =
+  | 'INVALID_SCHEMA'
+  | 'UNSUPPORTED_FUTURE_SCHEMA'
+  | 'UNSUPPORTED_SCHEMA_VERSION'
+```
+
+`BackupSchemaError` contains only the code and schema-version diagnostics. It
+must not copy user data or raw Zod issues into its message.
+
+Format detection has two successful classifications:
+
+- `versioned`: an object with an integer `schemaVersion` field.
+- `legacy`: an object with no `schemaVersion` field.
+
+Malformed JSON or a present but invalid `schemaVersion` is `INVALID_SCHEMA`.
+Detection does not parse or migrate legacy data.
+
+## Migration registry
+
+The pipeline is created with:
+
+- one positive integer `currentVersion`;
+- one `currentSchema` for the complete current envelope;
+- a map keyed by each supported source version below current;
+- one step for every version from the minimum supported version to current.
+
+Each step supplies its source envelope schema, target envelope schema, and pure
+migration function. Construction rejects gaps, out-of-range keys, and steps
+whose declared target is not exactly `source + 1`. This makes sequential
+migration a registry invariant instead of a runtime convention.
+
+## Data flow
+
+```text
+unknown JSON value
+  -> detect format
+     -> legacy: return dedicated legacy classification
+     -> versioned: read schemaVersion
+        -> greater than current: UNSUPPORTED_FUTURE_SCHEMA
+        -> below supported range or registry gap:
+           UNSUPPORTED_SCHEMA_VERSION
+        -> current: validate current schema and return without migration
+        -> older supported version:
+           validate source
+           -> migrate N to N+1
+           -> validate target
+           -> repeat until current
+           -> validate current and return
+```
+
+Validation occurs before and after every migration step. The migration callback
+does not receive `unknown`; it receives the parsed source schema output. A
+failure at any validation boundary becomes `INVALID_SCHEMA`.
+
+## Idempotence
+
+Current input bypasses every migration callback. Its parsed result is returned
+with the same logical fields and values. Object identity is not part of the
+contract because Zod parsing may clone values; semantic equality is.
+
+The test registry uses V2, V3, and V4-shaped logical fixtures so that Issue #718
+can later reuse the same `migrateToCurrent(current)` semantic invariant without
+making V4 a production backup version.
+
+## Fixture and test strategy
+
+Golden fixtures are static JSON inputs:
+
+- `backup-v2.json`: requires two sequential migrations.
+- `backup-v3.json`: requires one migration.
+- `backup-current.json`: validates without migration.
+- `backup-future.json`: is rejected with
+  `UNSUPPORTED_FUTURE_SCHEMA`.
+- `backup-invalid.json`: fails the declared version schema.
+
+TDD starts with tests for envelope detection and typed future rejection, then
+adds registry validation, sequential migration, per-step input/output
+validation, unsupported-version rejection, current idempotence, and legacy
+classification. Tests assert migration call order and semantic output, not
+implementation-specific object identity.
+
+An architecture policy test protects the documentation contract: three version
+domains, sequential validation, the #730 legacy boundary, and the 2026-08-31
+pre-IDB support cutoff.
+
+## Documentation
+
+`docs/architecture/backup-schema-versioning.md` is the operational reference.
+It explains:
+
+- the difference between app, backup schema, and database versions;
+- the supported-version registry and how to add one migration step;
+- future-version rejection;
+- current-schema idempotence;
+- the pre-IDB compatibility boundary and 2026-08-31 cutoff;
+- why Backup V2 is a logical mapper contract rather than an IndexedDB dump.
+
+`docs/architecture/persistence-model-v2.md` links to that reference without
+duplicating constants or migration rules.
+
+## Compatibility, security, and rollback
+
+No production import/export path changes in Issue #713, so existing backups and
+user data remain untouched. The only runtime surface added is a pure parser and
+migration library.
+
+Typed errors contain no backup payload. Future versions are never best-effort
+parsed as current. Legacy data is detected but never accepted by the versioned
+pipeline, preventing permanent compatibility code from entering the new public
+contract.
+
+Rollback is removal of the new unused library, fixtures, and documentation.
+Once #730 integrates the library, rollback policy belongs to that production
+integration and must preserve existing user backups.

--- a/docs/plans/2026-07-18-issue-713-backup-schema-versioning.md
+++ b/docs/plans/2026-07-18-issue-713-backup-schema-versioning.md
@@ -1,0 +1,499 @@
+# Issue #713 Backup Schema Versioning Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a generic, validated, sequential backup-schema migration pipeline that separates backup `schemaVersion` from application and IndexedDB versions without pre-empting Issue #730's concrete Backup V2 model.
+
+**Architecture:** Put the reusable envelope, format detector, typed errors, and migration registry in `src/lib/persistence`. Callers provide the current version and Zod schemas; the pipeline detects legacy input without migrating it, rejects unsupported versions, validates both sides of every pure migration step, and bypasses migrations for current input. Golden fixtures prove a V2 -> V3 -> V4 example while production version ownership remains with #730.
+
+**Tech Stack:** TypeScript, Zod 4, Vitest 4, Bun, oxfmt, Oxlint
+
+---
+
+### Task 1: Define envelope detection and typed schema errors with TDD
+
+**Files:**
+
+- Create: `src/lib/persistence/backupSchema.test.ts`
+- Create later: `src/lib/persistence/backupSchema.ts`
+
+**Step 1: Write the failing format-detection tests**
+
+Create `backupSchema.test.ts` with tests that express the public API before the
+implementation exists:
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import { BackupSchemaError, detectBackupFormat } from './backupSchema'
+
+describe('detectBackupFormat', () => {
+  it('detects a versioned envelope from an integer schemaVersion', () => {
+    expect(
+      detectBackupFormat({
+        appVersion: '2.0.0',
+        data: {},
+        exportedAt: '2026-07-18T00:00:00.000Z',
+        schemaVersion: 2,
+      }),
+    ).toEqual({ kind: 'versioned', schemaVersion: 2 })
+  })
+
+  it('classifies an object without schemaVersion as legacy', () => {
+    expect(detectBackupFormat({ version: '2.0.0' })).toEqual({
+      kind: 'legacy',
+    })
+  })
+
+  it.each([null, [], 'backup', { schemaVersion: 0 }, { schemaVersion: 1.5 }])(
+    'rejects malformed envelope input %#',
+    (input) => {
+      expect(() => detectBackupFormat(input)).toThrow(
+        expect.objectContaining<Partial<BackupSchemaError>>({
+          code: 'INVALID_SCHEMA',
+        }),
+      )
+    },
+  )
+})
+```
+
+Add a second test confirming the error message contains no serialized user
+payload:
+
+```ts
+it('keeps user data out of typed error messages', () => {
+  const secret = 'private-user-backup-value'
+
+  expect(() => detectBackupFormat({ schemaVersion: secret })).toThrowError(
+    expect.not.objectContaining({ message: expect.stringContaining(secret) }),
+  )
+})
+```
+
+**Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+bunx vitest run src/lib/persistence/backupSchema.test.ts
+```
+
+Expected: FAIL because `./backupSchema` does not exist.
+
+**Step 3: Implement the minimal envelope contract**
+
+Create `backupSchema.ts` with:
+
+```ts
+export type BackupEnvelope<TData, TVersion extends number = number> = {
+  readonly appVersion: string
+  readonly data: TData
+  readonly exportedAt: string
+  readonly schemaVersion: TVersion
+}
+
+export const BACKUP_SCHEMA_ERROR_CODES = [
+  'INVALID_SCHEMA',
+  'UNSUPPORTED_FUTURE_SCHEMA',
+  'UNSUPPORTED_SCHEMA_VERSION',
+] as const
+
+export type BackupSchemaErrorCode = (typeof BACKUP_SCHEMA_ERROR_CODES)[number]
+
+const BACKUP_SCHEMA_ERROR_MESSAGES: Readonly<
+  Record<BackupSchemaErrorCode, string>
+> = {
+  INVALID_SCHEMA: 'Backup schema is invalid',
+  UNSUPPORTED_FUTURE_SCHEMA: 'Backup schema is newer than supported',
+  UNSUPPORTED_SCHEMA_VERSION: 'Backup schema version is unsupported',
+}
+
+export class BackupSchemaError extends Error {
+  readonly code: BackupSchemaErrorCode
+  readonly currentVersion?: number
+  readonly receivedVersion?: number
+
+  constructor(
+    code: BackupSchemaErrorCode,
+    versions: {
+      readonly currentVersion?: number
+      readonly receivedVersion?: number
+    } = {},
+  ) {
+    super(BACKUP_SCHEMA_ERROR_MESSAGES[code])
+    this.name = 'BackupSchemaError'
+    this.code = code
+    this.currentVersion = versions.currentVersion
+    this.receivedVersion = versions.receivedVersion
+  }
+}
+
+export type BackupFormatDetection =
+  | { readonly kind: 'legacy' }
+  | { readonly kind: 'versioned'; readonly schemaVersion: number }
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+export const detectBackupFormat = (input: unknown): BackupFormatDetection => {
+  if (!isRecord(input)) {
+    throw new BackupSchemaError('INVALID_SCHEMA')
+  }
+  if (!Object.hasOwn(input, 'schemaVersion')) {
+    return { kind: 'legacy' }
+  }
+  const schemaVersion = input.schemaVersion
+  if (
+    !Number.isSafeInteger(schemaVersion) ||
+    typeof schemaVersion !== 'number' ||
+    schemaVersion < 1
+  ) {
+    throw new BackupSchemaError('INVALID_SCHEMA')
+  }
+  return { kind: 'versioned', schemaVersion }
+}
+```
+
+Let oxfmt decide final line wrapping and import order.
+
+**Step 4: Run the test and verify GREEN**
+
+Run the same targeted Vitest command.
+
+Expected: all `backupSchema.test.ts` tests PASS with no warnings.
+
+**Step 5: Commit the envelope contract**
+
+```bash
+git add src/lib/persistence/backupSchema.ts \
+  src/lib/persistence/backupSchema.test.ts
+git commit -m "feat: backup schema envelope を定義"
+```
+
+### Task 2: Add golden fixtures and the sequential registry with TDD
+
+**Files:**
+
+- Create: `src/lib/persistence/__fixtures__/backup-schema/backup-v2.json`
+- Create: `src/lib/persistence/__fixtures__/backup-schema/backup-v3.json`
+- Create: `src/lib/persistence/__fixtures__/backup-schema/backup-current.json`
+- Create: `src/lib/persistence/__fixtures__/backup-schema/backup-future.json`
+- Create: `src/lib/persistence/__fixtures__/backup-schema/backup-invalid.json`
+- Create: `src/lib/persistence/backupMigrationPipeline.test.ts`
+- Create later: `src/lib/persistence/backupMigrationPipeline.ts`
+
+**Step 1: Add deterministic golden fixture shapes**
+
+Use the same metadata across fixtures. The logical test-only schema evolves as:
+
+```text
+V2 data: { name: string }
+V3 data: { collection: { name: string } }
+V4 data: { collections: [{ name: string }] }
+```
+
+`backup-future.json` uses `schemaVersion: 5`. `backup-invalid.json` declares V3
+but omits `collection.name`. Keep every fixture free of production user data.
+
+**Step 2: Write the failing migration tests**
+
+In `backupMigrationPipeline.test.ts`:
+
+- import each JSON fixture;
+- define strict V2, V3, and V4 Zod envelope schemas;
+- define `migrateV2ToV3` and `migrateV3ToV4` as pure functions;
+- create a registry with keys 2 and 3 and current version 4;
+- assert V2 calls both migrations in order and equals the current fixture;
+- assert V3 calls only V3 -> V4;
+- assert current calls neither migration and preserves semantic data;
+- assert future throws `UNSUPPORTED_FUTURE_SCHEMA` with received/current versions;
+- assert version 1 throws `UNSUPPORTED_SCHEMA_VERSION`;
+- assert the invalid fixture throws `INVALID_SCHEMA` before migration;
+- assert a migration producing invalid target data throws `INVALID_SCHEMA`;
+- assert a missing or non-sequential registry step is rejected at construction;
+- assert legacy input returns `{ kind: 'legacy' }` without invoking migration.
+
+The intended API is:
+
+```ts
+const pipeline = createBackupMigrationPipeline({
+  currentSchema: backupV4Schema,
+  currentVersion: 4,
+  migrations: new Map([
+    [
+      2,
+      {
+        fromVersion: 2,
+        inputSchema: backupV2Schema,
+        migrate: migrateV2ToV3,
+        outputSchema: backupV3Schema,
+        toVersion: 3,
+      },
+    ],
+    [
+      3,
+      {
+        fromVersion: 3,
+        inputSchema: backupV3Schema,
+        migrate: migrateV3ToV4,
+        outputSchema: backupV4Schema,
+        toVersion: 4,
+      },
+    ],
+  ]),
+})
+```
+
+**Step 3: Run the migration test and verify RED**
+
+Run:
+
+```bash
+bunx vitest run src/lib/persistence/backupMigrationPipeline.test.ts
+```
+
+Expected: FAIL because `backupMigrationPipeline.ts` does not exist.
+
+**Step 4: Implement the minimal registry and pipeline**
+
+Create types equivalent to:
+
+```ts
+import type { z } from 'zod'
+
+import { BackupSchemaError, detectBackupFormat } from './backupSchema'
+
+export type BackupMigration<TFrom, TTo> = (input: TFrom) => TTo
+
+export type BackupMigrationStep<TFrom = unknown, TTo = unknown> = {
+  readonly fromVersion: number
+  readonly inputSchema: z.ZodType<TFrom>
+  readonly migrate: BackupMigration<TFrom, TTo>
+  readonly outputSchema: z.ZodType<TTo>
+  readonly toVersion: number
+}
+
+export type BackupMigrationResult<TCurrent> =
+  | { readonly kind: 'legacy' }
+  | {
+      readonly backup: TCurrent
+      readonly kind: 'current'
+      readonly sourceVersion: number
+    }
+```
+
+`createBackupMigrationPipeline` must:
+
+1. require a positive safe-integer current version;
+2. reject registry keys that do not equal `fromVersion`;
+3. require `toVersion === fromVersion + 1`;
+4. require every key from the minimum registered version through
+   `currentVersion - 1`;
+5. return legacy classification before any migration;
+6. reject versions greater than current as future;
+7. reject an older version without a registry entry as unsupported;
+8. use `safeParse` for the current schema and both schemas around each step;
+9. translate every Zod failure into `BackupSchemaError('INVALID_SCHEMA')`;
+10. return the final parsed current value and original source version.
+
+Do not expose Zod issues or the backup payload in thrown messages.
+
+**Step 5: Run the focused tests and verify GREEN**
+
+Run:
+
+```bash
+bunx vitest run \
+  src/lib/persistence/backupSchema.test.ts \
+  src/lib/persistence/backupMigrationPipeline.test.ts
+```
+
+Expected: both files PASS.
+
+**Step 6: Commit the migration kernel**
+
+```bash
+git add src/lib/persistence/backupMigrationPipeline.ts \
+  src/lib/persistence/backupMigrationPipeline.test.ts \
+  src/lib/persistence/__fixtures__/backup-schema
+git commit -m "feat: backup schema migration pipeline を追加"
+```
+
+### Task 3: Document and protect the compatibility policy
+
+**Files:**
+
+- Create: `docs/architecture/backup-schema-versioning.md`
+- Create: `src/lib/architecture/backupSchemaVersioningPolicy.test.ts`
+- Modify: `docs/architecture/persistence-model-v2.md`
+
+**Step 1: Write the failing architecture policy test**
+
+Read both architecture documents using the same `repoRoot` convention as
+`persistenceModelV2Policy.test.ts`. Assert that the new document contains:
+
+```text
+appVersion
+schemaVersion
+databaseVersion
+UNSUPPORTED_FUTURE_SCHEMA
+UNSUPPORTED_SCHEMA_VERSION
+INVALID_SCHEMA
+input validation
+output validation
+current-schema idempotence
+2026-08-31
+#730
+#734
+```
+
+Also assert that `persistence-model-v2.md` links to
+`./backup-schema-versioning.md`.
+
+**Step 2: Run the policy test and verify RED**
+
+Run:
+
+```bash
+bunx vitest run src/lib/architecture/backupSchemaVersioningPolicy.test.ts
+```
+
+Expected: FAIL because the architecture document and link do not exist.
+
+**Step 3: Write the operational architecture document**
+
+Cover the approved design exactly:
+
+- three separate version domains and owners;
+- caller-owned current version and registry;
+- legacy/versioned detection;
+- sequential input -> migrate -> output validation;
+- typed rejection and no best-effort future parsing;
+- no migrations for current input;
+- one-step procedure for adding a supported schema version;
+- #730 dedicated pre-IDB importer through 2026-08-31;
+- #734 removal from 2026-09-01 subject to the parent notice policy;
+- Backup V2 as logical JSON-safe data, never an IndexedDB dump.
+
+Add one relative link from the Backup V2 section in
+`persistence-model-v2.md`.
+
+**Step 4: Run the policy and migration tests and verify GREEN**
+
+Run:
+
+```bash
+bunx vitest run \
+  src/lib/architecture/backupSchemaVersioningPolicy.test.ts \
+  src/lib/persistence/backupSchema.test.ts \
+  src/lib/persistence/backupMigrationPipeline.test.ts
+```
+
+Expected: all three files PASS.
+
+**Step 5: Commit documentation and policy protection**
+
+```bash
+git add docs/architecture/backup-schema-versioning.md \
+  docs/architecture/persistence-model-v2.md \
+  src/lib/architecture/backupSchemaVersioningPolicy.test.ts
+git commit -m "docs: backup schema compatibility policy を追加"
+```
+
+### Task 4: Verify acceptance criteria and repository gates
+
+**Files:**
+
+- Modify only if verification finds an Issue-owned defect.
+
+**Step 1: Format the Issue-owned files**
+
+Run oxfmt on the exact changed paths, then inspect `git diff --check` and the
+Issue-owned diff.
+
+**Step 2: Run targeted node tests**
+
+```bash
+bunx vitest run \
+  src/lib/persistence/backupSchema.test.ts \
+  src/lib/persistence/backupMigrationPipeline.test.ts \
+  src/lib/architecture/backupSchemaVersioningPolicy.test.ts
+```
+
+Expected: all tests PASS with no warnings.
+
+**Step 3: Run the node project**
+
+```bash
+bun run test:node
+```
+
+Expected: all node tests PASS.
+
+**Step 4: Run coverage**
+
+```bash
+bun run test:coverage
+```
+
+Expected: exit 0 and repository-required 100% coverage.
+
+**Step 5: Run the broad quality gate**
+
+```bash
+bun run quality:check
+```
+
+Expected: format, tooling verification, compile, lint, tests, Knip,
+duplication, secretlint, and architecture checks all exit 0.
+
+**Step 6: Validate and audit the harness**
+
+Record checkpoints for the targeted tests and broad gates, then run:
+
+```bash
+bun run harness:validate
+bun run harness:audit
+```
+
+Expected: schemas valid and no unresolved blocking findings.
+
+**Step 7: Commit any verification-only corrections**
+
+Stage only Issue-owned paths and use a scoped Japanese commit message. Do not
+create an empty commit.
+
+### Task 5: Publish the standalone Issue implementation
+
+**Step 1: Verify the final diff and clean-tree commit state**
+
+Confirm every changed path belongs to Issue #713 and the worktree is clean.
+
+**Step 2: Run the clean-tree release gate**
+
+```bash
+bun run release:check
+```
+
+Expected: exit 0 on a clean committed tree.
+
+**Step 3: Push normally**
+
+```bash
+git push -u origin codex/issue-713-backup-schema-versioning
+```
+
+Do not force-push.
+
+**Step 4: Create or reuse one Open PR**
+
+Query all PR states for the exact head branch. If no matching Open PR exists,
+create a non-draft PR against `develop` whose body includes cause, changes,
+acceptance mapping, verification results, risk, and `Closes #713`.
+
+**Step 5: Verify live publication state**
+
+Confirm the PR is `OPEN`, `isDraft: false`, base `develop`, and local HEAD equals
+the remote branch. Report the commit hash, branch, PR URL, and synchronization
+result.

--- a/docs/plans/2026-07-18-issue-713-backup-schema-versioning.md
+++ b/docs/plans/2026-07-18-issue-713-backup-schema-versioning.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Define envelope detection and typed schema errors with TDD
+## Task 1: Define envelope detection and typed schema errors with TDD
 
 **Files:**
 
@@ -171,7 +171,7 @@ git add src/lib/persistence/backupSchema.ts \
 git commit -m "feat: backup schema envelope を定義"
 ```
 
-### Task 2: Add golden fixtures and the sequential registry with TDD
+## Task 2: Add golden fixtures and the sequential registry with TDD
 
 **Files:**
 
@@ -320,7 +320,7 @@ git add src/lib/persistence/backupMigrationPipeline.ts \
 git commit -m "feat: backup schema migration pipeline を追加"
 ```
 
-### Task 3: Document and protect the compatibility policy
+## Task 3: Document and protect the compatibility policy
 
 **Files:**
 
@@ -401,7 +401,7 @@ git add docs/architecture/backup-schema-versioning.md \
 git commit -m "docs: backup schema compatibility policy を追加"
 ```
 
-### Task 4: Verify acceptance criteria and repository gates
+## Task 4: Verify acceptance criteria and repository gates
 
 **Files:**
 
@@ -464,7 +464,7 @@ Expected: schemas valid and no unresolved blocking findings.
 Stage only Issue-owned paths and use a scoped Japanese commit message. Do not
 create an empty commit.
 
-### Task 5: Publish the standalone Issue implementation
+## Task 5: Publish the standalone Issue implementation
 
 **Step 1: Verify the final diff and clean-tree commit state**
 

--- a/src/lib/architecture/backupSchemaVersioningPolicy.test.ts
+++ b/src/lib/architecture/backupSchemaVersioningPolicy.test.ts
@@ -1,0 +1,66 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = resolve(import.meta.dirname, '..', '..', '..')
+const versioningDocumentPath = resolve(
+  repoRoot,
+  'docs/architecture/backup-schema-versioning.md',
+)
+const persistenceModelDocument = readFileSync(
+  resolve(repoRoot, 'docs/architecture/persistence-model-v2.md'),
+  'utf8',
+)
+
+const readVersioningDocument = (): string =>
+  existsSync(versioningDocumentPath)
+    ? readFileSync(versioningDocumentPath, 'utf8')
+    : ''
+
+describe('Backup schema versioning architecture contract', () => {
+  it('keeps the operational compatibility policy in an architecture document', () => {
+    expect(existsSync(versioningDocumentPath)).toBe(true)
+  })
+
+  it('separates all version domains and typed failures', () => {
+    const versioningDocument = readVersioningDocument()
+
+    for (const contract of [
+      '`appVersion`',
+      '`schemaVersion`',
+      '`databaseVersion`',
+      '`UNSUPPORTED_FUTURE_SCHEMA`',
+      '`UNSUPPORTED_SCHEMA_VERSION`',
+      '`INVALID_SCHEMA`',
+    ]) {
+      expect(versioningDocument).toContain(contract)
+    }
+  })
+
+  it('protects sequential validation and current-schema idempotence', () => {
+    const versioningDocument = readVersioningDocument()
+
+    for (const contract of [
+      'input validation',
+      'output validation',
+      'current-schema idempotence',
+    ]) {
+      expect(versioningDocument).toContain(contract)
+    }
+  })
+
+  it('keeps legacy compatibility in the temporary owning issues', () => {
+    const versioningDocument = readVersioningDocument()
+
+    for (const contract of ['2026-08-31', '#730', '#734']) {
+      expect(versioningDocument).toContain(contract)
+    }
+  })
+
+  it('links the detailed policy from Persistence Model v2', () => {
+    expect(persistenceModelDocument).toContain(
+      '[backup schema versioning](./backup-schema-versioning.md)',
+    )
+  })
+})

--- a/src/lib/persistence/__fixtures__/backup-schema/backup-current.json
+++ b/src/lib/persistence/__fixtures__/backup-schema/backup-current.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 4,
+  "appVersion": "2.0.0",
+  "exportedAt": "2026-07-18T00:00:00.000Z",
+  "data": {
+    "collections": [
+      {
+        "name": "Inbox"
+      }
+    ]
+  }
+}

--- a/src/lib/persistence/__fixtures__/backup-schema/backup-future.json
+++ b/src/lib/persistence/__fixtures__/backup-schema/backup-future.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 5,
+  "appVersion": "3.0.0",
+  "exportedAt": "2026-07-18T00:00:00.000Z",
+  "data": {
+    "collections": []
+  }
+}

--- a/src/lib/persistence/__fixtures__/backup-schema/backup-invalid.json
+++ b/src/lib/persistence/__fixtures__/backup-schema/backup-invalid.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 3,
+  "appVersion": "2.0.0",
+  "exportedAt": "2026-07-18T00:00:00.000Z",
+  "data": {
+    "collection": {}
+  }
+}

--- a/src/lib/persistence/__fixtures__/backup-schema/backup-v2.json
+++ b/src/lib/persistence/__fixtures__/backup-schema/backup-v2.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 2,
+  "appVersion": "2.0.0",
+  "exportedAt": "2026-07-18T00:00:00.000Z",
+  "data": {
+    "name": "Inbox"
+  }
+}

--- a/src/lib/persistence/__fixtures__/backup-schema/backup-v3.json
+++ b/src/lib/persistence/__fixtures__/backup-schema/backup-v3.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 3,
+  "appVersion": "2.0.0",
+  "exportedAt": "2026-07-18T00:00:00.000Z",
+  "data": {
+    "collection": {
+      "name": "Inbox"
+    }
+  }
+}

--- a/src/lib/persistence/backupMigrationPipeline.test.ts
+++ b/src/lib/persistence/backupMigrationPipeline.test.ts
@@ -123,6 +123,33 @@ const captureSchemaError = (action: () => unknown): BackupSchemaError => {
 }
 
 describe('createBackupMigrationPipeline', () => {
+  it.each([0, 1.5])(
+    'rejects invalid current schema version %s',
+    (currentVersion) => {
+      expect(() =>
+        createBackupMigrationPipeline({
+          currentSchema: backupV4Schema,
+          currentVersion,
+          migrations: new Map(),
+        }),
+      ).toThrow('Current backup schema version must be a positive integer')
+    },
+  )
+
+  it('supports a current-only registry with no migrations', () => {
+    const pipeline = createBackupMigrationPipeline({
+      currentSchema: backupV4Schema,
+      currentVersion: 4,
+      migrations: new Map(),
+    })
+
+    expect(pipeline.migrateToCurrent(backupCurrent)).toEqual({
+      backup: backupCurrent,
+      kind: 'current',
+      sourceVersion: 4,
+    })
+  })
+
   it('migrates V2 through every sequential step to the current schema', () => {
     const { migrateV2ToV3, migrateV3ToV4, pipeline } = createTestPipeline()
 
@@ -157,6 +184,26 @@ describe('createBackupMigrationPipeline', () => {
       backup: backupCurrent,
       kind: 'current',
       sourceVersion: 4,
+    })
+    expect(migrateV2ToV3).not.toHaveBeenCalled()
+    expect(migrateV3ToV4).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid current-schema input without migration', () => {
+    const { migrateV2ToV3, migrateV3ToV4, pipeline } = createTestPipeline()
+    const invalidCurrent = {
+      appVersion: '2.0.0',
+      data: { collections: [{ name: '' }] },
+      exportedAt: '2026-07-18T00:00:00.000Z',
+      schemaVersion: 4,
+    }
+
+    expect(
+      captureSchemaError(() => pipeline.migrateToCurrent(invalidCurrent)),
+    ).toMatchObject({
+      code: 'INVALID_SCHEMA',
+      currentVersion: 4,
+      receivedVersion: 4,
     })
     expect(migrateV2ToV3).not.toHaveBeenCalled()
     expect(migrateV3ToV4).not.toHaveBeenCalled()
@@ -244,6 +291,21 @@ describe('createBackupMigrationPipeline', () => {
     ).toThrow('Missing backup migration step for schema version 3')
   })
 
+  it('rejects a registry key that differs from its source version', () => {
+    const { v2ToV3, v3ToV4 } = createTestPipeline()
+
+    expect(() =>
+      createBackupMigrationPipeline({
+        currentSchema: backupV4Schema,
+        currentVersion: 4,
+        migrations: new Map([
+          [1, v2ToV3],
+          [3, v3ToV4],
+        ]),
+      }),
+    ).toThrow('Backup migration registry key must match its source version')
+  })
+
   it('rejects a migration that skips a schema version', () => {
     const { v3ToV4 } = createTestPipeline()
     const invalidStep = defineBackupMigrationStep({
@@ -264,6 +326,74 @@ describe('createBackupMigrationPipeline', () => {
         ]),
       }),
     ).toThrow('Backup migration steps must advance exactly one version')
+  })
+
+  it.each([
+    { fromVersion: 0, toVersion: 1 },
+    { fromVersion: 4, toVersion: 5 },
+  ])(
+    'rejects an out-of-range migration from $fromVersion to $toVersion',
+    ({ fromVersion, toVersion }) => {
+      const outOfRangeStep = defineBackupMigrationStep({
+        fromVersion,
+        inputSchema: backupV4Schema,
+        migrate: (input): BackupV4 => input,
+        outputSchema: backupV4Schema,
+        toVersion,
+      })
+
+      expect(() =>
+        createBackupMigrationPipeline({
+          currentSchema: backupV4Schema,
+          currentVersion: 4,
+          migrations: new Map([[fromVersion, outOfRangeStep]]),
+        }),
+      ).toThrow(
+        'Backup migration step must stay within the supported version range',
+      )
+    },
+  )
+
+  it('rejects a registry step removed after pipeline construction', () => {
+    const { v2ToV3, v3ToV4 } = createTestPipeline()
+    const migrations = new Map([
+      [2, v2ToV3],
+      [3, v3ToV4],
+    ])
+    const pipeline = createBackupMigrationPipeline({
+      currentSchema: backupV4Schema,
+      currentVersion: 4,
+      migrations,
+    })
+    migrations.delete(3)
+
+    expect(
+      captureSchemaError(() => pipeline.migrateToCurrent(backupV2)),
+    ).toMatchObject({
+      code: 'UNSUPPORTED_SCHEMA_VERSION',
+      currentVersion: 4,
+      receivedVersion: 2,
+    })
+  })
+
+  it('validates the final value with the declared current schema', () => {
+    const { v3ToV4 } = createTestPipeline()
+    const narrowedCurrentSchema = backupV4Schema.refine(
+      (backup) => backup.data.collections[0]?.name === 'Allowed',
+    )
+    const pipeline = createBackupMigrationPipeline({
+      currentSchema: narrowedCurrentSchema,
+      currentVersion: 4,
+      migrations: new Map([[3, v3ToV4]]),
+    })
+
+    expect(
+      captureSchemaError(() => pipeline.migrateToCurrent(backupV3)),
+    ).toMatchObject({
+      code: 'INVALID_SCHEMA',
+      currentVersion: 4,
+      receivedVersion: 3,
+    })
   })
 
   it('returns the dedicated legacy classification without migration', () => {

--- a/src/lib/persistence/backupMigrationPipeline.test.ts
+++ b/src/lib/persistence/backupMigrationPipeline.test.ts
@@ -1,0 +1,278 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+
+import {
+  createBackupMigrationPipeline,
+  defineBackupMigrationStep,
+} from './backupMigrationPipeline'
+import { BackupSchemaError } from './backupSchema'
+
+const envelopeMetadataSchema = z.object({
+  appVersion: z.string().min(1),
+  exportedAt: z.iso.datetime(),
+})
+
+const backupV2Schema = envelopeMetadataSchema
+  .extend({
+    data: z.object({ name: z.string().min(1) }).strict(),
+    schemaVersion: z.literal(2),
+  })
+  .strict()
+
+const backupV3Schema = envelopeMetadataSchema
+  .extend({
+    data: z
+      .object({
+        collection: z.object({ name: z.string().min(1) }).strict(),
+      })
+      .strict(),
+    schemaVersion: z.literal(3),
+  })
+  .strict()
+
+const backupV4Schema = envelopeMetadataSchema
+  .extend({
+    data: z
+      .object({
+        collections: z.array(z.object({ name: z.string().min(1) }).strict()),
+      })
+      .strict(),
+    schemaVersion: z.literal(4),
+  })
+  .strict()
+
+type BackupV2 = z.output<typeof backupV2Schema>
+type BackupV3 = z.output<typeof backupV3Schema>
+type BackupV4 = z.output<typeof backupV4Schema>
+
+const parseFixture = (filename: string): unknown => {
+  const fixtureUrl = new URL(
+    `__fixtures__/backup-schema/${filename}`,
+    import.meta.url,
+  )
+  const parsed: unknown = JSON.parse(readFileSync(fixtureUrl, 'utf8'))
+  return parsed
+}
+
+const backupV2 = parseFixture('backup-v2.json')
+const backupV3 = parseFixture('backup-v3.json')
+const backupCurrent = parseFixture('backup-current.json')
+const backupFuture = parseFixture('backup-future.json')
+const backupInvalid = parseFixture('backup-invalid.json')
+
+const createTestPipeline = () => {
+  const migrateV2ToV3 = vi.fn(
+    (input: BackupV2): BackupV3 => ({
+      appVersion: input.appVersion,
+      data: { collection: { name: input.data.name } },
+      exportedAt: input.exportedAt,
+      schemaVersion: 3,
+    }),
+  )
+  const migrateV3ToV4 = vi.fn(
+    (input: BackupV3): BackupV4 => ({
+      appVersion: input.appVersion,
+      data: { collections: [input.data.collection] },
+      exportedAt: input.exportedAt,
+      schemaVersion: 4,
+    }),
+  )
+  const v2ToV3 = defineBackupMigrationStep({
+    fromVersion: 2,
+    inputSchema: backupV2Schema,
+    migrate: migrateV2ToV3,
+    outputSchema: backupV3Schema,
+    toVersion: 3,
+  })
+  const v3ToV4 = defineBackupMigrationStep({
+    fromVersion: 3,
+    inputSchema: backupV3Schema,
+    migrate: migrateV3ToV4,
+    outputSchema: backupV4Schema,
+    toVersion: 4,
+  })
+
+  return {
+    migrateV2ToV3,
+    migrateV3ToV4,
+    pipeline: createBackupMigrationPipeline({
+      currentSchema: backupV4Schema,
+      currentVersion: 4,
+      migrations: new Map([
+        [2, v2ToV3],
+        [3, v3ToV4],
+      ]),
+    }),
+    v2ToV3,
+    v3ToV4,
+  }
+}
+
+const captureSchemaError = (action: () => unknown): BackupSchemaError => {
+  try {
+    action()
+  } catch (error) {
+    if (error instanceof BackupSchemaError) {
+      return error
+    }
+    throw error
+  }
+  throw new Error('A typed backup schema error must be thrown')
+}
+
+describe('createBackupMigrationPipeline', () => {
+  it('migrates V2 through every sequential step to the current schema', () => {
+    const { migrateV2ToV3, migrateV3ToV4, pipeline } = createTestPipeline()
+
+    expect(pipeline.migrateToCurrent(backupV2)).toEqual({
+      backup: backupCurrent,
+      kind: 'current',
+      sourceVersion: 2,
+    })
+    expect(migrateV2ToV3).toHaveBeenCalledTimes(1)
+    expect(migrateV3ToV4).toHaveBeenCalledTimes(1)
+    expect(migrateV2ToV3.mock.invocationCallOrder[0]).toBeLessThan(
+      migrateV3ToV4.mock.invocationCallOrder[0] ?? 0,
+    )
+  })
+
+  it('starts from the declared supported version', () => {
+    const { migrateV2ToV3, migrateV3ToV4, pipeline } = createTestPipeline()
+
+    expect(pipeline.migrateToCurrent(backupV3)).toEqual({
+      backup: backupCurrent,
+      kind: 'current',
+      sourceVersion: 3,
+    })
+    expect(migrateV2ToV3).not.toHaveBeenCalled()
+    expect(migrateV3ToV4).toHaveBeenCalledTimes(1)
+  })
+
+  it('validates current input without invoking a migration', () => {
+    const { migrateV2ToV3, migrateV3ToV4, pipeline } = createTestPipeline()
+
+    expect(pipeline.migrateToCurrent(backupCurrent)).toEqual({
+      backup: backupCurrent,
+      kind: 'current',
+      sourceVersion: 4,
+    })
+    expect(migrateV2ToV3).not.toHaveBeenCalled()
+    expect(migrateV3ToV4).not.toHaveBeenCalled()
+  })
+
+  it('rejects a future schema version with typed diagnostics', () => {
+    const { pipeline } = createTestPipeline()
+
+    expect(
+      captureSchemaError(() => pipeline.migrateToCurrent(backupFuture)),
+    ).toMatchObject({
+      code: 'UNSUPPORTED_FUTURE_SCHEMA',
+      currentVersion: 4,
+      receivedVersion: 5,
+    })
+  })
+
+  it('rejects an older schema outside the supported registry', () => {
+    const { pipeline } = createTestPipeline()
+
+    expect(
+      captureSchemaError(() => pipeline.migrateToCurrent({ schemaVersion: 1 })),
+    ).toMatchObject({
+      code: 'UNSUPPORTED_SCHEMA_VERSION',
+      currentVersion: 4,
+      receivedVersion: 1,
+    })
+  })
+
+  it('rejects invalid input before invoking its migration', () => {
+    const { migrateV3ToV4, pipeline } = createTestPipeline()
+
+    expect(
+      captureSchemaError(() => pipeline.migrateToCurrent(backupInvalid)),
+    ).toMatchObject({
+      code: 'INVALID_SCHEMA',
+      currentVersion: 4,
+      receivedVersion: 3,
+    })
+    expect(migrateV3ToV4).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid migration output before the next step', () => {
+    const { v3ToV4 } = createTestPipeline()
+    const invalidOutput: BackupV3 = {
+      appVersion: '2.0.0',
+      data: { collection: { name: '' } },
+      exportedAt: '2026-07-18T00:00:00.000Z',
+      schemaVersion: 3,
+    }
+    const invalidV2ToV3 = defineBackupMigrationStep({
+      fromVersion: 2,
+      inputSchema: backupV2Schema,
+      migrate: (): BackupV3 => invalidOutput,
+      outputSchema: backupV3Schema,
+      toVersion: 3,
+    })
+    const pipeline = createBackupMigrationPipeline({
+      currentSchema: backupV4Schema,
+      currentVersion: 4,
+      migrations: new Map([
+        [2, invalidV2ToV3],
+        [3, v3ToV4],
+      ]),
+    })
+
+    expect(
+      captureSchemaError(() => pipeline.migrateToCurrent(backupV2)),
+    ).toMatchObject({
+      code: 'INVALID_SCHEMA',
+      currentVersion: 4,
+      receivedVersion: 2,
+    })
+  })
+
+  it('rejects a gap in the supported sequential registry', () => {
+    const { v2ToV3 } = createTestPipeline()
+
+    expect(() =>
+      createBackupMigrationPipeline({
+        currentSchema: backupV4Schema,
+        currentVersion: 4,
+        migrations: new Map([[2, v2ToV3]]),
+      }),
+    ).toThrow('Missing backup migration step for schema version 3')
+  })
+
+  it('rejects a migration that skips a schema version', () => {
+    const { v3ToV4 } = createTestPipeline()
+    const invalidStep = defineBackupMigrationStep({
+      fromVersion: 2,
+      inputSchema: backupV2Schema,
+      migrate: () => backupCurrent,
+      outputSchema: backupV4Schema,
+      toVersion: 4,
+    })
+
+    expect(() =>
+      createBackupMigrationPipeline({
+        currentSchema: backupV4Schema,
+        currentVersion: 4,
+        migrations: new Map([
+          [2, invalidStep],
+          [3, v3ToV4],
+        ]),
+      }),
+    ).toThrow('Backup migration steps must advance exactly one version')
+  })
+
+  it('returns the dedicated legacy classification without migration', () => {
+    const { migrateV2ToV3, migrateV3ToV4, pipeline } = createTestPipeline()
+
+    expect(pipeline.migrateToCurrent({ version: '2.0.0' })).toEqual({
+      kind: 'legacy',
+    })
+    expect(migrateV2ToV3).not.toHaveBeenCalled()
+    expect(migrateV3ToV4).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/persistence/backupMigrationPipeline.test.ts
+++ b/src/lib/persistence/backupMigrationPipeline.test.ts
@@ -9,39 +9,29 @@ import {
 } from './backupMigrationPipeline'
 import { BackupSchemaError } from './backupSchema'
 
-const envelopeMetadataSchema = z.object({
+const envelopeMetadataSchema = z.strictObject({
   appVersion: z.string().min(1),
   exportedAt: z.iso.datetime(),
 })
 
-const backupV2Schema = envelopeMetadataSchema
-  .extend({
-    data: z.object({ name: z.string().min(1) }).strict(),
-    schemaVersion: z.literal(2),
-  })
-  .strict()
+const backupV2Schema = envelopeMetadataSchema.extend({
+  data: z.strictObject({ name: z.string().min(1) }),
+  schemaVersion: z.literal(2),
+})
 
-const backupV3Schema = envelopeMetadataSchema
-  .extend({
-    data: z
-      .object({
-        collection: z.object({ name: z.string().min(1) }).strict(),
-      })
-      .strict(),
-    schemaVersion: z.literal(3),
-  })
-  .strict()
+const backupV3Schema = envelopeMetadataSchema.extend({
+  data: z.strictObject({
+    collection: z.strictObject({ name: z.string().min(1) }),
+  }),
+  schemaVersion: z.literal(3),
+})
 
-const backupV4Schema = envelopeMetadataSchema
-  .extend({
-    data: z
-      .object({
-        collections: z.array(z.object({ name: z.string().min(1) }).strict()),
-      })
-      .strict(),
-    schemaVersion: z.literal(4),
-  })
-  .strict()
+const backupV4Schema = envelopeMetadataSchema.extend({
+  data: z.strictObject({
+    collections: z.array(z.strictObject({ name: z.string().min(1) })),
+  }),
+  schemaVersion: z.literal(4),
+})
 
 type BackupV2 = z.output<typeof backupV2Schema>
 type BackupV3 = z.output<typeof backupV3Schema>
@@ -123,6 +113,20 @@ const captureSchemaError = (action: () => unknown): BackupSchemaError => {
 }
 
 describe('createBackupMigrationPipeline', () => {
+  it('rejects malformed versions accepted by a permissive step schema', () => {
+    const migrate = vi.fn((input: unknown) => input)
+    const step = defineBackupMigrationStep({
+      fromVersion: 2,
+      inputSchema: z.unknown(),
+      migrate,
+      outputSchema: z.unknown(),
+      toVersion: 3,
+    })
+
+    expect(step.execute({ schemaVersion: '2' })).toEqual({ success: false })
+    expect(migrate).not.toHaveBeenCalled()
+  })
+
   it.each([0, 1.5])(
     'rejects invalid current schema version %s',
     (currentVersion) => {
@@ -279,6 +283,39 @@ describe('createBackupMigrationPipeline', () => {
     })
   })
 
+  it('rejects schemas whose data version does not match the step boundary', () => {
+    const invalidV2ToV3 = defineBackupMigrationStep({
+      fromVersion: 2,
+      inputSchema: backupV2Schema,
+      migrate: (): BackupV4 => backupV4Schema.parse(backupCurrent),
+      outputSchema: backupV4Schema,
+      toVersion: 3,
+    })
+    const invalidV3ToV4 = defineBackupMigrationStep({
+      fromVersion: 3,
+      inputSchema: backupV4Schema,
+      migrate: (input: BackupV4): BackupV4 => input,
+      outputSchema: backupV4Schema,
+      toVersion: 4,
+    })
+    const pipeline = createBackupMigrationPipeline({
+      currentSchema: backupV4Schema,
+      currentVersion: 4,
+      migrations: new Map([
+        [2, invalidV2ToV3],
+        [3, invalidV3ToV4],
+      ]),
+    })
+
+    expect(
+      captureSchemaError(() => pipeline.migrateToCurrent(backupV2)),
+    ).toMatchObject({
+      code: 'INVALID_SCHEMA',
+      currentVersion: 4,
+      receivedVersion: 2,
+    })
+  })
+
   it('rejects a gap in the supported sequential registry', () => {
     const { v2ToV3 } = createTestPipeline()
 
@@ -376,6 +413,37 @@ describe('createBackupMigrationPipeline', () => {
 
     migrations.set(2, skippingStep)
     migrations.delete(3)
+
+    expect(pipeline.migrateToCurrent(backupV2)).toEqual({
+      backup: backupCurrent,
+      kind: 'current',
+      sourceVersion: 2,
+    })
+    expect(migrateV2ToV3).toHaveBeenCalledTimes(1)
+    expect(migrateV3ToV4).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses validated step snapshots after caller mutation', () => {
+    const { migrateV2ToV3, migrateV3ToV4, v2ToV3, v3ToV4 } =
+      createTestPipeline()
+    const mutableV2ToV3 = { ...v2ToV3 }
+    const mutableV3ToV4 = { ...v3ToV4 }
+    const pipeline = createBackupMigrationPipeline({
+      currentSchema: backupV4Schema,
+      currentVersion: 4,
+      migrations: new Map([
+        [2, mutableV2ToV3],
+        [3, mutableV3ToV4],
+      ]),
+    })
+
+    mutableV2ToV3.execute = () => ({
+      data: backupV4Schema.parse(backupCurrent),
+      success: true,
+    })
+    mutableV2ToV3.toVersion = 4
+    mutableV3ToV4.execute = (input) => ({ data: input, success: true })
+    mutableV3ToV4.fromVersion = 4
 
     expect(pipeline.migrateToCurrent(backupV2)).toEqual({
       backup: backupCurrent,

--- a/src/lib/persistence/backupMigrationPipeline.test.ts
+++ b/src/lib/persistence/backupMigrationPipeline.test.ts
@@ -354,8 +354,9 @@ describe('createBackupMigrationPipeline', () => {
     },
   )
 
-  it('rejects a registry step removed after pipeline construction', () => {
-    const { v2ToV3, v3ToV4 } = createTestPipeline()
+  it('uses the validated registry snapshot after caller mutation', () => {
+    const { migrateV2ToV3, migrateV3ToV4, v2ToV3, v3ToV4 } =
+      createTestPipeline()
     const migrations = new Map([
       [2, v2ToV3],
       [3, v3ToV4],
@@ -365,15 +366,24 @@ describe('createBackupMigrationPipeline', () => {
       currentVersion: 4,
       migrations,
     })
+    const skippingStep = defineBackupMigrationStep({
+      fromVersion: 2,
+      inputSchema: backupV2Schema,
+      migrate: (): BackupV4 => backupV4Schema.parse(backupCurrent),
+      outputSchema: backupV4Schema,
+      toVersion: 4,
+    })
+
+    migrations.set(2, skippingStep)
     migrations.delete(3)
 
-    expect(
-      captureSchemaError(() => pipeline.migrateToCurrent(backupV2)),
-    ).toMatchObject({
-      code: 'UNSUPPORTED_SCHEMA_VERSION',
-      currentVersion: 4,
-      receivedVersion: 2,
+    expect(pipeline.migrateToCurrent(backupV2)).toEqual({
+      backup: backupCurrent,
+      kind: 'current',
+      sourceVersion: 2,
     })
+    expect(migrateV2ToV3).toHaveBeenCalledTimes(1)
+    expect(migrateV3ToV4).toHaveBeenCalledTimes(1)
   })
 
   it('validates the final value with the declared current schema', () => {

--- a/src/lib/persistence/backupMigrationPipeline.ts
+++ b/src/lib/persistence/backupMigrationPipeline.ts
@@ -1,0 +1,190 @@
+import type { z } from 'zod'
+
+import { BackupSchemaError, detectBackupFormat } from './backupSchema'
+
+export type BackupMigration<TFrom, TTo> = (input: TFrom) => TTo
+
+type BackupMigrationStepResult =
+  | { readonly data: unknown; readonly success: true }
+  | { readonly success: false }
+
+export type BackupMigrationStep = {
+  readonly execute: (input: unknown) => BackupMigrationStepResult
+  readonly fromVersion: number
+  readonly toVersion: number
+}
+
+type DefineBackupMigrationStepOptions<TFrom, TTo> = {
+  readonly fromVersion: number
+  readonly inputSchema: z.ZodType<TFrom>
+  readonly migrate: BackupMigration<TFrom, TTo>
+  readonly outputSchema: z.ZodType<TTo>
+  readonly toVersion: number
+}
+
+export const defineBackupMigrationStep = <TFrom, TTo>({
+  fromVersion,
+  inputSchema,
+  migrate,
+  outputSchema,
+  toVersion,
+}: DefineBackupMigrationStepOptions<TFrom, TTo>): BackupMigrationStep => ({
+  execute: (input) => {
+    const parsedInput = inputSchema.safeParse(input)
+    if (!parsedInput.success) {
+      return { success: false }
+    }
+
+    const migrated = migrate(parsedInput.data)
+    const parsedOutput = outputSchema.safeParse(migrated)
+    return parsedOutput.success
+      ? { data: parsedOutput.data, success: true }
+      : { success: false }
+  },
+  fromVersion,
+  toVersion,
+})
+
+export type BackupMigrationResult<TCurrent> =
+  | { readonly kind: 'legacy' }
+  | {
+      readonly backup: TCurrent
+      readonly kind: 'current'
+      readonly sourceVersion: number
+    }
+
+type CreateBackupMigrationPipelineOptions<TCurrent> = {
+  readonly currentSchema: z.ZodType<TCurrent>
+  readonly currentVersion: number
+  readonly migrations: ReadonlyMap<number, BackupMigrationStep>
+}
+
+type BackupMigrationPipeline<TCurrent> = {
+  readonly migrateToCurrent: (input: unknown) => BackupMigrationResult<TCurrent>
+}
+
+const assertValidRegistry = (
+  currentVersion: number,
+  migrations: ReadonlyMap<number, BackupMigrationStep>,
+): void => {
+  if (!Number.isSafeInteger(currentVersion) || currentVersion < 1) {
+    throw new TypeError(
+      'Current backup schema version must be a positive integer',
+    )
+  }
+
+  for (const [registeredVersion, step] of migrations) {
+    if (registeredVersion !== step.fromVersion) {
+      throw new TypeError(
+        'Backup migration registry key must match its source version',
+      )
+    }
+    if (step.toVersion !== step.fromVersion + 1) {
+      throw new TypeError(
+        'Backup migration steps must advance exactly one version',
+      )
+    }
+    if (step.fromVersion < 1 || step.toVersion > currentVersion) {
+      throw new TypeError(
+        'Backup migration step must stay within the supported version range',
+      )
+    }
+  }
+
+  const registeredVersions = [...migrations.keys()]
+  if (registeredVersions.length === 0) {
+    return
+  }
+
+  const minimumVersion = Math.min(...registeredVersions)
+  for (let version = minimumVersion; version < currentVersion; version += 1) {
+    if (!migrations.has(version)) {
+      throw new TypeError(
+        `Missing backup migration step for schema version ${version}`,
+      )
+    }
+  }
+}
+
+const invalidSchemaError = (
+  currentVersion: number,
+  receivedVersion: number,
+): BackupSchemaError =>
+  new BackupSchemaError('INVALID_SCHEMA', {
+    currentVersion,
+    receivedVersion,
+  })
+
+export const createBackupMigrationPipeline = <TCurrent>({
+  currentSchema,
+  currentVersion,
+  migrations,
+}: CreateBackupMigrationPipelineOptions<TCurrent>): BackupMigrationPipeline<TCurrent> => {
+  assertValidRegistry(currentVersion, migrations)
+
+  return {
+    migrateToCurrent: (input) => {
+      const format = detectBackupFormat(input)
+      if (format.kind === 'legacy') {
+        return { kind: 'legacy' }
+      }
+
+      const sourceVersion = format.schemaVersion
+      if (sourceVersion > currentVersion) {
+        throw new BackupSchemaError('UNSUPPORTED_FUTURE_SCHEMA', {
+          currentVersion,
+          receivedVersion: sourceVersion,
+        })
+      }
+
+      if (sourceVersion === currentVersion) {
+        const currentResult = currentSchema.safeParse(input)
+        if (!currentResult.success) {
+          throw invalidSchemaError(currentVersion, sourceVersion)
+        }
+        return {
+          backup: currentResult.data,
+          kind: 'current',
+          sourceVersion,
+        }
+      }
+
+      if (!migrations.has(sourceVersion)) {
+        throw new BackupSchemaError('UNSUPPORTED_SCHEMA_VERSION', {
+          currentVersion,
+          receivedVersion: sourceVersion,
+        })
+      }
+
+      let migrated: unknown = input
+      let version = sourceVersion
+      while (version < currentVersion) {
+        const step = migrations.get(version)
+        if (!step) {
+          throw new BackupSchemaError('UNSUPPORTED_SCHEMA_VERSION', {
+            currentVersion,
+            receivedVersion: sourceVersion,
+          })
+        }
+
+        const result = step.execute(migrated)
+        if (!result.success) {
+          throw invalidSchemaError(currentVersion, sourceVersion)
+        }
+        migrated = result.data
+        version = step.toVersion
+      }
+
+      const currentResult = currentSchema.safeParse(migrated)
+      if (!currentResult.success) {
+        throw invalidSchemaError(currentVersion, sourceVersion)
+      }
+
+      return {
+        backup: currentResult.data,
+        kind: 'current',
+        sourceVersion,
+      }
+    },
+  }
+}

--- a/src/lib/persistence/backupMigrationPipeline.ts
+++ b/src/lib/persistence/backupMigrationPipeline.ts
@@ -22,6 +22,20 @@ type DefineBackupMigrationStepOptions<TFrom, TTo> = {
   readonly toVersion: number
 }
 
+const hasExpectedSchemaVersion = (
+  input: unknown,
+  expectedVersion: number,
+): boolean => {
+  try {
+    const format = detectBackupFormat(input)
+    return (
+      format.kind === 'versioned' && format.schemaVersion === expectedVersion
+    )
+  } catch {
+    return false
+  }
+}
+
 export const defineBackupMigrationStep = <TFrom, TTo>({
   fromVersion,
   inputSchema,
@@ -31,13 +45,17 @@ export const defineBackupMigrationStep = <TFrom, TTo>({
 }: DefineBackupMigrationStepOptions<TFrom, TTo>): BackupMigrationStep => ({
   execute: (input) => {
     const parsedInput = inputSchema.safeParse(input)
-    if (!parsedInput.success) {
+    if (
+      !parsedInput.success ||
+      !hasExpectedSchemaVersion(parsedInput.data, fromVersion)
+    ) {
       return { success: false }
     }
 
     const migrated = migrate(parsedInput.data)
     const parsedOutput = outputSchema.safeParse(migrated)
-    return parsedOutput.success
+    return parsedOutput.success &&
+      hasExpectedSchemaVersion(parsedOutput.data, toVersion)
       ? { data: parsedOutput.data, success: true }
       : { success: false }
   },
@@ -126,7 +144,14 @@ export const createBackupMigrationPipeline = <TCurrent>({
   currentVersion,
   migrations,
 }: CreateBackupMigrationPipelineOptions<TCurrent>): BackupMigrationPipeline<TCurrent> => {
-  const migrationRegistry = new Map(migrations)
+  const migrationRegistry = new Map<number, BackupMigrationStep>()
+  for (const [version, step] of migrations) {
+    migrationRegistry.set(version, {
+      execute: step.execute,
+      fromVersion: step.fromVersion,
+      toVersion: step.toVersion,
+    })
+  }
   const migrationSteps = assertValidRegistry(currentVersion, migrationRegistry)
 
   return {

--- a/src/lib/persistence/backupMigrationPipeline.ts
+++ b/src/lib/persistence/backupMigrationPipeline.ts
@@ -66,14 +66,22 @@ type BackupMigrationPipeline<TCurrent> = {
 const assertValidRegistry = (
   currentVersion: number,
   migrations: ReadonlyMap<number, BackupMigrationStep>,
-): void => {
+): readonly BackupMigrationStep[] => {
   if (!Number.isSafeInteger(currentVersion) || currentVersion < 1) {
     throw new TypeError(
       'Current backup schema version must be a positive integer',
     )
   }
 
-  for (const [registeredVersion, step] of migrations) {
+  if (migrations.size === 0) {
+    return []
+  }
+
+  const sortedEntries = [...migrations.entries()].toSorted(
+    ([leftVersion], [rightVersion]) => leftVersion - rightVersion,
+  )
+
+  for (const [registeredVersion, step] of sortedEntries) {
     if (registeredVersion !== step.fromVersion) {
       throw new TypeError(
         'Backup migration registry key must match its source version',
@@ -91,12 +99,8 @@ const assertValidRegistry = (
     }
   }
 
-  const registeredVersions = [...migrations.keys()]
-  if (registeredVersions.length === 0) {
-    return
-  }
-
-  const minimumVersion = Math.min(...registeredVersions)
+  const firstEntry = sortedEntries[0]
+  const [minimumVersion] = firstEntry
   for (let version = minimumVersion; version < currentVersion; version += 1) {
     if (!migrations.has(version)) {
       throw new TypeError(
@@ -104,6 +108,8 @@ const assertValidRegistry = (
       )
     }
   }
+
+  return sortedEntries.map(([, step]) => step)
 }
 
 const invalidSchemaError = (
@@ -120,7 +126,8 @@ export const createBackupMigrationPipeline = <TCurrent>({
   currentVersion,
   migrations,
 }: CreateBackupMigrationPipelineOptions<TCurrent>): BackupMigrationPipeline<TCurrent> => {
-  assertValidRegistry(currentVersion, migrations)
+  const migrationRegistry = new Map(migrations)
+  const migrationSteps = assertValidRegistry(currentVersion, migrationRegistry)
 
   return {
     migrateToCurrent: (input) => {
@@ -149,7 +156,7 @@ export const createBackupMigrationPipeline = <TCurrent>({
         }
       }
 
-      if (!migrations.has(sourceVersion)) {
+      if (!migrationRegistry.has(sourceVersion)) {
         throw new BackupSchemaError('UNSUPPORTED_SCHEMA_VERSION', {
           currentVersion,
           receivedVersion: sourceVersion,
@@ -157,14 +164,9 @@ export const createBackupMigrationPipeline = <TCurrent>({
       }
 
       let migrated: unknown = input
-      let version = sourceVersion
-      while (version < currentVersion) {
-        const step = migrations.get(version)
-        if (!step) {
-          throw new BackupSchemaError('UNSUPPORTED_SCHEMA_VERSION', {
-            currentVersion,
-            receivedVersion: sourceVersion,
-          })
+      for (const step of migrationSteps) {
+        if (step.fromVersion < sourceVersion) {
+          continue
         }
 
         const result = step.execute(migrated)
@@ -172,7 +174,6 @@ export const createBackupMigrationPipeline = <TCurrent>({
           throw invalidSchemaError(currentVersion, sourceVersion)
         }
         migrated = result.data
-        version = step.toVersion
       }
 
       const currentResult = currentSchema.safeParse(migrated)

--- a/src/lib/persistence/backupSchema.test.ts
+++ b/src/lib/persistence/backupSchema.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it } from 'vitest'
 
 import { BackupSchemaError, detectBackupFormat } from './backupSchema'
 
+const captureError = (action: () => unknown): unknown => {
+  try {
+    action()
+  } catch (error) {
+    return error
+  }
+  return undefined
+}
+
 describe('detectBackupFormat', () => {
   it('detects a versioned envelope from an integer schemaVersion', () => {
     expect(
@@ -33,13 +42,11 @@ describe('detectBackupFormat', () => {
 
   it('keeps user data out of typed error messages', () => {
     const secret = 'private-user-backup-value'
+    const error = captureError(() =>
+      detectBackupFormat({ schemaVersion: secret }),
+    )
 
-    try {
-      detectBackupFormat({ schemaVersion: secret })
-      expect.unreachable('invalid schemaVersion must be rejected')
-    } catch (error) {
-      expect(error).toBeInstanceOf(BackupSchemaError)
-      expect((error as Error).message).not.toContain(secret)
-    }
+    expect(error).toBeInstanceOf(BackupSchemaError)
+    expect((error as Error).message).not.toContain(secret)
   })
 })

--- a/src/lib/persistence/backupSchema.test.ts
+++ b/src/lib/persistence/backupSchema.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { BackupSchemaError, detectBackupFormat } from './backupSchema'
+
+describe('detectBackupFormat', () => {
+  it('detects a versioned envelope from an integer schemaVersion', () => {
+    expect(
+      detectBackupFormat({
+        appVersion: '2.0.0',
+        data: {},
+        exportedAt: '2026-07-18T00:00:00.000Z',
+        schemaVersion: 2,
+      }),
+    ).toEqual({ kind: 'versioned', schemaVersion: 2 })
+  })
+
+  it('classifies an object without schemaVersion as legacy', () => {
+    expect(detectBackupFormat({ version: '2.0.0' })).toEqual({
+      kind: 'legacy',
+    })
+  })
+
+  it.each([null, [], 'backup', { schemaVersion: 0 }, { schemaVersion: 1.5 }])(
+    'rejects malformed envelope input %#',
+    (input) => {
+      expect(() => detectBackupFormat(input)).toThrow(
+        expect.objectContaining<Partial<BackupSchemaError>>({
+          code: 'INVALID_SCHEMA',
+        }),
+      )
+    },
+  )
+
+  it('keeps user data out of typed error messages', () => {
+    const secret = 'private-user-backup-value'
+
+    try {
+      detectBackupFormat({ schemaVersion: secret })
+      expect.unreachable('invalid schemaVersion must be rejected')
+    } catch (error) {
+      expect(error).toBeInstanceOf(BackupSchemaError)
+      expect((error as Error).message).not.toContain(secret)
+    }
+  })
+})

--- a/src/lib/persistence/backupSchema.ts
+++ b/src/lib/persistence/backupSchema.ts
@@ -1,0 +1,69 @@
+export type BackupEnvelope<TData, TVersion extends number = number> = {
+  readonly appVersion: string
+  readonly data: TData
+  readonly exportedAt: string
+  readonly schemaVersion: TVersion
+}
+
+export const BACKUP_SCHEMA_ERROR_CODES = [
+  'INVALID_SCHEMA',
+  'UNSUPPORTED_FUTURE_SCHEMA',
+  'UNSUPPORTED_SCHEMA_VERSION',
+] as const
+
+export type BackupSchemaErrorCode = (typeof BACKUP_SCHEMA_ERROR_CODES)[number]
+
+const BACKUP_SCHEMA_ERROR_MESSAGES: Readonly<
+  Record<BackupSchemaErrorCode, string>
+> = {
+  INVALID_SCHEMA: 'Backup schema is invalid',
+  UNSUPPORTED_FUTURE_SCHEMA: 'Backup schema is newer than supported',
+  UNSUPPORTED_SCHEMA_VERSION: 'Backup schema version is unsupported',
+}
+
+export class BackupSchemaError extends Error {
+  readonly code: BackupSchemaErrorCode
+  readonly currentVersion?: number
+  readonly receivedVersion?: number
+
+  constructor(
+    code: BackupSchemaErrorCode,
+    versions: {
+      readonly currentVersion?: number
+      readonly receivedVersion?: number
+    } = {},
+  ) {
+    super(BACKUP_SCHEMA_ERROR_MESSAGES[code])
+    this.name = 'BackupSchemaError'
+    this.code = code
+    this.currentVersion = versions.currentVersion
+    this.receivedVersion = versions.receivedVersion
+  }
+}
+
+export type BackupFormatDetection =
+  | { readonly kind: 'legacy' }
+  | { readonly kind: 'versioned'; readonly schemaVersion: number }
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+export const detectBackupFormat = (input: unknown): BackupFormatDetection => {
+  if (!isRecord(input)) {
+    throw new BackupSchemaError('INVALID_SCHEMA')
+  }
+  if (!Object.hasOwn(input, 'schemaVersion')) {
+    return { kind: 'legacy' }
+  }
+
+  const schemaVersion = input.schemaVersion
+  if (
+    typeof schemaVersion !== 'number' ||
+    !Number.isSafeInteger(schemaVersion) ||
+    schemaVersion < 1
+  ) {
+    throw new BackupSchemaError('INVALID_SCHEMA')
+  }
+
+  return { kind: 'versioned', schemaVersion }
+}


### PR DESCRIPTION
## Summary

- backup format の `schemaVersion` / `appVersion` / `databaseVersion` を分離する汎用 `BackupEnvelope` と typed schema error を追加
- version ごとの Zod validation を migration 前後で強制する、連続した N→N+1 migration pipeline を追加
- V2 / V3 / current / future / invalid の golden fixture と architecture policy test、互換性・廃止境界の設計資料を追加
- caller-owned migration registry を構築時に snapshot し、構築後の差し替えによる validation bypass を防止

## Scope

- 実 Backup V2 model と UI/import integration は #730 の責務として含めません
- legacy importer の削除境界は #734 と 2026-08-31 cutoff に合わせています

## Verification

- `bun run test:coverage` — 340 files / 3758 tests passed; 97.33% statements, 92.69% branches, 98.02% functions, 97.34% lines
- Issue-owned migration pipeline — 100% statements / branches / functions / lines
- `bun run quality:check`
- `bun run release:check` — Chrome/Firefox build、production logging/app version/network policy verification を含めて passed
- fresh-context harness evaluation

Closes #713


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * バックアップ形式のバージョンを判定し、過去の対応形式を現行形式へ段階的に移行できるようになりました。
  * 将来版、未対応版、不正なバックアップを区別して、安全にエラー通知できるようになりました。
  * 既存のレガシーバックアップは、従来形式として適切に扱われます。

* **ドキュメント**
  * バックアップのバージョニング方針、互換性、移行手順、エラー仕様を整理しました。

* **テスト**
  * 現行・過去・将来・不正なバックアップ形式の検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->