### PR TITLE
apm compile が .worktrees 配下の stale primitive を取り込まないよう除外する

### DIFF
--- a/apm.yml
+++ b/apm.yml
@@ -41,3 +41,4 @@ compilation:
     - coverage/**
     - playwright-report/**
     - test-results/**
+    - .worktrees/**

--- a/tools/scripts/agent-contract.test.ts
+++ b/tools/scripts/agent-contract.test.ts
@@ -53,3 +53,15 @@ describe('coverage completion contract matches vitest.ci.config.ts', () => {
     expect(guidelines).not.toMatch(/coverage\s*100%/)
   })
 })
+
+describe('apm compilation excludes nested worktree sources', () => {
+  it('apm.yml compilation.exclude contains .worktrees/** so stale worktree primitives do not leak into generated artifacts', () => {
+    const apmYml = readProjectFile('apm.yml')
+    const excludeIndex = apmYml.indexOf('exclude:')
+    const compilationIndex = apmYml.indexOf('compilation:')
+    expect(compilationIndex).toBeGreaterThanOrEqual(0)
+    expect(excludeIndex).toBeGreaterThan(compilationIndex)
+    const excludeSection = apmYml.slice(excludeIndex)
+    expect(excludeSection).toContain('- .worktrees/**')
+  })
+})


### PR DESCRIPTION
## 原因

PR #795（Issue #793）で `syncAgentConfig` の汚染検査を fail-closed にした結果、main checkout で `bun run apm:sync` が失敗するようになりました。

APM の `includes: auto` がプロジェクトツリー全体を走査し、`.worktrees/<worktree>/.apm/instructions/` 配下の古い instruction まで取り込んでいました。一部の既存 worktree（例: `fix-apm-sync`）の `01-rtk.instructions.md` は個人絶対パス `@/Users/tarou/.codex/RTK.md` を含む旧版で、これが生成 `AGENTS.md` / `CLAUDE.md` へ混入し、fail-closed 検査が正しく検出して停止していました。

PR #795 の作業 worktree には `.worktrees/` が無かったため本現象は出ず、main checkout で初めて顕在化しました。

## 採用した解決

`apm.yml` の `compilation.exclude` へ `.worktrees/**` を追加し、ネストした worktree の primitive が本体の compile 対象にならないようにしました。worktree 配下の `.apm/` はそれぞれの作業 branch 用であり、本体の生成物へ混入させるべきでありません。

## 主要変更ファイル

- `apm.yml`（`compilation.exclude` へ `.worktrees/**` を追加）
- `tools/scripts/agent-contract.test.ts`（apm.yml が `.worktrees/**` を除外していることを検証する回帰テスト）

## 検証結果

- `bun run apm:sync`：通過（二回実行で差分なし、idempotent）
- `bun run apm:check`：通過
- `bun run quality:check`：通過
- `bun run test:coverage`：通過（global + per-glob threshold 満足）
- 生成 `AGENTS.md` / `CLAUDE.md` から個人絶対パスが消失したことを確認

## Regression risk

低影響。`.worktrees/**` を compile 走査から除外するだけで、本体の `.apm/` source-of-truth には影響しません。生成物は PR #795 の worktree で生成された clean な状態と一致するため、generated artifact に差分は出ません。

Issue #793 の follow-up 修正です。

Closes #793


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * `.worktrees/` 配下のファイルがコンパイル対象から除外されるようになりました。

* **テスト**
  * `.worktrees/**` の除外設定が維持されていることを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->