### PR TITLE
fix(lint): ban fetch in domain/application layers (#648)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -837,6 +837,10 @@
           {
             "name": "indexedDB",
             "message": "domain 層は indexedDB を直接利用できません"
+          },
+          {
+            "name": "fetch",
+            "message": "domain 層は fetch を直接利用できません（HttpClientPort / AiClientPort / adapter 経由）"
           }
         ],
         "eslint/no-restricted-properties": [
@@ -1001,6 +1005,10 @@
           {
             "name": "indexedDB",
             "message": "application 層は indexedDB を直接利用できません（repository / storage adapter 経由）"
+          },
+          {
+            "name": "fetch",
+            "message": "application 層は fetch を直接利用できません（HttpClientPort / AiClientPort / adapter 経由）"
           }
         ]
       }

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -1705,7 +1705,6 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       expect(repositoryFiles.length).toBeGreaterThan(0)
     })
 
-
     for (const absolutePath of repositoryFiles) {
       const relativePath = relative(repoRoot, absolutePath).split(sep).join('/')
 

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -441,6 +441,32 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
         ).not.toMatch(/\bnew\s+Date\s*\(/)
       }
     })
+
+    it('issue #648: fetch の直接利用を no-restricted-globals で禁止している', () => {
+      const names = getRestrictedGlobals(globalsOverride)
+      expect(names).toContain('fetch')
+    })
+
+    it('issue #648: domain 層のソースファイルが fetch( を直接呼ばない', () => {
+      // JSDoc / コメント内の言及は対象外とする (issue #582 と同じ stripComments 方針)。
+      // domain 層は fetch を直接呼ばず、HttpClientPort / AiClientPort /
+      // repository / adapter 経由で外部通信する (issue #648)。
+      const stripComments = (source: string): string =>
+        source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+      const domainRoot = resolve(repoRoot, 'src/contexts/saved-tabs/domain')
+      const domainSourceFiles = collectSourceFiles(domainRoot)
+      expect(domainSourceFiles.length).toBeGreaterThan(0)
+      for (const absolutePath of domainSourceFiles) {
+        const relativePath = relative(repoRoot, absolutePath)
+          .split(sep)
+          .join('/')
+        const source = stripComments(readFileSync(absolutePath, 'utf8'))
+        expect(
+          source,
+          `${relativePath} should not call fetch() directly (use HttpClientPort / AiClientPort / adapter 経由)`,
+        ).not.toMatch(/\bfetch\s*\(/)
+      }
+    })
   })
 
   describe('application 層', () => {
@@ -539,6 +565,32 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
           source,
           `${relativePath} should not call crypto.randomUUID() directly (use IdGeneratorPort)`,
         ).not.toMatch(/\bcrypto\.randomUUID\s*\(/)
+      }
+    })
+
+    it('issue #648: fetch の直接利用を no-restricted-globals で禁止している', () => {
+      const names = getRestrictedGlobals(globalsOverride)
+      expect(names).toContain('fetch')
+    })
+
+    it('issue #648: application 層のソースファイルが fetch( を直接呼ばない', () => {
+      // JSDoc / コメント内の言及は対象外とする (issue #582 と同じ stripComments 方針)。
+      // application 層は fetch を直接呼ばず、HttpClientPort / AiClientPort /
+      // repository / adapter 経由で外部通信する (issue #648)。
+      const stripComments = (source: string): string =>
+        source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+      const appRoot = resolve(repoRoot, 'src/contexts/saved-tabs/application')
+      const appSourceFiles = collectSourceFiles(appRoot)
+      expect(appSourceFiles.length).toBeGreaterThan(0)
+      for (const absolutePath of appSourceFiles) {
+        const relativePath = relative(repoRoot, absolutePath)
+          .split(sep)
+          .join('/')
+        const source = stripComments(readFileSync(absolutePath, 'utf8'))
+        expect(
+          source,
+          `${relativePath} should not call fetch() directly (use HttpClientPort / AiClientPort / adapter 経由)`,
+        ).not.toMatch(/\bfetch\s*\(/)
       }
     })
   })

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -187,6 +187,12 @@ const collectTestFiles = (dir: string): string[] => {
   return result
 }
 
+// JSDoc / コメント内の言及は対象外とするため、検査対象 source から
+// ブロックコメント / 行コメントを除去する純粋関数 (issue #582 と同方針)。
+// 各テストで定義していた重複 helper を module-level に集約した (issue #648 review)。
+const stripComments = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+
 describe('src/contexts/saved-tabs DDD layer guard', () => {
   const config = loadOxlintConfig()
   const dependencyCruiserSource = readFileSync(
@@ -396,8 +402,6 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
     })
 
     it('issue #642: domain 層のソースファイルが Math.random( / crypto.randomUUID( を直接使わない', () => {
-      const stripComments = (source: string): string =>
-        source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
       const domainRoot = resolve(repoRoot, 'src/contexts/saved-tabs/domain')
       const domainSourceFiles = collectSourceFiles(domainRoot)
       expect(domainSourceFiles.length).toBeGreaterThan(0)
@@ -421,8 +425,6 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       // JSDoc やコメント内の言及は対象外とする。
       // 検出したいのは「現在時刻の取得」という
       // 副作用での実際のコード呼び出しのみ。
-      const stripComments = (source: string): string =>
-        source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
       const domainRoot = resolve(repoRoot, 'src/contexts/saved-tabs/domain')
       const domainSourceFiles = collectSourceFiles(domainRoot)
       expect(domainSourceFiles.length).toBeGreaterThan(0)
@@ -451,8 +453,6 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       // JSDoc / コメント内の言及は対象外とする (issue #582 と同じ stripComments 方針)。
       // domain 層は fetch を直接呼ばず、HttpClientPort / AiClientPort /
       // repository / adapter 経由で外部通信する (issue #648)。
-      const stripComments = (source: string): string =>
-        source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
       const domainRoot = resolve(repoRoot, 'src/contexts/saved-tabs/domain')
       const domainSourceFiles = collectSourceFiles(domainRoot)
       expect(domainSourceFiles.length).toBeGreaterThan(0)
@@ -539,8 +539,6 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
     })
 
     it('issue #642: application 層のソースファイルが Date.now( / new Date( / Math.random( / crypto.randomUUID( を直接使わない', () => {
-      const stripComments = (source: string): string =>
-        source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
       const appRoot = resolve(repoRoot, 'src/contexts/saved-tabs/application')
       const appSourceFiles = collectSourceFiles(appRoot)
       expect(appSourceFiles.length).toBeGreaterThan(0)
@@ -577,8 +575,6 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       // JSDoc / コメント内の言及は対象外とする (issue #582 と同じ stripComments 方針)。
       // application 層は fetch を直接呼ばず、HttpClientPort / AiClientPort /
       // repository / adapter 経由で外部通信する (issue #648)。
-      const stripComments = (source: string): string =>
-        source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
       const appRoot = resolve(repoRoot, 'src/contexts/saved-tabs/application')
       const appSourceFiles = collectSourceFiles(appRoot)
       expect(appSourceFiles.length).toBeGreaterThan(0)
@@ -1709,8 +1705,6 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       expect(repositoryFiles.length).toBeGreaterThan(0)
     })
 
-    const stripComments = (source: string): string =>
-      source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
 
     for (const absolutePath of repositoryFiles) {
       const relativePath = relative(repoRoot, absolutePath).split(sep).join('/')


### PR DESCRIPTION
## 原因 / 背景

Issue #648 は `src/contexts/*/domain/**` と `src/contexts/*/application/**` で
`fetch` の直接利用を禁止し、外部通信を `HttpClientPort` / `AiClientPort` /
repository / adapter 経由に寄せることを求めている。

現状の `.oxlintrc.json` では domain / application 層の
`eslint/no-restricted-globals` が `chrome` / `browser` / `localStorage` /
`sessionStorage` / `indexedDB` / `document` / `window` を禁止しているが、
`fetch` は未制限だった。`dddLayerGuard.test.ts` の既存 guard も
`domain/repositories/` 配下のみを検査しており、`domain/**` / `application/**`
全体の `fetch` 呼び出しを検出していなかった。

## 主な変更

- `.oxlintrc.json`: `src/contexts/*/domain/**` と
  `src/contexts/*/application/**` の両 override の
  `eslint/no-restricted-globals` に `fetch` を `error` で追加。
  lint message は代替口 (`HttpClientPort / AiClientPort / adapter 経由`) を明示。
- `src/contexts/saved-tabs/dddLayerGuard.test.ts`: issue #648 として
  domain / application 各層に (1) `fetch` が restricted globals に含まれること、
  (2) 当該層の production source file が `fetch(` を直接呼ばないこと、を検査する
  regression guard を追加。`collectSourceFiles` は既存 helper を再利用し、
  test file は除外、JSDoc / コメントは `stripComments` で対象外化
  (issue #582 と同方針)。

## `fetch` を許可する範囲 (acceptance criteria #2)

`fetch` の直接利用は lint で禁止されるのは domain / application 層のみ。
以下は引き続き許可される (本 PR では変更しない):

- `src/contexts/*/infrastructure/**`
- `src/contexts/*/presentation/**` (UI から外部 resource を取る許容範囲)
- `src/lib/**`
- `src/**/adapter/**`, `src/**/repository/**`
- `src/entrypoints/**` の bridge / bootstrap
- test helper / mock server, tools script, config file
- `src/components/**` (例: `src/components/ai-elements/prompt-input.tsx` は UI)

domain / application 層から外部通信が必要な場合は、各 context の
`application/ports/` に `HttpClientPort` / `AiClientPort` 等の port interface を
定義し、`infrastructure/**` 側の adapter で `fetch` を実装して注入する。

## 既存 `fetch` 直接利用の移行 (acceptance criteria #3)

`rtk rg "\bfetch\(" src/contexts` を実施した結果、domain / application 層の
production source に `fetch` 直接利用は存在しなかった
(検出されたのは `dddLayerGuard.test.ts` 内の検査 regex と
`src/components/ai-elements/prompt-input.tsx` のみで、後者は許可範囲)。
そのため本 PR で移行対象はなく、既存コードの振る舞い変更はない。
`HttpClientPort` / `AiClientPort` の具体的 interface file は、
現時点で消費 context (例: 将来の `ai-chat` context) が無く、YAGNI / KISS 観点から
実装を持たない speculative な型定義としては追加していない。
domain / application 層に `fetch` が必要になった時点で、各 context の
`application/ports/` に issue #648 の候補 shape で定義する運用とする。

## 受け入れ条件の対応

- [x] domain / application 層で `fetch` の直接利用が禁止されている
  — `eslint/no-restricted-globals` に `fetch` を `error` 追加 + guard test
- [x] `fetch` を許可する infrastructure / adapter / repository / lib の範囲が PR に明記されている
  — 上記「`fetch` を許可する範囲」セクション
- [x] 既存の `fetch` 直接利用がある場合、HttpClientPort / AiClientPort / adapter 経由に置き換えられている
  — N/A (domain / application 層に既存の直接利用なし、上記参照)
- [x] error handling / retry / timeout / JSON parse の責務が adapter 側に寄っている
  — N/A (対象となる既存 fetch 利用なし。新規に port を足す場合は adapter 側で集約する方針を issue 本文どおり維持)
- [x] test では fake client / mock client を使える構成になっている
  — N/A (既存 fetch 利用なし。port 経由にする際は fake / mock client を注入可能)
- [x] domain / application 層が fetch API の `Response` / `RequestInit` などに過度に依存していない
  — N/A (既存 fetch 利用なし。port 公開型に `Response` / `RequestInit` を持ち込まない方針は issue 本文どおり維持)
- [x] `bun run lint` が通る
- [x] `bun run test` が通る
- [x] `bun run build` が通る
- [x] `bun run quality:check` が通る

## 検証

test-first で実装:

1. domain 層に `fetch()` を呼ぶ一時 fixture を置き、既存 guard test が通ってしまう
   (guard gap) こと、および `bunx oxlint` が `fetch` を検出しない (rule missing) ことを確認 (RED)。
2. `dddLayerGuard.test.ts` に #648 guard を追加、`.oxlintrc.json` に `fetch` 制限を追加。
3. 同一 fixture で `bunx oxlint` が `no-restricted-globals` error を出すこと
   (domain / application 両層で確認)、guard test が新テスト 4 件を含め GREEN になることを確認。
4. fixture を削除。

実行コマンドと結果 (worktree: `~/Desktop/TABBIN/.worktrees/issue-648-ban-fetch-domain-application`):

- `bun run lint` → pass
- `bun run compile` (`tsgo --noEmit`) → pass
- `bun run test` → 350 files / 3876 tests passed
- `bun run test -- src/contexts/saved-tabs/dddLayerGuard.test.ts` (node project) → 849 tests passed
  (既存 845 + #648 追加 4)
- `bun run build` → chrome-mv3 / firefox-mv2 成功
- `bun run test:coverage` → Statements 97.41% / Branches 92.85% / Functions 98.07% / Lines 97.42%
  (本 PR は test / config のみで production code を含まないため coverage は既存 baseline から低下なし)
- `bun run quality:check` → EXIT 0 (format / compile / lint / html-validate / test / knip / jscpd / secretlint / depcruise 全 pass)
- `bun run release:check` → chrome / firefox build, production logging, app version, production network policy 全 verified

## リスク / Rollback

- lint / architecture test のみで runtime 挙動変更なし。既存 domain / application 層に
  `fetch` 直接利用が無いため、既存コードへの影響はない。
- rollback は `.oxlintrc.json` の `fetch` entry 2 件と guard test の #648 block を revert すれば完了。
- `fetch` を許可する層 (infrastructure / lib / presentation 等) には新規制限をかけていないため、
  UI の `prompt-input.tsx` 等の既存 `fetch` 利用は影響なし。

Closes #648


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **品質向上**
  - ドメイン層・アプリケーション層で、グローバルな `fetch` の直接利用を検出・防止するチェックを追加しました。
  - HTTP通信は定められたクライアント経由で行われるよう、レイヤー間の設計ルールを強化しました。
- **テスト**
  - 対象レイヤーの設定および直接呼び出し禁止ルールを自動検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->