### PR TITLE
Backup V2 と旧バックアップ期限ポリシーを導入

### DIFF
--- a/docs/architecture/backup-schema-versioning.md
+++ b/docs/architecture/backup-schema-versioning.md
@@ -36,13 +36,71 @@ type BackupEnvelope<TData> = {
 }
 ```
 
-The concrete current `data` schema and production current version belong to
-#730. Components and mappers consume the caller-owned schema registry; they do
-not duplicate a schema-version magic number.
+The production current contract is `BackupEnvelopeV2`:
+
+```ts
+type BackupEnvelopeV2 = {
+  readonly schemaVersion: 2
+  readonly appVersion: string
+  readonly exportedAt: string
+  readonly data: {
+    readonly savedTabs: {
+      readonly urls: readonly PersistenceV2Url[]
+      readonly collections: readonly PersistenceV2Collection[]
+      readonly memberships: readonly PersistenceV2CollectionMembership[]
+      readonly categories: readonly PersistenceV2CollectionCategory[]
+      readonly groups: readonly PersistenceV2CollectionGroup[]
+    }
+    readonly conversations: readonly PersistenceJsonRecord[]
+    readonly messages: readonly PersistenceMessageRecord[]
+    readonly analyticsViews: readonly PersistenceJsonRecord[]
+    readonly userSettings: UserSettings
+  }
+}
+```
 
 Backup V2 is a logical, JSON-safe projection selected by the Storage Placement
 Matrix. It is never an IndexedDB database, object-store, index, cache, migration
-metadata, or transaction log dump.
+metadata, recovery snapshot, revision, transaction log, or other internal
+control state.
+
+The concrete runtime contract and canonical mapper live in
+`src/features/options/lib/import-export/v2/BackupV2Schema.ts` and
+`BackupMapper.ts`. The current Options export entry point is composed in
+`src/app/composition/optionsBackupV2Export.ts`; the old schema-less
+`exportSettings` remains a compatibility boundary and is not called by the
+production Options export button.
+
+## Consistent and deterministic export
+
+The IndexedDB-backed portion of a backup is read by
+`IndexedDbPersistenceSnapshotReader` in one readonly transaction spanning the
+saved-tab, conversation, message, and analytics stores. The mapper then removes
+the internal revision and canonicalizes logical records, entity arrays, and
+JSON object keys. Equivalent logical snapshots therefore produce identical
+`data`; only the caller-provided `exportedAt` changes with the clock.
+
+User settings remain owned by `chrome.storage.local` and are read after the
+IndexedDB snapshot. Browser storage engines cannot participate in one atomic
+transaction, so Backup V2 does not claim cross-engine atomicity for settings.
+The schema still validates the combined public envelope strictly and rejects
+non-JSON-safe values without silently repairing them.
+
+Export validation order is:
+
+```text
+one IndexedDB logical snapshot
+  -> #712 saved-tabs integrity check
+  -> strict public mapping and canonical ordering
+  -> logical resource limits
+  -> JSON serialization
+  -> serialized-byte limit
+```
+
+The shared resource limits live in
+`src/lib/persistence/backupResourcePolicy.ts`. A healthy backup is not rejected
+by the former fixed 10 MiB file limit; both export and import use the shared
+128 MiB serialized limit plus entity, nested-array, and UTF-8 byte limits.
 
 ## Format detection boundary
 
@@ -57,6 +115,13 @@ unknown JSON
 
 Legacy classification is routing information only. The versioned pipeline does
 not parse, migrate, or accept pre-IndexedDB data.
+
+`BackupV2Inspector.ts` owns strict current, future, and legacy inspection.
+Current V2 is fully validated before it is accepted, a future positive integer
+version preserves `UNSUPPORTED_FUTURE_SCHEMA`, and a malformed versioned
+envelope is never retried as legacy. The temporary production mutation boundary
+is `productionImportGate.ts`, which runs before installed-data migration or any
+storage read/write.
 
 ## Sequential migration registry
 
@@ -148,8 +213,46 @@ The target support policy is:
   release, so a late notice release postpones the cutoff consistently across
   #724, #730, #731, #734, docs, i18n, constants, and tests.
 
+The central dates and notice calculation are defined only in
+`compatibility/legacyBackupPolicy.ts`:
+
+| Policy value                  | Date / rule  |
+| ----------------------------- | ------------ |
+| Last supported import date    | `2026-08-31` |
+| Cutoff date                   | `2026-09-01` |
+| Latest on-time notice release | `2026-08-01` |
+| Minimum notice                | 30 days      |
+
+Legacy preview metadata carries a content-free advisory with
+`requiresReExport: true`, `lastSupportedDate`, and `cutoffDate`. Notice rendering
+and translations belong to #731, not this persistence contract.
+
 The live installed-data `chrome.storage.local` to IndexedDB migration has a
 separate lifecycle and is not deleted by the backup cutoff.
+
+## Production import rollout gate
+
+Every production overwrite request, including a valid legacy backup, is
+deliberately fail-closed with the typed code
+`OVERWRITE_RECOVERY_UNAVAILABLE` until #740 provides and wires the required
+recovery-snapshot capability. Current V2 remains blocked in both merge and
+overwrite mode; only a valid legacy merge before the cutoff may pass the
+temporary gate. Versioned input is inspected before the recovery decision so
+future and invalid schemas retain their typed schema errors. No blocked request
+calls `ImportBackupV2UseCase`, installed-data migration, or storage mutation.
+
+An allowed legacy merge is converted by `LegacyBackupAdapter` and committed as
+strict IndexedDB `put` mutations through `IndexedDbPersistenceUnitOfWork`.
+Existing logical records are not cleared, and the actual persistence operation
+gate must authorize the `indexeddb` route. The merge never falls back to
+`chrome.storage.local` domain writes after IndexedDB cutover; user settings
+remain the separately owned cross-engine write.
+
+`ImportBackupV2UseCase.ts` defines the future transactional core and readback
+contract, including the unavoidable separate settings write. It is not a
+production entry point before #740. Legacy, future, expired-legacy, and invalid
+versioned inputs are also classified before mutation; the compatibility parser
+remains isolated under `import-export/legacy/`.
 
 ## Validation and review checklist
 
@@ -161,6 +264,9 @@ separate lifecycle and is not deleted by the backup cutoff.
 - Unsupported old input is rejected with `UNSUPPORTED_SCHEMA_VERSION`.
 - Invalid data is rejected with `INVALID_SCHEMA`.
 - Legacy detection does not import or migrate legacy data.
+- Every production overwrite remains blocked until #740 recovery is available.
+- Settings are documented as a separate cross-engine write.
+- Logical resource validation precedes serialized-byte validation.
 - Golden fixtures cover each supported version, current, future, and invalid
   data.
 - The public backup remains a logical JSON-safe contract rather than an

--- a/src/app/composition/optionsBackupV2Export.test.ts
+++ b/src/app/composition/optionsBackupV2Export.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { PersistenceOperationGatePort } from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+import type { IndexedDbConnectionManager } from '@/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbConnectionManager'
+import type { BackupEnvelopeV2 } from '@/features/options/lib/import-export/v2/BackupV2Schema'
+
+import {
+  getOptionsBackupV2ExportRuntime,
+  resetOptionsBackupV2ExportRuntimeForTesting,
+} from './optionsBackupV2Export'
+
+const envelope = {
+  appVersion: '2.0.8',
+  data: {
+    analyticsViews: [],
+    conversations: [],
+    messages: [],
+    savedTabs: {
+      categories: [],
+      collections: [],
+      groups: [],
+      memberships: [],
+      urls: [],
+    },
+    userSettings: {
+      clickBehavior: 'saveSameDomainTabs',
+      confirmDeleteAll: false,
+      confirmDeleteEach: false,
+      enableCategories: true,
+      excludePatterns: [],
+      excludePinnedTabs: true,
+      openAllInNewWindow: false,
+      openUrlInBackground: true,
+      removeTabAfterExternalDrop: false,
+      removeTabAfterOpen: false,
+      showSavedTime: false,
+    },
+  },
+  exportedAt: '2026-07-28T00:00:00.000Z',
+  schemaVersion: 2,
+} satisfies BackupEnvelopeV2
+
+describe('optionsBackupV2Export composition', () => {
+  beforeEach(() => {
+    resetOptionsBackupV2ExportRuntimeForTesting()
+  })
+
+  it('wires one lazy connection and snapshot reader into the V2 exporter', async () => {
+    const close = vi.fn()
+    const connectionManager = {
+      close,
+    } as unknown as IndexedDbConnectionManager
+    const operationGate = {} as PersistenceOperationGatePort
+    const snapshotReader = {
+      readConsistentSnapshot: vi.fn(),
+    }
+    const exportBackupV2 = vi.fn().mockResolvedValue(envelope)
+    const createConnectionManager = vi.fn(() => connectionManager)
+    const createSnapshotReader = vi.fn(() => snapshotReader)
+    const createExportUseCase = vi.fn(() => exportBackupV2)
+    const deps = {
+      createConnectionManager,
+      createExportUseCase,
+      createSnapshotReader,
+      getAppVersion: vi.fn(() => '2.0.8'),
+      getOperationGate: vi.fn(() => operationGate),
+      now: vi.fn(() => new Date('2026-07-28T00:00:00.000Z')),
+      readUserSettings: vi.fn(),
+    }
+
+    const first = getOptionsBackupV2ExportRuntime(deps)
+    const second = getOptionsBackupV2ExportRuntime(deps)
+
+    expect(second).toBe(first)
+    expect(createConnectionManager).toHaveBeenCalledOnce()
+    expect(createSnapshotReader).toHaveBeenCalledWith(
+      connectionManager,
+      operationGate,
+    )
+    expect(createExportUseCase).toHaveBeenCalledWith({
+      getAppVersion: deps.getAppVersion,
+      now: deps.now,
+      readUserSettings: deps.readUserSettings,
+      snapshotReader,
+    })
+    await expect(first.exportBackupV2()).resolves.toBe(envelope)
+    expect(exportBackupV2).toHaveBeenCalledOnce()
+
+    resetOptionsBackupV2ExportRuntimeForTesting()
+    expect(close).toHaveBeenCalledOnce()
+  })
+})

--- a/src/app/composition/optionsBackupV2Export.ts
+++ b/src/app/composition/optionsBackupV2Export.ts
@@ -1,0 +1,85 @@
+import { getAppVersion } from '@/constants/app-version'
+import type { PersistenceOperationGatePort } from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+import { getPersistenceBootstrapRuntime } from '@/contexts/saved-tabs/infrastructure/composition/persistenceBootstrapRuntime'
+import { IndexedDbConnectionManager } from '@/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbConnectionManager'
+import { IndexedDbPersistenceSnapshotReader } from '@/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbPersistenceSnapshotReader'
+import { createExportBackupV2UseCase } from '@/features/options/lib/import-export/v2/ExportBackupV2UseCase'
+import type {
+  ExportBackupV2UseCase,
+  ExportBackupV2UseCaseDeps,
+} from '@/features/options/lib/import-export/v2/ExportBackupV2UseCase'
+import { getUserSettings } from '@/lib/storage/settings'
+
+export type OptionsBackupV2ExportRuntime = {
+  readonly exportBackupV2: ExportBackupV2UseCase
+}
+
+export type OptionsBackupV2ExportRuntimeDeps = {
+  readonly createConnectionManager: () => IndexedDbConnectionManager
+  readonly createExportUseCase: (
+    deps: ExportBackupV2UseCaseDeps,
+  ) => ExportBackupV2UseCase
+  readonly createSnapshotReader: (
+    connectionManager: IndexedDbConnectionManager,
+    operationGate: PersistenceOperationGatePort,
+  ) => ExportBackupV2UseCaseDeps['snapshotReader']
+  readonly getAppVersion: () => string
+  readonly getOperationGate: () => PersistenceOperationGatePort
+  readonly now: () => Date
+  readonly readUserSettings: ExportBackupV2UseCaseDeps['readUserSettings']
+}
+
+type ManagedOptionsBackupV2ExportRuntime = OptionsBackupV2ExportRuntime & {
+  readonly close: () => void
+}
+
+const defaultDeps: OptionsBackupV2ExportRuntimeDeps = {
+  createConnectionManager: () => new IndexedDbConnectionManager(),
+  createExportUseCase: createExportBackupV2UseCase,
+  createSnapshotReader: (connectionManager, operationGate) =>
+    new IndexedDbPersistenceSnapshotReader(connectionManager, operationGate),
+  getAppVersion,
+  getOperationGate: () => getPersistenceBootstrapRuntime().operationGate,
+  now: () => new Date(),
+  readUserSettings: getUserSettings,
+}
+
+const createRuntime = (
+  deps: OptionsBackupV2ExportRuntimeDeps,
+): ManagedOptionsBackupV2ExportRuntime => {
+  const connectionManager = deps.createConnectionManager()
+  const snapshotReader = deps.createSnapshotReader(
+    connectionManager,
+    deps.getOperationGate(),
+  )
+  const exportBackupV2 = deps.createExportUseCase({
+    getAppVersion: deps.getAppVersion,
+    now: deps.now,
+    readUserSettings: deps.readUserSettings,
+    snapshotReader,
+  })
+
+  return {
+    close: () => {
+      connectionManager.close()
+    },
+    exportBackupV2,
+  }
+}
+
+let runtime: ManagedOptionsBackupV2ExportRuntime | undefined
+
+export const getOptionsBackupV2ExportRuntime = (
+  deps: OptionsBackupV2ExportRuntimeDeps = defaultDeps,
+): OptionsBackupV2ExportRuntime => {
+  runtime ??= createRuntime(deps)
+  return runtime
+}
+
+export const exportBackupV2 = async (): ReturnType<ExportBackupV2UseCase> =>
+  getOptionsBackupV2ExportRuntime().exportBackupV2()
+
+export const resetOptionsBackupV2ExportRuntimeForTesting = (): void => {
+  runtime?.close()
+  runtime = undefined
+}

--- a/src/app/composition/optionsLegacyBackupMerge.integration.test.ts
+++ b/src/app/composition/optionsLegacyBackupMerge.integration.test.ts
@@ -7,6 +7,7 @@ import type {
   PersistenceBootstrapPort,
   PersistenceControlStateRepositoryPort,
   PersistenceCoordinationPort,
+  PersistenceOperationGatePort,
   PersistenceRecoveryReporterPort,
 } from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
 import { PersistenceOperationGateService } from '@/contexts/saved-tabs/application/services/PersistenceOperationGateService'
@@ -169,5 +170,50 @@ describe('options legacy Backup merge integration', () => {
     )
     expect(snapshot.savedTabs.collections).toHaveLength(2)
     expect(writeUserSettings).toHaveBeenCalledOnce()
+
+    const duplicateResult = await importSettings(
+      legacyFixture,
+      true,
+      undefined,
+      {
+        importDate: '2026-08-31',
+      },
+    )
+
+    expect(duplicateResult).toEqual({
+      message: 'データをマージしました (0個のカテゴリ、0個のドメインを追加)',
+      success: true,
+    })
+  })
+
+  it('replaces a cached runtime when explicit dependencies are supplied', () => {
+    const firstManager = new IndexedDbConnectionManager({
+      databaseName: 'options-legacy-backup-merge-first',
+      indexedDb: new IDBFactory(),
+    })
+    const secondManager = new IndexedDbConnectionManager({
+      databaseName: 'options-legacy-backup-merge-second',
+      indexedDb: new IDBFactory(),
+    })
+    const operationGate = createIndexedDbGate()
+    const createDeps = (manager: IndexedDbConnectionManager) => ({
+      createConnectionManager: () => manager,
+      createUnitOfWork: (
+        connectionManager: IndexedDbConnectionManager,
+        gate: PersistenceOperationGatePort,
+      ) => new IndexedDbPersistenceUnitOfWork(connectionManager, gate),
+      getOperationGate: () => operationGate,
+      readUserSettings: vi.fn(async () => defaultSettings),
+      writeUserSettings: vi.fn(async () => undefined),
+    })
+
+    const firstRuntime = getOptionsLegacyBackupMergeRuntime(
+      createDeps(firstManager),
+    )
+    const secondRuntime = getOptionsLegacyBackupMergeRuntime(
+      createDeps(secondManager),
+    )
+
+    expect(secondRuntime).not.toBe(firstRuntime)
   })
 })

--- a/src/app/composition/optionsLegacyBackupMerge.integration.test.ts
+++ b/src/app/composition/optionsLegacyBackupMerge.integration.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from 'node:fs'
+
+import { IDBFactory } from 'fake-indexeddb'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  PersistenceBootstrapPort,
+  PersistenceControlStateRepositoryPort,
+  PersistenceCoordinationPort,
+  PersistenceRecoveryReporterPort,
+} from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+import { PersistenceOperationGateService } from '@/contexts/saved-tabs/application/services/PersistenceOperationGateService'
+import { IndexedDbConnectionManager } from '@/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbConnectionManager'
+import { IndexedDbPersistenceSnapshotReader } from '@/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbPersistenceSnapshotReader'
+import { IndexedDbPersistenceUnitOfWork } from '@/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbPersistenceUnitOfWork'
+import { defaultSettings } from '@/lib/storage/settings'
+
+vi.mock('@/lib/storage/migration', () => ({
+  migrateToUrlsStorage: vi.fn(),
+}))
+
+import { importSettings } from '@/features/options/lib/import-export/flows'
+import { migrateToUrlsStorage } from '@/lib/storage/migration'
+
+import {
+  getOptionsLegacyBackupMergeRuntime,
+  resetOptionsLegacyBackupMergeRuntimeForTesting,
+} from './optionsLegacyBackupMerge'
+
+const legacyFixture = readFileSync(
+  new URL(
+    '../../features/options/lib/import-export/v2/fixtures/legacy-tab-group-nested-urls.json',
+    import.meta.url,
+  ),
+  'utf8',
+)
+
+const createIndexedDbGate = () => {
+  const bootstrap: PersistenceBootstrapPort = {
+    migrate: vi.fn(async () => undefined),
+    readState: vi.fn(async () => ({
+      migrationId: 'migration-1',
+      persistenceGeneration: 2 as const,
+      status: 'indexeddb' as const,
+    })),
+    ready: vi.fn(async () => undefined),
+  }
+  const controlStateRepository: PersistenceControlStateRepositoryPort = {
+    read: vi.fn(async () => ({
+      migrationId: 'migration-1',
+      persistenceGeneration: 2 as const,
+      status: 'indexeddb' as const,
+    })),
+    transition: vi.fn(),
+  }
+  const coordination: PersistenceCoordinationPort = {
+    runExclusive: async (operation) => operation(),
+    runShared: async (operation) => operation(),
+  }
+  const recovery: PersistenceRecoveryReporterPort = {
+    reportUnavailable: vi.fn(),
+  }
+  return new PersistenceOperationGateService({
+    bootstrap,
+    controlStateRepository,
+    coordination,
+    recovery,
+  })
+}
+
+describe('options legacy Backup merge integration', () => {
+  afterEach(() => {
+    resetOptionsLegacyBackupMergeRuntimeForTesting()
+    vi.restoreAllMocks()
+  })
+
+  it('merges a supported legacy backup through the IndexedDB route', async () => {
+    const operationGate = createIndexedDbGate()
+    const connectionManager = new IndexedDbConnectionManager({
+      databaseName: 'options-legacy-backup-merge',
+      indexedDb: new IDBFactory(),
+    })
+    const writeUserSettings = vi.fn(async () => undefined)
+    getOptionsLegacyBackupMergeRuntime({
+      createConnectionManager: () => connectionManager,
+      createUnitOfWork: (manager, gate) =>
+        new IndexedDbPersistenceUnitOfWork(manager, gate),
+      getOperationGate: () => operationGate,
+      readUserSettings: vi.fn(async () => defaultSettings),
+      writeUserSettings,
+    })
+    await new IndexedDbPersistenceUnitOfWork(
+      connectionManager,
+      operationGate,
+    ).commit({
+      collections: {
+        put: [
+          {
+            createdAt: 1,
+            definition: {
+              domain: 'existing.example',
+              type: 'domain',
+            },
+            id: 'existing-collection',
+            name: 'existing.example',
+            sortOrder: 1024,
+            updatedAt: 1,
+          },
+        ],
+      },
+      memberships: {
+        put: [
+          {
+            addedAt: 1,
+            collectionId: 'existing-collection',
+            sortOrder: 1024,
+            updatedAt: 1,
+            urlId: 'existing-url',
+          },
+        ],
+      },
+      urls: {
+        put: [
+          {
+            firstSavedAt: 1,
+            id: 'existing-url',
+            lastSavedAt: 1,
+            normalizedUrl: 'https://existing.example/',
+            title: 'Existing',
+            updatedAt: 1,
+            url: 'https://existing.example/',
+          },
+        ],
+      },
+    })
+
+    const result = await importSettings(legacyFixture, true, undefined, {
+      importDate: '2026-08-31',
+    })
+
+    expect(result.success).toBe(true)
+    expect(migrateToUrlsStorage).not.toHaveBeenCalled()
+    const snapshot = await new IndexedDbPersistenceSnapshotReader(
+      connectionManager,
+      operationGate,
+    ).readConsistentSnapshot()
+    expect(snapshot.savedTabs.urls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'existing-url',
+          title: 'Existing',
+        }),
+        expect.objectContaining({
+          title: 'Nested guide',
+          url: 'https://nested.example.com/guide',
+        }),
+      ]),
+    )
+    expect(snapshot.savedTabs.urls).toHaveLength(2)
+    expect(snapshot.savedTabs.collections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'existing-collection',
+        }),
+        expect.objectContaining({
+          id: 'domain-nested',
+        }),
+      ]),
+    )
+    expect(snapshot.savedTabs.collections).toHaveLength(2)
+    expect(writeUserSettings).toHaveBeenCalledOnce()
+  })
+})

--- a/src/app/composition/optionsLegacyBackupMerge.ts
+++ b/src/app/composition/optionsLegacyBackupMerge.ts
@@ -1,0 +1,85 @@
+import type { PersistenceOperationGatePort } from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+import type { PersistenceV2UnitOfWorkPort } from '@/contexts/saved-tabs/application/ports/PersistenceV2UnitOfWorkPort'
+import { checkPersistenceIntegrity } from '@/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker'
+import { getPersistenceBootstrapRuntime } from '@/contexts/saved-tabs/infrastructure/composition/persistenceBootstrapRuntime'
+import { IndexedDbConnectionManager } from '@/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbConnectionManager'
+import { IndexedDbPersistenceUnitOfWork } from '@/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbPersistenceUnitOfWork'
+import { createImportLegacyBackupMergeUseCase } from '@/features/options/lib/import-export/legacy/ImportLegacyBackupMergeUseCase'
+import type {
+  LegacyBackupMergeInput,
+  LegacyBackupMergeResult,
+} from '@/features/options/lib/import-export/legacy/ImportLegacyBackupMergeUseCase'
+import { getUserSettings, saveUserSettings } from '@/lib/storage/settings'
+
+export type OptionsLegacyBackupMergeRuntime = {
+  readonly mergeLegacyBackup: (
+    input: LegacyBackupMergeInput,
+  ) => Promise<LegacyBackupMergeResult>
+}
+
+export type OptionsLegacyBackupMergeRuntimeDeps = {
+  readonly createConnectionManager: () => IndexedDbConnectionManager
+  readonly createUnitOfWork: (
+    connectionManager: IndexedDbConnectionManager,
+    operationGate: PersistenceOperationGatePort,
+  ) => PersistenceV2UnitOfWorkPort
+  readonly getOperationGate: () => PersistenceOperationGatePort
+  readonly readUserSettings: typeof getUserSettings
+  readonly writeUserSettings: typeof saveUserSettings
+}
+
+type ManagedOptionsLegacyBackupMergeRuntime =
+  OptionsLegacyBackupMergeRuntime & {
+    readonly close: () => void
+  }
+
+const defaultDeps: OptionsLegacyBackupMergeRuntimeDeps = {
+  createConnectionManager: () => new IndexedDbConnectionManager(),
+  createUnitOfWork: (connectionManager, operationGate) =>
+    new IndexedDbPersistenceUnitOfWork(connectionManager, operationGate),
+  getOperationGate: () => getPersistenceBootstrapRuntime().operationGate,
+  readUserSettings: getUserSettings,
+  writeUserSettings: saveUserSettings,
+}
+
+const createRuntime = (
+  deps: OptionsLegacyBackupMergeRuntimeDeps,
+): ManagedOptionsLegacyBackupMergeRuntime => {
+  const connectionManager = deps.createConnectionManager()
+  const unitOfWork = deps.createUnitOfWork(
+    connectionManager,
+    deps.getOperationGate(),
+  )
+  const mergeLegacyBackup = createImportLegacyBackupMergeUseCase({
+    commit: unitOfWork.commit.bind(unitOfWork),
+    isHealthySavedTabs: (savedTabs) =>
+      checkPersistenceIntegrity(savedTabs).isHealthy,
+    readUserSettings: deps.readUserSettings,
+    writeUserSettings: deps.writeUserSettings,
+  })
+  return {
+    close: () => {
+      connectionManager.close()
+    },
+    mergeLegacyBackup,
+  }
+}
+
+let runtime: ManagedOptionsLegacyBackupMergeRuntime | undefined
+
+export const getOptionsLegacyBackupMergeRuntime = (
+  deps: OptionsLegacyBackupMergeRuntimeDeps = defaultDeps,
+): OptionsLegacyBackupMergeRuntime => {
+  runtime ??= createRuntime(deps)
+  return runtime
+}
+
+export const mergeLegacyBackupIntoIndexedDb = async (
+  input: LegacyBackupMergeInput,
+): Promise<LegacyBackupMergeResult> =>
+  getOptionsLegacyBackupMergeRuntime().mergeLegacyBackup(input)
+
+export const resetOptionsLegacyBackupMergeRuntimeForTesting = (): void => {
+  runtime?.close()
+  runtime = undefined
+}

--- a/src/app/composition/optionsLegacyBackupMerge.ts
+++ b/src/app/composition/optionsLegacyBackupMerge.ts
@@ -3,6 +3,7 @@ import type { PersistenceV2UnitOfWorkPort } from '@/contexts/saved-tabs/applicat
 import { checkPersistenceIntegrity } from '@/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker'
 import { getPersistenceBootstrapRuntime } from '@/contexts/saved-tabs/infrastructure/composition/persistenceBootstrapRuntime'
 import { IndexedDbConnectionManager } from '@/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbConnectionManager'
+import { IndexedDbPersistenceSnapshotReader } from '@/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbPersistenceSnapshotReader'
 import { IndexedDbPersistenceUnitOfWork } from '@/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbPersistenceUnitOfWork'
 import { createImportLegacyBackupMergeUseCase } from '@/features/options/lib/import-export/legacy/ImportLegacyBackupMergeUseCase'
 import type {
@@ -46,14 +47,17 @@ const createRuntime = (
   deps: OptionsLegacyBackupMergeRuntimeDeps,
 ): ManagedOptionsLegacyBackupMergeRuntime => {
   const connectionManager = deps.createConnectionManager()
-  const unitOfWork = deps.createUnitOfWork(
+  const operationGate = deps.getOperationGate()
+  const unitOfWork = deps.createUnitOfWork(connectionManager, operationGate)
+  const snapshotReader = new IndexedDbPersistenceSnapshotReader(
     connectionManager,
-    deps.getOperationGate(),
+    operationGate,
   )
   const mergeLegacyBackup = createImportLegacyBackupMergeUseCase({
     commit: unitOfWork.commit.bind(unitOfWork),
     isHealthySavedTabs: (savedTabs) =>
       checkPersistenceIntegrity(savedTabs).isHealthy,
+    readSnapshot: snapshotReader.readConsistentSnapshot.bind(snapshotReader),
     readUserSettings: deps.readUserSettings,
     writeUserSettings: deps.writeUserSettings,
   })
@@ -68,9 +72,14 @@ const createRuntime = (
 let runtime: ManagedOptionsLegacyBackupMergeRuntime | undefined
 
 export const getOptionsLegacyBackupMergeRuntime = (
-  deps: OptionsLegacyBackupMergeRuntimeDeps = defaultDeps,
+  deps?: OptionsLegacyBackupMergeRuntimeDeps,
 ): OptionsLegacyBackupMergeRuntime => {
-  runtime ??= createRuntime(deps)
+  if (deps !== undefined) {
+    runtime?.close()
+    runtime = createRuntime(deps)
+    return runtime
+  }
+  runtime ??= createRuntime(defaultDeps)
   return runtime
 }
 

--- a/src/contexts/saved-tabs/application/ports/PersistenceV2ReplacementPort.ts
+++ b/src/contexts/saved-tabs/application/ports/PersistenceV2ReplacementPort.ts
@@ -1,0 +1,35 @@
+import type { PersistenceV2Snapshot } from '@/contexts/saved-tabs/domain/entities/PersistenceModelV2'
+
+import type {
+  PersistenceJsonRecord,
+  PersistenceMessageRecord,
+} from './PersistenceV2UnitOfWorkPort'
+
+export type PersistenceV2ReplacementTarget = {
+  readonly analyticsViews: readonly PersistenceJsonRecord[]
+  readonly conversations: readonly PersistenceJsonRecord[]
+  readonly messages: readonly PersistenceMessageRecord[]
+  readonly savedTabs: PersistenceV2Snapshot
+}
+
+export type PersistenceV2ReplacementResult = {
+  readonly revision: number
+}
+
+export type PersistenceV2ReplacementErrorCode =
+  | 'DUPLICATE_ANALYTICS_VIEW_ID'
+  | 'DUPLICATE_CONVERSATION_ID'
+  | 'DUPLICATE_MESSAGE_ID'
+  | 'INVALID_STORED_REVISION'
+  | 'INVALID_TARGET_RECORD'
+  | 'ORPHAN_MESSAGE_CONVERSATION'
+  | 'REVISION_NOT_COMMITTED'
+  | 'REVISION_OVERFLOW'
+  | 'TRANSACTION_FAILED'
+  | 'UNHEALTHY_SAVED_TABS'
+
+export type PersistenceV2ReplacementPort = {
+  readonly replaceAll: (
+    target: PersistenceV2ReplacementTarget,
+  ) => Promise<PersistenceV2ReplacementResult>
+}

--- a/src/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbPersistenceReplacementAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbPersistenceReplacementAdapter.test.ts
@@ -1,0 +1,470 @@
+import { IDBFactory, IDBObjectStore } from 'fake-indexeddb'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { PersistenceOperationGatePort } from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+import type { PersistenceV2ReplacementTarget } from '@/contexts/saved-tabs/application/ports/PersistenceV2ReplacementPort'
+import { createReadyPersistenceOperationGateStub } from '@/contexts/saved-tabs/application/testing/PersistenceOperationGateStub'
+
+import { IndexedDbConnectionManager } from './IndexedDbConnectionManager'
+import {
+  IndexedDbPersistenceReplacementAdapter,
+  PersistenceV2ReplacementError,
+} from './IndexedDbPersistenceReplacementAdapter'
+import { IndexedDbPersistenceSnapshotReader } from './IndexedDbPersistenceSnapshotReader'
+import { queueIndexedDbTransaction } from './IndexedDbTransaction'
+import { PERSISTENCE_STORE_NAMES } from './persistenceDatabaseSchema'
+
+const LOGICAL_STORE_NAMES = [
+  PERSISTENCE_STORE_NAMES.analyticsViews,
+  PERSISTENCE_STORE_NAMES.categories,
+  PERSISTENCE_STORE_NAMES.collections,
+  PERSISTENCE_STORE_NAMES.conversations,
+  PERSISTENCE_STORE_NAMES.groups,
+  PERSISTENCE_STORE_NAMES.memberships,
+  PERSISTENCE_STORE_NAMES.messages,
+  PERSISTENCE_STORE_NAMES.urls,
+] as const
+
+const createOperationGateSpy = () => {
+  const runIndexedDbWrite = vi.fn()
+  const operationGate: PersistenceOperationGatePort = {
+    ...createReadyPersistenceOperationGateStub(),
+    runIndexedDbWrite: async <Result>(
+      operation: () => Promise<Result>,
+    ): Promise<Result> => {
+      runIndexedDbWrite()
+      return operation()
+    },
+  }
+
+  return { operationGate, runIndexedDbWrite }
+}
+
+const createTarget = (
+  suffix: string,
+  messageValue: Readonly<Record<string, string>> = { text: suffix },
+): PersistenceV2ReplacementTarget => {
+  const collectionId = `collection-${suffix}`
+  const conversationId = `conversation-${suffix}`
+  const groupId = `group-${suffix}`
+  const urlId = `url-${suffix}`
+
+  return {
+    analyticsViews: [
+      {
+        id: `analytics-${suffix}`,
+        updatedAt: 1,
+        value: { title: suffix },
+      },
+    ],
+    conversations: [
+      {
+        id: conversationId,
+        updatedAt: 1,
+        value: { title: suffix },
+      },
+    ],
+    messages: [
+      {
+        conversationId,
+        createdAt: 1,
+        id: `message-${suffix}`,
+        value: messageValue,
+      },
+    ],
+    savedTabs: {
+      categories: [
+        {
+          collectionId,
+          createdAt: 1,
+          id: `category-${suffix}`,
+          keywords: [suffix],
+          name: suffix,
+          sortOrder: 1024,
+          updatedAt: 1,
+        },
+      ],
+      collections: [
+        {
+          createdAt: 1,
+          definition: {
+            projectKeywords: {
+              domainKeywords: [suffix],
+              titleKeywords: [],
+              urlKeywords: [],
+            },
+            type: 'custom',
+          },
+          groupId,
+          id: collectionId,
+          name: suffix,
+          sortOrder: 1024,
+          updatedAt: 1,
+        },
+      ],
+      groups: [
+        {
+          createdAt: 1,
+          id: groupId,
+          name: suffix,
+          sortOrder: 1024,
+          updatedAt: 1,
+        },
+      ],
+      memberships: [
+        {
+          addedAt: 1,
+          categoryId: `category-${suffix}`,
+          collectionId,
+          notes: suffix,
+          sortOrder: 1024,
+          updatedAt: 1,
+          urlId,
+        },
+      ],
+      urls: [
+        {
+          firstSavedAt: 1,
+          id: urlId,
+          lastSavedAt: 1,
+          normalizedUrl: `https://${suffix}.example.com/`,
+          title: suffix,
+          updatedAt: 1,
+          url: `https://${suffix}.example.com/`,
+        },
+      ],
+    },
+  }
+}
+
+const seedDatabase = async (
+  manager: IndexedDbConnectionManager,
+  target: PersistenceV2ReplacementTarget,
+  revision = 7,
+): Promise<IDBDatabase> => {
+  const database = await manager.open()
+  await queueIndexedDbTransaction(
+    {
+      database,
+      mode: 'readwrite',
+      storeNames: [
+        ...LOGICAL_STORE_NAMES,
+        PERSISTENCE_STORE_NAMES.metadata,
+        PERSISTENCE_STORE_NAMES.recoverySnapshots,
+      ],
+    },
+    (transaction) => {
+      for (const value of target.analyticsViews) {
+        transaction
+          .objectStore(PERSISTENCE_STORE_NAMES.analyticsViews)
+          .put(value)
+      }
+      for (const value of target.savedTabs.categories) {
+        transaction.objectStore(PERSISTENCE_STORE_NAMES.categories).put(value)
+      }
+      for (const value of target.savedTabs.collections) {
+        transaction.objectStore(PERSISTENCE_STORE_NAMES.collections).put(value)
+      }
+      for (const value of target.conversations) {
+        transaction
+          .objectStore(PERSISTENCE_STORE_NAMES.conversations)
+          .put(value)
+      }
+      for (const value of target.savedTabs.groups) {
+        transaction.objectStore(PERSISTENCE_STORE_NAMES.groups).put(value)
+      }
+      for (const value of target.savedTabs.memberships) {
+        transaction.objectStore(PERSISTENCE_STORE_NAMES.memberships).put(value)
+      }
+      for (const value of target.messages) {
+        transaction.objectStore(PERSISTENCE_STORE_NAMES.messages).put(value)
+      }
+      for (const value of target.savedTabs.urls) {
+        transaction.objectStore(PERSISTENCE_STORE_NAMES.urls).put(value)
+      }
+      transaction
+        .objectStore(PERSISTENCE_STORE_NAMES.metadata)
+        .put({ key: 'revision', value: revision })
+      transaction
+        .objectStore(PERSISTENCE_STORE_NAMES.metadata)
+        .put({ key: 'migration-state', value: 'preserve' })
+      transaction.objectStore(PERSISTENCE_STORE_NAMES.recoverySnapshots).put({
+        createdAt: 1,
+        expiresAt: 2,
+        id: 'recovery-1',
+        value: { revision },
+      })
+    },
+  )
+
+  return database
+}
+
+const readRecord = async (
+  database: IDBDatabase,
+  storeName: (typeof PERSISTENCE_STORE_NAMES)[keyof typeof PERSISTENCE_STORE_NAMES],
+  key: IDBValidKey,
+): Promise<unknown> => {
+  const transaction = database.transaction(storeName, 'readonly')
+  const request = transaction.objectStore(storeName).get(key)
+  const result = await new Promise<unknown>((resolve, reject) => {
+    request.addEventListener('error', () => {
+      reject(request.error ?? new Error('IndexedDB read failed.'))
+    })
+    request.addEventListener('success', () => {
+      resolve(request.result as unknown)
+    })
+  })
+
+  return result
+}
+
+describe('IndexedDbPersistenceReplacementAdapter', () => {
+  it('8 logical storeを1 strict transactionで全置換しrevisionだけ更新する', async () => {
+    const { operationGate, runIndexedDbWrite } = createOperationGateSpy()
+    const manager = new IndexedDbConnectionManager({
+      databaseName: 'backup-replacement-success',
+      indexedDb: new IDBFactory(),
+    })
+    const oldTarget = createTarget('old')
+    const nextTarget = createTarget('next')
+    const database = await seedDatabase(manager, oldTarget)
+    const transactionSpy = vi.spyOn(database, 'transaction')
+    const clearSpy = vi.spyOn(IDBObjectStore.prototype, 'clear')
+
+    const result = await new IndexedDbPersistenceReplacementAdapter(
+      manager,
+      operationGate,
+    ).replaceAll(nextTarget)
+
+    expect(result).toEqual({ revision: 8 })
+    expect(runIndexedDbWrite).toHaveBeenCalledOnce()
+    expect(transactionSpy).toHaveBeenCalledOnce()
+    expect(transactionSpy).toHaveBeenCalledWith(
+      [...LOGICAL_STORE_NAMES, PERSISTENCE_STORE_NAMES.metadata],
+      'readwrite',
+      { durability: 'strict' },
+    )
+    expect(
+      clearSpy.mock.contexts
+        .map((store) => (store as IDBObjectStore).name)
+        .toSorted((left, right) => left.localeCompare(right)),
+    ).toEqual(
+      [...LOGICAL_STORE_NAMES].toSorted((left, right) =>
+        left.localeCompare(right),
+      ),
+    )
+
+    const snapshot = await new IndexedDbPersistenceSnapshotReader(
+      manager,
+      operationGate,
+    ).readConsistentSnapshot()
+    expect(snapshot).toEqual({ ...nextTarget, revision: 8 })
+    await expect(
+      readRecord(
+        database,
+        PERSISTENCE_STORE_NAMES.recoverySnapshots,
+        'recovery-1',
+      ),
+    ).resolves.toMatchObject({ id: 'recovery-1' })
+    await expect(
+      readRecord(database, PERSISTENCE_STORE_NAMES.metadata, 'migration-state'),
+    ).resolves.toEqual({ key: 'migration-state', value: 'preserve' })
+
+    clearSpy.mockRestore()
+    transactionSpy.mockRestore()
+    manager.close()
+  })
+
+  it('途中のsynchronous request queue failureで全storeとrevisionをrollbackする', async () => {
+    const operationGate = createReadyPersistenceOperationGateStub()
+    const manager = new IndexedDbConnectionManager({
+      databaseName: 'backup-replacement-rollback',
+      indexedDb: new IDBFactory(),
+    })
+    const oldTarget = createTarget('old')
+    const secret = 'top-secret-message-content'
+    const nextTarget = createTarget('next', { text: secret })
+    await seedDatabase(manager, oldTarget)
+    const originalPut = IDBObjectStore.prototype.put
+    const putSpy = vi
+      .spyOn(IDBObjectStore.prototype, 'put')
+      .mockImplementation(
+        function putWithInjectedFailure(this: IDBObjectStore, value, key) {
+          if (
+            this.name === PERSISTENCE_STORE_NAMES.messages &&
+            typeof value === 'object' &&
+            value !== null &&
+            'id' in value &&
+            value.id === 'message-next'
+          ) {
+            throw new Error(secret)
+          }
+          return key === undefined
+            ? originalPut.call(this, value)
+            : originalPut.call(this, value, key)
+        },
+      )
+
+    const error = await new IndexedDbPersistenceReplacementAdapter(
+      manager,
+      operationGate,
+    )
+      .replaceAll(nextTarget)
+      .catch((error: unknown) => error)
+
+    expect(error).toBeInstanceOf(PersistenceV2ReplacementError)
+    expect(error).toMatchObject({ code: 'TRANSACTION_FAILED' })
+    expect(String(error)).not.toContain(secret)
+    expect(JSON.stringify(error)).not.toContain(secret)
+    putSpy.mockRestore()
+
+    const snapshot = await new IndexedDbPersistenceSnapshotReader(
+      manager,
+      operationGate,
+    ).readConsistentSnapshot()
+    expect(snapshot).toEqual({ ...oldTarget, revision: 7 })
+    manager.close()
+  })
+
+  it('invalid targetをoperation gateとconnection openより前にcontent-free codeでrejectする', async () => {
+    const { operationGate, runIndexedDbWrite } = createOperationGateSpy()
+    const manager = new IndexedDbConnectionManager({
+      databaseName: 'backup-replacement-invalid-target',
+      indexedDb: new IDBFactory(),
+    })
+    const openSpy = vi.spyOn(manager, 'open')
+    const target = createTarget('invalid')
+    const secret = 'private-invalid-record'
+    const invalidTarget = {
+      ...target,
+      conversations: [
+        {
+          id: `conversation-${secret}`,
+          updatedAt: -1,
+          value: { text: secret },
+        },
+      ],
+    }
+
+    const adapter = new IndexedDbPersistenceReplacementAdapter(
+      manager,
+      operationGate,
+    )
+    const error = await Reflect.apply(adapter.replaceAll, adapter, [
+      invalidTarget,
+    ]).catch((error: unknown) => error)
+
+    expect(error).toBeInstanceOf(PersistenceV2ReplacementError)
+    expect(error).toMatchObject({ code: 'INVALID_TARGET_RECORD' })
+    expect(String(error)).not.toContain(secret)
+    expect(JSON.stringify(error)).not.toContain(secret)
+    expect(runIndexedDbWrite).not.toHaveBeenCalled()
+    expect(openSpy).not.toHaveBeenCalled()
+    manager.close()
+  })
+
+  it.each([
+    {
+      code: 'DUPLICATE_ANALYTICS_VIEW_ID',
+      mutate: (target: PersistenceV2ReplacementTarget) => ({
+        ...target,
+        analyticsViews: [...target.analyticsViews, target.analyticsViews[0]],
+      }),
+    },
+    {
+      code: 'DUPLICATE_CONVERSATION_ID',
+      mutate: (target: PersistenceV2ReplacementTarget) => ({
+        ...target,
+        conversations: [...target.conversations, target.conversations[0]],
+      }),
+    },
+    {
+      code: 'DUPLICATE_MESSAGE_ID',
+      mutate: (target: PersistenceV2ReplacementTarget) => ({
+        ...target,
+        messages: [...target.messages, target.messages[0]],
+      }),
+    },
+    {
+      code: 'ORPHAN_MESSAGE_CONVERSATION',
+      mutate: (target: PersistenceV2ReplacementTarget) => ({
+        ...target,
+        messages: [
+          {
+            ...target.messages[0],
+            conversationId: 'missing-private-conversation',
+          },
+        ],
+      }),
+    },
+  ])('$codeをtransaction前にrejectする', async ({ code, mutate }) => {
+    const { operationGate, runIndexedDbWrite } = createOperationGateSpy()
+    const manager = new IndexedDbConnectionManager({
+      databaseName: `backup-replacement-${code}`,
+      indexedDb: new IDBFactory(),
+    })
+    const adapter = new IndexedDbPersistenceReplacementAdapter(
+      manager,
+      operationGate,
+    )
+
+    await expect(
+      adapter.replaceAll(mutate(createTarget('next'))),
+    ).rejects.toMatchObject({ code })
+    expect(runIndexedDbWrite).not.toHaveBeenCalled()
+    manager.close()
+  })
+
+  it('unhealthy saved-tabs graphをtransaction前にrejectする', async () => {
+    const { operationGate, runIndexedDbWrite } = createOperationGateSpy()
+    const manager = new IndexedDbConnectionManager({
+      databaseName: 'backup-replacement-unhealthy',
+      indexedDb: new IDBFactory(),
+    })
+    const target = createTarget('unhealthy')
+    const adapter = new IndexedDbPersistenceReplacementAdapter(
+      manager,
+      operationGate,
+    )
+
+    await expect(
+      adapter.replaceAll({
+        ...target,
+        savedTabs: {
+          ...target.savedTabs,
+          memberships: [],
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'UNHEALTHY_SAVED_TABS' })
+    expect(runIndexedDbWrite).not.toHaveBeenCalled()
+    manager.close()
+  })
+
+  it('unsafe revision overflowをabortしrevisionを変更しない', async () => {
+    const operationGate = createReadyPersistenceOperationGateStub()
+    const manager = new IndexedDbConnectionManager({
+      databaseName: 'backup-replacement-revision-overflow',
+      indexedDb: new IDBFactory(),
+    })
+    const oldTarget = createTarget('old')
+    await seedDatabase(manager, oldTarget, Number.MAX_SAFE_INTEGER)
+
+    await expect(
+      new IndexedDbPersistenceReplacementAdapter(
+        manager,
+        operationGate,
+      ).replaceAll(createTarget('next')),
+    ).rejects.toMatchObject({ code: 'REVISION_OVERFLOW' })
+
+    const snapshot = await new IndexedDbPersistenceSnapshotReader(
+      manager,
+      operationGate,
+    ).readConsistentSnapshot()
+    expect(snapshot).toEqual({
+      ...oldTarget,
+      revision: Number.MAX_SAFE_INTEGER,
+    })
+    manager.close()
+  })
+})

--- a/src/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbPersistenceReplacementAdapter.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbPersistenceReplacementAdapter.test.ts
@@ -1,5 +1,5 @@
 import { IDBFactory, IDBObjectStore } from 'fake-indexeddb'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { PersistenceOperationGatePort } from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
 import type { PersistenceV2ReplacementTarget } from '@/contexts/saved-tabs/application/ports/PersistenceV2ReplacementPort'
@@ -218,6 +218,10 @@ const readRecord = async (
 
   return result
 }
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 describe('IndexedDbPersistenceReplacementAdapter', () => {
   it('8 logical storeを1 strict transactionで全置換しrevisionだけ更新する', async () => {

--- a/src/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbPersistenceReplacementAdapter.ts
+++ b/src/contexts/saved-tabs/infrastructure/persistence/indexed-db/IndexedDbPersistenceReplacementAdapter.ts
@@ -1,0 +1,309 @@
+import type { PersistenceOperationGatePort } from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+import type {
+  PersistenceV2ReplacementErrorCode,
+  PersistenceV2ReplacementPort,
+  PersistenceV2ReplacementResult,
+  PersistenceV2ReplacementTarget,
+} from '@/contexts/saved-tabs/application/ports/PersistenceV2ReplacementPort'
+import { checkPersistenceIntegrity } from '@/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker'
+
+import type { IndexedDbConnectionManager } from './IndexedDbConnectionManager'
+import { queueIndexedDbTransaction } from './IndexedDbTransaction'
+import { PERSISTENCE_STORE_NAMES } from './persistenceDatabaseSchema'
+import {
+  decodePersistenceRecords,
+  isPersistenceJsonRecord,
+  isPersistenceMessageRecord,
+  isPersistenceV2Category,
+  isPersistenceV2Collection,
+  isPersistenceV2Group,
+  isPersistenceV2Membership,
+  isPersistenceV2Url,
+  readIndexedDbRequestResult,
+} from './PersistenceRecordDecoders'
+import { decodePersistenceRevision } from './PersistenceRevision'
+
+const LOGICAL_STORE_NAMES = [
+  PERSISTENCE_STORE_NAMES.analyticsViews,
+  PERSISTENCE_STORE_NAMES.categories,
+  PERSISTENCE_STORE_NAMES.collections,
+  PERSISTENCE_STORE_NAMES.conversations,
+  PERSISTENCE_STORE_NAMES.groups,
+  PERSISTENCE_STORE_NAMES.memberships,
+  PERSISTENCE_STORE_NAMES.messages,
+  PERSISTENCE_STORE_NAMES.urls,
+] as const
+
+const REPLACEMENT_ERROR_MESSAGES = {
+  DUPLICATE_ANALYTICS_VIEW_ID:
+    'Backup replacement contains duplicate analytics identifiers.',
+  DUPLICATE_CONVERSATION_ID:
+    'Backup replacement contains duplicate conversation identifiers.',
+  DUPLICATE_MESSAGE_ID:
+    'Backup replacement contains duplicate message identifiers.',
+  INVALID_STORED_REVISION:
+    'Persistence revision cannot be used for Backup replacement.',
+  INVALID_TARGET_RECORD:
+    'Backup replacement contains an invalid persistence record.',
+  ORPHAN_MESSAGE_CONVERSATION:
+    'Backup replacement contains an invalid message relation.',
+  REVISION_NOT_COMMITTED: 'Backup replacement revision was not committed.',
+  REVISION_OVERFLOW: 'Persistence revision cannot be incremented safely.',
+  TRANSACTION_FAILED: 'Backup replacement transaction failed.',
+  UNHEALTHY_SAVED_TABS:
+    'Backup replacement contains an unhealthy Saved Tabs graph.',
+} as const satisfies Readonly<Record<PersistenceV2ReplacementErrorCode, string>>
+
+export class PersistenceV2ReplacementError extends Error {
+  readonly code: PersistenceV2ReplacementErrorCode
+
+  constructor(code: PersistenceV2ReplacementErrorCode) {
+    super(REPLACEMENT_ERROR_MESSAGES[code])
+    this.code = code
+    this.name = 'PersistenceV2ReplacementError'
+  }
+}
+
+type UnknownRecord = Readonly<Record<string, unknown>>
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isTimestamp = (value: number): boolean =>
+  Number.isSafeInteger(value) && value >= 0
+
+const hasDuplicateId = (
+  records: readonly { readonly id: string }[],
+): boolean => {
+  const ids = new Set<string>()
+  for (const { id } of records) {
+    if (ids.has(id)) {
+      return true
+    }
+    ids.add(id)
+  }
+  return false
+}
+
+const decodeReplacementTarget = (
+  value: unknown,
+): PersistenceV2ReplacementTarget => {
+  if (!isRecord(value) || !isRecord(value.savedTabs)) {
+    throw new PersistenceV2ReplacementError('INVALID_TARGET_RECORD')
+  }
+
+  try {
+    return {
+      analyticsViews: decodePersistenceRecords(
+        value.analyticsViews,
+        isPersistenceJsonRecord,
+        PERSISTENCE_STORE_NAMES.analyticsViews,
+      ),
+      conversations: decodePersistenceRecords(
+        value.conversations,
+        isPersistenceJsonRecord,
+        PERSISTENCE_STORE_NAMES.conversations,
+      ),
+      messages: decodePersistenceRecords(
+        value.messages,
+        isPersistenceMessageRecord,
+        PERSISTENCE_STORE_NAMES.messages,
+      ),
+      savedTabs: {
+        categories: decodePersistenceRecords(
+          value.savedTabs.categories,
+          isPersistenceV2Category,
+          PERSISTENCE_STORE_NAMES.categories,
+        ),
+        collections: decodePersistenceRecords(
+          value.savedTabs.collections,
+          isPersistenceV2Collection,
+          PERSISTENCE_STORE_NAMES.collections,
+        ),
+        groups: decodePersistenceRecords(
+          value.savedTabs.groups,
+          isPersistenceV2Group,
+          PERSISTENCE_STORE_NAMES.groups,
+        ),
+        memberships: decodePersistenceRecords(
+          value.savedTabs.memberships,
+          isPersistenceV2Membership,
+          PERSISTENCE_STORE_NAMES.memberships,
+        ),
+        urls: decodePersistenceRecords(
+          value.savedTabs.urls,
+          isPersistenceV2Url,
+          PERSISTENCE_STORE_NAMES.urls,
+        ),
+      },
+    }
+  } catch {
+    throw new PersistenceV2ReplacementError('INVALID_TARGET_RECORD')
+  }
+}
+
+const hasValidTimestamps = (target: PersistenceV2ReplacementTarget): boolean =>
+  target.analyticsViews.every(({ updatedAt }) => isTimestamp(updatedAt)) &&
+  target.conversations.every(({ updatedAt }) => isTimestamp(updatedAt)) &&
+  target.messages.every(({ createdAt }) => isTimestamp(createdAt)) &&
+  target.savedTabs.categories.every(
+    ({ createdAt, updatedAt }) =>
+      isTimestamp(createdAt) && isTimestamp(updatedAt),
+  ) &&
+  target.savedTabs.collections.every(
+    ({ createdAt, updatedAt }) =>
+      isTimestamp(createdAt) && isTimestamp(updatedAt),
+  ) &&
+  target.savedTabs.groups.every(
+    ({ createdAt, updatedAt }) =>
+      isTimestamp(createdAt) && isTimestamp(updatedAt),
+  ) &&
+  target.savedTabs.memberships.every(
+    ({ addedAt, updatedAt }) => isTimestamp(addedAt) && isTimestamp(updatedAt),
+  ) &&
+  target.savedTabs.urls.every(
+    ({ firstSavedAt, lastSavedAt, updatedAt }) =>
+      isTimestamp(firstSavedAt) &&
+      isTimestamp(lastSavedAt) &&
+      isTimestamp(updatedAt),
+  )
+
+const validateReplacementTarget = (
+  value: unknown,
+): PersistenceV2ReplacementTarget => {
+  const target = decodeReplacementTarget(value)
+  if (!hasValidTimestamps(target)) {
+    throw new PersistenceV2ReplacementError('INVALID_TARGET_RECORD')
+  }
+
+  if (!checkPersistenceIntegrity(target.savedTabs).isHealthy) {
+    throw new PersistenceV2ReplacementError('UNHEALTHY_SAVED_TABS')
+  }
+  if (hasDuplicateId(target.analyticsViews)) {
+    throw new PersistenceV2ReplacementError('DUPLICATE_ANALYTICS_VIEW_ID')
+  }
+  if (hasDuplicateId(target.conversations)) {
+    throw new PersistenceV2ReplacementError('DUPLICATE_CONVERSATION_ID')
+  }
+  if (hasDuplicateId(target.messages)) {
+    throw new PersistenceV2ReplacementError('DUPLICATE_MESSAGE_ID')
+  }
+
+  const conversationIds = new Set(target.conversations.map(({ id }) => id))
+  if (
+    target.messages.some(
+      ({ conversationId }) => !conversationIds.has(conversationId),
+    )
+  ) {
+    throw new PersistenceV2ReplacementError('ORPHAN_MESSAGE_CONVERSATION')
+  }
+
+  return target
+}
+
+const recordsByStore = (target: PersistenceV2ReplacementTarget) =>
+  [
+    [PERSISTENCE_STORE_NAMES.analyticsViews, target.analyticsViews],
+    [PERSISTENCE_STORE_NAMES.categories, target.savedTabs.categories],
+    [PERSISTENCE_STORE_NAMES.collections, target.savedTabs.collections],
+    [PERSISTENCE_STORE_NAMES.conversations, target.conversations],
+    [PERSISTENCE_STORE_NAMES.groups, target.savedTabs.groups],
+    [PERSISTENCE_STORE_NAMES.memberships, target.savedTabs.memberships],
+    [PERSISTENCE_STORE_NAMES.messages, target.messages],
+    [PERSISTENCE_STORE_NAMES.urls, target.savedTabs.urls],
+  ] as const
+
+export class IndexedDbPersistenceReplacementAdapter implements PersistenceV2ReplacementPort {
+  private readonly connectionManager: IndexedDbConnectionManager
+  private readonly operationGate: PersistenceOperationGatePort
+
+  constructor(
+    connectionManager: IndexedDbConnectionManager,
+    operationGate: PersistenceOperationGatePort,
+  ) {
+    this.connectionManager = connectionManager
+    this.operationGate = operationGate
+  }
+
+  async replaceAll(
+    input: PersistenceV2ReplacementTarget,
+  ): Promise<PersistenceV2ReplacementResult> {
+    const target = validateReplacementTarget(input)
+
+    return this.operationGate.runIndexedDbWrite(async () => {
+      const database = await this.connectionManager.open()
+      let committedRevision: number | undefined
+      let transactionError: PersistenceV2ReplacementError | undefined
+
+      try {
+        await queueIndexedDbTransaction(
+          {
+            database,
+            durability: 'strict',
+            mode: 'readwrite',
+            storeNames: [
+              ...LOGICAL_STORE_NAMES,
+              PERSISTENCE_STORE_NAMES.metadata,
+            ],
+          },
+          (transaction) => {
+            const metadata = transaction.objectStore(
+              PERSISTENCE_STORE_NAMES.metadata,
+            )
+            const revisionRequest = metadata.get('revision')
+            revisionRequest.addEventListener('success', () => {
+              try {
+                let currentRevision: number
+                try {
+                  currentRevision = decodePersistenceRevision(
+                    readIndexedDbRequestResult(revisionRequest),
+                  )
+                } catch {
+                  throw new PersistenceV2ReplacementError(
+                    'INVALID_STORED_REVISION',
+                  )
+                }
+                if (currentRevision === Number.MAX_SAFE_INTEGER) {
+                  throw new PersistenceV2ReplacementError('REVISION_OVERFLOW')
+                }
+
+                for (const [storeName] of recordsByStore(target)) {
+                  transaction.objectStore(storeName).clear()
+                }
+                for (const [storeName, records] of recordsByStore(target)) {
+                  const store = transaction.objectStore(storeName)
+                  for (const record of records) {
+                    store.put(record)
+                  }
+                }
+
+                committedRevision = currentRevision + 1
+                metadata.put({
+                  key: 'revision',
+                  value: committedRevision,
+                })
+              } catch (error) {
+                transactionError =
+                  error instanceof PersistenceV2ReplacementError
+                    ? error
+                    : new PersistenceV2ReplacementError('TRANSACTION_FAILED')
+                transaction.abort()
+              }
+            })
+          },
+        )
+      } catch {
+        throw (
+          transactionError ??
+          new PersistenceV2ReplacementError('TRANSACTION_FAILED')
+        )
+      }
+
+      if (committedRevision === undefined) {
+        throw new PersistenceV2ReplacementError('REVISION_NOT_COMMITTED')
+      }
+
+      return { revision: committedRevision }
+    })
+  }
+}

--- a/src/contexts/saved-tabs/public-api.test.ts
+++ b/src/contexts/saved-tabs/public-api.test.ts
@@ -4,6 +4,7 @@ import { createHealthyPersistenceV2Snapshot } from './domain/testing/persistence
 import {
   checkPersistenceIntegrity,
   createStorageRepairPlan,
+  mapLegacyStorageToPersistenceV2,
 } from './public-api'
 
 describe('saved-tabs public persistence integrity API', () => {
@@ -18,5 +19,6 @@ describe('saved-tabs public persistence integrity API', () => {
       operations: [],
       unresolvedIssues: [],
     })
+    expect(mapLegacyStorageToPersistenceV2).toBeTypeOf('function')
   })
 })

--- a/src/contexts/saved-tabs/public-api.ts
+++ b/src/contexts/saved-tabs/public-api.ts
@@ -22,6 +22,12 @@ export type {
 } from './application/ports/RawLegacyStorageReaderPort'
 export type { PersistenceLogicalSnapshot } from './application/ports/PersistenceV2SnapshotReaderPort'
 export type {
+  PersistenceV2ReplacementErrorCode,
+  PersistenceV2ReplacementPort,
+  PersistenceV2ReplacementResult,
+  PersistenceV2ReplacementTarget,
+} from './application/ports/PersistenceV2ReplacementPort'
+export type {
   PersistenceJsonRecord,
   PersistenceMessageRecord,
 } from './application/ports/PersistenceV2UnitOfWorkPort'

--- a/src/contexts/saved-tabs/public-api.ts
+++ b/src/contexts/saved-tabs/public-api.ts
@@ -14,6 +14,18 @@
 
 export { normalizeDomainString } from './domain/value-objects/DomainName'
 
+export { mapLegacyStorageToPersistenceV2 } from './application/mappers/LegacyStorageToPersistenceV2Mapper'
+export type { LegacyMigrationIssueCode } from './application/mappers/LegacyStorageToPersistenceV2Mapper'
+export type {
+  RawLegacyStorageSnapshot,
+  RawLegacyStorageValue,
+} from './application/ports/RawLegacyStorageReaderPort'
+export type { PersistenceLogicalSnapshot } from './application/ports/PersistenceV2SnapshotReaderPort'
+export type {
+  PersistenceJsonRecord,
+  PersistenceMessageRecord,
+} from './application/ports/PersistenceV2UnitOfWorkPort'
+
 // issue #639: settings defaults を public API 経由で提供する
 export { savedTabsActionSettingsDefaults } from './domain/services/SavedTabsActionSettingsPolicy'
 export {

--- a/src/features/options/ImportExportSettings.test.tsx
+++ b/src/features/options/ImportExportSettings.test.tsx
@@ -20,7 +20,6 @@ vi.mock('sonner', () => ({
 }))
 
 vi.mock('@/features/options/lib/import-export', () => ({
-  exportSettings: vi.fn(),
   downloadAsJson: vi.fn(),
   importSettings: vi.fn(),
   getImportPreview: vi.fn().mockReturnValue({
@@ -36,6 +35,10 @@ vi.mock('@/features/options/lib/import-export', () => ({
       hasAnalytics: false,
     },
   }),
+}))
+
+vi.mock('@/app/composition/optionsBackupV2Export', () => ({
+  exportBackupV2: vi.fn(),
 }))
 
 vi.mock('@/lib/browser/runtime', () => ({
@@ -116,9 +119,9 @@ vi.mock('@/features/i18n/context/I18nProvider', () => ({
 
 import { toast } from 'sonner'
 
+import { exportBackupV2 } from '@/app/composition/optionsBackupV2Export'
 import {
   downloadAsJson,
-  exportSettings,
   getImportPreview,
   importSettings,
 } from '@/features/options/lib/import-export'
@@ -185,24 +188,35 @@ describe('ImportExportSettingsコンポーネント', () => {
     ;(globalThis as Record<string, unknown>).FileReader =
       MockFileReader as unknown as typeof FileReader
 
-    vi.mocked(exportSettings).mockResolvedValue({
-      version: '1.0.0',
-      timestamp: '2026-02-16T00:00:00.000Z',
-      userSettings: {
-        removeTabAfterOpen: true,
-        removeTabAfterExternalDrop: true,
-        excludePatterns: [],
-        enableCategories: true,
-        showSavedTime: false,
-        clickBehavior: 'saveWindowTabs',
-        excludePinnedTabs: true,
-        openUrlInBackground: true,
-        openAllInNewWindow: false,
-        confirmDeleteAll: false,
-        confirmDeleteEach: false,
+    vi.mocked(exportBackupV2).mockResolvedValue({
+      appVersion: '2.0.8',
+      data: {
+        analyticsViews: [],
+        conversations: [],
+        messages: [],
+        savedTabs: {
+          categories: [],
+          collections: [],
+          groups: [],
+          memberships: [],
+          urls: [],
+        },
+        userSettings: {
+          clickBehavior: 'saveWindowTabs',
+          confirmDeleteAll: false,
+          confirmDeleteEach: false,
+          enableCategories: true,
+          excludePatterns: [],
+          excludePinnedTabs: true,
+          openAllInNewWindow: false,
+          openUrlInBackground: true,
+          removeTabAfterExternalDrop: true,
+          removeTabAfterOpen: true,
+          showSavedTime: false,
+        },
       },
-      parentCategories: [],
-      savedTabs: [],
+      exportedAt: '2026-02-16T00:00:00.000Z',
+      schemaVersion: 2,
     })
   })
 
@@ -214,26 +228,6 @@ describe('ImportExportSettingsコンポーネント', () => {
 
   it('データをエクスポートしてバックアップファイルをダウンロードする', async () => {
     const user = userEvent.setup()
-    vi.mocked(exportSettings).mockResolvedValue({
-      version: '1.0.0',
-      timestamp: '2026-02-16T00:00:00.000Z',
-      userSettings: {
-        removeTabAfterOpen: true,
-        removeTabAfterExternalDrop: true,
-        excludePatterns: [],
-        enableCategories: true,
-        showSavedTime: false,
-        clickBehavior: 'saveWindowTabs',
-        excludePinnedTabs: true,
-        openUrlInBackground: true,
-        openAllInNewWindow: false,
-        confirmDeleteAll: false,
-        confirmDeleteEach: false,
-      },
-      parentCategories: [],
-      savedTabs: [],
-    })
-
     render(<ImportExportSettings />)
 
     await user.click(
@@ -241,7 +235,7 @@ describe('ImportExportSettingsコンポーネント', () => {
     )
 
     await waitFor(() => {
-      expect(exportSettings).toHaveBeenCalledTimes(1)
+      expect(exportBackupV2).toHaveBeenCalledTimes(1)
     })
 
     expect(downloadAsJson).toHaveBeenCalledTimes(1)
@@ -264,7 +258,8 @@ describe('ImportExportSettingsコンポーネント', () => {
 
   it('エクスポート失敗時にエラートーストを表示する', async () => {
     const user = userEvent.setup()
-    vi.mocked(exportSettings).mockRejectedValue(new Error('export failed'))
+    const secret = 'https://secret.example.test/private'
+    vi.mocked(exportBackupV2).mockRejectedValue(new Error(secret))
 
     render(<ImportExportSettings />)
 
@@ -277,6 +272,9 @@ describe('ImportExportSettingsコンポーネント', () => {
         'An error occurred while exporting',
       )
     })
+    expect(JSON.stringify(vi.mocked(console.error).mock.calls)).not.toContain(
+      secret,
+    )
   })
 
   it('マージ設定を切り替えるとインポート時に mergeData=false を渡す', async () => {
@@ -325,6 +323,7 @@ describe('ImportExportSettingsコンポーネント', () => {
         readerContent,
         false,
         expect.any(Function),
+        { importDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/) },
       )
     })
   })
@@ -379,6 +378,7 @@ describe('ImportExportSettingsコンポーネント', () => {
         readerContent,
         true,
         expect.any(Function),
+        { importDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/) },
       )
     })
   })
@@ -641,6 +641,7 @@ describe('ImportExportSettingsコンポーネント', () => {
         readerContent,
         true,
         expect.any(Function),
+        { importDate: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/) },
       )
     })
 

--- a/src/features/options/ImportExportSettings.tsx
+++ b/src/features/options/ImportExportSettings.tsx
@@ -2,14 +2,12 @@ import { AlertCircle, Download } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 
+import { exportBackupV2 } from '@/app/composition/optionsBackupV2Export'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { useI18n } from '@/features/i18n/context/I18nProvider'
 import { ImportFileDialog } from '@/features/options/ImportFileDialog'
-import {
-  downloadAsJson,
-  exportSettings,
-} from '@/features/options/lib/import-export'
+import { downloadAsJson } from '@/features/options/lib/import-export'
 import { sendRuntimeMessage } from '@/lib/browser/runtime'
 
 const handleImportSuccess = async () => {
@@ -23,7 +21,7 @@ export const ImportExportSettings: React.FC = () => {
   const handleExport = useCallback(async () => {
     try {
       setIsExporting(true)
-      const data = await exportSettings()
+      const data = await exportBackupV2()
 
       const date = new Date()
       const formattedDate = date.toISOString().split('T')[0]
@@ -31,8 +29,8 @@ export const ImportExportSettings: React.FC = () => {
 
       downloadAsJson(data, filename)
       toast.success(t('options.importExport.exportSuccess'))
-    } catch (error) {
-      console.error('エクスポートエラー:', error)
+    } catch {
+      console.error('エクスポートエラー')
       toast.error(t('options.importExport.exportError'))
     } finally {
       setIsExporting(false)

--- a/src/features/options/ImportFileDialog.tsx
+++ b/src/features/options/ImportFileDialog.tsx
@@ -35,6 +35,8 @@ import {
 } from './importFileDialog.helpers'
 import type { PreviewData } from './importFileDialog.helpers'
 
+const ISO_DATE_ONLY_LENGTH = 10
+
 type ImportSelectStepProps = {
   mergeData: boolean
   onMergeChange: (mergeData: boolean) => void
@@ -323,6 +325,11 @@ export const ImportFileDialog: React.FC<ImportFileDialogProps> = ({
             content,
             importDialog.mergeData,
             t,
+            {
+              importDate: new Date()
+                .toISOString()
+                .slice(0, ISO_DATE_ONLY_LENGTH),
+            },
           )
           if (result.success) {
             toast.success(result.message)

--- a/src/features/options/ImportFileDialog.tsx
+++ b/src/features/options/ImportFileDialog.tsx
@@ -21,6 +21,7 @@ import {
   getImportPreview,
   importSettings,
 } from '@/features/options/lib/import-export'
+import { getCurrentUtcDateOnly } from '@/features/options/lib/import-export/currentImportDate'
 import {
   BACKUP_MAX_SERIALIZED_SIZE_LABEL,
   validateBackupSerializedBytes,
@@ -34,8 +35,6 @@ import {
   resetImportFileInput,
 } from './importFileDialog.helpers'
 import type { PreviewData } from './importFileDialog.helpers'
-
-const ISO_DATE_ONLY_LENGTH = 10
 
 type ImportSelectStepProps = {
   mergeData: boolean
@@ -326,9 +325,7 @@ export const ImportFileDialog: React.FC<ImportFileDialogProps> = ({
             importDialog.mergeData,
             t,
             {
-              importDate: new Date()
-                .toISOString()
-                .slice(0, ISO_DATE_ONLY_LENGTH),
+              importDate: getCurrentUtcDateOnly(),
             },
           )
           if (result.success) {

--- a/src/features/options/lib/import-export.restore.test.ts
+++ b/src/features/options/lib/import-export.restore.test.ts
@@ -2,6 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { UserSettings } from '@/types/storage'
 
+// Production routing has dedicated actual-IndexedDB integration coverage.
+// This regression isolates the legacy post-gate merge mechanics.
+vi.mock('@/features/options/lib/import-export/productionImportGate', () => ({
+  assertProductionImportAllowed: vi.fn(),
+}))
+
 vi.mock('@/lib/storage/categories', () => ({
   getParentCategories: vi.fn(async () => {
     const result = await chrome.storage.local.get('parentCategories')

--- a/src/features/options/lib/import-export.test.ts
+++ b/src/features/options/lib/import-export.test.ts
@@ -25,6 +25,16 @@ vi.mock('@/lib/storage/migration', () => ({
   migrateToUrlsStorage: vi.fn(),
 }))
 
+vi.mock('@/features/options/lib/import-export/currentImportDate', () => ({
+  getCurrentUtcDateOnly: vi.fn(() => '2026-08-31'),
+}))
+
+// The production boundary has dedicated integration coverage. This suite keeps
+// the legacy post-gate conversion and merge/overwrite mechanics isolated.
+vi.mock('@/features/options/lib/import-export/productionImportGate', () => ({
+  assertProductionImportAllowed: vi.fn(),
+}))
+
 vi.mock('@/lib/storage/settings', () => {
   const defaultSettings: UserSettings = {
     removeTabAfterOpen: true,

--- a/src/features/options/lib/import-export/compatibility/legacyBackupPolicy.test.ts
+++ b/src/features/options/lib/import-export/compatibility/legacyBackupPolicy.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, expectTypeOf, it, vi } from 'vitest'
+
+import {
+  LEGACY_BACKUP_ADVISORY,
+  LEGACY_BACKUP_POLICY,
+  decideLegacyBackupCutoff,
+  isLegacyBackupImportSupported,
+} from './legacyBackupPolicy'
+import type {
+  LegacyBackupAdvisory,
+  LegacyBackupCutoffDecision,
+} from './legacyBackupPolicy'
+
+describe('LEGACY_BACKUP_POLICY', () => {
+  it('defines the fixed cutoff and notice policy', () => {
+    expect(LEGACY_BACKUP_POLICY).toEqual({
+      lastSupportedDate: '2026-08-31',
+      cutoffDate: '2026-09-01',
+      latestNoticeReleaseDate: '2026-08-01',
+      minimumNoticeDays: 30,
+    })
+  })
+})
+
+describe('decideLegacyBackupCutoff', () => {
+  it.each(['0000-01-01', '0099-12-31', '2026-07-01', '2026-08-01'])(
+    'keeps the cutoff for a valid notice release on %s',
+    (releaseDate) => {
+      expect(decideLegacyBackupCutoff(releaseDate)).toBe('keep-cutoff')
+    },
+  )
+
+  it.each(['2026-08-02', '2026-09-01', '2027-01-01'])(
+    'requires postponement for a release after the latest notice date on %s',
+    (releaseDate) => {
+      expect(decideLegacyBackupCutoff(releaseDate)).toBe('postpone-required')
+    },
+  )
+
+  it.each([
+    '2026-8-01',
+    '2026-08-1',
+    '2026-02-29',
+    '2026-13-01',
+    'not-a-date',
+    '2026-08-01T00:00:00Z',
+  ])('rejects invalid date-only ISO input %s', (releaseDate) => {
+    expect(() => decideLegacyBackupCutoff(releaseDate)).toThrow(RangeError)
+  })
+
+  it('is independent of the current time', () => {
+    vi.useFakeTimers()
+
+    try {
+      vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'))
+      const decisionsBeforeCutoff = [
+        decideLegacyBackupCutoff('2026-08-01'),
+        decideLegacyBackupCutoff('2026-08-02'),
+      ]
+
+      vi.setSystemTime(new Date('2027-01-01T00:00:00.000Z'))
+      const decisionsAfterCutoff = [
+        decideLegacyBackupCutoff('2026-08-01'),
+        decideLegacyBackupCutoff('2026-08-02'),
+      ]
+
+      expect(decisionsBeforeCutoff).toEqual([
+        'keep-cutoff',
+        'postpone-required',
+      ])
+      expect(decisionsAfterCutoff).toEqual(decisionsBeforeCutoff)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('LEGACY_BACKUP_ADVISORY', () => {
+  it('provides future preview data for legacy backups', () => {
+    expect(LEGACY_BACKUP_ADVISORY).toEqual({
+      cutoffDate: '2026-09-01',
+      lastSupportedDate: '2026-08-31',
+      requiresReExport: true,
+    })
+  })
+
+  it('retains literal types for advisory and decision consumers', () => {
+    expectTypeOf(LEGACY_BACKUP_ADVISORY).toExtend<LegacyBackupAdvisory>()
+    expectTypeOf(LEGACY_BACKUP_ADVISORY.requiresReExport).toEqualTypeOf<true>()
+    expectTypeOf(
+      decideLegacyBackupCutoff,
+    ).returns.toEqualTypeOf<LegacyBackupCutoffDecision>()
+  })
+})
+
+describe('isLegacyBackupImportSupported', () => {
+  it.each(['0000-01-01', '2026-08-30', '2026-08-31'])(
+    'supports a legacy import on %s',
+    (importDate) => {
+      expect(isLegacyBackupImportSupported(importDate)).toBe(true)
+    },
+  )
+
+  it.each(['2026-09-01', '2027-01-01'])(
+    'rejects a legacy import on %s',
+    (importDate) => {
+      expect(isLegacyBackupImportSupported(importDate)).toBe(false)
+    },
+  )
+
+  it.each(['2026-8-31', '2026-02-29', 'invalid'])(
+    'rejects an invalid date-only import date %s',
+    (importDate) => {
+      expect(() => isLegacyBackupImportSupported(importDate)).toThrow(
+        RangeError,
+      )
+    },
+  )
+})

--- a/src/features/options/lib/import-export/compatibility/legacyBackupPolicy.ts
+++ b/src/features/options/lib/import-export/compatibility/legacyBackupPolicy.ts
@@ -1,0 +1,91 @@
+const HOURS_PER_DAY = 24
+const MINUTES_PER_HOUR = 60
+const SECONDS_PER_MINUTE = 60
+const MILLISECONDS_PER_SECOND = 1000
+const MINIMUM_NOTICE_DAYS = 30
+const MILLISECONDS_PER_DAY =
+  HOURS_PER_DAY *
+  MINUTES_PER_HOUR *
+  SECONDS_PER_MINUTE *
+  MILLISECONDS_PER_SECOND
+const ISO_DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/
+
+export type LegacyBackupPolicy = {
+  readonly lastSupportedDate: '2026-08-31'
+  readonly cutoffDate: '2026-09-01'
+  readonly latestNoticeReleaseDate: '2026-08-01'
+  readonly minimumNoticeDays: typeof MINIMUM_NOTICE_DAYS
+}
+
+export const LEGACY_BACKUP_POLICY = {
+  lastSupportedDate: '2026-08-31',
+  cutoffDate: '2026-09-01',
+  latestNoticeReleaseDate: '2026-08-01',
+  minimumNoticeDays: MINIMUM_NOTICE_DAYS,
+} as const satisfies LegacyBackupPolicy
+
+export type LegacyBackupCutoffDecision = 'keep-cutoff' | 'postpone-required'
+
+export type LegacyBackupAdvisory = {
+  readonly cutoffDate: LegacyBackupPolicy['cutoffDate']
+  readonly lastSupportedDate: LegacyBackupPolicy['lastSupportedDate']
+  readonly requiresReExport: true
+}
+
+export const LEGACY_BACKUP_ADVISORY = {
+  cutoffDate: LEGACY_BACKUP_POLICY.cutoffDate,
+  lastSupportedDate: LEGACY_BACKUP_POLICY.lastSupportedDate,
+  requiresReExport: true,
+} as const satisfies LegacyBackupAdvisory
+
+export function decideLegacyBackupCutoff(
+  releaseDate: string,
+): LegacyBackupCutoffDecision {
+  const releaseTime = parseIsoDateOnlyUtc(releaseDate)
+  const latestNoticeTime = parseIsoDateOnlyUtc(
+    LEGACY_BACKUP_POLICY.latestNoticeReleaseDate,
+  )
+  const cutoffTime = parseIsoDateOnlyUtc(LEGACY_BACKUP_POLICY.cutoffDate)
+  const noticeDays = (cutoffTime - releaseTime) / MILLISECONDS_PER_DAY
+
+  if (
+    releaseTime <= latestNoticeTime &&
+    noticeDays >= LEGACY_BACKUP_POLICY.minimumNoticeDays
+  ) {
+    return 'keep-cutoff'
+  }
+
+  return 'postpone-required'
+}
+
+export function isLegacyBackupImportSupported(importDate: string): boolean {
+  return (
+    parseIsoDateOnlyUtc(importDate) <
+    parseIsoDateOnlyUtc(LEGACY_BACKUP_POLICY.cutoffDate)
+  )
+}
+
+function parseIsoDateOnlyUtc(dateOnly: string): number {
+  const match = ISO_DATE_ONLY_PATTERN.exec(dateOnly)
+
+  if (!match) {
+    throw new RangeError(`Invalid date-only ISO value: ${dateOnly}`)
+  }
+
+  const [, yearText, monthText, dayText] = match
+  const year = Number(yearText)
+  const month = Number(monthText)
+  const day = Number(dayText)
+  const date = new Date(0)
+  const timestamp = date.setUTCFullYear(year, month - 1, day)
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    throw new RangeError(`Invalid date-only ISO value: ${dateOnly}`)
+  }
+
+  return timestamp
+}

--- a/src/features/options/lib/import-export/currentImportDate.test.ts
+++ b/src/features/options/lib/import-export/currentImportDate.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { getCurrentUtcDateOnly } from './currentImportDate'
+
+describe('getCurrentUtcDateOnly', () => {
+  it('formats the injected clock as a UTC YYYY-MM-DD value', () => {
+    expect(
+      getCurrentUtcDateOnly(() => new Date('2026-08-31T23:59:59.999-07:00')),
+    ).toBe('2026-09-01')
+  })
+})

--- a/src/features/options/lib/import-export/currentImportDate.ts
+++ b/src/features/options/lib/import-export/currentImportDate.ts
@@ -1,0 +1,9 @@
+const ISO_DATE_ONLY_LENGTH = 10
+
+export type ImportDateClock = () => Date
+
+const systemClock: ImportDateClock = () => new Date()
+
+export const getCurrentUtcDateOnly = (
+  now: ImportDateClock = systemClock,
+): string => now().toISOString().slice(0, ISO_DATE_ONLY_LENGTH)

--- a/src/features/options/lib/import-export/flows.ts
+++ b/src/features/options/lib/import-export/flows.ts
@@ -1,3 +1,4 @@
+import { mergeLegacyBackupIntoIndexedDb } from '@/app/composition/optionsLegacyBackupMerge'
 import { getPersistenceStorageLocal } from '@/app/composition/persistenceStorageLocal'
 import { getAppVersion } from '@/constants/app-version'
 import {
@@ -33,6 +34,7 @@ import type {
 } from '@/types/storage'
 import { formatLocaleDateTime } from '@/utils/localDateTime'
 
+import { getCurrentUtcDateOnly } from './currentImportDate'
 import {
   alignCustomProjectsWithSavedTabs,
   mergeImportedCustomProjects,
@@ -43,6 +45,8 @@ import {
   resolveImportedCustomProjects,
   toExportCustomProject,
 } from './custom-projects'
+import { assertProductionImportAllowed } from './productionImportGate'
+import type { ProductionImportGateOptions } from './productionImportGate'
 import type { BackupData, ImportedUrlRecordData } from './schemas'
 import { parseBackupData } from './schemas'
 import {
@@ -211,7 +215,7 @@ const exportSettings = async (): Promise<BackupData> => {
  * @param data ダウンロードするデータ
  * @param filename ファイル名
  */
-const downloadAsJson = (data: BackupData, filename: string): void => {
+const downloadAsJson = (data: unknown, filename: string): void => {
   const json = JSON.stringify(data)
   const blob = new Blob([json], {
     type: 'application/json',
@@ -448,15 +452,34 @@ const importWithOverwrite = async ({
   }
 }
 
+// eslint-disable-next-line eslint/complexity -- routes strict Backup V2, canonical legacy merge, and compatibility parsing
 const importSettings = async (
   jsonData: string,
   mergeData = true, // デフォルトでマージを有効に
   translate?: Translate,
+  options: Partial<ProductionImportGateOptions> = {},
 ): Promise<{
   success: boolean
   message: string
 }> => {
   try {
+    const gateResult = assertProductionImportAllowed(jsonData, {
+      importDate: options.importDate ?? getCurrentUtcDateOnly(),
+      importMode: mergeData ? 'merge' : 'overwrite',
+    })
+    if (gateResult?.kind === 'legacy-merge') {
+      const mergeResult = await mergeLegacyBackupIntoIndexedDb(gateResult)
+      return {
+        success: true,
+        message: translate
+          ? translate('options.importExport.mergeSuccess', undefined, {
+              categories: String(mergeResult.entityCounts.groups),
+              domains: String(mergeResult.entityCounts.collections),
+              unresolved: '',
+            })
+          : `データをマージしました (${mergeResult.entityCounts.groups}個のカテゴリ、${mergeResult.entityCounts.collections}個のドメインを追加)`,
+      }
+    }
     await migrateToUrlsStorage()
     const importedData = parseBackupData(jsonData)
     if (!importedData) {

--- a/src/features/options/lib/import-export/flows.ts
+++ b/src/features/options/lib/import-export/flows.ts
@@ -473,11 +473,11 @@ const importSettings = async (
         success: true,
         message: translate
           ? translate('options.importExport.mergeSuccess', undefined, {
-              categories: String(mergeResult.entityCounts.groups),
-              domains: String(mergeResult.entityCounts.collections),
+              categories: String(mergeResult.addedEntityCounts.groups),
+              domains: String(mergeResult.addedEntityCounts.collections),
               unresolved: '',
             })
-          : `データをマージしました (${mergeResult.entityCounts.groups}個のカテゴリ、${mergeResult.entityCounts.collections}個のドメインを追加)`,
+          : `データをマージしました (${mergeResult.addedEntityCounts.groups}個のカテゴリ、${mergeResult.addedEntityCounts.collections}個のドメインを追加)`,
       }
     }
     await migrateToUrlsStorage()

--- a/src/features/options/lib/import-export/legacy/ImportLegacyBackupMergeUseCase.test.ts
+++ b/src/features/options/lib/import-export/legacy/ImportLegacyBackupMergeUseCase.test.ts
@@ -1,0 +1,130 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import type { PersistenceLogicalSnapshot } from '@/contexts/saved-tabs/public-api'
+import { inspectBackupV2 } from '@/features/options/lib/import-export/v2/BackupV2Inspector'
+import type { BackupPreviewEntityCounts } from '@/features/options/lib/import-export/v2/BackupV2Inspector'
+import {
+  BACKUP_RESOURCE_LIMITS,
+  BackupResourceLimitError,
+} from '@/lib/persistence/backupResourcePolicy'
+import { defaultSettings } from '@/lib/storage/settings'
+
+import { createImportLegacyBackupMergeUseCase } from './ImportLegacyBackupMergeUseCase'
+import type { LegacyBackupMergeInput } from './ImportLegacyBackupMergeUseCase'
+
+const legacyFixture = readFileSync(
+  new URL('../v2/fixtures/legacy-tab-group-nested-urls.json', import.meta.url),
+  'utf8',
+)
+
+const createInput = (
+  serializedBytes = new TextEncoder().encode(legacyFixture).byteLength,
+): LegacyBackupMergeInput => {
+  const inspection = inspectBackupV2(legacyFixture, {
+    importDate: '2026-08-31',
+  })
+  if (inspection.preview.formatKind !== 'legacy') {
+    throw new TypeError('Expected a legacy backup fixture')
+  }
+  return {
+    inspection: {
+      ...inspection,
+      preview: inspection.preview,
+    },
+    serializedBytes,
+    userSettingsPatch: {},
+  } as LegacyBackupMergeInput
+}
+
+const createSnapshot = (
+  input: LegacyBackupMergeInput,
+): PersistenceLogicalSnapshot => ({
+  ...structuredClone(input.inspection.data),
+  revision: 1,
+})
+
+const createDeps = (snapshot: PersistenceLogicalSnapshot) => {
+  const commit = vi.fn(async () => ({ revision: 2 }))
+  const readSnapshot = vi.fn(async () => snapshot)
+  const readUserSettings = vi.fn(async () => defaultSettings)
+  const writeUserSettings = vi.fn(async () => undefined)
+
+  return {
+    commit,
+    deps: {
+      commit,
+      isHealthySavedTabs: vi.fn(() => true),
+      readSnapshot,
+      readUserSettings,
+      writeUserSettings,
+    },
+    readSnapshot,
+    readUserSettings,
+    writeUserSettings,
+  }
+}
+
+describe('createImportLegacyBackupMergeUseCase', () => {
+  it('rejects the actual serialized legacy payload size before persistence', async () => {
+    const input = createInput(BACKUP_RESOURCE_LIMITS.maxSerializedBytes + 1)
+    const context = createDeps(createSnapshot(input))
+
+    const error = await createImportLegacyBackupMergeUseCase(context.deps)(
+      input,
+    ).catch((error: unknown) => error)
+
+    expect(error).toBeInstanceOf(BackupResourceLimitError)
+    expect(error).toMatchObject({ code: 'BACKUP_FILE_TOO_LARGE' })
+    expect(context.readSnapshot).not.toHaveBeenCalled()
+    expect(context.readUserSettings).not.toHaveBeenCalled()
+    expect(context.commit).not.toHaveBeenCalled()
+    expect(context.writeUserSettings).not.toHaveBeenCalled()
+  })
+
+  it('reports only groups and collections that are new to the snapshot', async () => {
+    const input = createInput()
+    const context = createDeps(createSnapshot(input))
+
+    const result = await createImportLegacyBackupMergeUseCase(context.deps)(
+      input,
+    )
+
+    expect(result.addedEntityCounts).toEqual({
+      collections: 0,
+      groups: 0,
+    })
+  })
+
+  it('uses logical data rather than preview counts to decide whether to commit', async () => {
+    const input = createInput()
+    const emptyEntityCounts: BackupPreviewEntityCounts = {
+      analyticsViews: 0,
+      categories: 0,
+      collections: 0,
+      conversations: 0,
+      groups: 0,
+      memberships: 0,
+      messages: 0,
+      urls: 0,
+    }
+    const inputWithStalePreview = {
+      ...input,
+      inspection: {
+        ...input.inspection,
+        preview: {
+          ...input.inspection.preview,
+          entityCounts: emptyEntityCounts,
+        },
+      },
+    }
+    const context = createDeps(createSnapshot(input))
+
+    await createImportLegacyBackupMergeUseCase(context.deps)(
+      inputWithStalePreview,
+    )
+
+    expect(context.commit).toHaveBeenCalledOnce()
+  })
+})

--- a/src/features/options/lib/import-export/legacy/ImportLegacyBackupMergeUseCase.ts
+++ b/src/features/options/lib/import-export/legacy/ImportLegacyBackupMergeUseCase.ts
@@ -1,0 +1,116 @@
+import { mergeUserSettings } from '@/features/options/lib/import-export/settings-merge'
+import type {
+  BackupV2Inspection,
+  BackupV2Preview,
+} from '@/features/options/lib/import-export/v2/BackupV2Inspector'
+import { collectBackupV2ResourceUsage } from '@/features/options/lib/import-export/v2/BackupV2ResourceUsage'
+import type { BackupDataV2 } from '@/features/options/lib/import-export/v2/BackupV2Schema'
+import type { UserSettings } from '@/types/storage'
+
+import type { LegacyBackupV0 } from './LegacyBackupV0Schema'
+
+type LegacyBackupPreview = Extract<
+  BackupV2Preview,
+  { readonly formatKind: 'legacy' }
+>
+
+export type LegacyBackupMergeInput = {
+  readonly inspection: BackupV2Inspection & {
+    readonly preview: LegacyBackupPreview
+  }
+  readonly userSettingsPatch: LegacyBackupV0['userSettings']
+}
+
+export type LegacyBackupMergeResult = {
+  readonly entityCounts: LegacyBackupPreview['entityCounts']
+  readonly revision: number | null
+}
+
+export type ImportLegacyBackupMergeDeps = {
+  readonly commit: (
+    plan: LegacyBackupMergeWritePlan,
+    options: { readonly durability: 'strict' },
+  ) => Promise<{ readonly revision: number }>
+  readonly isHealthySavedTabs: (savedTabs: BackupDataV2['savedTabs']) => boolean
+  readonly readUserSettings: () => Promise<UserSettings>
+  readonly writeUserSettings: (settings: UserSettings) => Promise<void>
+}
+
+type PutMutation<Value> = {
+  readonly put: readonly Value[]
+}
+
+export type LegacyBackupMergeWritePlan = {
+  readonly analyticsViews: PutMutation<BackupDataV2['analyticsViews'][number]>
+  readonly categories: PutMutation<
+    BackupDataV2['savedTabs']['categories'][number]
+  >
+  readonly collections: PutMutation<
+    BackupDataV2['savedTabs']['collections'][number]
+  >
+  readonly conversations: PutMutation<BackupDataV2['conversations'][number]>
+  readonly groups: PutMutation<BackupDataV2['savedTabs']['groups'][number]>
+  readonly memberships: PutMutation<
+    BackupDataV2['savedTabs']['memberships'][number]
+  >
+  readonly messages: PutMutation<BackupDataV2['messages'][number]>
+  readonly urls: PutMutation<BackupDataV2['savedTabs']['urls'][number]>
+}
+
+export class LegacyBackupMergeError extends Error {
+  readonly code: 'BACKUP_INTEGRITY_FAILED'
+
+  constructor() {
+    super('Legacy backup merge failed integrity validation')
+    this.code = 'BACKUP_INTEGRITY_FAILED'
+    this.name = 'LegacyBackupMergeError'
+  }
+}
+
+const toWritePlan = (
+  inspection: LegacyBackupMergeInput['inspection'],
+): LegacyBackupMergeWritePlan => {
+  const { data } = inspection
+  return {
+    analyticsViews: { put: data.analyticsViews },
+    categories: { put: data.savedTabs.categories },
+    collections: { put: data.savedTabs.collections },
+    conversations: { put: data.conversations },
+    groups: { put: data.savedTabs.groups },
+    memberships: { put: data.savedTabs.memberships },
+    messages: { put: data.messages },
+    urls: { put: data.savedTabs.urls },
+  }
+}
+
+const hasLogicalRecords = (
+  inspection: LegacyBackupMergeInput['inspection'],
+): boolean =>
+  Object.values(inspection.preview.entityCounts).some((count) => count > 0)
+
+export const createImportLegacyBackupMergeUseCase = (
+  deps: ImportLegacyBackupMergeDeps,
+) => {
+  return async ({
+    inspection,
+    userSettingsPatch,
+  }: LegacyBackupMergeInput): Promise<LegacyBackupMergeResult> => {
+    collectBackupV2ResourceUsage(inspection.data, 0)
+    if (!deps.isHealthySavedTabs(inspection.data.savedTabs)) {
+      throw new LegacyBackupMergeError()
+    }
+
+    const currentSettings = await deps.readUserSettings()
+    const commitResult = hasLogicalRecords(inspection)
+      ? await deps.commit(toWritePlan(inspection), { durability: 'strict' })
+      : null
+    await deps.writeUserSettings(
+      mergeUserSettings(currentSettings, userSettingsPatch),
+    )
+
+    return {
+      entityCounts: inspection.preview.entityCounts,
+      revision: commitResult?.revision ?? null,
+    }
+  }
+}

--- a/src/features/options/lib/import-export/legacy/ImportLegacyBackupMergeUseCase.ts
+++ b/src/features/options/lib/import-export/legacy/ImportLegacyBackupMergeUseCase.ts
@@ -1,3 +1,4 @@
+import type { PersistenceLogicalSnapshot } from '@/contexts/saved-tabs/public-api'
 import { mergeUserSettings } from '@/features/options/lib/import-export/settings-merge'
 import type {
   BackupV2Inspection,
@@ -18,10 +19,15 @@ export type LegacyBackupMergeInput = {
   readonly inspection: BackupV2Inspection & {
     readonly preview: LegacyBackupPreview
   }
+  readonly serializedBytes: number
   readonly userSettingsPatch: LegacyBackupV0['userSettings']
 }
 
 export type LegacyBackupMergeResult = {
+  readonly addedEntityCounts: {
+    readonly collections: number
+    readonly groups: number
+  }
   readonly entityCounts: LegacyBackupPreview['entityCounts']
   readonly revision: number | null
 }
@@ -32,6 +38,7 @@ export type ImportLegacyBackupMergeDeps = {
     options: { readonly durability: 'strict' },
   ) => Promise<{ readonly revision: number }>
   readonly isHealthySavedTabs: (savedTabs: BackupDataV2['savedTabs']) => boolean
+  readonly readSnapshot: () => Promise<PersistenceLogicalSnapshot>
   readonly readUserSettings: () => Promise<UserSettings>
   readonly writeUserSettings: (settings: UserSettings) => Promise<void>
 }
@@ -83,25 +90,44 @@ const toWritePlan = (
   }
 }
 
-const hasLogicalRecords = (
-  inspection: LegacyBackupMergeInput['inspection'],
-): boolean =>
-  Object.values(inspection.preview.entityCounts).some((count) => count > 0)
+const hasLogicalRecords = (data: BackupDataV2): boolean =>
+  [
+    data.analyticsViews,
+    data.conversations,
+    data.messages,
+    data.savedTabs.categories,
+    data.savedTabs.collections,
+    data.savedTabs.groups,
+    data.savedTabs.memberships,
+    data.savedTabs.urls,
+  ].some((records) => records.length > 0)
+
+const countNewIds = (
+  incoming: readonly { readonly id: string }[],
+  existing: readonly { readonly id: string }[],
+): number => {
+  const existingIds = new Set(existing.map(({ id }) => id))
+  return incoming.filter(({ id }) => !existingIds.has(id)).length
+}
 
 export const createImportLegacyBackupMergeUseCase = (
   deps: ImportLegacyBackupMergeDeps,
 ) => {
   return async ({
     inspection,
+    serializedBytes,
     userSettingsPatch,
   }: LegacyBackupMergeInput): Promise<LegacyBackupMergeResult> => {
-    collectBackupV2ResourceUsage(inspection.data, 0)
+    collectBackupV2ResourceUsage(inspection.data, serializedBytes)
     if (!deps.isHealthySavedTabs(inspection.data.savedTabs)) {
       throw new LegacyBackupMergeError()
     }
 
-    const currentSettings = await deps.readUserSettings()
-    const commitResult = hasLogicalRecords(inspection)
+    const [currentSnapshot, currentSettings] = await Promise.all([
+      deps.readSnapshot(),
+      deps.readUserSettings(),
+    ])
+    const commitResult = hasLogicalRecords(inspection.data)
       ? await deps.commit(toWritePlan(inspection), { durability: 'strict' })
       : null
     await deps.writeUserSettings(
@@ -109,6 +135,16 @@ export const createImportLegacyBackupMergeUseCase = (
     )
 
     return {
+      addedEntityCounts: {
+        collections: countNewIds(
+          inspection.data.savedTabs.collections,
+          currentSnapshot.savedTabs.collections,
+        ),
+        groups: countNewIds(
+          inspection.data.savedTabs.groups,
+          currentSnapshot.savedTabs.groups,
+        ),
+      },
       entityCounts: inspection.preview.entityCounts,
       revision: commitResult?.revision ?? null,
     }

--- a/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.test.ts
+++ b/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { BackupSchemaError } from '@/lib/persistence/backupSchema'
+
+import { convertLegacyBackup } from './LegacyBackupAdapter'
+
+describe('convertLegacyBackup', () => {
+  it('rejects non-legacy input before applying the legacy cutoff', () => {
+    const error = (() => {
+      try {
+        convertLegacyBackup({ schemaVersion: 2 }, '2026-09-01')
+      } catch (error) {
+        return error
+      }
+      throw new Error('Expected conversion to fail')
+    })()
+
+    expect(error).toBeInstanceOf(BackupSchemaError)
+    expect(error).toMatchObject({
+      code: 'INVALID_SCHEMA',
+      name: 'BackupSchemaError',
+    })
+  })
+})

--- a/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.ts
+++ b/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.ts
@@ -1,0 +1,181 @@
+import { mapLegacyStorageToPersistenceV2 } from '@/contexts/saved-tabs/public-api'
+import type {
+  LegacyMigrationIssueCode,
+  RawLegacyStorageSnapshot,
+  RawLegacyStorageValue,
+} from '@/contexts/saved-tabs/public-api'
+import { isLegacyBackupImportSupported } from '@/features/options/lib/import-export/compatibility/legacyBackupPolicy'
+import { BackupMapper } from '@/features/options/lib/import-export/v2/BackupMapper'
+import type { BackupDataV2 } from '@/features/options/lib/import-export/v2/BackupV2Schema'
+import {
+  BackupSchemaError,
+  detectBackupFormat,
+} from '@/lib/persistence/backupSchema'
+import { defaultSettings } from '@/lib/storage/settings'
+
+import { LegacyBackupV0Schema } from './LegacyBackupV0Schema'
+import type { LegacyBackupV0 } from './LegacyBackupV0Schema'
+
+export type LegacyBackupImportErrorCode =
+  | 'LEGACY_IMPORT_CUTOFF_REACHED'
+  | 'LEGACY_MIGRATION_BLOCKED'
+
+const LEGACY_BACKUP_IMPORT_ERROR_MESSAGES: Readonly<
+  Record<LegacyBackupImportErrorCode, string>
+> = {
+  LEGACY_IMPORT_CUTOFF_REACHED: 'Legacy backup import is no longer supported',
+  LEGACY_MIGRATION_BLOCKED: 'Legacy backup migration validation failed',
+}
+
+export class LegacyBackupImportError extends Error {
+  readonly code: LegacyBackupImportErrorCode
+  readonly issueCodes: readonly LegacyMigrationIssueCode[]
+
+  constructor(
+    code: LegacyBackupImportErrorCode,
+    issueCodes: readonly LegacyMigrationIssueCode[] = [],
+  ) {
+    super(LEGACY_BACKUP_IMPORT_ERROR_MESSAGES[code])
+    this.name = 'LegacyBackupImportError'
+    this.code = code
+    this.issueCodes = issueCodes
+  }
+}
+
+export type LegacyBackupWarning = {
+  readonly code: LegacyMigrationIssueCode
+  readonly count: number
+}
+
+export type LegacyBackupConversion = {
+  readonly appVersion: string
+  readonly data: BackupDataV2
+  readonly exportedAt: string
+  readonly warnings: readonly LegacyBackupWarning[]
+}
+
+const toLegacySourceValue = (
+  backup: Record<string, unknown>,
+  key: string,
+): RawLegacyStorageValue =>
+  Object.hasOwn(backup, key)
+    ? { status: 'present', value: backup[key] }
+    : { status: 'missing' }
+
+const toRawLegacyStorageSnapshot = (
+  backup: Record<string, unknown>,
+): RawLegacyStorageSnapshot => ({
+  activeAiChatConversationId: toLegacySourceValue(
+    backup,
+    'activeAiChatConversationId',
+  ),
+  aiChatConversations: toLegacySourceValue(backup, 'aiChatConversations'),
+  customProjectOrder: toLegacySourceValue(backup, 'customProjectOrder'),
+  customProjects: toLegacySourceValue(backup, 'customProjects'),
+  domainCategoryMappings: { status: 'missing' },
+  domainCategorySettings: { status: 'missing' },
+  parentCategories: toLegacySourceValue(backup, 'parentCategories'),
+  savedAnalyticsViews: toLegacySourceValue(backup, 'savedAnalyticsViews'),
+  savedTabs: toLegacySourceValue(backup, 'savedTabs'),
+  urls: toLegacySourceValue(backup, 'urls'),
+})
+
+type LegacyNestedUrl = NonNullable<
+  LegacyBackupV0['savedTabs'][number]['urls']
+>[number]
+
+const normalizeLegacyNestedUrl = (
+  url: LegacyNestedUrl,
+): Omit<LegacyNestedUrl, 'tabId' | 'timestamp'> => {
+  const savedAt = url.savedAt ?? url.timestamp
+  return {
+    ...(url.favIconUrl === undefined ? {} : { favIconUrl: url.favIconUrl }),
+    ...(url.id === undefined ? {} : { id: url.id }),
+    ...(savedAt === undefined ? {} : { savedAt }),
+    ...(url.subCategory === undefined ? {} : { subCategory: url.subCategory }),
+    title: url.title,
+    url: url.url,
+  }
+}
+
+const normalizeLegacyBackupForMapper = (
+  backup: LegacyBackupV0,
+): LegacyBackupV0 => ({
+  ...backup,
+  ...(backup.customProjects === undefined
+    ? {}
+    : {
+        customProjects: backup.customProjects.map((project) => ({
+          ...project,
+          ...(project.projectKeywords === undefined
+            ? {}
+            : {
+                projectKeywords: {
+                  domainKeywords: project.projectKeywords.domainKeywords ?? [],
+                  titleKeywords: project.projectKeywords.titleKeywords ?? [],
+                  urlKeywords: project.projectKeywords.urlKeywords ?? [],
+                },
+              }),
+        })),
+      }),
+  savedTabs: backup.savedTabs.map((savedTab) => ({
+    ...savedTab,
+    ...(savedTab.urls === undefined
+      ? {}
+      : { urls: savedTab.urls.map(normalizeLegacyNestedUrl) }),
+  })),
+})
+
+export const convertLegacyBackup = (
+  input: unknown,
+  importDate: string,
+): LegacyBackupConversion => {
+  if (!isLegacyBackupImportSupported(importDate)) {
+    throw new LegacyBackupImportError('LEGACY_IMPORT_CUTOFF_REACHED')
+  }
+  if (detectBackupFormat(input).kind !== 'legacy') {
+    throw new BackupSchemaError('INVALID_SCHEMA')
+  }
+
+  const legacyResult = LegacyBackupV0Schema.safeParse(input)
+  if (!legacyResult.success) {
+    throw new BackupSchemaError('INVALID_SCHEMA')
+  }
+
+  const legacyBackup = legacyResult.data
+  const normalizedLegacyBackup = normalizeLegacyBackupForMapper(legacyBackup)
+  const migration = mapLegacyStorageToPersistenceV2(
+    toRawLegacyStorageSnapshot(normalizedLegacyBackup),
+  )
+  const errors = migration.issues.filter(({ severity }) => severity === 'error')
+  if (errors.length > 0) {
+    throw new LegacyBackupImportError(
+      'LEGACY_MIGRATION_BLOCKED',
+      errors.map(({ code }) => code),
+    )
+  }
+
+  const userSettings = {
+    ...structuredClone(defaultSettings),
+    ...structuredClone(legacyBackup.userSettings),
+  }
+  const data = BackupMapper.toBackupData(
+    {
+      ...migration.target,
+      revision: 0,
+    },
+    userSettings,
+  )
+
+  return {
+    appVersion: legacyBackup.version,
+    data,
+    exportedAt: legacyBackup.timestamp,
+    warnings: migration.issues
+      .filter(({ severity }) => severity === 'warning')
+      .map(({ code, occurrenceCount }) => ({
+        code,
+        count: occurrenceCount,
+      })),
+  }
+}

--- a/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.ts
+++ b/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.ts
@@ -130,11 +130,11 @@ export const convertLegacyBackup = (
   input: unknown,
   importDate: string,
 ): LegacyBackupConversion => {
-  if (!isLegacyBackupImportSupported(importDate)) {
-    throw new LegacyBackupImportError('LEGACY_IMPORT_CUTOFF_REACHED')
-  }
   if (detectBackupFormat(input).kind !== 'legacy') {
     throw new BackupSchemaError('INVALID_SCHEMA')
+  }
+  if (!isLegacyBackupImportSupported(importDate)) {
+    throw new LegacyBackupImportError('LEGACY_IMPORT_CUTOFF_REACHED')
   }
 
   const legacyResult = LegacyBackupV0Schema.safeParse(input)
@@ -171,11 +171,14 @@ export const convertLegacyBackup = (
     appVersion: legacyBackup.version,
     data,
     exportedAt: legacyBackup.timestamp,
-    warnings: migration.issues
-      .filter(({ severity }) => severity === 'warning')
-      .map(({ code, occurrenceCount }) => ({
-        code,
-        count: occurrenceCount,
-      })),
+    warnings: migration.issues.reduce<LegacyBackupWarning[]>(
+      (warnings, { code, occurrenceCount, severity }) => {
+        if (severity === 'warning') {
+          warnings.push({ code, count: occurrenceCount })
+        }
+        return warnings
+      },
+      [],
+    ),
   }
 }

--- a/src/features/options/lib/import-export/legacy/LegacyBackupV0Schema.test.ts
+++ b/src/features/options/lib/import-export/legacy/LegacyBackupV0Schema.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest'
+
+import { LegacyBackupV0Schema } from './LegacyBackupV0Schema'
+
+const createLegacyBackup = (): Record<string, unknown> => ({
+  parentCategories: [],
+  savedTabs: [
+    {
+      domain: 'strict.example.com',
+      id: 'strict-group',
+      savedAt: 1,
+      urls: [
+        {
+          savedAt: 2,
+          title: 'Strict URL',
+          url: 'https://strict.example.com/path',
+        },
+      ],
+    },
+  ],
+  timestamp: '2026-07-01T00:00:00.000Z',
+  userSettings: {
+    excludePatterns: ['https://allowed.example/*'],
+    showSavedTime: true,
+  },
+  version: '1.9.0',
+})
+
+describe('LegacyBackupV0Schema', () => {
+  it('accepts explicitly supported legacy representations', () => {
+    expect(LegacyBackupV0Schema.safeParse(createLegacyBackup()).success).toBe(
+      true,
+    )
+  })
+
+  it('accepts legacy nested timestamp and runtime tabId fields', () => {
+    const backup = createLegacyBackup()
+    backup.savedTabs = [
+      {
+        domain: 'runtime.example.com',
+        id: 'runtime-group',
+        urls: [
+          {
+            tabId: 42,
+            timestamp: 123,
+            title: 'Runtime URL',
+            url: 'https://runtime.example.com/path',
+          },
+        ],
+      },
+    ]
+
+    expect(LegacyBackupV0Schema.safeParse(backup).success).toBe(true)
+  })
+
+  it('accepts prior optional parent and project keyword fields', () => {
+    const backup = createLegacyBackup()
+    backup.parentCategories = [
+      {
+        domainNames: ['strict.example.com'],
+        domains: ['strict-group'],
+        id: 'parent-1',
+        keywords: ['strict'],
+        name: 'Parent',
+      },
+    ]
+    backup.customProjects = [
+      {
+        id: 'project-1',
+        name: 'Project',
+        projectKeywords: {
+          titleKeywords: ['title'],
+        },
+      },
+    ]
+    backup.customProjectOrder = ['project-1']
+
+    expect(LegacyBackupV0Schema.safeParse(backup).success).toBe(true)
+  })
+
+  it('accepts the legacy analytics time grouping alias', () => {
+    const backup = createLegacyBackup()
+    backup.savedAnalyticsViews = [
+      {
+        createdAt: 1,
+        id: 'view-1',
+        name: 'Legacy time',
+        query: {
+          chartType: 'bar',
+          compareBy: 'none',
+          filters: {
+            excludedDomains: [],
+            excludedParentCategories: [],
+            excludedProjectCategories: [],
+            excludedProjects: [],
+            excludedSubCategories: [],
+            includedDomains: [],
+            includedParentCategories: [],
+            includedProjectCategories: [],
+            includedProjects: [],
+            includedSubCategories: [],
+          },
+          groupBy: 'time',
+          limit: 10,
+          mode: 'both',
+          normalize: false,
+          sort: 'value-desc',
+          stacked: false,
+          timeBucket: 'day',
+          timeRange: '30d',
+        },
+        updatedAt: 2,
+      },
+    ]
+
+    const result = LegacyBackupV0Schema.parse(backup)
+
+    expect(result.savedAnalyticsViews?.[0]?.query.groupBy).toBe('timeRecent')
+  })
+
+  it('rejects a mixed array containing an invalid member', () => {
+    const backup = createLegacyBackup()
+    backup.urls = [
+      {
+        id: 'valid-url',
+        savedAt: 1,
+        title: 'Valid',
+        url: 'https://valid.example/path',
+      },
+      {
+        id: 'invalid-url',
+        savedAt: 2,
+        title: 'Invalid',
+        url: 42,
+      },
+    ]
+
+    expect(LegacyBackupV0Schema.safeParse(backup).success).toBe(false)
+  })
+
+  it('rejects an invalid member inside a legacy settings array', () => {
+    const backup = createLegacyBackup()
+    backup.userSettings = {
+      excludePatterns: ['https://valid.example/*', 42],
+    }
+
+    expect(LegacyBackupV0Schema.safeParse(backup).success).toBe(false)
+  })
+
+  it('rejects an invalid legacy settings field instead of dropping it', () => {
+    const backup = createLegacyBackup()
+    backup.userSettings = {
+      showSavedTime: 'yes',
+    }
+
+    expect(LegacyBackupV0Schema.safeParse(backup).success).toBe(false)
+  })
+
+  it('rejects unknown top-level fields', () => {
+    const backup = createLegacyBackup()
+    backup.internalMetadata = { revision: 123 }
+
+    expect(LegacyBackupV0Schema.safeParse(backup).success).toBe(false)
+  })
+
+  it('rejects unknown fields in known nested objects', () => {
+    const backup = createLegacyBackup()
+    const savedTabs = backup.savedTabs
+    if (!Array.isArray(savedTabs)) {
+      throw new TypeError('Expected saved tabs fixture')
+    }
+    const savedTab: unknown = savedTabs[0]
+    if (
+      typeof savedTab !== 'object' ||
+      savedTab === null ||
+      Array.isArray(savedTab)
+    ) {
+      throw new TypeError('Expected saved tab fixture')
+    }
+    Object.assign(savedTab, { internalCache: true })
+
+    expect(LegacyBackupV0Schema.safeParse(backup).success).toBe(false)
+  })
+
+  it.each([
+    { field: 'version', value: '' },
+    { field: 'timestamp', value: 'not-an-iso-datetime' },
+  ])('rejects invalid $field metadata', ({ field, value }) => {
+    const backup = createLegacyBackup()
+    backup[field] = value
+
+    expect(LegacyBackupV0Schema.safeParse(backup).success).toBe(false)
+  })
+})

--- a/src/features/options/lib/import-export/legacy/LegacyBackupV0Schema.ts
+++ b/src/features/options/lib/import-export/legacy/LegacyBackupV0Schema.ts
@@ -1,0 +1,287 @@
+import { z } from 'zod'
+
+import { isValidUrl } from '@/lib/url-filter'
+
+const legacyImportableUrlSchema = z.string().refine(isValidUrl, {
+  error: 'Invalid URL',
+})
+
+const legacyFavIconUrlSchema = legacyImportableUrlSchema.or(z.literal(''))
+
+const legacyAiSystemPromptPresetSchema = z.strictObject({
+  createdAt: z.number(),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  template: z.string(),
+  updatedAt: z.number(),
+})
+
+const legacyUserSettingsSchema = z.strictObject({
+  activeAiSystemPromptId: z.string().optional(),
+  aiSystemPrompts: z.array(legacyAiSystemPromptPresetSchema).optional(),
+  autoDeletePeriod: z
+    .enum([
+      'never',
+      '30sec',
+      '1min',
+      '1hour',
+      '1day',
+      '7days',
+      '14days',
+      '30days',
+      '180days',
+      '365days',
+    ])
+    .optional(),
+  clickBehavior: z
+    .enum([
+      'saveCurrentTab',
+      'saveWindowTabs',
+      'saveSameDomainTabs',
+      'saveAllWindowsTabs',
+    ])
+    .optional(),
+  colors: z.record(z.string(), z.string()).optional(),
+  confirmDeleteAll: z.boolean().optional(),
+  confirmDeleteEach: z.boolean().optional(),
+  enableCategories: z.boolean().optional(),
+  excludePatterns: z.array(z.string()).optional(),
+  excludePinnedTabs: z.boolean().optional(),
+  fontSizePercent: z.number().optional(),
+  language: z.enum(['system', 'ja', 'en']).optional(),
+  ollamaModel: z.string().optional(),
+  openAllInNewWindow: z.boolean().optional(),
+  openUrlInBackground: z.boolean().optional(),
+  removeTabAfterExternalDrop: z.boolean().optional(),
+  removeTabAfterOpen: z.boolean().optional(),
+  showSavedTime: z.boolean().optional(),
+})
+
+const legacyNestedUrlSchema = z.strictObject({
+  favIconUrl: legacyFavIconUrlSchema.optional(),
+  id: z.string().optional(),
+  savedAt: z.number().optional(),
+  subCategory: z.string().optional(),
+  tabId: z.number().optional(),
+  timestamp: z.number().optional(),
+  title: z.string(),
+  url: legacyImportableUrlSchema,
+})
+
+const legacyCanonicalUrlSchema = z.strictObject({
+  favIconUrl: legacyFavIconUrlSchema.optional(),
+  id: z.string(),
+  savedAt: z.number().optional(),
+  title: z.string(),
+  url: legacyImportableUrlSchema,
+})
+
+const legacyCategoryKeywordSchema = z.strictObject({
+  categoryName: z.string(),
+  keywords: z.array(z.string()),
+})
+
+const legacySavedTabSchema = z.strictObject({
+  categoryKeywords: z.array(legacyCategoryKeywordSchema).optional(),
+  domain: z.string(),
+  id: z.string(),
+  parentCategoryId: z.string().optional(),
+  savedAt: z.number().optional(),
+  subCategories: z.array(z.string()).optional(),
+  subCategoryOrder: z.array(z.string()).optional(),
+  subCategoryOrderWithUncategorized: z.array(z.string()).optional(),
+  urlIds: z.array(z.string()).optional(),
+  urls: z.array(legacyNestedUrlSchema).optional(),
+  urlSubCategories: z.record(z.string(), z.string()).optional(),
+})
+
+const legacyProjectKeywordsSchema = z.strictObject({
+  domainKeywords: z.array(z.string()).optional(),
+  titleKeywords: z.array(z.string()).optional(),
+  urlKeywords: z.array(z.string()).optional(),
+})
+
+const legacyCustomProjectUrlSchema = z.strictObject({
+  category: z.string().optional(),
+  notes: z.string().optional(),
+  savedAt: z.number().optional(),
+  title: z.string(),
+  url: legacyImportableUrlSchema,
+})
+
+const legacyUrlMetadataSchema = z.record(
+  z.string(),
+  z.strictObject({
+    category: z.string().optional(),
+    notes: z.string().optional(),
+  }),
+)
+
+const legacyCustomProjectSchema = z.strictObject({
+  categories: z.array(z.string()).optional(),
+  categoryOrder: z.array(z.string()).optional(),
+  createdAt: z.number().optional(),
+  id: z.string(),
+  name: z.string(),
+  projectKeywords: legacyProjectKeywordsSchema.optional(),
+  updatedAt: z.number().optional(),
+  urlIds: z.array(z.string()).optional(),
+  urlMetadata: legacyUrlMetadataSchema.optional(),
+  urls: z.array(legacyCustomProjectUrlSchema).optional(),
+})
+
+const legacyParentCategorySchema = z.strictObject({
+  domainNames: z.array(z.string()),
+  domains: z.array(z.string()),
+  id: z.string(),
+  keywords: z.array(z.string()).optional(),
+  name: z.string(),
+})
+
+const legacyAnalyticsGroupBySchema = z.preprocess(
+  (value) => (value === 'time' ? 'timeRecent' : value),
+  z.enum([
+    'domain',
+    'parentCategory',
+    'project',
+    'projectCategory',
+    'subCategory',
+    'timeRecent',
+    'timeTop',
+  ]),
+)
+
+const legacyAnalyticsFiltersSchema = z.strictObject({
+  excludedDomains: z.array(z.string()),
+  excludedParentCategories: z.array(z.string()),
+  excludedProjectCategories: z.array(z.string()),
+  excludedProjects: z.array(z.string()),
+  excludedSubCategories: z.array(z.string()),
+  includedDomains: z.array(z.string()),
+  includedParentCategories: z.array(z.string()),
+  includedProjectCategories: z.array(z.string()),
+  includedProjects: z.array(z.string()),
+  includedSubCategories: z.array(z.string()),
+})
+
+const legacyAnalyticsQuerySchema = z.strictObject({
+  chartType: z.enum(['area', 'bar', 'line', 'pie', 'radar']),
+  compareBy: z.enum(['mode', 'none']),
+  customDateRange: z
+    .strictObject({
+      from: z.string().optional(),
+      to: z.string().optional(),
+    })
+    .optional(),
+  filters: legacyAnalyticsFiltersSchema,
+  groupBy: legacyAnalyticsGroupBySchema,
+  limit: z.number(),
+  mode: z.enum(['both', 'custom', 'domain']),
+  normalize: z.boolean(),
+  sort: z.enum(['label-asc', 'label-desc', 'value-asc', 'value-desc']),
+  stacked: z.boolean(),
+  timeBucket: z.enum(['day', 'month', 'week']),
+  timeRange: z.enum(['30d', '365d', '7d', '90d', 'all', 'custom']),
+  title: z.string().optional(),
+})
+
+const legacySavedAnalyticsViewSchema = z.strictObject({
+  createdAt: z.number(),
+  id: z.string(),
+  name: z.string(),
+  query: legacyAnalyticsQuerySchema,
+  updatedAt: z.number(),
+})
+
+const legacyAiChartSeriesSchema = z.strictObject({
+  colorToken: z.string(),
+  dataKey: z.string(),
+  label: z.string(),
+})
+
+const legacyAiChartSpecSchema = z.strictObject({
+  categoryKey: z.string().optional(),
+  data: z.array(
+    z.record(z.string(), z.union([z.number(), z.string(), z.null()])),
+  ),
+  description: z.string().optional(),
+  emptyMessage: z.string().optional(),
+  series: z.array(legacyAiChartSeriesSchema),
+  showLegend: z.boolean().optional(),
+  stacked: z.boolean().optional(),
+  title: z.string(),
+  type: z.enum(['area', 'bar', 'line', 'pie', 'radar']),
+  valueFormat: z.enum(['count', 'date', 'label', 'percent']).optional(),
+  xKey: z.string().optional(),
+})
+
+const legacyAiChatAttachmentSchema = z.strictObject({
+  content: z.string(),
+  filename: z.string(),
+  kind: z.enum(['text', 'image']),
+  mediaType: z.string(),
+})
+
+const legacyAiChatToolTraceSchema = z.strictObject({
+  errorText: z.string().optional(),
+  input: z.unknown(),
+  output: z.unknown().optional(),
+  state: z.enum([
+    'approval-requested',
+    'approval-responded',
+    'input-available',
+    'input-streaming',
+    'output-available',
+    'output-denied',
+    'output-error',
+  ]),
+  title: z.string(),
+  toolCallId: z.string(),
+  toolName: z.string(),
+  type: z.literal('dynamic-tool'),
+})
+
+const legacyOllamaErrorDetailsSchema = z.strictObject({
+  allowedOrigins: z.string().optional(),
+  baseUrl: legacyImportableUrlSchema,
+  downloadUrl: legacyImportableUrlSchema,
+  faqUrl: legacyImportableUrlSchema,
+  kind: z.enum(['forbidden', 'notInstalledOrNotRunning']),
+  tagsUrl: legacyImportableUrlSchema,
+})
+
+const legacyAiChatMessageSchema = z.strictObject({
+  attachments: z.array(legacyAiChatAttachmentSchema).optional(),
+  charts: z.array(legacyAiChartSpecSchema).optional(),
+  content: z.string(),
+  id: z.string(),
+  isStreaming: z.boolean().optional(),
+  ollamaError: legacyOllamaErrorDetailsSchema.optional(),
+  reasoning: z.string().optional(),
+  role: z.enum(['user', 'assistant']),
+  toolTraces: z.array(legacyAiChatToolTraceSchema).optional(),
+})
+
+const legacyAiChatConversationSchema = z.strictObject({
+  createdAt: z.number(),
+  id: z.string(),
+  messages: z.array(legacyAiChatMessageSchema),
+  title: z.string(),
+  updatedAt: z.number(),
+})
+
+export const LegacyBackupV0Schema = z.strictObject({
+  activeAiChatConversationId: z.string().optional(),
+  aiChatConversations: z.array(legacyAiChatConversationSchema).optional(),
+  customProjectOrder: z.array(z.string()).optional(),
+  customProjects: z.array(legacyCustomProjectSchema).optional(),
+  parentCategories: z.array(legacyParentCategorySchema),
+  savedAnalyticsViews: z.array(legacySavedAnalyticsViewSchema).optional(),
+  savedTabs: z.array(legacySavedTabSchema),
+  timestamp: z.iso.datetime(),
+  urls: z.array(legacyCanonicalUrlSchema).optional(),
+  userSettings: legacyUserSettingsSchema,
+  version: z.string().min(1),
+})
+
+export type LegacyBackupV0 = z.infer<typeof LegacyBackupV0Schema>

--- a/src/features/options/lib/import-export/productionImportGate.integration.test.ts
+++ b/src/features/options/lib/import-export/productionImportGate.integration.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/storage/migration', () => ({
+  migrateToUrlsStorage: vi.fn(),
+}))
+
+import { migrateToUrlsStorage } from '@/lib/storage/migration'
+
+vi.mock('./currentImportDate', () => ({
+  getCurrentUtcDateOnly: vi.fn(),
+}))
+
+import { getCurrentUtcDateOnly } from './currentImportDate'
+import { importSettings } from './flows'
+
+const currentV2 = {
+  appVersion: '2.0.8',
+  data: {
+    analyticsViews: [],
+    conversations: [],
+    messages: [],
+    savedTabs: {
+      categories: [],
+      collections: [],
+      groups: [],
+      memberships: [],
+      urls: [],
+    },
+    userSettings: {
+      clickBehavior: 'saveSameDomainTabs',
+      confirmDeleteAll: false,
+      confirmDeleteEach: false,
+      enableCategories: true,
+      excludePatterns: [],
+      excludePinnedTabs: true,
+      openAllInNewWindow: false,
+      openUrlInBackground: true,
+      removeTabAfterExternalDrop: false,
+      removeTabAfterOpen: false,
+      showSavedTime: false,
+    },
+  },
+  exportedAt: '2026-07-28T00:00:00.000Z',
+  schemaVersion: 2,
+}
+
+const futureV2 = {
+  appVersion: '3.0.0',
+  data: {},
+  exportedAt: '2027-01-01T00:00:00.000Z',
+  schemaVersion: 3,
+}
+
+const legacyBackup = {
+  parentCategories: [],
+  savedTabs: [],
+  timestamp: '2026-07-28T00:00:00.000Z',
+  userSettings: {},
+  version: '1.0.0',
+}
+
+describe('importSettings production pre-mutation gate', () => {
+  const get = vi.fn()
+  const set = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(migrateToUrlsStorage).mockResolvedValue(undefined)
+    vi.mocked(getCurrentUtcDateOnly).mockReturnValue('2026-08-31')
+    Object.defineProperty(globalThis, 'chrome', {
+      configurable: true,
+      value: {
+        storage: {
+          local: { get, set },
+        },
+      },
+    })
+  })
+
+  it.each([
+    ['current V2', currentV2, '2026-07-28'],
+    ['future V2', futureV2, '2026-07-28'],
+    ['expired legacy', legacyBackup, '2026-09-01'],
+  ])(
+    'rejects %s before migration or storage access',
+    async (_label, backup, importDate) => {
+      const result = await importSettings(
+        JSON.stringify(backup),
+        true,
+        undefined,
+        { importDate },
+      )
+
+      expect(result.success).toBe(false)
+      expect(migrateToUrlsStorage).not.toHaveBeenCalled()
+      expect(get).not.toHaveBeenCalled()
+      expect(set).not.toHaveBeenCalled()
+    },
+  )
+
+  it('enforces the provider date for a non-UI legacy caller', async () => {
+    vi.mocked(getCurrentUtcDateOnly).mockReturnValue('2026-09-01')
+
+    const result = await importSettings(JSON.stringify(legacyBackup))
+
+    expect(result.success).toBe(false)
+    expect(getCurrentUtcDateOnly).toHaveBeenCalledOnce()
+    expect(migrateToUrlsStorage).not.toHaveBeenCalled()
+    expect(get).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('blocks a valid legacy overwrite before migration or storage access', async () => {
+    const result = await importSettings(JSON.stringify(legacyBackup), false)
+
+    expect(result.success).toBe(false)
+    expect(migrateToUrlsStorage).not.toHaveBeenCalled()
+    expect(get).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed legacy-shaped input before every mutation route', async () => {
+    const result = await importSettings(
+      JSON.stringify({
+        ...legacyBackup,
+        privatePayload: 'secret',
+      }),
+      true,
+    )
+
+    expect(result.success).toBe(false)
+    expect(migrateToUrlsStorage).not.toHaveBeenCalled()
+    expect(get).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/options/lib/import-export/productionImportGate.test.ts
+++ b/src/features/options/lib/import-export/productionImportGate.test.ts
@@ -1,0 +1,156 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+import type { BackupSchemaError } from '@/lib/persistence/backupSchema'
+
+import type { LegacyBackupImportError } from './legacy/LegacyBackupAdapter'
+import { assertProductionImportAllowed } from './productionImportGate'
+import type { ProductionBackupImportError } from './productionImportGate'
+
+const readFixture = (name: string): string =>
+  readFileSync(new URL(`v2/fixtures/${name}`, import.meta.url), 'utf8')
+
+const captureError = (action: () => unknown): Error => {
+  try {
+    action()
+  } catch (error) {
+    if (error instanceof Error) {
+      return error
+    }
+  }
+  throw new Error('Expected action to throw')
+}
+
+describe('assertProductionImportAllowed', () => {
+  it('strictly validates current V2 and blocks overwrite until #740 exists', () => {
+    const error = captureError(() =>
+      assertProductionImportAllowed(readFixture('backup-v2-current.json'), {
+        importDate: '2026-07-28',
+        importMode: 'merge',
+      }),
+    )
+
+    expect(error).toMatchObject<Partial<ProductionBackupImportError>>({
+      code: 'OVERWRITE_RECOVERY_UNAVAILABLE',
+      name: 'ProductionBackupImportError',
+    })
+    expect(JSON.stringify(error)).not.toContain('userSettings')
+  })
+
+  it('preserves the typed future-schema rejection', () => {
+    const error = captureError(() =>
+      assertProductionImportAllowed(readFixture('backup-v2-future.json'), {
+        importDate: '2026-07-28',
+        importMode: 'overwrite',
+      }),
+    )
+
+    expect(error).toMatchObject<Partial<BackupSchemaError>>({
+      code: 'UNSUPPORTED_FUTURE_SCHEMA',
+      currentVersion: 2,
+      name: 'BackupSchemaError',
+      receivedVersion: 3,
+    })
+  })
+
+  it('rejects malformed versioned input before legacy handling', () => {
+    const error = captureError(() =>
+      assertProductionImportAllowed(
+        JSON.stringify({ schemaVersion: 2, privatePayload: 'secret' }),
+        { importDate: '2026-07-28', importMode: 'overwrite' },
+      ),
+    )
+
+    expect(error).toMatchObject<Partial<BackupSchemaError>>({
+      code: 'INVALID_SCHEMA',
+      name: 'BackupSchemaError',
+    })
+    expect(JSON.stringify(error)).not.toContain('secret')
+  })
+
+  it('rejects malformed legacy-shaped input before compatibility parsing', () => {
+    const error = captureError(() =>
+      assertProductionImportAllowed(
+        JSON.stringify({
+          parentCategories: [],
+          privatePayload: 'secret',
+          savedTabs: [],
+          timestamp: '2026-07-28T00:00:00.000Z',
+          userSettings: {},
+          version: '1.0.0',
+        }),
+        { importDate: '2026-08-31', importMode: 'merge' },
+      ),
+    )
+
+    expect(error).toMatchObject<Partial<BackupSchemaError>>({
+      code: 'INVALID_SCHEMA',
+      name: 'BackupSchemaError',
+    })
+    expect(JSON.stringify(error)).not.toContain('secret')
+  })
+
+  it('allows legacy through the last date and rejects it at the cutoff', () => {
+    const legacy = readFixture('legacy-tab-group-url-ids.json')
+
+    const allowed = assertProductionImportAllowed(legacy, {
+      importDate: '2026-08-31',
+      importMode: 'merge',
+    })
+    expect(allowed).toMatchObject({
+      inspection: {
+        preview: { formatKind: 'legacy' },
+      },
+      kind: 'legacy-merge',
+      userSettingsPatch: expect.any(Object),
+    })
+
+    const error = captureError(() =>
+      assertProductionImportAllowed(legacy, {
+        importDate: '2026-09-01',
+        importMode: 'merge',
+      }),
+    )
+    expect(error).toMatchObject<Partial<LegacyBackupImportError>>({
+      code: 'LEGACY_IMPORT_CUTOFF_REACHED',
+      name: 'LegacyBackupImportError',
+    })
+  })
+
+  it('blocks a supported legacy overwrite until #740 is available', () => {
+    const error = captureError(() =>
+      assertProductionImportAllowed(
+        readFixture('legacy-tab-group-url-ids.json'),
+        {
+          importDate: '2026-08-31',
+          importMode: 'overwrite',
+        },
+      ),
+    )
+
+    expect(error).toMatchObject<Partial<ProductionBackupImportError>>({
+      code: 'OVERWRITE_RECOVERY_UNAVAILABLE',
+      name: 'ProductionBackupImportError',
+    })
+    expect(JSON.stringify(error)).not.toContain('urls')
+  })
+
+  it('does not accept an omitted import date', () => {
+    const legacy = readFixture('legacy-tab-group-url-ids.json')
+    const callWithoutDate = assertProductionImportAllowed as (
+      input: string,
+    ) => void
+
+    expect(() => callWithoutDate(legacy)).toThrow('Import date is required')
+  })
+
+  it('leaves malformed JSON to the existing legacy format-error path', () => {
+    expect(() =>
+      assertProductionImportAllowed('{malformed-json', {
+        importDate: '2026-07-28',
+        importMode: 'overwrite',
+      }),
+    ).not.toThrow()
+  })
+})

--- a/src/features/options/lib/import-export/productionImportGate.test.ts
+++ b/src/features/options/lib/import-export/productionImportGate.test.ts
@@ -103,6 +103,7 @@ describe('assertProductionImportAllowed', () => {
         preview: { formatKind: 'legacy' },
       },
       kind: 'legacy-merge',
+      serializedBytes: new TextEncoder().encode(legacy).byteLength,
       userSettingsPatch: expect.any(Object),
     })
 

--- a/src/features/options/lib/import-export/productionImportGate.ts
+++ b/src/features/options/lib/import-export/productionImportGate.ts
@@ -1,0 +1,106 @@
+import {
+  BackupSchemaError,
+  detectBackupFormat,
+} from '@/lib/persistence/backupSchema'
+
+import { isLegacyBackupImportSupported } from './compatibility/legacyBackupPolicy'
+import type { LegacyBackupMergeInput } from './legacy/ImportLegacyBackupMergeUseCase'
+import { LegacyBackupImportError } from './legacy/LegacyBackupAdapter'
+import { LegacyBackupV0Schema } from './legacy/LegacyBackupV0Schema'
+import { inspectBackupV2 } from './v2/BackupV2Inspector'
+
+export type ProductionBackupImportErrorCode = 'OVERWRITE_RECOVERY_UNAVAILABLE'
+
+export class ProductionBackupImportError extends Error {
+  readonly code: ProductionBackupImportErrorCode
+
+  constructor(code: ProductionBackupImportErrorCode) {
+    super('Backup overwrite recovery is unavailable')
+    this.name = 'ProductionBackupImportError'
+    this.code = code
+  }
+}
+
+export type ProductionImportGateOptions = {
+  readonly importDate: string
+  readonly importMode: 'merge' | 'overwrite'
+}
+
+export type ProductionImportGateResult =
+  | ({ readonly kind: 'legacy-merge' } & LegacyBackupMergeInput)
+  | undefined
+
+type JsonParseResult =
+  | { readonly success: false }
+  | { readonly data: unknown; readonly success: true }
+
+const parseJson = (input: string): JsonParseResult => {
+  try {
+    const parsed: unknown = JSON.parse(input)
+    return { data: parsed, success: true }
+  } catch {
+    return { success: false }
+  }
+}
+
+/**
+ * Fail-closed production boundary for backup import.
+ *
+ * Current V2 is validated before reporting the temporary #740 recovery
+ * blocker. Schema-less backups are strictly validated before entering the
+ * legacy flow through the cutoff. Invalid JSON is left to the existing parser
+ * so its user-facing behavior does not change.
+ */
+export function assertProductionImportAllowed(
+  input: string,
+  options: ProductionImportGateOptions,
+): ProductionImportGateResult
+export function assertProductionImportAllowed(
+  input: string,
+  options?: ProductionImportGateOptions,
+): ProductionImportGateResult {
+  const importDate = options?.importDate
+  if (typeof importDate !== 'string') {
+    throw new TypeError('Import date is required')
+  }
+  const importMode = options?.importMode
+  if (importMode !== 'merge' && importMode !== 'overwrite') {
+    throw new TypeError('Import mode is required')
+  }
+  const isLegacySupported = isLegacyBackupImportSupported(importDate)
+  const parseResult = parseJson(input)
+  if (!parseResult.success) {
+    return undefined
+  }
+
+  const format = detectBackupFormat(parseResult.data)
+  if (format.kind === 'legacy') {
+    if (!isLegacySupported) {
+      throw new LegacyBackupImportError('LEGACY_IMPORT_CUTOFF_REACHED')
+    }
+    const legacyResult = LegacyBackupV0Schema.safeParse(parseResult.data)
+    if (!legacyResult.success) {
+      throw new BackupSchemaError('INVALID_SCHEMA')
+    }
+    const inspection = inspectBackupV2(parseResult.data, { importDate })
+    if (inspection.preview.formatKind !== 'legacy') {
+      throw new BackupSchemaError('INVALID_SCHEMA')
+    }
+    if (importMode === 'overwrite') {
+      throw new ProductionBackupImportError('OVERWRITE_RECOVERY_UNAVAILABLE')
+    }
+    return {
+      inspection: {
+        ...inspection,
+        preview: inspection.preview,
+      },
+      kind: 'legacy-merge',
+      userSettingsPatch: legacyResult.data.userSettings,
+    }
+  }
+
+  inspectBackupV2(parseResult.data, {
+    importDate,
+  })
+  throw new ProductionBackupImportError('OVERWRITE_RECOVERY_UNAVAILABLE')
+}

--- a/src/features/options/lib/import-export/productionImportGate.ts
+++ b/src/features/options/lib/import-export/productionImportGate.ts
@@ -8,6 +8,7 @@ import type { LegacyBackupMergeInput } from './legacy/ImportLegacyBackupMergeUse
 import { LegacyBackupImportError } from './legacy/LegacyBackupAdapter'
 import { LegacyBackupV0Schema } from './legacy/LegacyBackupV0Schema'
 import { inspectBackupV2 } from './v2/BackupV2Inspector'
+import type { BackupV2Inspection } from './v2/BackupV2Inspector'
 
 export type ProductionBackupImportErrorCode = 'OVERWRITE_RECOVERY_UNAVAILABLE'
 
@@ -42,6 +43,13 @@ const parseJson = (input: string): JsonParseResult => {
     return { success: false }
   }
 }
+
+const isLegacyInspection = (
+  inspection: BackupV2Inspection,
+): inspection is LegacyBackupMergeInput['inspection'] =>
+  inspection.preview.formatKind === 'legacy'
+
+const textEncoder = new TextEncoder()
 
 /**
  * Fail-closed production boundary for backup import.
@@ -83,18 +91,16 @@ export function assertProductionImportAllowed(
       throw new BackupSchemaError('INVALID_SCHEMA')
     }
     const inspection = inspectBackupV2(parseResult.data, { importDate })
-    if (inspection.preview.formatKind !== 'legacy') {
+    if (!isLegacyInspection(inspection)) {
       throw new BackupSchemaError('INVALID_SCHEMA')
     }
     if (importMode === 'overwrite') {
       throw new ProductionBackupImportError('OVERWRITE_RECOVERY_UNAVAILABLE')
     }
     return {
-      inspection: {
-        ...inspection,
-        preview: inspection.preview,
-      },
+      inspection,
       kind: 'legacy-merge',
+      serializedBytes: textEncoder.encode(input).byteLength,
       userSettingsPatch: legacyResult.data.userSettings,
     }
   }

--- a/src/features/options/lib/import-export/v2/BackupMapper.ts
+++ b/src/features/options/lib/import-export/v2/BackupMapper.ts
@@ -1,0 +1,230 @@
+import type {
+  PersistenceJsonRecord,
+  PersistenceLogicalSnapshot,
+  PersistenceMessageRecord,
+  PersistenceV2Collection,
+  PersistenceV2CollectionDefinition,
+  PersistenceV2Snapshot,
+} from '@/contexts/saved-tabs/public-api'
+import type { JsonObject, JsonValue } from '@/lib/persistence/jsonValue'
+import { isJsonValue } from '@/lib/persistence/jsonValue'
+import type { UserSettings } from '@/types/storage'
+
+import { BackupDataV2Schema } from './BackupV2Schema'
+import type { BackupDataV2 } from './BackupV2Schema'
+
+const compareCodePointStrings = (left: string, right: string): number => {
+  const leftCodePoints = Array.from(left)
+  const rightCodePoints = Array.from(right)
+  const sharedLength = Math.min(leftCodePoints.length, rightCodePoints.length)
+
+  for (let index = 0; index < sharedLength; index += 1) {
+    const leftCodePoint = leftCodePoints[index]?.codePointAt(0) ?? -1
+    const rightCodePoint = rightCodePoints[index]?.codePointAt(0) ?? -1
+    if (leftCodePoint !== rightCodePoint) {
+      return leftCodePoint - rightCodePoint
+    }
+  }
+
+  return leftCodePoints.length - rightCodePoints.length
+}
+
+const compareCompositeKey = (
+  left: readonly string[],
+  right: readonly string[],
+): number => {
+  const sharedLength = Math.min(left.length, right.length)
+  for (let index = 0; index < sharedLength; index += 1) {
+    const result = compareCodePointStrings(
+      left[index] ?? '',
+      right[index] ?? '',
+    )
+    if (result !== 0) {
+      return result
+    }
+  }
+  return left.length - right.length
+}
+
+const isJsonValueArray = (value: JsonValue): value is readonly JsonValue[] =>
+  Array.isArray(value)
+
+const canonicalizeJsonValue = (value: JsonValue): JsonValue => {
+  if (value === null || typeof value !== 'object') {
+    return value
+  }
+  if (isJsonValueArray(value)) {
+    return value.map(canonicalizeJsonValue)
+  }
+
+  const canonical: Record<string, JsonValue> = {}
+  for (const key of Object.keys(value).toSorted(compareCodePointStrings)) {
+    canonical[key] = canonicalizeJsonValue(value[key])
+  }
+  return canonical satisfies JsonObject
+}
+
+const canonicalizeRecordValue = (value: JsonValue): JsonValue => {
+  if (!isJsonValue(value)) {
+    throw new TypeError('Persistence record value must be JSON-safe')
+  }
+  return canonicalizeJsonValue(value)
+}
+
+const canonicalizeJsonRecord = (
+  record: PersistenceJsonRecord,
+): PersistenceJsonRecord => ({
+  id: record.id,
+  updatedAt: record.updatedAt,
+  value: canonicalizeRecordValue(record.value),
+})
+
+const canonicalizeMessageRecord = (
+  record: PersistenceMessageRecord,
+): PersistenceMessageRecord => ({
+  conversationId: record.conversationId,
+  createdAt: record.createdAt,
+  id: record.id,
+  value: canonicalizeRecordValue(record.value),
+})
+
+const canonicalizeCollectionDefinition = (
+  definition: PersistenceV2CollectionDefinition,
+): PersistenceV2CollectionDefinition => {
+  if (definition.type === 'domain') {
+    return {
+      domain: definition.domain,
+      type: 'domain',
+    }
+  }
+  return {
+    projectKeywords: {
+      domainKeywords: definition.projectKeywords.domainKeywords.toSorted(
+        compareCodePointStrings,
+      ),
+      titleKeywords: definition.projectKeywords.titleKeywords.toSorted(
+        compareCodePointStrings,
+      ),
+      urlKeywords: definition.projectKeywords.urlKeywords.toSorted(
+        compareCodePointStrings,
+      ),
+    },
+    type: 'custom',
+  }
+}
+
+const canonicalizeCollection = (
+  collection: PersistenceV2Collection,
+): PersistenceV2Collection => ({
+  createdAt: collection.createdAt,
+  definition: canonicalizeCollectionDefinition(collection.definition),
+  ...(collection.groupId === undefined ? {} : { groupId: collection.groupId }),
+  id: collection.id,
+  name: collection.name,
+  sortOrder: collection.sortOrder,
+  updatedAt: collection.updatedAt,
+})
+
+const canonicalizeSavedTabs = (
+  savedTabs: PersistenceV2Snapshot,
+): PersistenceV2Snapshot => ({
+  categories: savedTabs.categories
+    .map((category) => ({
+      collectionId: category.collectionId,
+      createdAt: category.createdAt,
+      id: category.id,
+      keywords: category.keywords.toSorted(compareCodePointStrings),
+      name: category.name,
+      sortOrder: category.sortOrder,
+      updatedAt: category.updatedAt,
+    }))
+    .toSorted((left, right) => compareCodePointStrings(left.id, right.id)),
+  collections: savedTabs.collections
+    .map(canonicalizeCollection)
+    .toSorted((left, right) => compareCodePointStrings(left.id, right.id)),
+  groups: savedTabs.groups
+    .map((group) => ({ ...group }))
+    .toSorted((left, right) => compareCodePointStrings(left.id, right.id)),
+  memberships: savedTabs.memberships
+    .map((membership) => ({ ...membership }))
+    .toSorted((left, right) =>
+      compareCompositeKey(
+        [left.collectionId, left.urlId],
+        [right.collectionId, right.urlId],
+      ),
+    ),
+  urls: savedTabs.urls
+    .map((url) => ({ ...url }))
+    .toSorted((left, right) => compareCodePointStrings(left.id, right.id)),
+})
+
+const canonicalizeUserSettings = (userSettings: UserSettings): UserSettings => {
+  if (!isJsonValue(userSettings)) {
+    throw new TypeError('User settings must be JSON-safe')
+  }
+
+  const canonical = canonicalizeJsonValue({
+    ...userSettings,
+    excludePatterns: userSettings.excludePatterns.toSorted(
+      compareCodePointStrings,
+    ),
+  })
+  return BackupDataV2Schema.shape.userSettings.parse(canonical)
+}
+
+const canonicalizeBackupData = (data: BackupDataV2): BackupDataV2 =>
+  BackupDataV2Schema.parse({
+    analyticsViews: data.analyticsViews
+      .map(canonicalizeJsonRecord)
+      .toSorted((left, right) => compareCodePointStrings(left.id, right.id)),
+    conversations: data.conversations
+      .map(canonicalizeJsonRecord)
+      .toSorted((left, right) => compareCodePointStrings(left.id, right.id)),
+    messages: data.messages
+      .map(canonicalizeMessageRecord)
+      .toSorted((left, right) =>
+        compareCompositeKey(
+          [left.conversationId, left.id],
+          [right.conversationId, right.id],
+        ),
+      ),
+    savedTabs: canonicalizeSavedTabs(data.savedTabs),
+    userSettings: canonicalizeUserSettings(data.userSettings),
+  })
+
+const toBackupData = (
+  snapshot: PersistenceLogicalSnapshot,
+  userSettings: UserSettings,
+): BackupDataV2 => {
+  const validated = BackupDataV2Schema.parse({
+    analyticsViews: snapshot.analyticsViews,
+    conversations: snapshot.conversations,
+    messages: snapshot.messages,
+    savedTabs: snapshot.savedTabs,
+    userSettings,
+  })
+  return canonicalizeBackupData(validated)
+}
+
+const toLogicalSnapshot = (
+  data: BackupDataV2,
+  revision: number,
+): PersistenceLogicalSnapshot => {
+  if (!Number.isSafeInteger(revision) || revision < 0) {
+    throw new RangeError('Persistence revision must be a non-negative integer')
+  }
+
+  const canonical = canonicalizeBackupData(BackupDataV2Schema.parse(data))
+  return {
+    analyticsViews: canonical.analyticsViews,
+    conversations: canonical.conversations,
+    messages: canonical.messages,
+    revision,
+    savedTabs: canonical.savedTabs,
+  }
+}
+
+export const BackupMapper = {
+  toBackupData,
+  toLogicalSnapshot,
+} as const

--- a/src/features/options/lib/import-export/v2/BackupV2Inspector.test.ts
+++ b/src/features/options/lib/import-export/v2/BackupV2Inspector.test.ts
@@ -1,0 +1,431 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+
+import { LegacyBackupImportError } from '@/features/options/lib/import-export/legacy/LegacyBackupAdapter'
+import type { BackupSchemaError } from '@/lib/persistence/backupSchema'
+
+import { inspectBackupV2 } from './BackupV2Inspector'
+import { BackupEnvelopeV2Schema } from './BackupV2Schema'
+
+const readFixture = (name: string): string =>
+  readFileSync(new URL(`fixtures/${name}`, import.meta.url), 'utf8')
+
+const parseFixture = (name: string): unknown => {
+  const parsed: unknown = JSON.parse(readFixture(name))
+  return parsed
+}
+
+const inspectFixture = (name: string, importDate = '2026-08-31') =>
+  inspectBackupV2(readFixture(name), { importDate })
+
+const captureError = (action: () => unknown): Error => {
+  try {
+    action()
+  } catch (error) {
+    if (error instanceof Error) {
+      return error
+    }
+  }
+  throw new Error('Expected action to throw')
+}
+
+describe('inspectBackupV2 legacy conversion', () => {
+  it('preserves a nested tab URL, category membership, and timestamp fallback', () => {
+    const result = inspectFixture('legacy-tab-group-nested-urls.json')
+
+    expect(result.data.savedTabs.urls).toEqual([
+      expect.objectContaining({
+        firstSavedAt: 0,
+        title: 'Nested guide',
+        url: 'https://nested.example.com/guide',
+      }),
+    ])
+    expect(result.data.savedTabs.categories).toEqual([
+      expect.objectContaining({
+        collectionId: 'domain-nested',
+        name: 'docs',
+      }),
+    ])
+    expect(result.data.savedTabs.memberships).toEqual([
+      expect.objectContaining({
+        categoryId: 'domain-nested:category:0',
+        collectionId: 'domain-nested',
+      }),
+    ])
+    expect(result.data.userSettings.showSavedTime).toBe(true)
+    expect(
+      result.preview.warnings.find(
+        ({ code }) => code === 'MISSING_TIMESTAMP_PROVENANCE',
+      ),
+    ).toEqual({
+      code: 'MISSING_TIMESTAMP_PROVENANCE',
+      count: 2,
+    })
+  })
+
+  it('normalizes a legacy nested timestamp and removes runtime tabId', () => {
+    const input = parseFixture('legacy-tab-group-nested-urls.json')
+    if (
+      typeof input !== 'object' ||
+      input === null ||
+      !('savedTabs' in input) ||
+      !Array.isArray(input.savedTabs)
+    ) {
+      throw new TypeError('Expected saved tabs fixture')
+    }
+    const savedTab: unknown = input.savedTabs[0]
+    if (
+      typeof savedTab !== 'object' ||
+      savedTab === null ||
+      !('urls' in savedTab) ||
+      !Array.isArray(savedTab.urls)
+    ) {
+      throw new TypeError('Expected nested URLs fixture')
+    }
+    const nestedUrl: unknown = savedTab.urls[0]
+    if (typeof nestedUrl !== 'object' || nestedUrl === null) {
+      throw new TypeError('Expected nested URL fixture')
+    }
+    Object.assign(nestedUrl, { tabId: 99, timestamp: 321 })
+
+    const result = inspectBackupV2(input, {
+      importDate: '2026-08-31',
+    })
+
+    expect(result.data.savedTabs.urls[0]?.firstSavedAt).toBe(321)
+    expect(JSON.stringify(result.data)).not.toContain('tabId')
+    expect(JSON.stringify(result.data)).not.toContain('timestamp')
+  })
+
+  it('prefers nested savedAt over the legacy timestamp alias', () => {
+    const input = parseFixture('legacy-tab-group-nested-urls.json')
+    if (
+      typeof input !== 'object' ||
+      input === null ||
+      !('savedTabs' in input) ||
+      !Array.isArray(input.savedTabs)
+    ) {
+      throw new TypeError('Expected saved tabs fixture')
+    }
+    const savedTab: unknown = input.savedTabs[0]
+    if (
+      typeof savedTab !== 'object' ||
+      savedTab === null ||
+      !('urls' in savedTab) ||
+      !Array.isArray(savedTab.urls)
+    ) {
+      throw new TypeError('Expected nested URLs fixture')
+    }
+    const nestedUrl: unknown = savedTab.urls[0]
+    if (typeof nestedUrl !== 'object' || nestedUrl === null) {
+      throw new TypeError('Expected nested URL fixture')
+    }
+    Object.assign(nestedUrl, { savedAt: 654, timestamp: 321 })
+
+    const result = inspectBackupV2(input, {
+      importDate: '2026-08-31',
+    })
+
+    expect(result.data.savedTabs.urls[0]?.firstSavedAt).toBe(654)
+  })
+
+  it('preserves a canonical URL id and its domain membership', () => {
+    const result = inspectFixture('legacy-tab-group-url-ids.json')
+
+    expect(result.data.savedTabs.urls).toEqual([
+      expect.objectContaining({
+        firstSavedAt: 101,
+        id: 'url-canonical',
+      }),
+    ])
+    expect(result.data.savedTabs.memberships).toEqual([
+      expect.objectContaining({
+        categoryId: 'domain-ids:category:0',
+        collectionId: 'domain-ids',
+        urlId: 'url-canonical',
+      }),
+    ])
+  })
+
+  it('preserves nested custom project notes and category membership', () => {
+    const result = inspectFixture('legacy-custom-project-urls.json')
+
+    expect(result.data.savedTabs.collections).toEqual([
+      expect.objectContaining({
+        id: 'project-nested',
+        name: 'Nested project',
+      }),
+    ])
+    expect(result.data.savedTabs.memberships).toEqual([
+      expect.objectContaining({
+        categoryId: 'project-nested:category:0',
+        notes: 'private-project-note',
+      }),
+    ])
+  })
+
+  it('normalizes missing project keyword arrays while preserving supplied values', () => {
+    const input = parseFixture('legacy-custom-project-urls.json')
+    if (
+      typeof input !== 'object' ||
+      input === null ||
+      !('customProjects' in input) ||
+      !Array.isArray(input.customProjects)
+    ) {
+      throw new TypeError('Expected custom projects fixture')
+    }
+    const project: unknown = input.customProjects[0]
+    if (typeof project !== 'object' || project === null) {
+      throw new TypeError('Expected custom project fixture')
+    }
+    Object.assign(project, {
+      projectKeywords: {
+        titleKeywords: ['preserved-title'],
+      },
+    })
+
+    const result = inspectBackupV2(input, {
+      importDate: '2026-08-31',
+    })
+
+    expect(result.data.savedTabs.collections[0]?.definition).toEqual({
+      projectKeywords: {
+        domainKeywords: [],
+        titleKeywords: ['preserved-title'],
+        urlKeywords: [],
+      },
+      type: 'custom',
+    })
+  })
+
+  it('preserves urlMetadata notes and category membership', () => {
+    const result = inspectFixture('legacy-custom-project-url-metadata.json')
+
+    expect(result.data.savedTabs.memberships).toEqual([
+      expect.objectContaining({
+        categoryId: 'project-metadata:category:0',
+        notes: 'private-metadata-note',
+        urlId: 'url-project-metadata',
+      }),
+    ])
+  })
+
+  it('preserves the parent category relation', () => {
+    const result = inspectFixture('legacy-parent-category.json')
+
+    expect(result.data.savedTabs.groups).toEqual([
+      expect.objectContaining({
+        id: 'parent-work',
+        name: 'Work',
+      }),
+    ])
+    expect(result.data.savedTabs.collections).toEqual([
+      expect.objectContaining({
+        groupId: 'parent-work',
+        id: 'domain-parented',
+      }),
+    ])
+  })
+
+  it('accepts a fixture with mixed legacy URL representations', () => {
+    const result = inspectFixture('legacy-mixed-fields.json')
+
+    expect(result.preview.entityCounts).toEqual({
+      analyticsViews: 0,
+      categories: 0,
+      collections: 3,
+      conversations: 0,
+      groups: 0,
+      memberships: 3,
+      messages: 0,
+      urls: 3,
+    })
+    expect(result.data.userSettings.language).toBe('en')
+  })
+
+  it('normalizes the legacy analytics time grouping alias', () => {
+    const input = parseFixture('legacy-tab-group-url-ids.json')
+    if (typeof input !== 'object' || input === null) {
+      throw new TypeError('Expected legacy fixture')
+    }
+    Object.assign(input, {
+      savedAnalyticsViews: [
+        {
+          createdAt: 1,
+          id: 'legacy-time-view',
+          name: 'Legacy time',
+          query: {
+            chartType: 'bar',
+            compareBy: 'none',
+            filters: {
+              excludedDomains: [],
+              excludedParentCategories: [],
+              excludedProjectCategories: [],
+              excludedProjects: [],
+              excludedSubCategories: [],
+              includedDomains: [],
+              includedParentCategories: [],
+              includedProjectCategories: [],
+              includedProjects: [],
+              includedSubCategories: [],
+            },
+            groupBy: 'time',
+            limit: 10,
+            mode: 'both',
+            normalize: false,
+            sort: 'value-desc',
+            stacked: false,
+            timeBucket: 'day',
+            timeRange: '30d',
+          },
+          updatedAt: 2,
+        },
+      ],
+    })
+
+    const result = inspectBackupV2(input, {
+      importDate: '2026-08-31',
+    })
+
+    expect(result.data.analyticsViews[0]?.value).toMatchObject({
+      query: { groupBy: 'timeRecent' },
+    })
+  })
+
+  it('rejects a malformed legacy fixture', () => {
+    const error = captureError(() => inspectFixture('legacy-malformed.json'))
+
+    expect(error).toMatchObject<Partial<BackupSchemaError>>({
+      code: 'INVALID_SCHEMA',
+      name: 'BackupSchemaError',
+    })
+  })
+
+  it('keeps preview diagnostics content-free', () => {
+    const result = inspectFixture('legacy-custom-project-urls.json')
+    const previewJson = JSON.stringify(result.preview)
+
+    expect(result.preview).toMatchObject({
+      advisory: {
+        cutoffDate: '2026-09-01',
+        lastSupportedDate: '2026-08-31',
+        requiresReExport: true,
+      },
+      formatKind: 'legacy',
+      schemaVersion: null,
+    })
+    expect(result.preview.appVersion).toBe('1.9.0')
+    expect(result.preview.exportedAt).toBe('2026-07-03T00:00:00.000Z')
+    expect(
+      result.preview.warnings.every(
+        (warning) => Object.keys(warning).toSorted().join(',') === 'code,count',
+      ),
+    ).toBe(true)
+    expect(previewJson).not.toContain('private-project-note')
+    expect(previewJson).not.toContain('project.example.com')
+  })
+
+  it('rejects mapper errors with content-free issue codes', () => {
+    const input = parseFixture('legacy-tab-group-url-ids.json')
+    if (
+      typeof input !== 'object' ||
+      input === null ||
+      !('savedTabs' in input) ||
+      !Array.isArray(input.savedTabs)
+    ) {
+      throw new TypeError('Expected the test fixture to contain saved tabs')
+    }
+    const [savedTab] = input.savedTabs
+    if (typeof savedTab !== 'object' || savedTab === null) {
+      throw new TypeError('Expected the test fixture to contain a saved tab')
+    }
+    savedTab.urlIds = ['private-dangling-url-id']
+
+    const error = captureError(() =>
+      inspectBackupV2(input, { importDate: '2026-08-31' }),
+    )
+
+    expect(error).toMatchObject<Partial<LegacyBackupImportError>>({
+      code: 'LEGACY_MIGRATION_BLOCKED',
+      name: 'LegacyBackupImportError',
+    })
+    if (!(error instanceof LegacyBackupImportError)) {
+      throw new TypeError('Expected a legacy backup import error')
+    }
+    expect(error.issueCodes).toContain('LEGACY_URL_REFERENCE_CONFLICT')
+    expect(JSON.stringify(error)).not.toContain('private-dangling-url-id')
+  })
+
+  it('supports the last legacy import date and rejects the cutoff date', () => {
+    expect(() =>
+      inspectFixture('legacy-tab-group-url-ids.json', '2026-08-31'),
+    ).not.toThrow()
+
+    const error = captureError(() =>
+      inspectFixture('legacy-tab-group-url-ids.json', '2026-09-01'),
+    )
+    expect(error).toMatchObject<Partial<LegacyBackupImportError>>({
+      code: 'LEGACY_IMPORT_CUTOFF_REACHED',
+      name: 'LegacyBackupImportError',
+    })
+  })
+})
+
+describe('inspectBackupV2 versioned backups', () => {
+  it('strictly validates the current V2 fixture', () => {
+    const fixture = BackupEnvelopeV2Schema.parse(
+      parseFixture('backup-v2-current.json'),
+    )
+
+    const result = inspectBackupV2(fixture, {
+      importDate: '2027-01-01',
+    })
+
+    expect(result).toMatchObject({
+      data: fixture.data,
+      preview: {
+        appVersion: '2.0.0',
+        entityCounts: {
+          analyticsViews: 0,
+          categories: 0,
+          collections: 0,
+          conversations: 0,
+          groups: 0,
+          memberships: 0,
+          messages: 0,
+          urls: 0,
+        },
+        exportedAt: '2026-07-08T00:00:00.000Z',
+        formatKind: 'current-v2',
+        schemaVersion: 2,
+        warnings: [],
+      },
+    })
+  })
+
+  it('rejects a future schema with current and received versions', () => {
+    const error = captureError(() => inspectFixture('backup-v2-future.json'))
+
+    expect(error).toMatchObject<Partial<BackupSchemaError>>({
+      code: 'UNSUPPORTED_FUTURE_SCHEMA',
+      currentVersion: 2,
+      name: 'BackupSchemaError',
+      receivedVersion: 3,
+    })
+  })
+
+  it('rejects invalid JSON without leaking parser details', () => {
+    const error = captureError(() =>
+      inspectBackupV2('{"schemaVersion":', {
+        importDate: '2026-08-31',
+      }),
+    )
+
+    expect(error).toMatchObject<Partial<BackupSchemaError>>({
+      code: 'INVALID_SCHEMA',
+      message: 'Backup schema is invalid',
+      name: 'BackupSchemaError',
+    })
+  })
+})

--- a/src/features/options/lib/import-export/v2/BackupV2Inspector.ts
+++ b/src/features/options/lib/import-export/v2/BackupV2Inspector.ts
@@ -1,0 +1,116 @@
+import { LEGACY_BACKUP_ADVISORY } from '@/features/options/lib/import-export/compatibility/legacyBackupPolicy'
+import { convertLegacyBackup } from '@/features/options/lib/import-export/legacy/LegacyBackupAdapter'
+import type { LegacyBackupWarning } from '@/features/options/lib/import-export/legacy/LegacyBackupAdapter'
+import { createBackupMigrationPipeline } from '@/lib/persistence/backupMigrationPipeline'
+import { BackupSchemaError } from '@/lib/persistence/backupSchema'
+
+import {
+  BACKUP_V2_SCHEMA_VERSION,
+  BackupEnvelopeV2Schema,
+} from './BackupV2Schema'
+import type { BackupDataV2, BackupEnvelopeV2 } from './BackupV2Schema'
+
+export type BackupPreviewEntityCounts = {
+  readonly analyticsViews: number
+  readonly categories: number
+  readonly collections: number
+  readonly conversations: number
+  readonly groups: number
+  readonly memberships: number
+  readonly messages: number
+  readonly urls: number
+}
+
+type BackupPreviewBase = {
+  readonly appVersion: string
+  readonly entityCounts: BackupPreviewEntityCounts
+  readonly exportedAt: string
+  readonly warnings: readonly LegacyBackupWarning[]
+}
+
+export type BackupV2Preview =
+  | (BackupPreviewBase & {
+      readonly formatKind: 'current-v2'
+      readonly schemaVersion: 2
+    })
+  | (BackupPreviewBase & {
+      readonly advisory: typeof LEGACY_BACKUP_ADVISORY
+      readonly formatKind: 'legacy'
+      readonly schemaVersion: null
+    })
+
+export type BackupV2Inspection = {
+  readonly data: BackupDataV2
+  readonly preview: BackupV2Preview
+}
+
+export type InspectBackupV2Options = {
+  readonly importDate: string
+}
+
+const migrationPipeline = createBackupMigrationPipeline<BackupEnvelopeV2>({
+  currentSchema: BackupEnvelopeV2Schema,
+  currentVersion: BACKUP_V2_SCHEMA_VERSION,
+  migrations: new Map(),
+})
+
+const parseUnknownInput = (input: unknown): unknown => {
+  if (typeof input !== 'string') {
+    return input
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(input)
+    return parsed
+  } catch {
+    throw new BackupSchemaError('INVALID_SCHEMA')
+  }
+}
+
+const countEntities = (data: BackupDataV2): BackupPreviewEntityCounts => ({
+  analyticsViews: data.analyticsViews.length,
+  categories: data.savedTabs.categories.length,
+  collections: data.savedTabs.collections.length,
+  conversations: data.conversations.length,
+  groups: data.savedTabs.groups.length,
+  memberships: data.savedTabs.memberships.length,
+  messages: data.messages.length,
+  urls: data.savedTabs.urls.length,
+})
+
+export const inspectBackupV2 = (
+  input: unknown,
+  { importDate }: InspectBackupV2Options,
+): BackupV2Inspection => {
+  const parsedInput = parseUnknownInput(input)
+  const migrationResult = migrationPipeline.migrateToCurrent(parsedInput)
+
+  if (migrationResult.kind === 'current') {
+    const { backup } = migrationResult
+    return {
+      data: backup.data,
+      preview: {
+        appVersion: backup.appVersion,
+        entityCounts: countEntities(backup.data),
+        exportedAt: backup.exportedAt,
+        formatKind: 'current-v2',
+        schemaVersion: BACKUP_V2_SCHEMA_VERSION,
+        warnings: [],
+      },
+    }
+  }
+
+  const legacy = convertLegacyBackup(parsedInput, importDate)
+  return {
+    data: legacy.data,
+    preview: {
+      advisory: LEGACY_BACKUP_ADVISORY,
+      appVersion: legacy.appVersion,
+      entityCounts: countEntities(legacy.data),
+      exportedAt: legacy.exportedAt,
+      formatKind: 'legacy',
+      schemaVersion: null,
+      warnings: legacy.warnings,
+    },
+  }
+}

--- a/src/features/options/lib/import-export/v2/BackupV2ResourceUsage.test.ts
+++ b/src/features/options/lib/import-export/v2/BackupV2ResourceUsage.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  BACKUP_RESOURCE_LIMITS,
+  BackupResourceLimitError,
+} from '@/lib/persistence/backupResourcePolicy'
+import type { JsonValue } from '@/lib/persistence/jsonValue'
+import type { UserSettings } from '@/types/storage'
+
+import { BackupMapper } from './BackupMapper'
+import { collectBackupV2ResourceUsage } from './BackupV2ResourceUsage'
+
+type PersistenceLogicalSnapshot = Parameters<
+  typeof BackupMapper.toBackupData
+>[0]
+
+const utf8Bytes = (value: string): number =>
+  new TextEncoder().encode(value).byteLength
+
+const userSettings = {
+  clickBehavior: 'saveCurrentTab',
+  confirmDeleteAll: true,
+  confirmDeleteEach: true,
+  enableCategories: true,
+  excludePatterns: [],
+  excludePinnedTabs: false,
+  openAllInNewWindow: false,
+  openUrlInBackground: false,
+  removeTabAfterExternalDrop: false,
+  removeTabAfterOpen: false,
+  showSavedTime: true,
+} satisfies UserSettings
+
+const createLogicalSnapshot = (
+  values: readonly JsonValue[],
+): PersistenceLogicalSnapshot => ({
+  analyticsViews: [
+    { id: 'analytics-1', updatedAt: 1, value: { name: 'view' } },
+  ],
+  conversations: [
+    {
+      id: 'conversation-1',
+      updatedAt: 1,
+      value: { title: '会話タイトル' },
+    },
+  ],
+  messages: values.map((value, index) => ({
+    conversationId: 'conversation-1',
+    createdAt: index + 1,
+    id: `message-${index + 1}`,
+    value,
+  })),
+  revision: 42,
+  savedTabs: {
+    categories: [
+      {
+        collectionId: 'collection-1',
+        createdAt: 1,
+        id: 'category-1',
+        keywords: ['猫', 'category-keyword'],
+        name: '分類名',
+        sortOrder: 1024,
+        updatedAt: 1,
+      },
+    ],
+    collections: [
+      {
+        createdAt: 1,
+        definition: {
+          projectKeywords: {
+            domainKeywords: ['領域'],
+            titleKeywords: ['題'],
+            urlKeywords: ['URL🌐'],
+          },
+          type: 'custom',
+        },
+        groupId: 'group-1',
+        id: 'collection-1',
+        name: '収集名',
+        sortOrder: 1024,
+        updatedAt: 1,
+      },
+    ],
+    groups: [
+      {
+        createdAt: 1,
+        id: 'group-1',
+        name: 'グループ名',
+        sortOrder: 1024,
+        updatedAt: 1,
+      },
+    ],
+    memberships: [
+      {
+        addedAt: 1,
+        categoryId: 'category-1',
+        collectionId: 'collection-1',
+        notes: 'メモ📝',
+        sortOrder: 1024,
+        updatedAt: 1,
+        urlId: 'url-1',
+      },
+    ],
+    urls: [
+      {
+        firstSavedAt: 1,
+        id: 'url-1',
+        lastSavedAt: 1,
+        normalizedUrl: 'https://xn--r8jz45g.test/%F0%9F%8C%90',
+        title: '題名🌐',
+        updatedAt: 1,
+        url: 'https://例え.test/🌐',
+      },
+    ],
+  },
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('collectBackupV2ResourceUsage', () => {
+  it('collects every resource family with UTF-8 and nested AI payload semantics', () => {
+    const toolTrace1 = {
+      input: { query: '猫' },
+      output: { count: 1 },
+      state: 'output-available',
+      title: '検索',
+      toolCallId: 'tool-1',
+      toolName: 'search',
+      type: 'dynamic-tool',
+    }
+    const toolTrace2 = {
+      input: { query: '犬' },
+      state: 'input-available',
+      title: '検索2',
+      toolCallId: 'tool-2',
+      toolName: 'search',
+      type: 'dynamic-tool',
+    }
+    const toolTrace3 = {
+      input: { period: 'week' },
+      output: { points: [1, 2] },
+      state: 'output-available',
+      title: '分析',
+      toolCallId: 'tool-3',
+      toolName: 'analytics',
+      type: 'dynamic-tool',
+    }
+    const attachmentContents = [
+      '添付テキスト',
+      'data:image/png;base64,aGVsbG8=',
+      '短い',
+    ]
+    const values = [
+      {
+        attachments: [
+          {
+            content: attachmentContents[0],
+            filename: '資料.txt',
+            kind: 'text',
+            mediaType: 'text/plain',
+          },
+          {
+            content: attachmentContents[1],
+            filename: '画像.png',
+            kind: 'image',
+            mediaType: 'image/png',
+          },
+        ],
+        charts: [
+          {
+            data: [{ label: 'a' }, { label: 'b' }],
+            series: [],
+            title: '図',
+            type: 'bar',
+          },
+          {
+            data: [{ x: 1 }, { x: 2 }, { x: 3 }],
+            series: [],
+            title: '図2',
+            type: 'line',
+          },
+        ],
+        content: 'こんにちは🌐',
+        role: 'assistant',
+        toolTraces: [toolTrace1, toolTrace2],
+      },
+      {
+        attachments: [
+          {
+            content: attachmentContents[2],
+            filename: '短.txt',
+            kind: 'text',
+            mediaType: 'text/plain',
+          },
+        ],
+        charts: [],
+        content: '短文',
+        role: 'user',
+        toolTraces: [toolTrace3],
+      },
+    ] satisfies JsonValue[]
+    const data = BackupMapper.toBackupData(
+      createLogicalSnapshot(values),
+      userSettings,
+    )
+    const toolTraceBytes = [toolTrace1, toolTrace2, toolTrace3].map(
+      (trace) =>
+        utf8Bytes(JSON.stringify(trace.input)) +
+        ('output' in trace ? utf8Bytes(JSON.stringify(trace.output)) : 0),
+    )
+
+    expect(collectBackupV2ResourceUsage(data, 321)).toEqual({
+      analyticsViews: 1,
+      attachmentAggregateBytes:
+        utf8Bytes(attachmentContents[0]) + 5 + utf8Bytes(attachmentContents[2]),
+      attachmentBytes: Math.max(
+        utf8Bytes(attachmentContents[0]),
+        5,
+        utf8Bytes(attachmentContents[2]),
+      ),
+      attachments: 3,
+      attachmentsPerMessage: 2,
+      categories: 1,
+      chartDataPoints: 5,
+      chartDataPointsPerChart: 3,
+      collections: 1,
+      conversations: 1,
+      groups: 1,
+      keywordBytes: Math.max(
+        ...['猫', 'category-keyword', '領域', '題', 'URL🌐'].map(utf8Bytes),
+      ),
+      keywordsPerEntity: 3,
+      memberships: 1,
+      messageContentBytes: utf8Bytes('こんにちは🌐'),
+      messages: 2,
+      messagesPerConversation: 2,
+      nameBytes: Math.max(...['分類名', '収集名', 'グループ名'].map(utf8Bytes)),
+      notesBytes: utf8Bytes('メモ📝'),
+      serializedBytes: 321,
+      titleBytes: utf8Bytes('題名🌐'),
+      toolTraceAggregateBytes: toolTraceBytes.reduce(
+        (total, bytes) => total + bytes,
+        0,
+      ),
+      toolTraceBytes: Math.max(...toolTraceBytes),
+      toolTraces: 3,
+      urlBytes: Math.max(
+        ...[
+          'https://例え.test/🌐',
+          'https://xn--r8jz45g.test/%F0%9F%8C%90',
+        ].map(utf8Bytes),
+      ),
+      urls: 1,
+    })
+  })
+
+  it('counts only structurally recognizable nested AI values', () => {
+    const data = BackupMapper.toBackupData(
+      createLogicalSnapshot([
+        {
+          attachments: ['private attachment', { content: 123 }],
+          charts: [{ data: 'private chart datum' }, null],
+          content: 123,
+          toolTraces: ['private tool trace', null],
+        },
+      ]),
+      userSettings,
+    )
+
+    const usage = collectBackupV2ResourceUsage(data, 100)
+
+    expect(usage).toMatchObject({
+      attachmentAggregateBytes: 0,
+      attachmentBytes: 0,
+      attachments: 0,
+      attachmentsPerMessage: 0,
+      chartDataPoints: 0,
+      chartDataPointsPerChart: 0,
+      messageContentBytes: 0,
+      toolTraceAggregateBytes: 0,
+      toolTraceBytes: 0,
+      toolTraces: 0,
+    })
+  })
+
+  it('reports logical overflow before simultaneous serialized overflow', () => {
+    const data = BackupMapper.toBackupData(
+      createLogicalSnapshot([
+        {
+          attachments: Array.from(
+            { length: BACKUP_RESOURCE_LIMITS.maxAttachmentsPerMessage + 1 },
+            (_, index) => ({
+              content: `private-${index}`,
+              filename: `${index}.txt`,
+              kind: 'text',
+              mediaType: 'text/plain',
+            }),
+          ),
+          content: 'private message content',
+        },
+      ]),
+      userSettings,
+    )
+
+    let caught: unknown
+    try {
+      collectBackupV2ResourceUsage(
+        data,
+        BACKUP_RESOURCE_LIMITS.maxSerializedBytes + 1,
+      )
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(BackupResourceLimitError)
+    expect(caught).toMatchObject({
+      code: 'BACKUP_NESTED_PAYLOAD_TOO_LARGE',
+      diagnostic: {
+        actual: BACKUP_RESOURCE_LIMITS.maxAttachmentsPerMessage + 1,
+        limit: BACKUP_RESOURCE_LIMITS.maxAttachmentsPerMessage,
+        resource: 'attachmentsPerMessage',
+      },
+    })
+    expect(JSON.stringify(caught)).not.toContain('private')
+  })
+
+  it('rejects unsafe serialized metrics and arithmetic overflow', () => {
+    const data = BackupMapper.toBackupData(
+      createLogicalSnapshot([
+        {
+          attachments: [
+            {
+              content: 'first private attachment',
+              kind: 'text',
+            },
+            {
+              content: 'second private attachment',
+              kind: 'text',
+            },
+          ],
+        },
+      ]),
+      userSettings,
+    )
+
+    expect(() =>
+      collectBackupV2ResourceUsage(data, Number.MAX_SAFE_INTEGER + 1),
+    ).toThrow(BackupResourceLimitError)
+
+    vi.spyOn(TextEncoder.prototype, 'encode').mockReturnValue({
+      byteLength: Number.MAX_SAFE_INTEGER,
+    } as Uint8Array<ArrayBuffer>)
+
+    let caught: unknown
+    try {
+      collectBackupV2ResourceUsage(data, 1)
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(BackupResourceLimitError)
+    expect(caught).toMatchObject({
+      code: 'INVALID_BACKUP',
+      diagnostic: { resource: 'attachmentAggregateBytes' },
+    })
+    expect(JSON.stringify(caught)).not.toContain('private')
+  })
+})

--- a/src/features/options/lib/import-export/v2/BackupV2ResourceUsage.ts
+++ b/src/features/options/lib/import-export/v2/BackupV2ResourceUsage.ts
@@ -1,0 +1,321 @@
+import {
+  BackupResourceLimitError,
+  assertBackupSerializedBytes,
+  createEmptyBackupResourceUsage,
+  validateBackupResourceUsage,
+} from '@/lib/persistence/backupResourcePolicy'
+import type {
+  BackupResourceName,
+  BackupResourceUsage,
+} from '@/lib/persistence/backupResourcePolicy'
+
+import type { BackupDataV2 } from './BackupV2Schema'
+
+type MutableBackupResourceUsage = {
+  -readonly [Key in keyof BackupResourceUsage]: BackupResourceUsage[Key]
+}
+
+type JsonRecord = Record<string, unknown>
+
+const BASE64_BLOCK_LENGTH = 4
+const BASE64_BYTES_PER_BLOCK = 3
+const BASE64_DOUBLE_PADDING_LENGTH = 2
+const BASE64_SINGLE_PADDING_LENGTH = 1
+const textEncoder = new TextEncoder()
+
+const isJsonRecord = (value: unknown): value is JsonRecord =>
+  value !== null && typeof value === 'object' && !Array.isArray(value)
+
+const readString = (
+  value: JsonRecord,
+  property: string,
+): string | undefined => {
+  const candidate = value[property]
+  return typeof candidate === 'string' ? candidate : undefined
+}
+
+const utf8Bytes = (value: string): number =>
+  textEncoder.encode(value).byteLength
+
+const createInvalidMetricError = (
+  resource: Exclude<BackupResourceName, 'serializedBytes'>,
+): BackupResourceLimitError => {
+  const result = validateBackupResourceUsage({
+    ...createEmptyBackupResourceUsage(),
+    [resource]: Number.NaN,
+  })
+  if (result.success) {
+    throw new Error(`Missing backup resource policy for ${resource}`)
+  }
+  return new BackupResourceLimitError(result.error)
+}
+
+const safeAdd = (
+  left: number,
+  right: number,
+  resource: Exclude<BackupResourceName, 'serializedBytes'>,
+): number => {
+  if (
+    !Number.isSafeInteger(left) ||
+    left < 0 ||
+    !Number.isSafeInteger(right) ||
+    right < 0 ||
+    left > Number.MAX_SAFE_INTEGER - right
+  ) {
+    throw createInvalidMetricError(resource)
+  }
+  return left + right
+}
+
+const observeUtf8Maximum = (
+  usage: MutableBackupResourceUsage,
+  resource:
+    | 'keywordBytes'
+    | 'messageContentBytes'
+    | 'nameBytes'
+    | 'notesBytes'
+    | 'titleBytes'
+    | 'urlBytes',
+  value: string,
+): void => {
+  usage[resource] = Math.max(usage[resource], utf8Bytes(value))
+}
+
+const getDecodedBase64Bytes = (value: string): number | null => {
+  const match = /^data:[^,]*;base64,(?<payload>[A-Za-z0-9+/]*={0,2})$/u.exec(
+    value,
+  )
+  const payload = match?.groups?.payload
+  if (
+    payload === undefined ||
+    payload.length % BASE64_BLOCK_LENGTH === BASE64_SINGLE_PADDING_LENGTH
+  ) {
+    return null
+  }
+
+  let padding = 0
+  if (payload.endsWith('==')) {
+    padding = BASE64_DOUBLE_PADDING_LENGTH
+  } else if (payload.endsWith('=')) {
+    padding = BASE64_SINGLE_PADDING_LENGTH
+  }
+  const decodedBytes =
+    Math.floor(
+      (payload.length * BASE64_BYTES_PER_BLOCK) / BASE64_BLOCK_LENGTH,
+    ) - padding
+  return Number.isSafeInteger(decodedBytes) && decodedBytes >= 0
+    ? decodedBytes
+    : null
+}
+
+const getAttachmentBytes = (attachment: JsonRecord): number | null => {
+  const content = readString(attachment, 'content')
+  const kind = readString(attachment, 'kind')
+  if (content === undefined || (kind !== 'image' && kind !== 'text')) {
+    return null
+  }
+  if (kind === 'image') {
+    return getDecodedBase64Bytes(content) ?? utf8Bytes(content)
+  }
+  return utf8Bytes(content)
+}
+
+const isRecognizableToolTrace = (value: unknown): value is JsonRecord => {
+  if (!isJsonRecord(value) || !Object.hasOwn(value, 'input')) {
+    return false
+  }
+  return ['state', 'title', 'toolCallId', 'toolName', 'type'].every(
+    (property) => readString(value, property) !== undefined,
+  )
+}
+
+const getToolTracePayloadBytes = (toolTrace: JsonRecord): number => {
+  const getSerializedBytes = (value: unknown): number => {
+    const serialized: unknown = JSON.stringify(value)
+    if (typeof serialized !== 'string') {
+      throw createInvalidMetricError('toolTraceBytes')
+    }
+    return utf8Bytes(serialized)
+  }
+
+  const inputBytes = getSerializedBytes(toolTrace.input)
+  if (!Object.hasOwn(toolTrace, 'output')) {
+    return inputBytes
+  }
+  return safeAdd(
+    inputBytes,
+    getSerializedBytes(toolTrace.output),
+    'toolTraceBytes',
+  )
+}
+
+const collectKeywords = (
+  usage: MutableBackupResourceUsage,
+  keywords: readonly string[],
+): void => {
+  usage.keywordsPerEntity = Math.max(usage.keywordsPerEntity, keywords.length)
+  for (const keyword of keywords) {
+    observeUtf8Maximum(usage, 'keywordBytes', keyword)
+  }
+}
+
+const collectMessageResources = (
+  usage: MutableBackupResourceUsage,
+  value: unknown,
+): void => {
+  if (!isJsonRecord(value)) {
+    return
+  }
+
+  const content = readString(value, 'content')
+  if (content !== undefined) {
+    observeUtf8Maximum(usage, 'messageContentBytes', content)
+  }
+
+  const attachments = value.attachments
+  if (Array.isArray(attachments)) {
+    let recognizedAttachments = 0
+    for (const attachment of attachments) {
+      if (!isJsonRecord(attachment)) {
+        continue
+      }
+      const bytes = getAttachmentBytes(attachment)
+      if (bytes === null) {
+        continue
+      }
+      recognizedAttachments = safeAdd(
+        recognizedAttachments,
+        1,
+        'attachmentsPerMessage',
+      )
+      usage.attachments = safeAdd(usage.attachments, 1, 'attachments')
+      usage.attachmentBytes = Math.max(usage.attachmentBytes, bytes)
+      usage.attachmentAggregateBytes = safeAdd(
+        usage.attachmentAggregateBytes,
+        bytes,
+        'attachmentAggregateBytes',
+      )
+    }
+    usage.attachmentsPerMessage = Math.max(
+      usage.attachmentsPerMessage,
+      recognizedAttachments,
+    )
+  }
+
+  const charts = value.charts
+  if (Array.isArray(charts)) {
+    for (const chart of charts) {
+      if (!isJsonRecord(chart) || !Array.isArray(chart.data)) {
+        continue
+      }
+      const dataPoints = chart.data.length
+      usage.chartDataPoints = safeAdd(
+        usage.chartDataPoints,
+        dataPoints,
+        'chartDataPoints',
+      )
+      usage.chartDataPointsPerChart = Math.max(
+        usage.chartDataPointsPerChart,
+        dataPoints,
+      )
+    }
+  }
+
+  const toolTraces = value.toolTraces
+  if (Array.isArray(toolTraces)) {
+    for (const toolTrace of toolTraces) {
+      if (!isRecognizableToolTrace(toolTrace)) {
+        continue
+      }
+      const bytes = getToolTracePayloadBytes(toolTrace)
+      usage.toolTraces = safeAdd(usage.toolTraces, 1, 'toolTraces')
+      usage.toolTraceBytes = Math.max(usage.toolTraceBytes, bytes)
+      usage.toolTraceAggregateBytes = safeAdd(
+        usage.toolTraceAggregateBytes,
+        bytes,
+        'toolTraceAggregateBytes',
+      )
+    }
+  }
+}
+
+/**
+ * Collects the numeric Backup V2 policy metrics without retaining user content.
+ *
+ * `serializedBytes` is supplied by the compact envelope serializer so callers
+ * validate the exact representation that will be written.
+ */
+export const collectBackupV2ResourceUsage = (
+  data: BackupDataV2,
+  serializedBytes: number,
+): BackupResourceUsage => {
+  const usage: MutableBackupResourceUsage = {
+    ...createEmptyBackupResourceUsage(),
+    analyticsViews: data.analyticsViews.length,
+    categories: data.savedTabs.categories.length,
+    collections: data.savedTabs.collections.length,
+    conversations: data.conversations.length,
+    groups: data.savedTabs.groups.length,
+    memberships: data.savedTabs.memberships.length,
+    messages: data.messages.length,
+    serializedBytes: 0,
+    urls: data.savedTabs.urls.length,
+  }
+
+  for (const url of data.savedTabs.urls) {
+    observeUtf8Maximum(usage, 'urlBytes', url.url)
+    observeUtf8Maximum(usage, 'urlBytes', url.normalizedUrl)
+    if (url.favIconUrl !== undefined) {
+      observeUtf8Maximum(usage, 'urlBytes', url.favIconUrl)
+    }
+    observeUtf8Maximum(usage, 'titleBytes', url.title)
+  }
+
+  for (const collection of data.savedTabs.collections) {
+    observeUtf8Maximum(usage, 'nameBytes', collection.name)
+    if (collection.definition.type === 'custom') {
+      collectKeywords(usage, [
+        ...collection.definition.projectKeywords.domainKeywords,
+        ...collection.definition.projectKeywords.titleKeywords,
+        ...collection.definition.projectKeywords.urlKeywords,
+      ])
+    }
+  }
+
+  for (const category of data.savedTabs.categories) {
+    observeUtf8Maximum(usage, 'nameBytes', category.name)
+    collectKeywords(usage, category.keywords)
+  }
+
+  for (const group of data.savedTabs.groups) {
+    observeUtf8Maximum(usage, 'nameBytes', group.name)
+  }
+
+  for (const membership of data.savedTabs.memberships) {
+    if (membership.notes !== undefined) {
+      observeUtf8Maximum(usage, 'notesBytes', membership.notes)
+    }
+  }
+
+  const messagesByConversation = new Map<string, number>()
+  for (const message of data.messages) {
+    const count = safeAdd(
+      messagesByConversation.get(message.conversationId) ?? 0,
+      1,
+      'messagesPerConversation',
+    )
+    messagesByConversation.set(message.conversationId, count)
+    usage.messagesPerConversation = Math.max(
+      usage.messagesPerConversation,
+      count,
+    )
+    collectMessageResources(usage, message.value)
+  }
+
+  const validation = validateBackupResourceUsage(usage)
+  if (!validation.success) {
+    throw new BackupResourceLimitError(validation.error)
+  }
+  assertBackupSerializedBytes(serializedBytes)
+  return { ...usage, serializedBytes }
+}

--- a/src/features/options/lib/import-export/v2/BackupV2Schema.test.ts
+++ b/src/features/options/lib/import-export/v2/BackupV2Schema.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  PersistenceLogicalSnapshot,
+  PersistenceV2Snapshot,
+} from '@/contexts/saved-tabs/public-api'
+import type { UserSettings } from '@/types/storage'
+
+import { BackupMapper } from './BackupMapper'
+import {
+  BACKUP_V2_SCHEMA_VERSION,
+  BackupDataV2Schema,
+  BackupEnvelopeV2Schema,
+  PersistenceJsonRecordSchema,
+  PersistenceMessageRecordSchema,
+  PersistenceV2CollectionCategorySchema,
+  PersistenceV2CollectionGroupSchema,
+  PersistenceV2CollectionMembershipSchema,
+  PersistenceV2CollectionSchema,
+  PersistenceV2UrlSchema,
+} from './BackupV2Schema'
+
+const userSettings = {
+  clickBehavior: 'saveCurrentTab',
+  confirmDeleteAll: true,
+  confirmDeleteEach: true,
+  enableCategories: true,
+  excludePatterns: ['z.example', 'a.example'],
+  excludePinnedTabs: false,
+  openAllInNewWindow: false,
+  openUrlInBackground: false,
+  removeTabAfterExternalDrop: false,
+  removeTabAfterOpen: false,
+  showSavedTime: true,
+} satisfies UserSettings
+
+const createSavedTabs = (reverse = false): PersistenceV2Snapshot => {
+  const urls = [
+    {
+      firstSavedAt: 10,
+      id: 'url-z',
+      lastSavedAt: 20,
+      normalizedUrl: 'https://z.example/',
+      title: 'Z title',
+      updatedAt: 20,
+      url: 'https://z.example/',
+    },
+    {
+      firstSavedAt: 10,
+      id: 'url-a',
+      lastSavedAt: 20,
+      normalizedUrl: 'https://a.example/',
+      title: 'A title',
+      updatedAt: 20,
+      url: 'https://a.example/',
+    },
+  ] as const
+  const memberships = urls.map(({ id }, index) => ({
+    addedAt: 10,
+    collectionId: 'collection-1',
+    notes: id,
+    sortOrder: (index + 1) * 1024,
+    updatedAt: 20,
+    urlId: id,
+  }))
+
+  return {
+    categories: [
+      {
+        collectionId: 'collection-1',
+        createdAt: 10,
+        id: 'category-1',
+        keywords: reverse ? ['zeta', 'alpha'] : ['alpha', 'zeta'],
+        name: 'Category',
+        sortOrder: 1024,
+        updatedAt: 20,
+      },
+    ],
+    collections: [
+      {
+        createdAt: 10,
+        definition: { domain: 'example.test', type: 'domain' },
+        groupId: 'group-1',
+        id: 'collection-1',
+        name: 'Collection',
+        sortOrder: 1024,
+        updatedAt: 20,
+      },
+    ],
+    groups: [
+      {
+        createdAt: 10,
+        id: 'group-1',
+        name: 'Group',
+        sortOrder: 1024,
+        updatedAt: 20,
+      },
+    ],
+    memberships: reverse ? memberships.toReversed() : memberships,
+    urls: reverse ? urls.toReversed() : urls,
+  }
+}
+
+const createLogicalSnapshot = (reverse = false): PersistenceLogicalSnapshot => {
+  const conversations = [
+    {
+      id: 'conversation-z',
+      updatedAt: 20,
+      value: reverse
+        ? { nested: { z: 1, a: 2 }, title: 'Z' }
+        : { title: 'Z', nested: { a: 2, z: 1 } },
+    },
+    {
+      id: 'conversation-a',
+      updatedAt: 20,
+      value: { title: 'A' },
+    },
+  ] as const
+  const messages = [
+    {
+      conversationId: 'conversation-z',
+      createdAt: 20,
+      id: 'message-z',
+      value: reverse
+        ? { role: 'assistant', content: 'Z' }
+        : { content: 'Z', role: 'assistant' },
+    },
+    {
+      conversationId: 'conversation-a',
+      createdAt: 10,
+      id: 'message-a',
+      value: { content: 'A', role: 'user' },
+    },
+  ] as const
+  const analyticsViews = [
+    {
+      id: 'view-z',
+      updatedAt: 20,
+      value: reverse ? { z: 1, a: 2 } : { a: 2, z: 1 },
+    },
+    { id: 'view-a', updatedAt: 10, value: { name: 'A' } },
+  ] as const
+
+  return {
+    analyticsViews: reverse ? analyticsViews.toReversed() : analyticsViews,
+    conversations: reverse ? conversations.toReversed() : conversations,
+    messages: reverse ? messages.toReversed() : messages,
+    revision: reverse ? 99 : 1,
+    savedTabs: createSavedTabs(reverse),
+  }
+}
+
+describe('Backup V2 schemas', () => {
+  it('separates schema and app versions and round-trips JSON', () => {
+    const data = BackupMapper.toBackupData(
+      createLogicalSnapshot(),
+      userSettings,
+    )
+    const envelope = BackupEnvelopeV2Schema.parse({
+      appVersion: '2026.7.28',
+      data,
+      exportedAt: '2026-07-28T00:00:00.000Z',
+      schemaVersion: BACKUP_V2_SCHEMA_VERSION,
+    })
+
+    expect(envelope.schemaVersion).toBe(2)
+    expect(envelope.appVersion).toBe('2026.7.28')
+    const serialized = JSON.stringify(envelope)
+    const parsed: unknown = JSON.parse(serialized)
+    expect(BackupEnvelopeV2Schema.parse(parsed)).toEqual(envelope)
+  })
+
+  it('rejects unknown internal and legacy fields at every public boundary', () => {
+    const data = BackupMapper.toBackupData(
+      createLogicalSnapshot(),
+      userSettings,
+    )
+    const envelope = {
+      appVersion: '2026.7.28',
+      data,
+      exportedAt: '2026-07-28T00:00:00.000Z',
+      schemaVersion: 2,
+    }
+
+    expect(
+      BackupEnvelopeV2Schema.safeParse({ ...envelope, revision: 1 }).success,
+    ).toBe(false)
+    expect(
+      BackupDataV2Schema.safeParse({ ...data, recoverySnapshots: [] }).success,
+    ).toBe(false)
+    expect(
+      BackupDataV2Schema.safeParse({
+        ...data,
+        savedTabs: { ...data.savedTabs, urlIds: [] },
+      }).success,
+    ).toBe(false)
+    expect(
+      BackupDataV2Schema.safeParse({
+        ...data,
+        savedTabs: {
+          ...data.savedTabs,
+          collections: [{ ...data.savedTabs.collections[0], urls: [] }],
+        },
+      }).success,
+    ).toBe(false)
+    expect(
+      BackupDataV2Schema.safeParse({
+        ...data,
+        userSettings: { ...data.userSettings, legacySetting: true },
+      }).success,
+    ).toBe(false)
+  })
+
+  it('uses isJsonValue semantics for persistence record values', () => {
+    const data = BackupMapper.toBackupData(
+      createLogicalSnapshot(),
+      userSettings,
+    )
+
+    expect(
+      BackupDataV2Schema.safeParse({
+        ...data,
+        conversations: [
+          {
+            id: 'conversation-invalid',
+            updatedAt: 1,
+            value: { invalid: Number.POSITIVE_INFINITY },
+          },
+        ],
+      }).success,
+    ).toBe(false)
+  })
+
+  it.each([
+    {
+      fields: ['firstSavedAt', 'lastSavedAt', 'updatedAt'],
+      name: 'saved URL',
+      record: createSavedTabs().urls[0],
+      schema: PersistenceV2UrlSchema,
+    },
+    {
+      fields: ['createdAt', 'updatedAt'],
+      name: 'collection',
+      record: createSavedTabs().collections[0],
+      schema: PersistenceV2CollectionSchema,
+    },
+    {
+      fields: ['addedAt', 'updatedAt'],
+      name: 'membership',
+      record: createSavedTabs().memberships[0],
+      schema: PersistenceV2CollectionMembershipSchema,
+    },
+    {
+      fields: ['createdAt', 'updatedAt'],
+      name: 'category',
+      record: createSavedTabs().categories[0],
+      schema: PersistenceV2CollectionCategorySchema,
+    },
+    {
+      fields: ['createdAt', 'updatedAt'],
+      name: 'group',
+      record: createSavedTabs().groups[0],
+      schema: PersistenceV2CollectionGroupSchema,
+    },
+    {
+      fields: ['updatedAt'],
+      name: 'JSON record',
+      record: createLogicalSnapshot().conversations[0],
+      schema: PersistenceJsonRecordSchema,
+    },
+    {
+      fields: ['createdAt'],
+      name: 'message record',
+      record: createLogicalSnapshot().messages[0],
+      schema: PersistenceMessageRecordSchema,
+    },
+  ])(
+    'rejects invalid epoch milliseconds for $name',
+    ({ fields, record, schema }) => {
+      const invalidValues = [-1, 1.5, Number.MAX_SAFE_INTEGER + 1, -0] as const
+
+      for (const field of fields) {
+        for (const value of invalidValues) {
+          expect(
+            schema.safeParse({ ...record, [field]: value }).success,
+            `${field} accepted ${Object.is(value, -0) ? '-0' : value}`,
+          ).toBe(false)
+        }
+      }
+    },
+  )
+
+  it.each(['createdAt', 'updatedAt'] as const)(
+    'rejects invalid epoch milliseconds for AI prompt %s',
+    (field) => {
+      const invalidValues = [-1, 1.5, Number.MAX_SAFE_INTEGER + 1, -0] as const
+
+      for (const value of invalidValues) {
+        expect(
+          BackupDataV2Schema.shape.userSettings.safeParse({
+            ...userSettings,
+            aiSystemPrompts: [
+              {
+                createdAt: 1,
+                id: 'prompt-1',
+                name: 'Prompt',
+                template: 'Template',
+                updatedAt: 2,
+                [field]: value,
+              },
+            ],
+          }).success,
+          `${field} accepted ${Object.is(value, -0) ? '-0' : value}`,
+        ).toBe(false)
+      }
+    },
+  )
+})
+
+describe('BackupMapper', () => {
+  it('omits revision and canonicalizes unordered containers and JSON keys', () => {
+    const forward = BackupMapper.toBackupData(
+      createLogicalSnapshot(),
+      userSettings,
+    )
+    const reversed = BackupMapper.toBackupData(createLogicalSnapshot(true), {
+      ...userSettings,
+      excludePatterns: userSettings.excludePatterns.toReversed(),
+    })
+
+    expect(forward).not.toHaveProperty('revision')
+    expect(JSON.stringify(forward)).toBe(JSON.stringify(reversed))
+    expect(forward.savedTabs.urls.map(({ id }) => id)).toEqual([
+      'url-a',
+      'url-z',
+    ])
+    expect(forward.savedTabs.categories[0]?.keywords).toEqual(['alpha', 'zeta'])
+    expect(forward.conversations.map(({ id }) => id)).toEqual([
+      'conversation-a',
+      'conversation-z',
+    ])
+  })
+
+  it('injects import revision explicitly instead of reading backup metadata', () => {
+    const data = BackupMapper.toBackupData(
+      createLogicalSnapshot(),
+      userSettings,
+    )
+    const snapshot = BackupMapper.toLogicalSnapshot(data, 42)
+
+    expect(snapshot.revision).toBe(42)
+    expect(snapshot.savedTabs).toEqual(data.savedTabs)
+    expect(snapshot.conversations).toEqual(data.conversations)
+    expect(() => BackupMapper.toLogicalSnapshot(data, -1)).toThrow('revision')
+  })
+
+  it('preserves the semantic order of AI system prompts', () => {
+    const settingsWithPrompts = {
+      ...userSettings,
+      aiSystemPrompts: [
+        {
+          createdAt: 1,
+          id: 'prompt-z',
+          name: 'First',
+          template: 'First template',
+          updatedAt: 2,
+        },
+        {
+          createdAt: 3,
+          id: 'prompt-a',
+          name: 'Second',
+          template: 'Second template',
+          updatedAt: 4,
+        },
+      ],
+    } satisfies UserSettings
+
+    const mapped = BackupMapper.toBackupData(
+      createLogicalSnapshot(),
+      settingsWithPrompts,
+    )
+
+    expect(mapped.userSettings.aiSystemPrompts?.map(({ id }) => id)).toEqual([
+      'prompt-z',
+      'prompt-a',
+    ])
+  })
+})

--- a/src/features/options/lib/import-export/v2/BackupV2Schema.ts
+++ b/src/features/options/lib/import-export/v2/BackupV2Schema.ts
@@ -1,0 +1,164 @@
+import { z } from 'zod'
+
+import type {
+  PersistenceJsonRecord,
+  PersistenceMessageRecord,
+  PersistenceV2Collection,
+  PersistenceV2CollectionCategory,
+  PersistenceV2CollectionGroup,
+  PersistenceV2CollectionMembership,
+  PersistenceV2Snapshot,
+  PersistenceV2Url,
+} from '@/contexts/saved-tabs/public-api'
+import { isJsonValue } from '@/lib/persistence/jsonValue'
+import type { JsonValue } from '@/lib/persistence/jsonValue'
+import {
+  aiSystemPromptPresetSchema,
+  UserSettingsSchema,
+} from '@/lib/storage/zod-storage'
+import type { UserSettings } from '@/types/storage'
+
+export const BACKUP_V2_SCHEMA_VERSION = 2 as const
+
+export const BackupV2EpochMillisecondsSchema = z
+  .number()
+  .refine(
+    (value) =>
+      Number.isSafeInteger(value) && value >= 0 && !Object.is(value, -0),
+    {
+      error: 'Expected non-negative epoch milliseconds',
+    },
+  )
+
+const jsonValueSchema = z.custom<JsonValue>(isJsonValue, {
+  error: 'Expected a JSON-safe value',
+})
+
+const persistenceV2ProjectKeywordSettingsSchema = z.strictObject({
+  domainKeywords: z.array(z.string()),
+  titleKeywords: z.array(z.string()),
+  urlKeywords: z.array(z.string()),
+})
+
+const persistenceV2CollectionDefinitionSchema = z.discriminatedUnion('type', [
+  z.strictObject({
+    domain: z.string(),
+    type: z.literal('domain'),
+  }),
+  z.strictObject({
+    projectKeywords: persistenceV2ProjectKeywordSettingsSchema,
+    type: z.literal('custom'),
+  }),
+])
+
+export const PersistenceV2UrlSchema: z.ZodType<PersistenceV2Url> =
+  z.strictObject({
+    favIconUrl: z.string().optional(),
+    firstSavedAt: BackupV2EpochMillisecondsSchema,
+    id: z.string(),
+    lastSavedAt: BackupV2EpochMillisecondsSchema,
+    normalizedUrl: z.string(),
+    title: z.string(),
+    updatedAt: BackupV2EpochMillisecondsSchema,
+    url: z.string(),
+  })
+
+export const PersistenceV2CollectionSchema: z.ZodType<PersistenceV2Collection> =
+  z.strictObject({
+    createdAt: BackupV2EpochMillisecondsSchema,
+    definition: persistenceV2CollectionDefinitionSchema,
+    groupId: z.string().optional(),
+    id: z.string(),
+    name: z.string(),
+    sortOrder: z.number(),
+    updatedAt: BackupV2EpochMillisecondsSchema,
+  })
+
+export const PersistenceV2CollectionMembershipSchema: z.ZodType<PersistenceV2CollectionMembership> =
+  z.strictObject({
+    addedAt: BackupV2EpochMillisecondsSchema,
+    categoryId: z.string().optional(),
+    collectionId: z.string(),
+    notes: z.string().optional(),
+    sortOrder: z.number(),
+    updatedAt: BackupV2EpochMillisecondsSchema,
+    urlId: z.string(),
+  })
+
+export const PersistenceV2CollectionCategorySchema: z.ZodType<PersistenceV2CollectionCategory> =
+  z.strictObject({
+    collectionId: z.string(),
+    createdAt: BackupV2EpochMillisecondsSchema,
+    id: z.string(),
+    keywords: z.array(z.string()),
+    name: z.string(),
+    sortOrder: z.number(),
+    updatedAt: BackupV2EpochMillisecondsSchema,
+  })
+
+export const PersistenceV2CollectionGroupSchema: z.ZodType<PersistenceV2CollectionGroup> =
+  z.strictObject({
+    createdAt: BackupV2EpochMillisecondsSchema,
+    id: z.string(),
+    name: z.string(),
+    sortOrder: z.number(),
+    updatedAt: BackupV2EpochMillisecondsSchema,
+  })
+
+export const PersistenceV2SnapshotSchema: z.ZodType<PersistenceV2Snapshot> =
+  z.strictObject({
+    categories: z.array(PersistenceV2CollectionCategorySchema),
+    collections: z.array(PersistenceV2CollectionSchema),
+    groups: z.array(PersistenceV2CollectionGroupSchema),
+    memberships: z.array(PersistenceV2CollectionMembershipSchema),
+    urls: z.array(PersistenceV2UrlSchema),
+  })
+
+export const PersistenceJsonRecordSchema: z.ZodType<PersistenceJsonRecord> =
+  z.strictObject({
+    id: z.string(),
+    updatedAt: BackupV2EpochMillisecondsSchema,
+    value: jsonValueSchema,
+  })
+
+export const PersistenceMessageRecordSchema: z.ZodType<PersistenceMessageRecord> =
+  z.strictObject({
+    conversationId: z.string(),
+    createdAt: BackupV2EpochMillisecondsSchema,
+    id: z.string(),
+    value: jsonValueSchema,
+  })
+
+const backupAiSystemPromptPresetSchema = z.strictObject({
+  ...aiSystemPromptPresetSchema.shape,
+  createdAt: BackupV2EpochMillisecondsSchema,
+  updatedAt: BackupV2EpochMillisecondsSchema,
+})
+
+const BackupUserSettingsSchema: z.ZodType<UserSettings> = z
+  .strictObject({
+    ...UserSettingsSchema.shape,
+    aiSystemPrompts: z.array(backupAiSystemPromptPresetSchema).optional(),
+  })
+  .refine(isJsonValue, {
+    error: 'Expected JSON-safe user settings',
+  })
+
+export const BackupDataV2Schema = z.strictObject({
+  analyticsViews: z.array(PersistenceJsonRecordSchema),
+  conversations: z.array(PersistenceJsonRecordSchema),
+  messages: z.array(PersistenceMessageRecordSchema),
+  savedTabs: PersistenceV2SnapshotSchema,
+  userSettings: BackupUserSettingsSchema,
+})
+
+export type BackupDataV2 = z.infer<typeof BackupDataV2Schema>
+
+export const BackupEnvelopeV2Schema = z.strictObject({
+  appVersion: z.string().min(1),
+  data: BackupDataV2Schema,
+  exportedAt: z.iso.datetime(),
+  schemaVersion: z.literal(BACKUP_V2_SCHEMA_VERSION),
+})
+
+export type BackupEnvelopeV2 = z.infer<typeof BackupEnvelopeV2Schema>

--- a/src/features/options/lib/import-export/v2/ExportBackupV2UseCase.test.ts
+++ b/src/features/options/lib/import-export/v2/ExportBackupV2UseCase.test.ts
@@ -69,6 +69,15 @@ const createLogicalSnapshot = (
         role: 'user',
       },
     },
+    {
+      conversationId: 'conversation-1',
+      createdAt: 2,
+      id: 'message-2',
+      value: {
+        content: 'reply',
+        role: 'assistant',
+      },
+    },
   ] as const
 
   return {
@@ -109,15 +118,12 @@ const createLogicalSnapshot = (
 
 const createDeps = (
   snapshot: PersistenceLogicalSnapshot = createLogicalSnapshot(),
-): {
-  deps: ExportBackupV2UseCaseDeps
-  getAppVersion: ReturnType<typeof vi.fn>
-  now: ReturnType<typeof vi.fn>
-  readConsistentSnapshot: ReturnType<typeof vi.fn>
-  readUserSettings: ReturnType<typeof vi.fn>
-} => {
-  const readConsistentSnapshot = vi.fn().mockResolvedValue(snapshot)
-  const readUserSettings = vi.fn().mockResolvedValue(userSettings)
+) => {
+  const readConsistentSnapshot =
+    vi.fn<() => Promise<PersistenceLogicalSnapshot>>()
+  readConsistentSnapshot.mockResolvedValue(snapshot)
+  const readUserSettings = vi.fn<() => Promise<UserSettings>>()
+  readUserSettings.mockResolvedValue(userSettings)
   const getAppVersion = vi.fn().mockReturnValue('2026.7.28')
   const now = vi.fn().mockReturnValue(new Date('2026-07-28T03:04:05.000Z'))
   const snapshotReader = {
@@ -168,6 +174,42 @@ describe('createExportBackupV2UseCase', () => {
     expect(firstEnvelope.data).toEqual(secondEnvelope.data)
     expect(firstEnvelope.appVersion).toBe(secondEnvelope.appVersion)
     expect(firstEnvelope.exportedAt).not.toBe(secondEnvelope.exportedAt)
+    expect(firstEnvelope.data.messages.map(({ id }) => id)).toEqual([
+      'message-1',
+      'message-2',
+    ])
+  })
+
+  it('starts the independent snapshot and settings reads concurrently', async () => {
+    const context = createDeps()
+    let releaseSnapshot!: () => void
+    let releaseSettings!: () => void
+    const snapshotReady = new Promise<void>((resolve) => {
+      releaseSnapshot = resolve
+    })
+    const settingsReady = new Promise<void>((resolve) => {
+      releaseSettings = resolve
+    })
+    const snapshot = createLogicalSnapshot()
+    const settings = userSettings
+    context.readConsistentSnapshot.mockImplementation(async () => {
+      await snapshotReady
+      return snapshot
+    })
+    context.readUserSettings.mockImplementation(async () => {
+      await settingsReady
+      return settings
+    })
+
+    const exportPromise = createExportBackupV2UseCase(context.deps)()
+    await Promise.resolve()
+    const settingsStartedBeforeSnapshotReleased =
+      context.readUserSettings.mock.calls.length
+    releaseSnapshot()
+    releaseSettings()
+    await exportPromise
+
+    expect(settingsStartedBeforeSnapshotReleased).toBe(1)
   })
 
   it('validates logical resources before serializing the envelope', async () => {
@@ -237,7 +279,7 @@ describe('createExportBackupV2UseCase', () => {
     },
   )
 
-  it('propagates snapshot failures unchanged and does not continue', async () => {
+  it('propagates snapshot failures unchanged and does not build the envelope', async () => {
     const context = createDeps()
     const failure = new Error('snapshot failed')
     context.readConsistentSnapshot.mockRejectedValue(failure)
@@ -246,7 +288,7 @@ describe('createExportBackupV2UseCase', () => {
       failure,
     )
     expect(context.readConsistentSnapshot).toHaveBeenCalledTimes(1)
-    expect(context.readUserSettings).not.toHaveBeenCalled()
+    expect(context.readUserSettings).toHaveBeenCalledTimes(1)
     expect(context.getAppVersion).not.toHaveBeenCalled()
     expect(context.now).not.toHaveBeenCalled()
   })

--- a/src/features/options/lib/import-export/v2/ExportBackupV2UseCase.test.ts
+++ b/src/features/options/lib/import-export/v2/ExportBackupV2UseCase.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ZodError } from 'zod'
+
+import {
+  BACKUP_RESOURCE_LIMITS,
+  BackupResourceLimitError,
+} from '@/lib/persistence/backupResourcePolicy'
+import type { UserSettings } from '@/types/storage'
+
+import type { BackupMapper } from './BackupMapper'
+import { createExportBackupV2UseCase } from './ExportBackupV2UseCase'
+import type { ExportBackupV2UseCaseDeps } from './ExportBackupV2UseCase'
+
+type PersistenceLogicalSnapshot = Parameters<
+  typeof BackupMapper.toBackupData
+>[0]
+
+const userSettings = {
+  clickBehavior: 'saveCurrentTab',
+  confirmDeleteAll: true,
+  confirmDeleteEach: true,
+  enableCategories: true,
+  excludePatterns: ['z.example', 'a.example'],
+  excludePinnedTabs: false,
+  openAllInNewWindow: false,
+  openUrlInBackground: false,
+  removeTabAfterExternalDrop: false,
+  removeTabAfterOpen: false,
+  showSavedTime: true,
+} satisfies UserSettings
+
+const createLogicalSnapshot = (
+  reverse = false,
+  attachmentCount = 0,
+): PersistenceLogicalSnapshot => {
+  const urls = [
+    {
+      firstSavedAt: 1,
+      id: 'url-z',
+      lastSavedAt: 2,
+      normalizedUrl: 'https://z.example/',
+      title: 'Z',
+      updatedAt: 2,
+      url: 'https://z.example/',
+    },
+    {
+      firstSavedAt: 1,
+      id: 'url-a',
+      lastSavedAt: 2,
+      normalizedUrl: 'https://a.example/',
+      title: 'A',
+      updatedAt: 2,
+      url: 'https://a.example/',
+    },
+  ]
+  const messages = [
+    {
+      conversationId: 'conversation-1',
+      createdAt: 1,
+      id: 'message-1',
+      value: {
+        attachments: Array.from({ length: attachmentCount }, (_, index) => ({
+          content: `attachment-${index}`,
+          filename: `${index}.txt`,
+          kind: 'text',
+          mediaType: 'text/plain',
+        })),
+        content: 'message',
+        role: 'user',
+      },
+    },
+  ] as const
+
+  return {
+    analyticsViews: [{ id: 'view-1', updatedAt: 2, value: { kind: 'weekly' } }],
+    conversations: [
+      {
+        id: 'conversation-1',
+        updatedAt: 2,
+        value: { title: 'Conversation' },
+      },
+    ],
+    messages: reverse ? messages.toReversed() : messages,
+    revision: 91,
+    savedTabs: {
+      categories: [],
+      collections: [
+        {
+          createdAt: 1,
+          definition: { domain: 'example.test', type: 'domain' },
+          id: 'collection-1',
+          name: 'Collection',
+          sortOrder: 1024,
+          updatedAt: 2,
+        },
+      ],
+      groups: [],
+      memberships: urls.map(({ id }, index) => ({
+        addedAt: 1,
+        collectionId: 'collection-1',
+        sortOrder: (index + 1) * 1024,
+        updatedAt: 2,
+        urlId: id,
+      })),
+      urls: reverse ? urls.toReversed() : urls,
+    },
+  }
+}
+
+const createDeps = (
+  snapshot: PersistenceLogicalSnapshot = createLogicalSnapshot(),
+): {
+  deps: ExportBackupV2UseCaseDeps
+  getAppVersion: ReturnType<typeof vi.fn>
+  now: ReturnType<typeof vi.fn>
+  readConsistentSnapshot: ReturnType<typeof vi.fn>
+  readUserSettings: ReturnType<typeof vi.fn>
+} => {
+  const readConsistentSnapshot = vi.fn().mockResolvedValue(snapshot)
+  const readUserSettings = vi.fn().mockResolvedValue(userSettings)
+  const getAppVersion = vi.fn().mockReturnValue('2026.7.28')
+  const now = vi.fn().mockReturnValue(new Date('2026-07-28T03:04:05.000Z'))
+  const snapshotReader = {
+    readConsistentSnapshot,
+  } satisfies ExportBackupV2UseCaseDeps['snapshotReader']
+
+  return {
+    deps: {
+      getAppVersion,
+      now,
+      readUserSettings,
+      snapshotReader,
+    },
+    getAppVersion,
+    now,
+    readConsistentSnapshot,
+    readUserSettings,
+  }
+}
+
+describe('createExportBackupV2UseCase', () => {
+  it('reads every dependency once and returns a strict V2 envelope without internals', async () => {
+    const context = createDeps()
+
+    const envelope = await createExportBackupV2UseCase(context.deps)()
+
+    expect(context.readConsistentSnapshot).toHaveBeenCalledTimes(1)
+    expect(context.readUserSettings).toHaveBeenCalledTimes(1)
+    expect(context.getAppVersion).toHaveBeenCalledTimes(1)
+    expect(context.now).toHaveBeenCalledTimes(1)
+    expect(envelope).toMatchObject({
+      appVersion: '2026.7.28',
+      exportedAt: '2026-07-28T03:04:05.000Z',
+      schemaVersion: 2,
+    })
+    expect(JSON.stringify(envelope)).not.toContain('revision')
+    expect(JSON.stringify(envelope)).not.toContain('recoverySnapshots')
+  })
+
+  it('is deterministic for equivalent snapshots except for exportedAt', async () => {
+    const first = createDeps(createLogicalSnapshot())
+    const second = createDeps(createLogicalSnapshot(true))
+    second.now.mockReturnValue(new Date('2026-07-28T03:04:06.000Z'))
+
+    const firstEnvelope = await createExportBackupV2UseCase(first.deps)()
+    const secondEnvelope = await createExportBackupV2UseCase(second.deps)()
+
+    expect(firstEnvelope.data).toEqual(secondEnvelope.data)
+    expect(firstEnvelope.appVersion).toBe(secondEnvelope.appVersion)
+    expect(firstEnvelope.exportedAt).not.toBe(secondEnvelope.exportedAt)
+  })
+
+  it('validates logical resources before serializing the envelope', async () => {
+    const context = createDeps(
+      createLogicalSnapshot(
+        false,
+        BACKUP_RESOURCE_LIMITS.maxAttachmentsPerMessage + 1,
+      ),
+    )
+    const originalEncode = TextEncoder.prototype.encode.bind(new TextEncoder())
+    let envelopeEncodeCalls = 0
+    const encodeSpy = vi
+      .spyOn(TextEncoder.prototype, 'encode')
+      .mockImplementation((value) => {
+        if (value?.includes('"schemaVersion":2') === true) {
+          envelopeEncodeCalls += 1
+          return {
+            byteLength: BACKUP_RESOURCE_LIMITS.maxSerializedBytes + 1,
+          } as Uint8Array<ArrayBuffer>
+        }
+        return originalEncode(value)
+      })
+
+    let caught: unknown
+    try {
+      await createExportBackupV2UseCase(context.deps)()
+    } catch (error) {
+      caught = error
+    } finally {
+      encodeSpy.mockRestore()
+    }
+
+    expect(caught).toBeInstanceOf(BackupResourceLimitError)
+    expect(caught).toMatchObject({
+      code: 'BACKUP_NESTED_PAYLOAD_TOO_LARGE',
+      diagnostic: { resource: 'attachmentsPerMessage' },
+    })
+    expect(envelopeEncodeCalls).toBe(0)
+    expect(JSON.stringify(caught)).not.toContain('attachment-')
+  })
+
+  it.each([
+    {
+      errorType: ZodError,
+      label: 'empty app version',
+      override: (deps: ExportBackupV2UseCaseDeps) => ({
+        ...deps,
+        getAppVersion: () => '',
+      }),
+    },
+    {
+      errorType: RangeError,
+      label: 'invalid clock',
+      override: (deps: ExportBackupV2UseCaseDeps) => ({
+        ...deps,
+        now: () => new Date(Number.NaN),
+      }),
+    },
+  ])(
+    'rejects $label instead of repairing the envelope',
+    async ({ errorType, override }) => {
+      const context = createDeps()
+
+      await expect(
+        createExportBackupV2UseCase(override(context.deps))(),
+      ).rejects.toBeInstanceOf(errorType)
+    },
+  )
+
+  it('propagates snapshot failures unchanged and does not continue', async () => {
+    const context = createDeps()
+    const failure = new Error('snapshot failed')
+    context.readConsistentSnapshot.mockRejectedValue(failure)
+
+    await expect(createExportBackupV2UseCase(context.deps)()).rejects.toBe(
+      failure,
+    )
+    expect(context.readConsistentSnapshot).toHaveBeenCalledTimes(1)
+    expect(context.readUserSettings).not.toHaveBeenCalled()
+    expect(context.getAppVersion).not.toHaveBeenCalled()
+    expect(context.now).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/options/lib/import-export/v2/ExportBackupV2UseCase.ts
+++ b/src/features/options/lib/import-export/v2/ExportBackupV2UseCase.ts
@@ -36,8 +36,10 @@ export const createExportBackupV2UseCase = (
   deps: ExportBackupV2UseCaseDeps,
 ): ExportBackupV2UseCase => {
   return async () => {
-    const snapshot = await deps.snapshotReader.readConsistentSnapshot()
-    const userSettings = await deps.readUserSettings()
+    const [snapshot, userSettings] = await Promise.all([
+      deps.snapshotReader.readConsistentSnapshot(),
+      deps.readUserSettings(),
+    ])
     const appVersion = deps.getAppVersion()
     const exportedAt = deps.now().toISOString()
     const data = BackupMapper.toBackupData(snapshot, userSettings)

--- a/src/features/options/lib/import-export/v2/ExportBackupV2UseCase.ts
+++ b/src/features/options/lib/import-export/v2/ExportBackupV2UseCase.ts
@@ -1,0 +1,55 @@
+import { assertBackupSerializedBytes } from '@/lib/persistence/backupResourcePolicy'
+import type { UserSettings } from '@/types/storage'
+
+import { BackupMapper } from './BackupMapper'
+import { collectBackupV2ResourceUsage } from './BackupV2ResourceUsage'
+import {
+  BACKUP_V2_SCHEMA_VERSION,
+  BackupEnvelopeV2Schema,
+} from './BackupV2Schema'
+import type { BackupEnvelopeV2 } from './BackupV2Schema'
+
+type PersistenceLogicalSnapshot = Parameters<
+  typeof BackupMapper.toBackupData
+>[0]
+
+export type ExportBackupV2UseCaseDeps = {
+  readonly getAppVersion: () => string
+  readonly now: () => Date
+  readonly readUserSettings: () => Promise<UserSettings>
+  readonly snapshotReader: {
+    readonly readConsistentSnapshot: () => Promise<PersistenceLogicalSnapshot>
+  }
+}
+
+export type ExportBackupV2UseCase = () => Promise<BackupEnvelopeV2>
+
+/**
+ * Creates the public Backup V2 envelope.
+ *
+ * The snapshot reader owns the one-transaction consistent view of IndexedDB
+ * logical data. User settings are intentionally read through a separate
+ * dependency because their Chrome-owned storage cannot be part of that IndexedDB
+ * transaction; this use case does not claim cross-engine atomicity.
+ */
+export const createExportBackupV2UseCase = (
+  deps: ExportBackupV2UseCaseDeps,
+): ExportBackupV2UseCase => {
+  return async () => {
+    const snapshot = await deps.snapshotReader.readConsistentSnapshot()
+    const userSettings = await deps.readUserSettings()
+    const appVersion = deps.getAppVersion()
+    const exportedAt = deps.now().toISOString()
+    const data = BackupMapper.toBackupData(snapshot, userSettings)
+    const envelope = BackupEnvelopeV2Schema.parse({
+      appVersion,
+      data,
+      exportedAt,
+      schemaVersion: BACKUP_V2_SCHEMA_VERSION,
+    })
+    collectBackupV2ResourceUsage(envelope.data, 0)
+    const serialized = JSON.stringify(envelope)
+    assertBackupSerializedBytes(new TextEncoder().encode(serialized).byteLength)
+    return envelope
+  }
+}

--- a/src/features/options/lib/import-export/v2/ImportBackupV2UseCase.test.ts
+++ b/src/features/options/lib/import-export/v2/ImportBackupV2UseCase.test.ts
@@ -1,0 +1,569 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { LEGACY_BACKUP_ADVISORY } from '@/features/options/lib/import-export/compatibility/legacyBackupPolicy'
+import { BACKUP_RESOURCE_LIMITS } from '@/lib/persistence/backupResourcePolicy'
+import type { UserSettings } from '@/types/storage'
+
+import { BackupMapper } from './BackupMapper'
+import type { BackupV2Inspection } from './BackupV2Inspector'
+import {
+  BackupV2ImportError,
+  createImportBackupV2UseCase,
+} from './ImportBackupV2UseCase'
+import type {
+  ImportBackupV2UseCaseDeps,
+  OverwriteRecoveryCapability,
+} from './ImportBackupV2UseCase'
+
+type PersistenceLogicalSnapshot = Parameters<
+  typeof BackupMapper.toBackupData
+>[0]
+
+const SECRET_VALUES = [
+  'https://secret.example.test/private',
+  'private title',
+  'private membership note',
+  'private system prompt',
+] as const
+
+const createUserSettings = (): UserSettings => ({
+  activeAiSystemPromptId: 'prompt-secret',
+  aiSystemPrompts: [
+    {
+      createdAt: 1,
+      id: 'prompt-secret',
+      name: 'Private prompt',
+      template: SECRET_VALUES[3],
+      updatedAt: 1,
+    },
+  ],
+  clickBehavior: 'saveCurrentTab',
+  confirmDeleteAll: true,
+  confirmDeleteEach: false,
+  enableCategories: true,
+  excludePatterns: ['*.internal.example', '*.private.example'],
+  excludePinnedTabs: false,
+  openAllInNewWindow: false,
+  openUrlInBackground: true,
+  removeTabAfterExternalDrop: false,
+  removeTabAfterOpen: false,
+  showSavedTime: true,
+})
+
+const createSnapshot = (revision = 12): PersistenceLogicalSnapshot => ({
+  analyticsViews: [
+    {
+      id: 'analytics-b',
+      updatedAt: 2,
+      value: { title: 'secondary' },
+    },
+    {
+      id: 'analytics-a',
+      updatedAt: 1,
+      value: { title: 'primary' },
+    },
+  ],
+  conversations: [
+    {
+      id: 'conversation-b',
+      updatedAt: 2,
+      value: { title: 'secondary conversation' },
+    },
+    {
+      id: 'conversation-a',
+      updatedAt: 1,
+      value: { title: SECRET_VALUES[1] },
+    },
+  ],
+  messages: [
+    {
+      conversationId: 'conversation-b',
+      createdAt: 2,
+      id: 'message-b',
+      value: { content: 'secondary message' },
+    },
+    {
+      conversationId: 'conversation-a',
+      createdAt: 1,
+      id: 'message-a',
+      value: { content: 'private message' },
+    },
+  ],
+  revision,
+  savedTabs: {
+    categories: [],
+    collections: [
+      {
+        createdAt: 1,
+        definition: {
+          domain: 'secret.example.test',
+          type: 'domain',
+        },
+        id: 'collection-secret',
+        name: 'Private collection',
+        sortOrder: 1024,
+        updatedAt: 1,
+      },
+    ],
+    groups: [],
+    memberships: [
+      {
+        addedAt: 1,
+        collectionId: 'collection-secret',
+        notes: SECRET_VALUES[2],
+        sortOrder: 1024,
+        updatedAt: 1,
+        urlId: 'url-secret',
+      },
+    ],
+    urls: [
+      {
+        firstSavedAt: 1,
+        id: 'url-secret',
+        lastSavedAt: 1,
+        normalizedUrl: SECRET_VALUES[0],
+        title: SECRET_VALUES[1],
+        updatedAt: 1,
+        url: SECRET_VALUES[0],
+      },
+    ],
+  },
+})
+
+const countSnapshotEntities = (snapshot: PersistenceLogicalSnapshot) => ({
+  analyticsViews: snapshot.analyticsViews.length,
+  categories: snapshot.savedTabs.categories.length,
+  collections: snapshot.savedTabs.collections.length,
+  conversations: snapshot.conversations.length,
+  groups: snapshot.savedTabs.groups.length,
+  memberships: snapshot.savedTabs.memberships.length,
+  messages: snapshot.messages.length,
+  urls: snapshot.savedTabs.urls.length,
+})
+
+const createInspection = (
+  formatKind: 'current-v2' | 'legacy' = 'current-v2',
+): BackupV2Inspection => {
+  const snapshot = createSnapshot()
+  const data = BackupMapper.toBackupData(snapshot, createUserSettings())
+  const previewBase = {
+    appVersion: '2.0.0',
+    entityCounts: countSnapshotEntities(snapshot),
+    exportedAt: '2026-07-28T00:00:00.000Z',
+    warnings: [],
+  }
+
+  return {
+    data,
+    preview:
+      formatKind === 'current-v2'
+        ? {
+            ...previewBase,
+            formatKind,
+            schemaVersion: 2,
+          }
+        : {
+            ...previewBase,
+            advisory: LEGACY_BACKUP_ADVISORY,
+            formatKind,
+            schemaVersion: null,
+          },
+  }
+}
+
+type DepsOverrides = Partial<ImportBackupV2UseCaseDeps> & {
+  readonly readbackSnapshot?: PersistenceLogicalSnapshot
+  readonly readbackSettings?: UserSettings
+}
+
+const createDeps = (
+  events: string[],
+  overrides: DepsOverrides = {},
+): ImportBackupV2UseCaseDeps => {
+  const inspection = createInspection()
+  const canonicalSnapshot = BackupMapper.toLogicalSnapshot(inspection.data, 77)
+  const recovery: OverwriteRecoveryCapability = {
+    captureBeforeOverwrite: vi.fn(async () => {
+      events.push('capture')
+      return 'recovery-opaque-id'
+    }),
+    restore: vi.fn(async (recoveryId) => {
+      events.push(`restore:${String(recoveryId)}`)
+    }),
+  }
+
+  return {
+    readUserSettings: vi.fn(async () => {
+      events.push('read-settings')
+      return structuredClone(
+        overrides.readbackSettings ?? inspection.data.userSettings,
+      )
+    }),
+    recovery,
+    replacement: {
+      replaceAll: vi.fn(async () => {
+        events.push('replace')
+        return { revision: 77 }
+      }),
+    },
+    snapshotReader: {
+      readConsistentSnapshot: vi.fn(async () => {
+        events.push('read-snapshot')
+        return structuredClone(overrides.readbackSnapshot ?? canonicalSnapshot)
+      }),
+    },
+    writeUserSettings: vi.fn(async () => {
+      events.push('write-settings')
+    }),
+    ...overrides,
+  }
+}
+
+const captureImportError = async (
+  action: () => Promise<unknown>,
+): Promise<BackupV2ImportError> => {
+  try {
+    await action()
+  } catch (error) {
+    if (error instanceof BackupV2ImportError) {
+      return error
+    }
+  }
+  throw new Error('Expected BackupV2ImportError')
+}
+
+describe('createImportBackupV2UseCase', () => {
+  it.each(['current-v2', 'legacy'] as const)(
+    'imports a normalized %s inspection and verifies readback',
+    async (formatKind) => {
+      const events: string[] = []
+      const deps = createDeps(events)
+      const inspection = createInspection(formatKind)
+
+      const result = await createImportBackupV2UseCase(deps)(inspection)
+
+      expect(result).toEqual({
+        entityCounts: inspection.preview.entityCounts,
+        revision: 77,
+      })
+      expect(events).toEqual([
+        'capture',
+        'replace',
+        'write-settings',
+        'read-snapshot',
+        'read-settings',
+      ])
+      expect(deps.replacement.replaceAll).toHaveBeenCalledOnce()
+      expect(deps.replacement.replaceAll).toHaveBeenCalledWith(
+        expect.not.objectContaining({ revision: expect.anything() }),
+      )
+      expect(deps.recovery?.restore).not.toHaveBeenCalled()
+    },
+  )
+
+  it('accepts readback whose unordered records use a different order', async () => {
+    const events: string[] = []
+    const inspection = createInspection()
+    const readback = BackupMapper.toLogicalSnapshot(inspection.data, 77)
+    const reversedReadback: PersistenceLogicalSnapshot = {
+      analyticsViews: readback.analyticsViews.toReversed(),
+      conversations: readback.conversations.toReversed(),
+      messages: readback.messages.toReversed(),
+      revision: readback.revision,
+      savedTabs: {
+        categories: readback.savedTabs.categories.toReversed(),
+        collections: readback.savedTabs.collections.toReversed(),
+        groups: readback.savedTabs.groups.toReversed(),
+        memberships: readback.savedTabs.memberships.toReversed(),
+        urls: readback.savedTabs.urls.toReversed(),
+      },
+    }
+    const deps = createDeps(events, {
+      readbackSettings: {
+        ...inspection.data.userSettings,
+        excludePatterns:
+          inspection.data.userSettings.excludePatterns.toReversed(),
+      },
+      readbackSnapshot: reversedReadback,
+    })
+
+    await expect(
+      createImportBackupV2UseCase(deps)(inspection),
+    ).resolves.toMatchObject({ revision: 77 })
+  })
+
+  it('fails closed before mutation when recovery is unavailable', async () => {
+    const events: string[] = []
+    const deps = createDeps(events, { recovery: undefined })
+
+    const error = await captureImportError(async () =>
+      createImportBackupV2UseCase(deps)(createInspection()),
+    )
+
+    expect(error.code).toBe('OVERWRITE_RECOVERY_UNAVAILABLE')
+    expect(events).toEqual([])
+    expect(deps.replacement.replaceAll).not.toHaveBeenCalled()
+    expect(deps.writeUserSettings).not.toHaveBeenCalled()
+  })
+
+  it('does not mutate or restore when recovery capture fails', async () => {
+    const events: string[] = []
+    const deps = createDeps(events, {
+      recovery: {
+        captureBeforeOverwrite: vi.fn(async () => {
+          events.push('capture')
+          throw new Error(SECRET_VALUES[0])
+        }),
+        restore: vi.fn(async () => {
+          events.push('restore')
+        }),
+      },
+    })
+
+    const error = await captureImportError(async () =>
+      createImportBackupV2UseCase(deps)(createInspection()),
+    )
+
+    expect(error.code).toBe('RECOVERY_CAPTURE_FAILED')
+    expect(events).toEqual(['capture'])
+    expect(deps.replacement.replaceAll).not.toHaveBeenCalled()
+    expect(deps.recovery?.restore).not.toHaveBeenCalled()
+  })
+
+  it('restores once when atomic replacement fails', async () => {
+    const events: string[] = []
+    const deps = createDeps(events, {
+      replacement: {
+        replaceAll: vi.fn(async () => {
+          events.push('replace')
+          throw new Error(SECRET_VALUES[1])
+        }),
+      },
+    })
+
+    const error = await captureImportError(async () =>
+      createImportBackupV2UseCase(deps)(createInspection()),
+    )
+
+    expect(error.code).toBe('PERSISTENCE_REPLACEMENT_FAILED')
+    expect(events).toEqual(['capture', 'replace', 'restore:recovery-opaque-id'])
+    expect(deps.recovery?.restore).toHaveBeenCalledOnce()
+  })
+
+  it('restores once when the separate settings write fails', async () => {
+    const events: string[] = []
+    const deps = createDeps(events, {
+      writeUserSettings: vi.fn(async () => {
+        events.push('write-settings')
+        throw new Error(SECRET_VALUES[3])
+      }),
+    })
+
+    const error = await captureImportError(async () =>
+      createImportBackupV2UseCase(deps)(createInspection()),
+    )
+
+    expect(error.code).toBe('SETTINGS_WRITE_FAILED')
+    expect(events).toEqual([
+      'capture',
+      'replace',
+      'write-settings',
+      'restore:recovery-opaque-id',
+    ])
+    expect(deps.recovery?.restore).toHaveBeenCalledOnce()
+  })
+
+  it('restores once when the consistent snapshot readback fails', async () => {
+    const events: string[] = []
+    const deps = createDeps(events, {
+      snapshotReader: {
+        readConsistentSnapshot: vi.fn(async () => {
+          events.push('read-snapshot')
+          throw new Error(SECRET_VALUES[2])
+        }),
+      },
+    })
+
+    const error = await captureImportError(async () =>
+      createImportBackupV2UseCase(deps)(createInspection()),
+    )
+
+    expect(error.code).toBe('READBACK_FAILED')
+    expect(events).toEqual([
+      'capture',
+      'replace',
+      'write-settings',
+      'read-snapshot',
+      'restore:recovery-opaque-id',
+    ])
+    expect(deps.readUserSettings).not.toHaveBeenCalled()
+  })
+
+  it('restores once when canonical readback does not match', async () => {
+    const events: string[] = []
+    const unchangedSnapshot = createSnapshot(77)
+    const firstUrl = unchangedSnapshot.savedTabs.urls[0]
+    if (firstUrl === undefined) {
+      throw new Error('Missing test URL')
+    }
+    const changedSnapshot: PersistenceLogicalSnapshot = {
+      ...unchangedSnapshot,
+      savedTabs: {
+        ...unchangedSnapshot.savedTabs,
+        urls: [{ ...firstUrl, title: 'different title' }],
+      },
+    }
+    const deps = createDeps(events, { readbackSnapshot: changedSnapshot })
+
+    const error = await captureImportError(async () =>
+      createImportBackupV2UseCase(deps)(createInspection()),
+    )
+
+    expect(error.code).toBe('READBACK_MISMATCH')
+    expect(events).toEqual([
+      'capture',
+      'replace',
+      'write-settings',
+      'read-snapshot',
+      'read-settings',
+      'restore:recovery-opaque-id',
+    ])
+  })
+
+  it('surfaces a fixed restore failure code without the prior failure', async () => {
+    const events: string[] = []
+    const deps = createDeps(events, {
+      recovery: {
+        captureBeforeOverwrite: vi.fn(async () => {
+          events.push('capture')
+          return 'recovery-opaque-id'
+        }),
+        restore: vi.fn(async () => {
+          events.push('restore')
+          throw new Error(`${SECRET_VALUES[0]} ${SECRET_VALUES[3]}`)
+        }),
+      },
+      replacement: {
+        replaceAll: vi.fn(async () => {
+          events.push('replace')
+          throw new Error(SECRET_VALUES[1])
+        }),
+      },
+    })
+
+    const error = await captureImportError(async () =>
+      createImportBackupV2UseCase(deps)(createInspection()),
+    )
+
+    expect(error.code).toBe('RECOVERY_RESTORE_FAILED')
+    expect(events).toEqual(['capture', 'replace', 'restore'])
+  })
+
+  it('rejects logical resource excess before recovery capture', async () => {
+    const events: string[] = []
+    const inspection = createInspection()
+    const collection = inspection.data.savedTabs.collections[0]
+    if (collection === undefined) {
+      throw new Error('Missing test collection')
+    }
+    const oversizedInspection: BackupV2Inspection = {
+      ...inspection,
+      data: {
+        ...inspection.data,
+        savedTabs: {
+          ...inspection.data.savedTabs,
+          collections: [
+            {
+              ...collection,
+              name: 'x'.repeat(BACKUP_RESOURCE_LIMITS.maxNameBytes + 1),
+            },
+          ],
+        },
+      },
+    }
+    const deps = createDeps(events)
+
+    const error = await captureImportError(async () =>
+      createImportBackupV2UseCase(deps)(oversizedInspection),
+    )
+
+    expect(error.code).toBe('BACKUP_RESOURCE_REJECTED')
+    expect(events).toEqual([])
+  })
+
+  it('rejects unhealthy saved-tab relations before recovery capture', async () => {
+    const events: string[] = []
+    const inspection = createInspection()
+    const membership = inspection.data.savedTabs.memberships[0]
+    if (membership === undefined) {
+      throw new Error('Missing test membership')
+    }
+    const unhealthyInspection: BackupV2Inspection = {
+      ...inspection,
+      data: {
+        ...inspection.data,
+        savedTabs: {
+          ...inspection.data.savedTabs,
+          memberships: [{ ...membership, urlId: 'missing-url-id' }],
+        },
+      },
+    }
+    const deps = createDeps(events)
+
+    const error = await captureImportError(async () =>
+      createImportBackupV2UseCase(deps)(unhealthyInspection),
+    )
+
+    expect(error.code).toBe('BACKUP_INTEGRITY_FAILED')
+    expect(events).toEqual([])
+  })
+
+  it('strictly rejects internal envelope data before recovery capture', async () => {
+    const events: string[] = []
+    const inspection = createInspection()
+    Object.assign(inspection.data, { internalRevision: 999 })
+    const deps = createDeps(events)
+
+    const error = await captureImportError(async () =>
+      createImportBackupV2UseCase(deps)(inspection),
+    )
+
+    expect(error.code).toBe('INVALID_BACKUP')
+    expect(events).toEqual([])
+  })
+
+  it('never exposes imported content through typed errors', async () => {
+    const events: string[] = []
+    const deps = createDeps(events, {
+      replacement: {
+        replaceAll: vi.fn(async () => {
+          throw new Error(SECRET_VALUES.join(' '))
+        }),
+      },
+    })
+
+    const error = await captureImportError(async () =>
+      createImportBackupV2UseCase(deps)(createInspection()),
+    )
+    const serializedError = JSON.stringify(error)
+
+    for (const secret of SECRET_VALUES) {
+      expect(error.message).not.toContain(secret)
+      expect(serializedError).not.toContain(secret)
+    }
+  })
+
+  it('treats a mismatched committed revision as a readback mismatch', async () => {
+    const events: string[] = []
+    const deps = createDeps(events, {
+      readbackSnapshot: createSnapshot(76),
+    })
+
+    const error = await captureImportError(async () =>
+      createImportBackupV2UseCase(deps)(createInspection()),
+    )
+
+    expect(error.code).toBe('READBACK_MISMATCH')
+    expect(deps.recovery?.restore).toHaveBeenCalledOnce()
+  })
+})

--- a/src/features/options/lib/import-export/v2/ImportBackupV2UseCase.ts
+++ b/src/features/options/lib/import-export/v2/ImportBackupV2UseCase.ts
@@ -1,0 +1,251 @@
+import { checkPersistenceIntegrity } from '@/contexts/saved-tabs/public-api'
+import type {
+  PersistenceLogicalSnapshot,
+  PersistenceV2Snapshot,
+} from '@/contexts/saved-tabs/public-api'
+import type { UserSettings } from '@/types/storage'
+
+import { BackupMapper } from './BackupMapper'
+import type {
+  BackupPreviewEntityCounts,
+  BackupV2Inspection,
+} from './BackupV2Inspector'
+import { collectBackupV2ResourceUsage } from './BackupV2ResourceUsage'
+import {
+  BACKUP_V2_SCHEMA_VERSION,
+  BackupEnvelopeV2Schema,
+} from './BackupV2Schema'
+import type { BackupDataV2, BackupEnvelopeV2 } from './BackupV2Schema'
+
+export type BackupV2ImportErrorCode =
+  | 'BACKUP_INTEGRITY_FAILED'
+  | 'BACKUP_RESOURCE_REJECTED'
+  | 'INVALID_BACKUP'
+  | 'OVERWRITE_RECOVERY_UNAVAILABLE'
+  | 'PERSISTENCE_REPLACEMENT_FAILED'
+  | 'READBACK_FAILED'
+  | 'READBACK_MISMATCH'
+  | 'RECOVERY_CAPTURE_FAILED'
+  | 'RECOVERY_RESTORE_FAILED'
+  | 'SETTINGS_WRITE_FAILED'
+
+const BACKUP_V2_IMPORT_ERROR_MESSAGES = {
+  BACKUP_INTEGRITY_FAILED: 'The backup failed the persistence integrity check.',
+  BACKUP_RESOURCE_REJECTED: 'The backup exceeds an import resource limit.',
+  INVALID_BACKUP: 'The backup does not match Backup V2.',
+  OVERWRITE_RECOVERY_UNAVAILABLE:
+    'Overwrite import requires a recovery snapshot capability.',
+  PERSISTENCE_REPLACEMENT_FAILED: 'The atomic persistence replacement failed.',
+  READBACK_FAILED: 'The imported data could not be read back.',
+  READBACK_MISMATCH: 'The imported data did not match readback.',
+  RECOVERY_CAPTURE_FAILED:
+    'The pre-overwrite recovery snapshot could not be captured.',
+  RECOVERY_RESTORE_FAILED: 'The recovery snapshot could not be restored.',
+  SETTINGS_WRITE_FAILED: 'The separate settings write failed.',
+} as const satisfies Record<BackupV2ImportErrorCode, string>
+
+export class BackupV2ImportError extends Error {
+  readonly code: BackupV2ImportErrorCode
+
+  constructor(code: BackupV2ImportErrorCode) {
+    super(BACKUP_V2_IMPORT_ERROR_MESSAGES[code])
+    this.name = 'BackupV2ImportError'
+    this.code = code
+  }
+}
+
+type PersistenceV2ReplacementTarget = {
+  readonly analyticsViews: PersistenceLogicalSnapshot['analyticsViews']
+  readonly conversations: PersistenceLogicalSnapshot['conversations']
+  readonly messages: PersistenceLogicalSnapshot['messages']
+  readonly savedTabs: PersistenceV2Snapshot
+}
+
+type PersistenceV2ReplacementPort = {
+  readonly replaceAll: (
+    target: PersistenceV2ReplacementTarget,
+  ) => Promise<{ readonly revision: number }>
+}
+
+export type OverwriteRecoveryCapability = {
+  readonly captureBeforeOverwrite: () => Promise<unknown>
+  readonly restore: (recoveryId: unknown) => Promise<void>
+}
+
+export type ImportBackupV2UseCaseDeps = {
+  readonly readUserSettings: () => Promise<UserSettings>
+  readonly recovery?: OverwriteRecoveryCapability | undefined
+  readonly replacement: PersistenceV2ReplacementPort
+  readonly snapshotReader: {
+    readonly readConsistentSnapshot: () => Promise<PersistenceLogicalSnapshot>
+  }
+  readonly writeUserSettings: (settings: UserSettings) => Promise<void>
+}
+
+export type ImportBackupV2Result = {
+  readonly entityCounts: BackupPreviewEntityCounts
+  readonly revision: number
+}
+
+export type ImportBackupV2UseCase = (
+  inspection: BackupV2Inspection,
+) => Promise<ImportBackupV2Result>
+
+const textEncoder = new TextEncoder()
+
+const createEntityCounts = (data: BackupDataV2): BackupPreviewEntityCounts => ({
+  analyticsViews: data.analyticsViews.length,
+  categories: data.savedTabs.categories.length,
+  collections: data.savedTabs.collections.length,
+  conversations: data.conversations.length,
+  groups: data.savedTabs.groups.length,
+  memberships: data.savedTabs.memberships.length,
+  messages: data.messages.length,
+  urls: data.savedTabs.urls.length,
+})
+
+const reconstructEnvelope = (
+  inspection: BackupV2Inspection,
+): BackupEnvelopeV2 => {
+  try {
+    return BackupEnvelopeV2Schema.parse({
+      appVersion: inspection.preview.appVersion,
+      data: inspection.data,
+      exportedAt: inspection.preview.exportedAt,
+      schemaVersion: BACKUP_V2_SCHEMA_VERSION,
+    })
+  } catch {
+    throw new BackupV2ImportError('INVALID_BACKUP')
+  }
+}
+
+const createReplacementTarget = (
+  logicalSnapshot: PersistenceLogicalSnapshot,
+): PersistenceV2ReplacementTarget => ({
+  analyticsViews: logicalSnapshot.analyticsViews,
+  conversations: logicalSnapshot.conversations,
+  messages: logicalSnapshot.messages,
+  savedTabs: logicalSnapshot.savedTabs,
+})
+
+const assertPreflight = (
+  envelope: BackupEnvelopeV2,
+): PersistenceLogicalSnapshot => {
+  const serialized = JSON.stringify(envelope)
+  try {
+    collectBackupV2ResourceUsage(
+      envelope.data,
+      textEncoder.encode(serialized).byteLength,
+    )
+  } catch {
+    throw new BackupV2ImportError('BACKUP_RESOURCE_REJECTED')
+  }
+
+  if (!checkPersistenceIntegrity(envelope.data.savedTabs).isHealthy) {
+    throw new BackupV2ImportError('BACKUP_INTEGRITY_FAILED')
+  }
+
+  try {
+    return BackupMapper.toLogicalSnapshot(envelope.data, 0)
+  } catch {
+    throw new BackupV2ImportError('INVALID_BACKUP')
+  }
+}
+
+const restoreAndThrow = async (
+  recovery: OverwriteRecoveryCapability,
+  recoveryId: unknown,
+  failureCode: BackupV2ImportErrorCode,
+): Promise<never> => {
+  try {
+    await recovery.restore(recoveryId)
+  } catch {
+    throw new BackupV2ImportError('RECOVERY_RESTORE_FAILED')
+  }
+  throw new BackupV2ImportError(failureCode)
+}
+
+/**
+ * Performs an overwrite import with recovery and verified readback.
+ *
+ * IndexedDB logical data is replaced atomically by `replacement`. Chrome-owned
+ * settings are necessarily written afterward through a separate storage engine,
+ * so this use case intentionally makes no cross-engine atomicity claim. Any
+ * failure after recovery capture requests restoration, but a settings backend
+ * could still have applied a partial write before reporting failure.
+ */
+export const createImportBackupV2UseCase = (
+  deps: ImportBackupV2UseCaseDeps,
+): ImportBackupV2UseCase => {
+  return async (inspection) => {
+    const envelope = reconstructEnvelope(inspection)
+    const requestedSnapshot = assertPreflight(envelope)
+    const requestedData = BackupMapper.toBackupData(
+      requestedSnapshot,
+      envelope.data.userSettings,
+    )
+    const recovery = deps.recovery
+
+    if (recovery === undefined) {
+      throw new BackupV2ImportError('OVERWRITE_RECOVERY_UNAVAILABLE')
+    }
+
+    let recoveryId: unknown
+    try {
+      recoveryId = await recovery.captureBeforeOverwrite()
+    } catch {
+      throw new BackupV2ImportError('RECOVERY_CAPTURE_FAILED')
+    }
+
+    let replacementResult: { readonly revision: number }
+    try {
+      replacementResult = await deps.replacement.replaceAll(
+        createReplacementTarget(requestedSnapshot),
+      )
+    } catch {
+      return restoreAndThrow(
+        recovery,
+        recoveryId,
+        'PERSISTENCE_REPLACEMENT_FAILED',
+      )
+    }
+
+    try {
+      await deps.writeUserSettings(requestedData.userSettings)
+    } catch {
+      return restoreAndThrow(recovery, recoveryId, 'SETTINGS_WRITE_FAILED')
+    }
+
+    let readbackSnapshot: PersistenceLogicalSnapshot
+    let readbackSettings: UserSettings
+    try {
+      readbackSnapshot = await deps.snapshotReader.readConsistentSnapshot()
+      readbackSettings = await deps.readUserSettings()
+    } catch {
+      return restoreAndThrow(recovery, recoveryId, 'READBACK_FAILED')
+    }
+
+    let readbackData: BackupDataV2
+    try {
+      readbackData = BackupMapper.toBackupData(
+        readbackSnapshot,
+        readbackSettings,
+      )
+    } catch {
+      return restoreAndThrow(recovery, recoveryId, 'READBACK_MISMATCH')
+    }
+
+    if (
+      readbackSnapshot.revision !== replacementResult.revision ||
+      !checkPersistenceIntegrity(readbackSnapshot.savedTabs).isHealthy ||
+      JSON.stringify(readbackData) !== JSON.stringify(requestedData)
+    ) {
+      return restoreAndThrow(recovery, recoveryId, 'READBACK_MISMATCH')
+    }
+
+    return {
+      entityCounts: createEntityCounts(requestedData),
+      revision: replacementResult.revision,
+    }
+  }
+}

--- a/src/features/options/lib/import-export/v2/ImportBackupV2UseCase.ts
+++ b/src/features/options/lib/import-export/v2/ImportBackupV2UseCase.ts
@@ -1,7 +1,8 @@
 import { checkPersistenceIntegrity } from '@/contexts/saved-tabs/public-api'
 import type {
   PersistenceLogicalSnapshot,
-  PersistenceV2Snapshot,
+  PersistenceV2ReplacementPort,
+  PersistenceV2ReplacementTarget,
 } from '@/contexts/saved-tabs/public-api'
 import type { UserSettings } from '@/types/storage'
 
@@ -52,19 +53,6 @@ export class BackupV2ImportError extends Error {
     this.name = 'BackupV2ImportError'
     this.code = code
   }
-}
-
-type PersistenceV2ReplacementTarget = {
-  readonly analyticsViews: PersistenceLogicalSnapshot['analyticsViews']
-  readonly conversations: PersistenceLogicalSnapshot['conversations']
-  readonly messages: PersistenceLogicalSnapshot['messages']
-  readonly savedTabs: PersistenceV2Snapshot
-}
-
-type PersistenceV2ReplacementPort = {
-  readonly replaceAll: (
-    target: PersistenceV2ReplacementTarget,
-  ) => Promise<{ readonly revision: number }>
 }
 
 export type OverwriteRecoveryCapability = {

--- a/src/features/options/lib/import-export/v2/fixtures/backup-v2-current.json
+++ b/src/features/options/lib/import-export/v2/fixtures/backup-v2-current.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 2,
+  "appVersion": "2.0.0",
+  "exportedAt": "2026-07-08T00:00:00.000Z",
+  "data": {
+    "savedTabs": {
+      "urls": [],
+      "collections": [],
+      "memberships": [],
+      "categories": [],
+      "groups": []
+    },
+    "conversations": [],
+    "messages": [],
+    "analyticsViews": [],
+    "userSettings": {
+      "removeTabAfterOpen": false,
+      "removeTabAfterExternalDrop": false,
+      "excludePatterns": [],
+      "enableCategories": true,
+      "showSavedTime": false,
+      "clickBehavior": "saveSameDomainTabs",
+      "excludePinnedTabs": true,
+      "openUrlInBackground": true,
+      "openAllInNewWindow": false,
+      "confirmDeleteAll": true,
+      "confirmDeleteEach": false
+    }
+  }
+}

--- a/src/features/options/lib/import-export/v2/fixtures/backup-v2-future.json
+++ b/src/features/options/lib/import-export/v2/fixtures/backup-v2-future.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 3,
+  "appVersion": "3.0.0",
+  "exportedAt": "2027-01-01T00:00:00.000Z",
+  "data": {}
+}

--- a/src/features/options/lib/import-export/v2/fixtures/legacy-custom-project-url-metadata.json
+++ b/src/features/options/lib/import-export/v2/fixtures/legacy-custom-project-url-metadata.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.9.0",
+  "timestamp": "2026-07-04T00:00:00.000Z",
+  "userSettings": {},
+  "parentCategories": [],
+  "urls": [
+    {
+      "id": "url-project-metadata",
+      "url": "https://metadata.example.com/item",
+      "title": "Metadata item",
+      "savedAt": 606
+    }
+  ],
+  "savedTabs": [],
+  "customProjects": [
+    {
+      "id": "project-metadata",
+      "name": "Metadata project",
+      "categories": ["important"],
+      "categoryOrder": ["important"],
+      "createdAt": 707,
+      "updatedAt": 808,
+      "urlIds": ["url-project-metadata"],
+      "urls": [
+        {
+          "url": "https://metadata.example.com/item",
+          "title": "Metadata item",
+          "savedAt": 606
+        }
+      ],
+      "urlMetadata": {
+        "url-project-metadata": {
+          "notes": "private-metadata-note",
+          "category": "important"
+        }
+      }
+    }
+  ],
+  "customProjectOrder": ["project-metadata"]
+}

--- a/src/features/options/lib/import-export/v2/fixtures/legacy-custom-project-urls.json
+++ b/src/features/options/lib/import-export/v2/fixtures/legacy-custom-project-urls.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.9.0",
+  "timestamp": "2026-07-03T00:00:00.000Z",
+  "userSettings": {},
+  "parentCategories": [],
+  "savedTabs": [],
+  "customProjects": [
+    {
+      "id": "project-nested",
+      "name": "Nested project",
+      "categories": ["research"],
+      "categoryOrder": ["research"],
+      "createdAt": 303,
+      "updatedAt": 404,
+      "urls": [
+        {
+          "url": "https://project.example.com/paper",
+          "title": "Project paper",
+          "notes": "private-project-note",
+          "savedAt": 505,
+          "category": "research"
+        }
+      ]
+    }
+  ],
+  "customProjectOrder": ["project-nested"]
+}

--- a/src/features/options/lib/import-export/v2/fixtures/legacy-malformed.json
+++ b/src/features/options/lib/import-export/v2/fixtures/legacy-malformed.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.9.0",
+  "timestamp": "2026-07-07T00:00:00.000Z",
+  "userSettings": {},
+  "parentCategories": [],
+  "savedTabs": "not-an-array"
+}

--- a/src/features/options/lib/import-export/v2/fixtures/legacy-mixed-fields.json
+++ b/src/features/options/lib/import-export/v2/fixtures/legacy-mixed-fields.json
@@ -1,0 +1,54 @@
+{
+  "version": "1.9.0",
+  "timestamp": "2026-07-06T00:00:00.000Z",
+  "userSettings": {
+    "language": "en"
+  },
+  "parentCategories": [],
+  "urls": [
+    {
+      "id": "url-mixed-canonical",
+      "url": "https://mixed.example.com/canonical",
+      "title": "Mixed canonical",
+      "savedAt": 1001
+    }
+  ],
+  "savedTabs": [
+    {
+      "id": "domain-mixed",
+      "domain": "mixed.example.com",
+      "savedAt": 1002,
+      "urlIds": ["url-mixed-canonical"]
+    },
+    {
+      "id": "domain-mixed-nested",
+      "domain": "mixed-nested.example.com",
+      "savedAt": 1003,
+      "urls": [
+        {
+          "url": "https://mixed-nested.example.com/nested",
+          "title": "Mixed nested",
+          "savedAt": 1004
+        }
+      ]
+    }
+  ],
+  "customProjects": [
+    {
+      "id": "project-mixed",
+      "name": "Mixed project",
+      "categories": [],
+      "categoryOrder": [],
+      "createdAt": 1005,
+      "updatedAt": 1006,
+      "urls": [
+        {
+          "url": "https://mixed-project.example.com/item",
+          "title": "Mixed project item",
+          "savedAt": 1007
+        }
+      ]
+    }
+  ],
+  "customProjectOrder": ["project-mixed"]
+}

--- a/src/features/options/lib/import-export/v2/fixtures/legacy-parent-category.json
+++ b/src/features/options/lib/import-export/v2/fixtures/legacy-parent-category.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.9.0",
+  "timestamp": "2026-07-05T00:00:00.000Z",
+  "userSettings": {},
+  "parentCategories": [
+    {
+      "id": "parent-work",
+      "name": "Work",
+      "domains": ["domain-parented"],
+      "domainNames": ["parented.example.com"]
+    }
+  ],
+  "savedTabs": [
+    {
+      "id": "domain-parented",
+      "domain": "parented.example.com",
+      "parentCategoryId": "parent-work",
+      "savedAt": 909,
+      "urlIds": []
+    }
+  ]
+}

--- a/src/features/options/lib/import-export/v2/fixtures/legacy-tab-group-nested-urls.json
+++ b/src/features/options/lib/import-export/v2/fixtures/legacy-tab-group-nested-urls.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.9.0",
+  "timestamp": "2026-07-01T00:00:00.000Z",
+  "userSettings": {
+    "showSavedTime": true
+  },
+  "parentCategories": [],
+  "savedTabs": [
+    {
+      "id": "domain-nested",
+      "domain": "nested.example.com",
+      "subCategories": ["docs"],
+      "urls": [
+        {
+          "url": "https://nested.example.com/guide",
+          "title": "Nested guide",
+          "subCategory": "docs"
+        }
+      ]
+    }
+  ]
+}

--- a/src/features/options/lib/import-export/v2/fixtures/legacy-tab-group-url-ids.json
+++ b/src/features/options/lib/import-export/v2/fixtures/legacy-tab-group-url-ids.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.9.0",
+  "timestamp": "2026-07-02T00:00:00.000Z",
+  "userSettings": {},
+  "parentCategories": [],
+  "urls": [
+    {
+      "id": "url-canonical",
+      "url": "https://ids.example.com/reference",
+      "title": "Canonical reference",
+      "savedAt": 101
+    }
+  ],
+  "savedTabs": [
+    {
+      "id": "domain-ids",
+      "domain": "ids.example.com",
+      "savedAt": 202,
+      "subCategories": ["reference"],
+      "urlIds": ["url-canonical"],
+      "urlSubCategories": {
+        "url-canonical": "reference"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 背景 / 原因

Options のバックアップ経路が、Persistence v2 の logical snapshot・versioned schema・resource policy・transaction 境界を利用せず、旧 `chrome.storage.local` 形式を直接 export / import していました。

そのため、Backup V2 の public contract、旧 backup の期限付き互換性、strict な legacy boundary、IndexedDB transaction による import、deterministic export が production 経路に統合されていませんでした。

## 採用した解決

- storage engine から独立した strict `BackupEnvelopeV2` と mapper を追加
- IndexedDB の consistent logical snapshot から deterministic に V2 export
- resource / integrity / schema / future-version validation を import・export で共通化
- 旧 backup を strict V0 schema と dedicated adapter に隔離
- 2026-08-31 までの legacy merge を canonical IndexedDB UnitOfWork へ接続
- 2026-09-01 cutoff と 30 日 notice policy を単一 module に集約
- #740 完了前は、current V2 と全 overwrite import を mutation 前に fail-closed
- strict-invalid legacy input も旧 parser へフォールバックさせず、mutation 前に拒否

## 主な変更

- Backup V2 schema、mapper、inspector、resource usage、export/import use case
- 8 logical store と revision を扱う atomic replacement adapter
- Options の production export を Backup V2 composition へ切替
- production import gate と UTC date provider
- legacy merge の actual IndexedDB composition / integration test
- legacy/current/future/malformed fixtures と round-trip / rollback / zero-mutation regression
- Backup schema versioning / rollout boundary の architecture document 更新

## 検証

- `bun run agent:check`
  - format / lint / type / full test / Knip / duplication: passed
- `bun run test:coverage`
  - 398 files passed
  - 4,505 passed / 1 skipped
  - statements 96.2%
  - branches 91.17%
  - functions 96.95%
  - lines 96.18%
- actual IndexedDB production gate integration: 16/16 passed
- legacy import regression: 68/68 passed
- `bun run arch:check`: 0 violations
- React Doctor changed scope: no issues
- fresh-context Harness Evaluator: approved, no findings

## Acceptance criteria 対応

- Backup V2 は IndexedDB internal schema / metadata / revision / recovery state を含まない public contract
- `schemaVersion` と `appVersion` を分離
- export は consistent snapshot と `BackupMapper` を利用
- Backup V2 transactional import core と atomic replacement adapter を実装
- 旧 pre-IDB backup は 2026-08-31 まで production の canonical IndexedDB merge 経路で import 可能
- legacy parser / adapter / policy を独立した削除可能な境界へ隔離
- current V2 schema に legacy optional field を持ち込まない
- legacy preview に cutoff / re-export advisory を保持
- required fixtures、semantic preservation、round-trip、rollback regression を追加

## Regression risk

- import/export の production routing を変更するため、schema classification と persistence route が主な risk
- current V2 と全 overwrite は #740 完了まで fail-closed とし、blocked request の zero-mutation test で保護
- rendered notice / i18n / dismiss state は #731 の scope
- UI の視覚変更はないため screenshot は対象外

Closes #730


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Backup V2形式（保存タブ・会話・メッセージ・設定）をエクスポート／インポートできるようになりました。
  * 旧形式バックアップを、既存データを保持しつつ統合して取り込めます。
* **改善**
  * UTC基準の日付で互換性の可否や期限を判定し、不正データ／将来形式は安全に拒否します。
  * 本番向けインポートは fail-closed で、上書き時も復旧条件を満たさない場合は保護されます。
  * エラー表示・ログに機密情報が混ざりにくくしました。
* **ドキュメント**
  * Backup V2の契約、移行・検証境界、復旧ルールを整理しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->