### PR TITLE
永続化 migration / import-export の property-based test を追加 (#718)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -453,7 +453,10 @@
     "vitest/require-top-level-describe": "error",
     "vitest/no-identical-title": "error",
     "vitest/valid-title": "error",
-    "vitest/expect-expect": "error",
+    "vitest/expect-expect": [
+      "error",
+      { "assertFunctionNames": ["expect", "expectTypeOf", "fc.assert"] }
+    ],
     "vitest/no-conditional-expect": "error",
     "vitest/no-conditional-tests": "error",
     "vitest/prefer-expect-resolves": "error",

--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,7 @@
         "eslint-plugin-storybook": "^10.4.6",
         "eslint-plugin-testing-library": "^7.16.2",
         "fake-indexeddb": "^6.2.5",
+        "fast-check": "^4.9.0",
         "happy-dom": "^20.10.6",
         "html-validate": "^11.5.5",
         "jscpd": "^5.0.11",
@@ -1569,6 +1570,8 @@
 
     "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -2210,6 +2213,8 @@
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "pupa": ["pupa@3.3.0", "", { "dependencies": { "escape-goat": "^4.0.0" } }, "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA=="],
+
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 

--- a/docs/testing/property-based-tests.md
+++ b/docs/testing/property-based-tests.md
@@ -1,0 +1,95 @@
+# Property-based tests for storage migration / import-export
+
+Issue #718 導入の property-based test（fast-check）の対象 invariant、
+generator 配置、seed 再現手順、regression fixture 昇格基準をまとめる。
+
+## 対象 invariant
+
+| Invariant                                                                                              | Property test                                                                                     |
+| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `normalize(normalize(x)) === normalize(x)`（URL identity / URL candidate / domain）                    | `src/contexts/saved-tabs/domain/services/urlNormalization.property.test.ts`                       |
+| `check(snapshot) === check(snapshot)`（#712 integrity checker 決定性）                                 | `src/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker.property.test.ts`            |
+| corruption generator が誘発した issue code を checker が検出する                                       | 同上                                                                                              |
+| `repair(repair(x)) === repair(x)`（automatic-safe repair の fixpoint）                                 | `src/contexts/saved-tabs/domain/services/PersistenceRepairPlanner.property.test.ts`               |
+| `migrateLegacy(x)` の決定性（fixed clock / id generator 不要の純粋 mapper）                            | `src/contexts/saved-tabs/application/mappers/LegacyStorageToPersistenceV2Mapper.property.test.ts` |
+| migration が relation を保持する（canonical / nested URL、notes、category 割当）                       | 同上                                                                                              |
+| `Url.firstSavedAt <= Url.lastSavedAt`（fallback 後も成立）                                             | 同上                                                                                              |
+| 同一 URL の複数 collection 所属で `Membership.addedAt` が `Url.lastSavedAt` へ不正同期されない（#732） | 同上                                                                                              |
+| `import(export(v2))` が canonicalized logical snapshot を保持する（Backup V2 round trip）              | `src/features/options/lib/import-export/v2/BackupMapper.property.test.ts`                         |
+| pre-IDB legacy backup 変換の決定性と Backup V2 schema 適合（#730）                                     | `src/features/options/lib/import-export/legacy/LegacyBackupAdapter.property.test.ts`              |
+
+## Generator 配置
+
+共有 arbitrary は `src/test/arbitraries/persistence/` に集約し、test file ごとの
+重複定義を禁止する。
+
+- `primitives.ts` — timestamp / sortOrder / domain / URL / display text
+- `persistenceSnapshotArbitrary.ts` — Persistence Model v2 の valid snapshot
+  generator、malformed / corrupted snapshot generator（誘発 issue code 付き）
+- `legacyStorageSnapshotArbitrary.ts` — 歴史的 legacy chrome.storage shape
+  （`TabGroup.urlIds` / nested `urls` / parallel mixed、`urlSubCategories`、
+  `CustomProject.urlIds` / `urls` / `urlMetadata`、`ParentCategory.domains` /
+  `domainNames`、`parentCategoryId`、`DomainParentCategoryMapping`）の
+  well-formed generator と malformed / partially corrupted raw generator
+- `backupArbitrary.ts` — canonical user settings と pre-IDB backup envelope
+- `fastCheckParameters.ts` — 全 property test 共通の seed / numRuns 制御
+
+current production type（Persistence Model v2）を legacy arbitrary の型として
+再利用しない。legacy shape は `src/types/storage.ts` の legacy schema 型に
+揃える。
+
+## Seed reproduction
+
+fast-check は failure 時に seed と path を出力する。
+
+```text
+Property failed after 134 tests
+{ seed: 18927364, path: "12:3:1", endOnFailure: true }
+```
+
+CI failure と同じ case を local で再現するには:
+
+```bash
+FAST_CHECK_SEED=18927364 bunx vitest run --config vitest.ci.config.ts \
+  --project=node <failing-file>
+```
+
+run 数を増やした深掘り実行（nightly / manual 相当）:
+
+```bash
+FAST_CHECK_RUNS=500 bun run test:node
+```
+
+## Regression fixture 昇格基準
+
+property test で見つかった bug を random generator だけに任せ続けない。
+以下に該当する failure は explicit regression fixture / example test へ昇格する。
+
+- production data loss risk
+- migration conflict rule bug
+- timestamp corruption
+- note / category relation loss
+- source-of-truth cutover bug
+- legacy backup compatibility bug
+
+昇格先は対象 module の既存 example test（例:
+`LegacyStorageToPersistenceV2Mapper.test.ts`）に minimal counterexample を
+fixture として追加する。
+
+## Execution strategy
+
+- PR quality gate: 各 property `numRuns = 50`（既定）。全 property file 合計で
+  1 秒未満に収まり、通常 quality gate を過度に遅くしない
+- nightly / manual: `FAST_CHECK_RUNS` で numRuns を引き上げ、malformed case を
+  広く探索する
+- critical migration property（migration determinism、timestamp invariant、
+  Backup V2 round trip）は常に PR gate に含める。「重いから migration test
+  全体を nightly だけ」にはしない
+
+## #734 cleanup 対象の識別
+
+`src/features/options/lib/import-export/legacy/LegacyBackupAdapter.property.test.ts`
+は pre-IDB legacy backup importer（2026-08-31 までの temporary compatibility
+scope）を対象にする。#734 の cutoff release で legacy importer とともに削除し、
+archived historical fixture と current Backup V2 test を分離する。ファイル先頭の
+コメントでも同じ旨を明示している。

--- a/package.json
+++ b/package.json
@@ -172,6 +172,7 @@
     "eslint-plugin-storybook": "^10.4.6",
     "eslint-plugin-testing-library": "^7.16.2",
     "fake-indexeddb": "^6.2.5",
+    "fast-check": "^4.9.0",
     "happy-dom": "^20.10.6",
     "html-validate": "^11.5.5",
     "jscpd": "^5.0.11",

--- a/src/contexts/saved-tabs/application/mappers/LegacyStorageToPersistenceV2Mapper.property.test.ts
+++ b/src/contexts/saved-tabs/application/mappers/LegacyStorageToPersistenceV2Mapper.property.test.ts
@@ -1,0 +1,286 @@
+import * as fc from 'fast-check'
+import { describe, it } from 'vitest'
+
+import { PERSISTENCE_V2_INVARIANT_CODES } from '@/contexts/saved-tabs/domain/entities/PersistenceModelV2'
+import { checkPersistenceIntegrity } from '@/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker'
+import { fastCheckParameters } from '@/test/arbitraries/persistence/fastCheckParameters'
+import {
+  rawLegacyStorageSnapshotArbitrary,
+  sharedUrlLegacyStorageArbitrary,
+  toRawLegacyStorageSnapshot,
+  wellFormedLegacyStorageArbitrary,
+} from '@/test/arbitraries/persistence/legacyStorageSnapshotArbitrary'
+
+import { mapLegacyStorageToPersistenceV2 } from './LegacyStorageToPersistenceV2Mapper'
+
+const MIGRATION_SPECIFIC_CODES = [
+  'LEGACY_AI_ENTITY_ID_COLLISION',
+  'LEGACY_CUSTOM_PROJECT_ORDER_CONFLICT',
+  'LEGACY_DOMAIN_CATEGORY_MAPPING_CONFLICT',
+  'LEGACY_PARENT_CATEGORY_CONFLICT',
+  'LEGACY_URL_REFERENCE_CONFLICT',
+  'MIGRATION_SOURCE_INVALID_TYPE',
+  'MIGRATION_SOURCE_MISSING_KEY',
+] as const
+
+const KNOWN_ISSUE_CODES: ReadonlySet<string> = new Set([
+  ...PERSISTENCE_V2_INVARIANT_CODES,
+  ...MIGRATION_SPECIFIC_CODES,
+])
+
+// Property targets from issue #718: determinism, semantic preservation,
+// and timestamp invariants for the #728 legacy storage migration.
+describe('mapLegacyStorageToPersistenceV2 properties', () => {
+  it('is deterministic for arbitrary raw storage input', () => {
+    fc.assert(
+      fc.property(rawLegacyStorageSnapshotArbitrary, (source) => {
+        const first = mapLegacyStorageToPersistenceV2(source)
+        const second = mapLegacyStorageToPersistenceV2(source)
+        return JSON.stringify(first) === JSON.stringify(second)
+      }),
+      fastCheckParameters,
+    )
+  })
+
+  it('reports only known issue codes for arbitrary raw storage input', () => {
+    fc.assert(
+      fc.property(rawLegacyStorageSnapshotArbitrary, (source) => {
+        const { issueCodes } = mapLegacyStorageToPersistenceV2(source)
+        return issueCodes.every((code) => KNOWN_ISSUE_CODES.has(code))
+      }),
+      fastCheckParameters,
+    )
+  })
+
+  it('keeps timestamp invariants even after fallback for malformed input', () => {
+    fc.assert(
+      fc.property(rawLegacyStorageSnapshotArbitrary, (source) => {
+        const { snapshot } = mapLegacyStorageToPersistenceV2(source)
+        return (
+          snapshot.urls.every((url) => url.firstSavedAt <= url.lastSavedAt) &&
+          snapshot.memberships.every(
+            (membership) => membership.addedAt <= membership.updatedAt,
+          ) &&
+          [
+            ...snapshot.collections,
+            ...snapshot.categories,
+            ...snapshot.groups,
+          ].every((entity) => entity.createdAt <= entity.updatedAt)
+        )
+      }),
+      fastCheckParameters,
+    )
+  })
+
+  it('produces healthy v2 snapshots from well-formed legacy storage', () => {
+    fc.assert(
+      fc.property(wellFormedLegacyStorageArbitrary, (storage) => {
+        const { snapshot } = mapLegacyStorageToPersistenceV2(
+          toRawLegacyStorageSnapshot(storage),
+        )
+        return checkPersistenceIntegrity(snapshot).isHealthy
+      }),
+      fastCheckParameters,
+    )
+  })
+
+  it('preserves URLs, notes, and category relations from legacy storage', () => {
+    fc.assert(
+      fc.property(wellFormedLegacyStorageArbitrary, (storage) => {
+        const { snapshot } = mapLegacyStorageToPersistenceV2(
+          toRawLegacyStorageSnapshot(storage),
+        )
+        const urlsById = new Map(snapshot.urls.map((url) => [url.id, url]))
+        const urlsByValue = new Map(snapshot.urls.map((url) => [url.url, url]))
+
+        const canonicalPreserved = storage.urls.every(
+          (url) => urlsById.get(url.id)?.url === url.url,
+        )
+        const nestedUrlStrings = [
+          ...storage.savedTabs.flatMap((group) =>
+            (group.urls ?? []).map((url) => url.url),
+          ),
+          ...storage.customProjects.flatMap((project) =>
+            (project.urls ?? []).map((url) => url.url),
+          ),
+        ]
+        const nestedPreserved = nestedUrlStrings.every((value) =>
+          urlsByValue.has(value),
+        )
+
+        const findMembership = (collectionId: string, urlId: string) =>
+          snapshot.memberships.find(
+            (candidate) =>
+              candidate.collectionId === collectionId &&
+              candidate.urlId === urlId,
+          )
+        const categoryMatches = (
+          collectionId: string,
+          categoryId: string | undefined,
+          name: string,
+        ) => {
+          const category = snapshot.categories.find(
+            (candidate) => candidate.id === categoryId,
+          )
+          return (
+            category?.collectionId === collectionId && category?.name === name
+          )
+        }
+
+        const projectSemantics = storage.customProjects.every((project) =>
+          (project.urls ?? []).every((nested) => {
+            const url = urlsByValue.get(nested.url)
+            if (!url) {
+              return false
+            }
+            const membership = findMembership(project.id, url.id)
+            if (!membership) {
+              return false
+            }
+            if (
+              nested.notes !== undefined &&
+              membership.notes !== nested.notes
+            ) {
+              return false
+            }
+            if (
+              nested.category !== undefined &&
+              !categoryMatches(
+                project.id,
+                membership.categoryId,
+                nested.category,
+              )
+            ) {
+              return false
+            }
+            return true
+          }),
+        )
+
+        const metadataSemantics = storage.customProjects.every((project) =>
+          Object.entries(project.urlMetadata ?? {}).every(
+            ([urlId, metadata]) => {
+              const membership = findMembership(project.id, urlId)
+              if (!membership) {
+                return false
+              }
+              if (
+                metadata.notes !== undefined &&
+                membership.notes !== metadata.notes
+              ) {
+                return false
+              }
+              if (
+                metadata.category !== undefined &&
+                !categoryMatches(
+                  project.id,
+                  membership.categoryId,
+                  metadata.category,
+                )
+              ) {
+                return false
+              }
+              return true
+            },
+          ),
+        )
+
+        const groupSemantics = storage.savedTabs.every((group) =>
+          Object.entries(group.urlSubCategories ?? {}).every(
+            ([urlId, subCategory]) => {
+              const membership = findMembership(group.id, urlId)
+              return (
+                membership !== undefined &&
+                categoryMatches(group.id, membership.categoryId, subCategory)
+              )
+            },
+          ),
+        )
+
+        const groupNestedSemantics = storage.savedTabs.every((group) =>
+          (group.urls ?? []).every((nested) => {
+            if (nested.id === undefined) {
+              return true
+            }
+            const url = urlsByValue.get(nested.url)
+            if (!url || url.id !== nested.id) {
+              // Parallel mixed copies are covered by canonicalPreserved.
+              return urlsById.has(nested.id)
+            }
+            const membership = findMembership(group.id, url.id)
+            if (!membership) {
+              return false
+            }
+            if (
+              nested.subCategory !== undefined &&
+              !categoryMatches(
+                group.id,
+                membership.categoryId,
+                nested.subCategory,
+              )
+            ) {
+              return false
+            }
+            return true
+          }),
+        )
+
+        return (
+          canonicalPreserved &&
+          nestedPreserved &&
+          projectSemantics &&
+          metadataSemantics &&
+          groupSemantics &&
+          groupNestedSemantics
+        )
+      }),
+      fastCheckParameters,
+    )
+  })
+
+  it('keeps one Url and per-collection memberships for shared legacy URLs (#732)', () => {
+    fc.assert(
+      fc.property(sharedUrlLegacyStorageArbitrary, (source) => {
+        const { snapshot } = mapLegacyStorageToPersistenceV2(source)
+        const shared = snapshot.urls.filter(
+          (url) => url.url === 'https://shared.example/page',
+        )
+        if (shared.length !== 1) {
+          return false
+        }
+        const [url] = shared
+        const memberships = snapshot.memberships.filter(
+          (membership) => membership.urlId === url.id,
+        )
+        const collectionIds = new Set(
+          memberships.map((membership) => membership.collectionId),
+        )
+        const savedTabs =
+          source.savedTabs.status === 'present' &&
+          Array.isArray(source.savedTabs.value)
+            ? (source.savedTabs.value as readonly {
+                id: string
+                savedAt?: number
+              }[])
+            : []
+        const groupSavedAt = new Map(
+          savedTabs.map((group) => [group.id, group.savedAt ?? 0]),
+        )
+        // Membership.addedAt follows the collection-side timestamp and
+        // must not be overwritten by Url.lastSavedAt (#732 semantics).
+        return (
+          url.firstSavedAt <= url.lastSavedAt &&
+          collectionIds.size >= 2 &&
+          memberships.length === collectionIds.size &&
+          memberships.every(
+            (membership) =>
+              membership.addedAt ===
+                groupSavedAt.get(membership.collectionId) &&
+              membership.addedAt <= membership.updatedAt,
+          )
+        )
+      }),
+      fastCheckParameters,
+    )
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker.property.test.ts
+++ b/src/contexts/saved-tabs/domain/services/PersistenceIntegrityChecker.property.test.ts
@@ -1,0 +1,60 @@
+import * as fc from 'fast-check'
+import { describe, it } from 'vitest'
+
+import { fastCheckParameters } from '@/test/arbitraries/persistence/fastCheckParameters'
+import {
+  corruptedPersistenceV2SnapshotArbitrary,
+  validPersistenceV2SnapshotArbitrary,
+} from '@/test/arbitraries/persistence/persistenceSnapshotArbitrary'
+
+import { checkPersistenceIntegrity } from './PersistenceIntegrityChecker'
+
+// Property targets from issue #718: checker determinism and corruption
+// detection for the #712 integrity checker.
+describe('checkPersistenceIntegrity properties', () => {
+  it('generated valid snapshots are healthy', () => {
+    fc.assert(
+      fc.property(validPersistenceV2SnapshotArbitrary, (snapshot) => {
+        const report = checkPersistenceIntegrity(snapshot)
+        return report.isHealthy && report.issues.length === 0
+      }),
+      fastCheckParameters,
+    )
+  })
+
+  it('is deterministic for valid and corrupted snapshots', () => {
+    fc.assert(
+      fc.property(
+        fc.oneof(
+          validPersistenceV2SnapshotArbitrary,
+          corruptedPersistenceV2SnapshotArbitrary.map(
+            ({ snapshot }) => snapshot,
+          ),
+        ),
+        (snapshot) => {
+          const first = checkPersistenceIntegrity(snapshot)
+          const second = checkPersistenceIntegrity(snapshot)
+          return JSON.stringify(first) === JSON.stringify(second)
+        },
+      ),
+      fastCheckParameters,
+    )
+  })
+
+  it('detects every induced corruption code', () => {
+    fc.assert(
+      fc.property(
+        corruptedPersistenceV2SnapshotArbitrary,
+        ({ expectedCodes, snapshot }) => {
+          const report = checkPersistenceIntegrity(snapshot)
+          const detected = new Set(report.issues.map((issue) => issue.code))
+          return (
+            !report.isHealthy &&
+            expectedCodes.every((code) => detected.has(code))
+          )
+        },
+      ),
+      fastCheckParameters,
+    )
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/PersistenceRepairPlanner.property.test.ts
+++ b/src/contexts/saved-tabs/domain/services/PersistenceRepairPlanner.property.test.ts
@@ -1,0 +1,92 @@
+import * as fc from 'fast-check'
+import { describe, it } from 'vitest'
+
+import type { PersistenceV2Snapshot } from '@/contexts/saved-tabs/domain/entities/PersistenceModelV2'
+import { fastCheckParameters } from '@/test/arbitraries/persistence/fastCheckParameters'
+import {
+  corruptedPersistenceV2SnapshotArbitrary,
+  duplicateMembershipCorruptedSnapshotArbitrary,
+} from '@/test/arbitraries/persistence/persistenceSnapshotArbitrary'
+
+import { checkPersistenceIntegrity } from './PersistenceIntegrityChecker'
+import type { StorageRepairOperation } from './PersistenceRepairPlanner'
+import { createStorageRepairPlan } from './PersistenceRepairPlanner'
+
+/**
+ * Test-local executor for the pure repair plan. Production keeps plan
+ * execution caller-owned; here it validates the repair fixpoint.
+ */
+const applyRemoveDuplicateMembership = (
+  snapshot: PersistenceV2Snapshot,
+  operation: Extract<
+    StorageRepairOperation,
+    { type: 'REMOVE_DUPLICATE_MEMBERSHIP' }
+  >,
+): PersistenceV2Snapshot => {
+  let keptFirst = false
+  let removed = 0
+  const memberships = snapshot.memberships.filter((membership) => {
+    if (
+      membership.collectionId !== operation.collectionId ||
+      membership.urlId !== operation.urlId
+    ) {
+      return true
+    }
+    if (!keptFirst) {
+      keptFirst = true
+      return true
+    }
+    if (removed < operation.removeCount) {
+      removed += 1
+      return false
+    }
+    return true
+  })
+  return { ...snapshot, memberships }
+}
+
+describe('createStorageRepairPlan properties', () => {
+  it('is deterministic for arbitrary integrity reports', () => {
+    fc.assert(
+      fc.property(corruptedPersistenceV2SnapshotArbitrary, ({ snapshot }) => {
+        const report = checkPersistenceIntegrity(snapshot)
+        const first = createStorageRepairPlan(report)
+        const second = createStorageRepairPlan(report)
+        return JSON.stringify(first) === JSON.stringify(second)
+      }),
+      fastCheckParameters,
+    )
+  })
+
+  it('safe repair reaches a duplicate-free fixpoint (repair(repair(x)) === repair(x))', () => {
+    fc.assert(
+      fc.property(
+        duplicateMembershipCorruptedSnapshotArbitrary,
+        ({ snapshot }) => {
+          const plan = createStorageRepairPlan(
+            checkPersistenceIntegrity(snapshot),
+          )
+          const repaired = plan.operations.reduce(
+            (current, operation) =>
+              operation.type === 'REMOVE_DUPLICATE_MEMBERSHIP'
+                ? applyRemoveDuplicateMembership(current, operation)
+                : current,
+            snapshot,
+          )
+          const afterReport = checkPersistenceIntegrity(repaired)
+          const replan = createStorageRepairPlan(afterReport)
+          return (
+            plan.operations.every(
+              (operation) => operation.type === 'REMOVE_DUPLICATE_MEMBERSHIP',
+            ) &&
+            !afterReport.issues.some(
+              (issue) => issue.code === 'DUPLICATE_MEMBERSHIP',
+            ) &&
+            replan.operations.length === 0
+          )
+        },
+      ),
+      fastCheckParameters,
+    )
+  })
+})

--- a/src/contexts/saved-tabs/domain/services/urlNormalization.property.test.ts
+++ b/src/contexts/saved-tabs/domain/services/urlNormalization.property.test.ts
@@ -1,0 +1,68 @@
+import * as fc from 'fast-check'
+import { describe, it } from 'vitest'
+
+import {
+  createDomainName,
+  domainNameToString,
+  normalizeDomainString,
+} from '@/contexts/saved-tabs/domain/value-objects/DomainName'
+import { normalizeUrlCandidate } from '@/lib/url-filter'
+import { fastCheckParameters } from '@/test/arbitraries/persistence/fastCheckParameters'
+import {
+  domainNameArbitrary,
+  urlStringArbitrary,
+} from '@/test/arbitraries/persistence/primitives'
+
+import { createUrlIdentityKey, hasSameUrlIdentity } from './UrlIdentityPolicy'
+
+// Invariant reference: docs/testing/property-based-tests.md
+describe('URL / domain normalization properties', () => {
+  it('createUrlIdentityKey is idempotent (exact-url-v1)', () => {
+    fc.assert(
+      fc.property(urlStringArbitrary, (url) => {
+        const once = createUrlIdentityKey(url)
+        return (
+          createUrlIdentityKey(once) === once && hasSameUrlIdentity(url, once)
+        )
+      }),
+      fastCheckParameters,
+    )
+  })
+
+  it('normalizeUrlCandidate is idempotent over arbitrary input', () => {
+    fc.assert(
+      fc.property(
+        fc.oneof(fc.string(), fc.constant(null), fc.constant(undefined)),
+        (input) =>
+          normalizeUrlCandidate(normalizeUrlCandidate(input)) ===
+          normalizeUrlCandidate(input),
+      ),
+      fastCheckParameters,
+    )
+  })
+
+  it('normalizeDomainString is idempotent over arbitrary input', () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        (input) =>
+          normalizeDomainString(normalizeDomainString(input)) ===
+          normalizeDomainString(input),
+      ),
+      fastCheckParameters,
+    )
+  })
+
+  it('createDomainName normalization is idempotent for valid inputs', () => {
+    fc.assert(
+      fc.property(
+        domainNameArbitrary,
+        (input) =>
+          domainNameToString(
+            createDomainName(domainNameToString(createDomainName(input))),
+          ) === domainNameToString(createDomainName(input)),
+      ),
+      fastCheckParameters,
+    )
+  })
+})

--- a/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.property.test.ts
+++ b/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.property.test.ts
@@ -1,5 +1,5 @@
 import * as fc from 'fast-check'
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { checkPersistenceIntegrity } from '@/contexts/saved-tabs/public-api'
 import { BackupDataV2Schema } from '@/features/options/lib/import-export/v2/BackupV2Schema'
@@ -27,10 +27,13 @@ describe('convertLegacyBackup properties (temporary compatibility scope)', () =>
     fc.assert(
       fc.property(legacyBackupV0Arbitrary, ({ backup, importDate }) => {
         const conversion = convertLegacyBackup(backup, importDate)
-        return (
-          BackupDataV2Schema.safeParse(conversion.data).success &&
-          checkPersistenceIntegrity(conversion.data.savedTabs).isHealthy
-        )
+        const parsed = BackupDataV2Schema.safeParse(conversion.data)
+        // Report the exact schema / integrity issue instead of a bare
+        // counterexample when the property fails.
+        expect(parsed.error?.issues ?? []).toEqual([])
+        expect(
+          checkPersistenceIntegrity(conversion.data.savedTabs).issues,
+        ).toEqual([])
       }),
       fastCheckParameters,
     )

--- a/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.property.test.ts
+++ b/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.property.test.ts
@@ -1,0 +1,38 @@
+import * as fc from 'fast-check'
+import { describe, it } from 'vitest'
+
+import { checkPersistenceIntegrity } from '@/contexts/saved-tabs/public-api'
+import { BackupDataV2Schema } from '@/features/options/lib/import-export/v2/BackupV2Schema'
+import { legacyBackupV0Arbitrary } from '@/test/arbitraries/persistence/backupArbitrary'
+import { fastCheckParameters } from '@/test/arbitraries/persistence/fastCheckParameters'
+
+import { convertLegacyBackup } from './LegacyBackupAdapter'
+
+// #734 cleanup target: this file covers the pre-IndexedDB legacy backup
+// importer, whose temporary compatibility scope ends 2026-08-31. Delete
+// together with the legacy importer in the #734 cutoff release.
+describe('convertLegacyBackup properties (temporary compatibility scope)', () => {
+  it('is deterministic for a fixed import date', () => {
+    fc.assert(
+      fc.property(legacyBackupV0Arbitrary, ({ backup, importDate }) => {
+        const first = convertLegacyBackup(backup, importDate)
+        const second = convertLegacyBackup(backup, importDate)
+        return JSON.stringify(first) === JSON.stringify(second)
+      }),
+      fastCheckParameters,
+    )
+  })
+
+  it('converts well-formed legacy backups into valid, healthy Backup V2 data', () => {
+    fc.assert(
+      fc.property(legacyBackupV0Arbitrary, ({ backup, importDate }) => {
+        const conversion = convertLegacyBackup(backup, importDate)
+        return (
+          BackupDataV2Schema.safeParse(conversion.data).success &&
+          checkPersistenceIntegrity(conversion.data.savedTabs).isHealthy
+        )
+      }),
+      fastCheckParameters,
+    )
+  })
+})

--- a/src/features/options/lib/import-export/v2/BackupMapper.property.test.ts
+++ b/src/features/options/lib/import-export/v2/BackupMapper.property.test.ts
@@ -1,7 +1,11 @@
 import * as fc from 'fast-check'
-import { describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { checkPersistenceIntegrity } from '@/contexts/saved-tabs/public-api'
+import type {
+  PersistenceV2CollectionMembership,
+  PersistenceV2Snapshot,
+} from '@/contexts/saved-tabs/public-api'
 import { canonicalUserSettings } from '@/test/arbitraries/persistence/backupArbitrary'
 import { fastCheckParameters } from '@/test/arbitraries/persistence/fastCheckParameters'
 import { validPersistenceV2SnapshotArbitrary } from '@/test/arbitraries/persistence/persistenceSnapshotArbitrary'
@@ -19,6 +23,55 @@ const logicalSnapshotArbitrary = validPersistenceV2SnapshotArbitrary.map(
     savedTabs,
   }),
 )
+
+const indexById = <T extends { readonly id: string }>(
+  items: readonly T[],
+): Map<string, T> => new Map(items.map((item) => [item.id, item]))
+
+const membershipKey = (
+  membership: Pick<PersistenceV2CollectionMembership, 'collectionId' | 'urlId'>,
+): string => `${membership.collectionId} ${membership.urlId}`
+
+// Canonicalization only reorders urls / groups / memberships, so every
+// restored entity must deep-equal the input entity with the same key.
+// Collections and categories get sorted keywords; assert their id sets
+// survive so no entity is dropped or invented.
+const expectLogicalContentPreserved = (
+  input: PersistenceV2Snapshot,
+  restored: PersistenceV2Snapshot,
+) => {
+  const inputUrls = indexById(input.urls)
+  expect(restored.urls).toHaveLength(inputUrls.size)
+  for (const restoredUrl of restored.urls) {
+    expect(restoredUrl).toEqual(inputUrls.get(restoredUrl.id))
+  }
+
+  const inputGroups = indexById(input.groups)
+  expect(restored.groups).toHaveLength(inputGroups.size)
+  for (const restoredGroup of restored.groups) {
+    expect(restoredGroup).toEqual(inputGroups.get(restoredGroup.id))
+  }
+
+  const inputMemberships = new Map(
+    input.memberships.map((membership) => [
+      membershipKey(membership),
+      membership,
+    ]),
+  )
+  expect(restored.memberships).toHaveLength(inputMemberships.size)
+  for (const restoredMembership of restored.memberships) {
+    expect(restoredMembership).toEqual(
+      inputMemberships.get(membershipKey(restoredMembership)),
+    )
+  }
+
+  expect(restored.collections.map(({ id }) => id).toSorted()).toEqual(
+    input.collections.map(({ id }) => id).toSorted(),
+  )
+  expect(restored.categories.map(({ id }) => id).toSorted()).toEqual(
+    input.categories.map(({ id }) => id).toSorted(),
+  )
+}
 
 // Property target from issue #718: Backup V2 round trip preserves the
 // canonicalized logical snapshot and its integrity (#713 / #730).
@@ -59,11 +112,13 @@ describe('BackupMapper round-trip properties', () => {
             canonicalUserSettings,
           )
           const restored = BackupMapper.toLogicalSnapshot(exported, revision)
-          return (
-            checkPersistenceIntegrity(restored.savedTabs).isHealthy &&
-            JSON.stringify(restored.savedTabs) ===
-              JSON.stringify(exported.savedTabs)
+          expect(checkPersistenceIntegrity(restored.savedTabs).isHealthy).toBe(
+            true,
           )
+          expect(JSON.stringify(restored.savedTabs)).toBe(
+            JSON.stringify(exported.savedTabs),
+          )
+          expectLogicalContentPreserved(snapshot.savedTabs, restored.savedTabs)
         },
       ),
       fastCheckParameters,

--- a/src/features/options/lib/import-export/v2/BackupMapper.property.test.ts
+++ b/src/features/options/lib/import-export/v2/BackupMapper.property.test.ts
@@ -1,0 +1,72 @@
+import * as fc from 'fast-check'
+import { describe, it } from 'vitest'
+
+import { checkPersistenceIntegrity } from '@/contexts/saved-tabs/public-api'
+import { canonicalUserSettings } from '@/test/arbitraries/persistence/backupArbitrary'
+import { fastCheckParameters } from '@/test/arbitraries/persistence/fastCheckParameters'
+import { validPersistenceV2SnapshotArbitrary } from '@/test/arbitraries/persistence/persistenceSnapshotArbitrary'
+
+import { BackupMapper } from './BackupMapper'
+
+const revisionArbitrary = fc.integer({ min: 0, max: 1_000_000 })
+
+const logicalSnapshotArbitrary = validPersistenceV2SnapshotArbitrary.map(
+  (savedTabs) => ({
+    analyticsViews: [],
+    conversations: [],
+    messages: [],
+    revision: 0,
+    savedTabs,
+  }),
+)
+
+// Property target from issue #718: Backup V2 round trip preserves the
+// canonicalized logical snapshot and its integrity (#713 / #730).
+describe('BackupMapper round-trip properties', () => {
+  it('import(export(v2)) reaches a canonical fixpoint', () => {
+    fc.assert(
+      fc.property(
+        logicalSnapshotArbitrary,
+        revisionArbitrary,
+        (snapshot, revision) => {
+          const exported = BackupMapper.toBackupData(
+            snapshot,
+            canonicalUserSettings,
+          )
+          const restored = BackupMapper.toLogicalSnapshot(exported, revision)
+          const reExported = BackupMapper.toBackupData(
+            restored,
+            canonicalUserSettings,
+          )
+          return (
+            restored.revision === revision &&
+            JSON.stringify(reExported) === JSON.stringify(exported)
+          )
+        },
+      ),
+      fastCheckParameters,
+    )
+  })
+
+  it('round trip preserves saved-tabs integrity and logical content', () => {
+    fc.assert(
+      fc.property(
+        logicalSnapshotArbitrary,
+        revisionArbitrary,
+        (snapshot, revision) => {
+          const exported = BackupMapper.toBackupData(
+            snapshot,
+            canonicalUserSettings,
+          )
+          const restored = BackupMapper.toLogicalSnapshot(exported, revision)
+          return (
+            checkPersistenceIntegrity(restored.savedTabs).isHealthy &&
+            JSON.stringify(restored.savedTabs) ===
+              JSON.stringify(exported.savedTabs)
+          )
+        },
+      ),
+      fastCheckParameters,
+    )
+  })
+})

--- a/src/test/arbitraries/persistence/backupArbitrary.ts
+++ b/src/test/arbitraries/persistence/backupArbitrary.ts
@@ -1,0 +1,45 @@
+import * as fc from 'fast-check'
+
+import type { UserSettings } from '@/types/storage'
+
+import { wellFormedLegacyStorageArbitrary } from './legacyStorageSnapshotArbitrary'
+import { timestampArbitrary } from './primitives'
+
+/**
+ * Canonical valid user settings shared by the backup round-trip and the
+ * legacy backup conversion property tests.
+ */
+export const canonicalUserSettings = {
+  clickBehavior: 'saveCurrentTab',
+  confirmDeleteAll: true,
+  confirmDeleteEach: true,
+  enableCategories: true,
+  excludePatterns: ['z.example', 'a.example'],
+  excludePinnedTabs: false,
+  openAllInNewWindow: false,
+  openUrlInBackground: false,
+  removeTabAfterExternalDrop: false,
+  removeTabAfterOpen: false,
+  showSavedTime: true,
+} as const satisfies UserSettings
+
+/**
+ * Well-formed pre-IndexedDB backup envelope (Backup V0). Scoped to the
+ * temporary compatibility window ending 2026-08-31; the property test
+ * using this arbitrary is a #734 cleanup target.
+ */
+export const legacyBackupV0Arbitrary = fc
+  .tuple(wellFormedLegacyStorageArbitrary, timestampArbitrary)
+  .map(([storage, exportedAt]) => ({
+    backup: {
+      customProjectOrder: storage.customProjectOrder,
+      customProjects: storage.customProjects,
+      parentCategories: storage.parentCategories,
+      savedTabs: storage.savedTabs,
+      timestamp: new Date(exportedAt).toISOString(),
+      urls: storage.urls,
+      userSettings: canonicalUserSettings,
+      version: '0.0.0-property-test',
+    },
+    importDate: '2026-08-01',
+  }))

--- a/src/test/arbitraries/persistence/fastCheckParameters.test.ts
+++ b/src/test/arbitraries/persistence/fastCheckParameters.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const importParameters = async (env: { runs?: string; seed?: string }) => {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+  if (env.runs !== undefined) {
+    vi.stubEnv('FAST_CHECK_RUNS', env.runs)
+  }
+  if (env.seed !== undefined) {
+    vi.stubEnv('FAST_CHECK_SEED', env.seed)
+  }
+  const { fastCheckParameters } = await import('./fastCheckParameters')
+  return fastCheckParameters
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('fastCheckParameters', () => {
+  it('defaults to 50 runs without a seed', async () => {
+    const parameters = await importParameters({})
+    expect(parameters.numRuns).toBe(50)
+    expect('seed' in parameters).toBe(false)
+  })
+
+  it('replays a negative FAST_CHECK_SEED reported by fast-check', async () => {
+    const parameters = await importParameters({ seed: '-18927364' })
+    expect('seed' in parameters && parameters.seed).toBe(-18927364)
+  })
+
+  it('replays a zero FAST_CHECK_SEED', async () => {
+    const parameters = await importParameters({ seed: '0' })
+    expect('seed' in parameters && parameters.seed).toBe(0)
+  })
+
+  it.each(['abc', '1.5', '', '   '])(
+    'drops the invalid FAST_CHECK_SEED %j',
+    async (seed) => {
+      const parameters = await importParameters({ seed })
+      expect('seed' in parameters).toBe(false)
+    },
+  )
+
+  it('uses a positive FAST_CHECK_RUNS', async () => {
+    const parameters = await importParameters({ runs: '200' })
+    expect(parameters.numRuns).toBe(200)
+  })
+
+  it.each(['0', '-3', 'abc'])(
+    'falls back to the default run count for FAST_CHECK_RUNS %j',
+    async (runs) => {
+      const parameters = await importParameters({ runs })
+      expect(parameters.numRuns).toBe(50)
+    },
+  )
+})

--- a/src/test/arbitraries/persistence/fastCheckParameters.test.ts
+++ b/src/test/arbitraries/persistence/fastCheckParameters.test.ts
@@ -3,6 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 const importParameters = async (env: { runs?: string; seed?: string }) => {
   vi.resetModules()
   vi.unstubAllEnvs()
+  // Start each import without values inherited from the outer environment.
+  vi.stubEnv('FAST_CHECK_RUNS', undefined)
+  vi.stubEnv('FAST_CHECK_SEED', undefined)
   if (env.runs !== undefined) {
     vi.stubEnv('FAST_CHECK_RUNS', env.runs)
   }

--- a/src/test/arbitraries/persistence/fastCheckParameters.ts
+++ b/src/test/arbitraries/persistence/fastCheckParameters.ts
@@ -1,15 +1,22 @@
-const parsePositiveInteger = (
-  value: string | undefined,
-): number | undefined => {
-  if (value === undefined) {
+const parseSafeInteger = (value: string | undefined): number | undefined => {
+  if (value === undefined || value.trim() === '') {
     return undefined
   }
   const parsed = Number(value)
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined
+  return Number.isSafeInteger(parsed) ? parsed : undefined
+}
+
+const parsePositiveInteger = (
+  value: string | undefined,
+): number | undefined => {
+  const parsed = parseSafeInteger(value)
+  return parsed !== undefined && parsed > 0 ? parsed : undefined
 }
 
 const numRuns = parsePositiveInteger(process.env.FAST_CHECK_RUNS)
-const seed = parsePositiveInteger(process.env.FAST_CHECK_SEED)
+// fast-check accepts any 32-bit seed and reports negative seeds on failure,
+// so replay values must accept negative integers and 0 as well.
+const seed = parseSafeInteger(process.env.FAST_CHECK_SEED)
 
 /**
  * Shared fast-check parameters for every persistence property test.

--- a/src/test/arbitraries/persistence/fastCheckParameters.ts
+++ b/src/test/arbitraries/persistence/fastCheckParameters.ts
@@ -1,0 +1,24 @@
+const parsePositiveInteger = (
+  value: string | undefined,
+): number | undefined => {
+  if (value === undefined) {
+    return undefined
+  }
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined
+}
+
+const numRuns = parsePositiveInteger(process.env.FAST_CHECK_RUNS)
+const seed = parsePositiveInteger(process.env.FAST_CHECK_SEED)
+
+/**
+ * Shared fast-check parameters for every persistence property test.
+ *
+ * `FAST_CHECK_RUNS` raises the run count for nightly / manual deep runs and
+ * `FAST_CHECK_SEED` replays the exact failing seed printed by fast-check.
+ * See docs/testing/property-based-tests.md for the reproduction workflow.
+ */
+export const fastCheckParameters = {
+  numRuns: numRuns ?? 50,
+  ...(seed === undefined ? {} : { seed }),
+} as const

--- a/src/test/arbitraries/persistence/legacyStorageSnapshotArbitrary.ts
+++ b/src/test/arbitraries/persistence/legacyStorageSnapshotArbitrary.ts
@@ -366,15 +366,18 @@ export const toRawLegacyStorageSnapshot = (
  * improper sync of `Membership.addedAt` into `Url.lastSavedAt`.
  */
 export const sharedUrlLegacyStorageArbitrary = fc
-  .record({
-    groupCount: fc.integer({ min: 2, max: 3 }),
-    groupSavedAts: fc.array(timestampArbitrary, {
-      minLength: 3,
-      maxLength: 3,
+  .integer({ min: 2, max: 3 })
+  .chain((groupCount) =>
+    fc.record({
+      groupCount: fc.constant(groupCount),
+      groupSavedAts: fc.array(timestampArbitrary, {
+        minLength: groupCount,
+        maxLength: groupCount,
+      }),
+      savedAt: timestampArbitrary,
+      title: displayTextArbitrary,
     }),
-    savedAt: timestampArbitrary,
-    title: displayTextArbitrary,
-  })
+  )
   .map((seed): RawLegacyStorageSnapshot => {
     const savedTabs: TabGroup[] = Array.from(
       { length: seed.groupCount },

--- a/src/test/arbitraries/persistence/legacyStorageSnapshotArbitrary.ts
+++ b/src/test/arbitraries/persistence/legacyStorageSnapshotArbitrary.ts
@@ -1,0 +1,447 @@
+import * as fc from 'fast-check'
+
+import type { RawLegacyStorageSnapshot } from '@/contexts/saved-tabs/public-api'
+import type {
+  CustomProject,
+  DomainCategorySettings,
+  DomainParentCategoryMapping,
+  ParentCategory,
+  TabGroup,
+  UrlRecord,
+} from '@/types/storage'
+
+import {
+  displayTextArbitrary,
+  orderedTimestampPairArbitrary,
+  timestampArbitrary,
+  urlStringArbitrary,
+} from './primitives'
+
+const categoryNameArbitrary = fc.string({ minLength: 1, maxLength: 12 })
+
+/**
+ * Legacy reference modes per collection:
+ * - `ids`: `urlIds` referencing canonical `urls` (new format). Custom
+ *   projects additionally require parallel nested copies, because the
+ *   migration treats `urlIds` without a same-length `urls` array as a
+ *   conflict; tab groups accept `urlIds`-only references.
+ * - `nested`: nested `urls` only, carrying inline data (old format)
+ * - `mixed`: `urlIds` plus parallel nested copies of the same canonical
+ *   records (the only conflict-free combination of both fields)
+ */
+const referenceModeArbitrary = fc.constantFrom('ids', 'mixed', 'nested')
+
+const canonicalUrlSeedArbitrary = fc.record({
+  savedAt: timestampArbitrary,
+  title: displayTextArbitrary,
+})
+
+const groupSeedArbitrary = fc.record({
+  mode: referenceModeArbitrary,
+  nested: fc.array(
+    fc.record({
+      savedAt: timestampArbitrary,
+      title: displayTextArbitrary,
+    }),
+    { maxLength: 2 },
+  ),
+  parentAssigned: fc.boolean(),
+  savedAt: timestampArbitrary,
+  subCategories: fc.uniqueArray(categoryNameArbitrary, { maxLength: 2 }),
+})
+
+const projectSeedArbitrary = fc.record({
+  categories: fc.uniqueArray(categoryNameArbitrary, { maxLength: 2 }),
+  mode: referenceModeArbitrary,
+  nested: fc.array(
+    fc.record({
+      notes: displayTextArbitrary,
+      savedAt: timestampArbitrary,
+      title: displayTextArbitrary,
+    }),
+    { maxLength: 2 },
+  ),
+  timestamps: orderedTimestampPairArbitrary,
+})
+
+const wellFormedSeedArbitrary = fc.record({
+  canonicalUrls: fc.array(canonicalUrlSeedArbitrary, { maxLength: 5 }),
+  groups: fc.array(groupSeedArbitrary, { maxLength: 3 }),
+  projects: fc.array(projectSeedArbitrary, { maxLength: 2 }),
+})
+
+type WellFormedSeed =
+  typeof wellFormedSeedArbitrary extends fc.Arbitrary<infer T> ? T : never
+type GroupSeed = WellFormedSeed['groups'][number]
+type ProjectSeed = WellFormedSeed['projects'][number]
+
+/**
+ * Legacy chrome.storage content covering the historical shapes:
+ * canonical `urls`, `TabGroup.urlIds` / nested `urls` / parallel mixed
+ * groups, `urlSubCategories`, `CustomProject.urlIds` / `urls` /
+ * `urlMetadata`, `ParentCategory.domains` / `domainNames`,
+ * `parentCategoryId`, and `DomainParentCategoryMapping`. References are
+ * mutually consistent and every timestamp is present so the v2 migration
+ * result stays healthy.
+ */
+export type WellFormedLegacyStorage = {
+  readonly customProjectOrder: readonly string[]
+  readonly customProjects: readonly CustomProject[]
+  readonly domainCategoryMappings: readonly DomainParentCategoryMapping[]
+  readonly domainCategorySettings: readonly DomainCategorySettings[]
+  readonly parentCategories: readonly ParentCategory[]
+  readonly savedTabs: readonly TabGroup[]
+  readonly urls: readonly UrlRecord[]
+}
+
+type AssemblyContext = {
+  readonly urls: readonly UrlRecord[]
+}
+
+type ReferenceMode = 'ids' | 'mixed' | 'nested'
+
+const resolveGroupMode = (
+  group: GroupSeed,
+  urlIds: readonly string[],
+): ReferenceMode => {
+  if (group.mode !== 'mixed') {
+    return group.mode
+  }
+  if (urlIds.length > 0) {
+    return 'mixed'
+  }
+  return group.nested.length > 0 ? 'nested' : 'ids'
+}
+
+const resolveProjectMode = (
+  project: ProjectSeed,
+  urlIds: readonly string[],
+): ReferenceMode => {
+  if (project.mode === 'nested') {
+    return 'nested'
+  }
+  if (urlIds.length > 0) {
+    return 'mixed'
+  }
+  return project.nested.length > 0 ? 'nested' : 'ids'
+}
+
+const assembleGroup = (
+  group: GroupSeed,
+  index: number,
+  urlIds: readonly string[],
+  context: AssemblyContext,
+): TabGroup => {
+  const subCategories = group.subCategories
+  const canonicalById = new Map(context.urls.map((url) => [url.id, url]))
+  const mode = resolveGroupMode(group, urlIds)
+  const base: TabGroup = {
+    domain: `domain-${index}.test`,
+    id: `group-${index}`,
+    ...(group.parentAssigned ? { parentCategoryId: 'category-parent-0' } : {}),
+    savedAt: group.savedAt,
+    ...(subCategories.length > 0 ? { subCategories } : {}),
+  }
+  const urlSubCategories =
+    urlIds.length > 0 && subCategories.length > 0
+      ? Object.fromEntries(
+          urlIds.map((id, position) => [
+            id,
+            subCategories[position % subCategories.length],
+          ]),
+        )
+      : undefined
+
+  if (mode === 'nested') {
+    return {
+      ...base,
+      urls: group.nested.map((nested, nestedIndex) => ({
+        id: `url-nested-${index}-${nestedIndex}`,
+        savedAt: nested.savedAt,
+        ...(subCategories.length > 0
+          ? {
+              subCategory: subCategories[nestedIndex % subCategories.length],
+            }
+          : {}),
+        title: nested.title,
+        url: `https://nested-${index}-${nestedIndex}.example/`,
+      })),
+    }
+  }
+  if (mode === 'mixed') {
+    return {
+      ...base,
+      urlIds: [...urlIds],
+      ...(urlSubCategories ? { urlSubCategories } : {}),
+      urls: urlIds.map((id) => {
+        const canonical = canonicalById.get(id)
+        return {
+          id,
+          savedAt: canonical?.savedAt,
+          title: canonical?.title ?? '',
+          url: canonical?.url ?? '',
+        }
+      }),
+    }
+  }
+  return {
+    ...base,
+    urlIds: [...urlIds],
+    ...(urlSubCategories ? { urlSubCategories } : {}),
+  }
+}
+
+const assembleProject = (
+  project: ProjectSeed,
+  index: number,
+  urlIds: readonly string[],
+  context: AssemblyContext,
+): CustomProject => {
+  const categories = project.categories
+  const canonicalById = new Map(context.urls.map((url) => [url.id, url]))
+  const mode = resolveProjectMode(project, urlIds)
+  const base: CustomProject = {
+    categories,
+    createdAt: project.timestamps[0],
+    id: `project-${index}`,
+    name: `Project ${index}`,
+    updatedAt: project.timestamps[1],
+  }
+  const urlMetadata =
+    urlIds.length > 0
+      ? Object.fromEntries(
+          urlIds.map((id, position) => [
+            id,
+            {
+              notes: `note-${index}-${position}`,
+              ...(categories.length > 0
+                ? { category: categories[position % categories.length] }
+                : {}),
+            },
+          ]),
+        )
+      : undefined
+
+  if (mode === 'nested') {
+    return {
+      ...base,
+      urls: project.nested.map((nested, nestedIndex) => ({
+        ...(categories.length > 0
+          ? { category: categories[nestedIndex % categories.length] }
+          : {}),
+        notes: nested.notes,
+        savedAt: nested.savedAt,
+        title: nested.title,
+        url: `https://project-${index}-${nestedIndex}.example/`,
+      })),
+    }
+  }
+  if (mode === 'mixed') {
+    return {
+      ...base,
+      urlIds: [...urlIds],
+      ...(urlMetadata ? { urlMetadata } : {}),
+      urls: urlIds.map((id) => {
+        const canonical = canonicalById.get(id)
+        return {
+          savedAt: canonical?.savedAt,
+          title: canonical?.title ?? '',
+          url: canonical?.url ?? '',
+        }
+      }),
+    }
+  }
+  return {
+    ...base,
+    urlIds: [...urlIds],
+    ...(urlMetadata ? { urlMetadata } : {}),
+  }
+}
+
+const assembleWellFormed = (seed: WellFormedSeed): WellFormedLegacyStorage => {
+  // Canonical urls must be referenced by an ids/mixed collection;
+  // nested-only collections cannot reference them and would orphan them.
+  const referenceTargets = [
+    ...seed.groups.flatMap((group, index) =>
+      group.mode === 'nested' ? [] : [{ kind: 'group', index } as const],
+    ),
+    ...seed.projects.flatMap((project, index) =>
+      project.mode === 'nested' ? [] : [{ kind: 'project', index } as const],
+    ),
+  ]
+  const urls: UrlRecord[] =
+    referenceTargets.length === 0
+      ? []
+      : seed.canonicalUrls.map((url, index) => ({
+          id: `url-${index}`,
+          savedAt: url.savedAt,
+          title: url.title,
+          url: `https://canonical-${index}.example/page`,
+        }))
+  const context: AssemblyContext = { urls }
+
+  const groupUrlIds = seed.groups.map((): string[] => [])
+  const projectUrlIds = seed.projects.map((): string[] => [])
+  for (const [index, url] of urls.entries()) {
+    const target = referenceTargets[index % referenceTargets.length]
+    if (target.kind === 'group') {
+      groupUrlIds[target.index].push(url.id)
+    } else {
+      projectUrlIds[target.index].push(url.id)
+    }
+  }
+
+  const savedTabs = seed.groups.map((group, index) =>
+    assembleGroup(group, index, groupUrlIds[index], context),
+  )
+  const customProjects = seed.projects.map((project, index) =>
+    assembleProject(project, index, projectUrlIds[index], context),
+  )
+
+  const parentedGroups = savedTabs.filter(
+    (group) => group.parentCategoryId !== undefined,
+  )
+  const parentCategories: ParentCategory[] =
+    parentedGroups.length > 0
+      ? [
+          {
+            domainNames: parentedGroups.map((group) => group.domain),
+            domains: parentedGroups.map((group) => group.id),
+            id: 'category-parent-0',
+            name: 'Parent',
+          },
+        ]
+      : []
+  const domainCategoryMappings: DomainParentCategoryMapping[] =
+    parentedGroups.map((group) => ({
+      categoryId: 'category-parent-0',
+      domain: group.domain,
+    }))
+  const domainCategorySettings: DomainCategorySettings[] = savedTabs
+    .filter((group) => (group.subCategories?.length ?? 0) > 0)
+    .map((group) => ({
+      categoryKeywords: (group.subCategories ?? []).map((name) => ({
+        categoryName: name,
+        keywords: [name],
+      })),
+      domain: group.domain,
+      subCategories: group.subCategories ?? [],
+    }))
+
+  return {
+    customProjectOrder: customProjects.map((project) => project.id),
+    customProjects,
+    domainCategoryMappings,
+    domainCategorySettings,
+    parentCategories,
+    savedTabs,
+    urls,
+  }
+}
+
+export const wellFormedLegacyStorageArbitrary =
+  wellFormedSeedArbitrary.map(assembleWellFormed)
+
+const present = (value: unknown) => ({ status: 'present', value }) as const
+
+/** Wraps well-formed legacy storage into the raw reader port shape. */
+export const toRawLegacyStorageSnapshot = (
+  storage: WellFormedLegacyStorage,
+): RawLegacyStorageSnapshot => ({
+  activeAiChatConversationId: present(''),
+  aiChatConversations: present([]),
+  customProjectOrder: present(storage.customProjectOrder),
+  customProjects: present(storage.customProjects),
+  domainCategoryMappings: present(storage.domainCategoryMappings),
+  domainCategorySettings: present(storage.domainCategorySettings),
+  parentCategories: present(storage.parentCategories),
+  savedAnalyticsViews: present([]),
+  savedTabs: present(storage.savedTabs),
+  urls: present(storage.urls),
+})
+
+/**
+ * Same canonical URL referenced by multiple legacy tab groups. Covers the
+ * #732 semantics: one Url entity, one membership per collection, and no
+ * improper sync of `Membership.addedAt` into `Url.lastSavedAt`.
+ */
+export const sharedUrlLegacyStorageArbitrary = fc
+  .record({
+    groupCount: fc.integer({ min: 2, max: 3 }),
+    groupSavedAts: fc.array(timestampArbitrary, {
+      minLength: 3,
+      maxLength: 3,
+    }),
+    savedAt: timestampArbitrary,
+    title: displayTextArbitrary,
+  })
+  .map((seed): RawLegacyStorageSnapshot => {
+    const savedTabs: TabGroup[] = Array.from(
+      { length: seed.groupCount },
+      (_, index) => ({
+        domain: `shared-${index}.test`,
+        id: `group-shared-${index}`,
+        savedAt: seed.groupSavedAts[index],
+        urlIds: ['url-shared'],
+      }),
+    )
+    const urls: UrlRecord[] = [
+      {
+        id: 'url-shared',
+        savedAt: seed.savedAt,
+        title: seed.title,
+        url: 'https://shared.example/page',
+      },
+    ]
+    return {
+      activeAiChatConversationId: present(''),
+      aiChatConversations: present([]),
+      customProjectOrder: present([]),
+      customProjects: present([]),
+      domainCategoryMappings: present([]),
+      domainCategorySettings: present([]),
+      parentCategories: present([]),
+      savedAnalyticsViews: present([]),
+      savedTabs: present(savedTabs),
+      urls: present(urls),
+    }
+  })
+
+const messyScalarArbitrary = fc.oneof(
+  fc.jsonValue(),
+  fc.record({
+    id: fc.string({ maxLength: 8 }),
+    savedAt: fc.integer(),
+    title: fc.string({ maxLength: 8 }),
+    url: fc.oneof(urlStringArbitrary, fc.string({ maxLength: 8 })),
+  }),
+)
+
+const messyValueArbitrary = fc.oneof(
+  messyScalarArbitrary,
+  fc.array(messyScalarArbitrary, { maxLength: 4 }),
+)
+
+const messySourceValueArbitrary = fc.oneof(
+  fc.constant({ status: 'missing' } as const),
+  messyValueArbitrary.map((value) => ({ status: 'present', value }) as const),
+)
+
+/**
+ * Malformed / partially corrupted raw storage: missing keys, wrong types,
+ * dangling references, duplicate ids, and extreme timestamps. Used for
+ * determinism and no-throw guarantees only, never for health assertions.
+ */
+export const rawLegacyStorageSnapshotArbitrary: fc.Arbitrary<RawLegacyStorageSnapshot> =
+  fc.record({
+    activeAiChatConversationId: messySourceValueArbitrary,
+    aiChatConversations: messySourceValueArbitrary,
+    customProjectOrder: messySourceValueArbitrary,
+    customProjects: messySourceValueArbitrary,
+    domainCategoryMappings: messySourceValueArbitrary,
+    domainCategorySettings: messySourceValueArbitrary,
+    parentCategories: messySourceValueArbitrary,
+    savedAnalyticsViews: messySourceValueArbitrary,
+    savedTabs: messySourceValueArbitrary,
+    urls: messySourceValueArbitrary,
+  })

--- a/src/test/arbitraries/persistence/persistenceSnapshotArbitrary.ts
+++ b/src/test/arbitraries/persistence/persistenceSnapshotArbitrary.ts
@@ -1,0 +1,503 @@
+import * as fc from 'fast-check'
+
+import type {
+  PersistenceV2Collection,
+  PersistenceV2CollectionCategory,
+  PersistenceV2CollectionGroup,
+  PersistenceV2CollectionMembership,
+  PersistenceV2InvariantCode,
+  PersistenceV2Snapshot,
+  PersistenceV2Url,
+} from '@/contexts/saved-tabs/public-api'
+
+import {
+  displayTextArbitrary,
+  orderedTimestampPairArbitrary,
+  sortOrderArbitrary,
+  timestampArbitrary,
+  urlStringArbitrary,
+} from './primitives'
+
+const categorySeedArbitrary = fc.record({
+  keywords: fc.array(displayTextArbitrary, { maxLength: 3 }),
+  name: displayTextArbitrary,
+  sortOrder: sortOrderArbitrary,
+  timestamps: orderedTimestampPairArbitrary,
+})
+
+const collectionSeedArbitrary = fc.record({
+  categories: fc.array(categorySeedArbitrary, { maxLength: 2 }),
+  customKeywords: fc.option(
+    fc.record({
+      domainKeywords: fc.array(displayTextArbitrary, { maxLength: 2 }),
+      titleKeywords: fc.array(displayTextArbitrary, { maxLength: 2 }),
+      urlKeywords: fc.array(displayTextArbitrary, { maxLength: 2 }),
+    }),
+    { nil: undefined },
+  ),
+  groupPick: fc.option(fc.nat({ max: 1 }), { nil: undefined }),
+  isDomain: fc.boolean(),
+  name: displayTextArbitrary,
+  sortOrder: sortOrderArbitrary,
+  timestamps: orderedTimestampPairArbitrary,
+})
+
+const membershipSeedArbitrary = fc.record({
+  note: fc.option(displayTextArbitrary, { nil: undefined }),
+  sortOrder: sortOrderArbitrary,
+  timestamps: orderedTimestampPairArbitrary,
+})
+
+const urlSeedArbitrary = fc.record({
+  extraMembership: fc.option(
+    fc.record({
+      offset: fc.nat({ max: 2 }),
+      seed: membershipSeedArbitrary,
+    }),
+    { nil: undefined },
+  ),
+  favIconUrl: fc.option(urlStringArbitrary, { nil: undefined }),
+  primaryMembership: membershipSeedArbitrary,
+  savedTimestamps: orderedTimestampPairArbitrary,
+  title: displayTextArbitrary,
+  updatedAt: timestampArbitrary,
+  url: urlStringArbitrary,
+})
+
+type CollectionSeed =
+  typeof collectionSeedArbitrary extends fc.Arbitrary<infer T> ? T : never
+type GroupSeed = {
+  readonly name: string
+  readonly sortOrder: number
+  readonly timestamps: readonly [number, number]
+}
+type UrlSeed = typeof urlSeedArbitrary extends fc.Arbitrary<infer T> ? T : never
+
+const assembleGroups = (
+  seeds: readonly GroupSeed[],
+): PersistenceV2CollectionGroup[] =>
+  seeds.map((seed, index) => ({
+    createdAt: seed.timestamps[0],
+    id: `group-${index}`,
+    name: seed.name,
+    sortOrder: seed.sortOrder,
+    updatedAt: seed.timestamps[1],
+  }))
+
+const assembleCollections = (
+  seeds: readonly CollectionSeed[],
+  groups: readonly PersistenceV2CollectionGroup[],
+): {
+  readonly categories: PersistenceV2CollectionCategory[]
+  readonly collections: PersistenceV2Collection[]
+} => {
+  const categories: PersistenceV2CollectionCategory[] = []
+  const collections = seeds.map((seed, index): PersistenceV2Collection => {
+    const id = `collection-${index}`
+    for (const [categoryIndex, category] of seed.categories.entries()) {
+      categories.push({
+        collectionId: id,
+        createdAt: category.timestamps[0],
+        id: `${id}-category-${categoryIndex}`,
+        keywords: category.keywords,
+        name: category.name,
+        sortOrder: category.sortOrder,
+        updatedAt: category.timestamps[1],
+      })
+    }
+    return {
+      createdAt: seed.timestamps[0],
+      definition: seed.isDomain
+        ? { domain: `domain-${index}.test`, type: 'domain' }
+        : {
+            projectKeywords: seed.customKeywords ?? {
+              domainKeywords: [],
+              titleKeywords: [],
+              urlKeywords: [],
+            },
+            type: 'custom',
+          },
+      ...(seed.groupPick === undefined || groups.length === 0
+        ? {}
+        : { groupId: groups[seed.groupPick % groups.length].id }),
+      id,
+      name: seed.name,
+      sortOrder: seed.sortOrder,
+      updatedAt: seed.timestamps[1],
+    }
+  })
+  return { categories, collections }
+}
+
+const assembleUrls = (
+  seeds: readonly UrlSeed[],
+): readonly PersistenceV2Url[] => {
+  const seen = new Set<string>()
+  return seeds.map((seed, index) => {
+    const url = seen.has(seed.url) ? `${seed.url}#variant-${index}` : seed.url
+    seen.add(url)
+    return {
+      ...(seed.favIconUrl === undefined ? {} : { favIconUrl: seed.favIconUrl }),
+      firstSavedAt: seed.savedTimestamps[0],
+      id: `url-${index}`,
+      lastSavedAt: seed.savedTimestamps[1],
+      normalizedUrl: url,
+      title: seed.title,
+      updatedAt: seed.updatedAt,
+      url,
+    }
+  })
+}
+
+const assembleMemberships = (
+  seeds: readonly UrlSeed[],
+  urls: readonly PersistenceV2Url[],
+  collections: readonly PersistenceV2Collection[],
+  categories: readonly PersistenceV2CollectionCategory[],
+): PersistenceV2CollectionMembership[] => {
+  const memberships: PersistenceV2CollectionMembership[] = []
+  const buildMembership = (
+    seed: typeof membershipSeedArbitrary extends fc.Arbitrary<infer T>
+      ? T
+      : never,
+    collection: PersistenceV2Collection,
+    url: PersistenceV2Url,
+    urlIndex: number,
+  ): PersistenceV2CollectionMembership => {
+    const collectionCategories = categories.filter(
+      (category) => category.collectionId === collection.id,
+    )
+    return {
+      addedAt: seed.timestamps[0],
+      ...(collectionCategories.length > 0 && urlIndex % 2 === 0
+        ? {
+            categoryId:
+              collectionCategories[urlIndex % collectionCategories.length].id,
+          }
+        : {}),
+      collectionId: collection.id,
+      ...(seed.note === undefined ? {} : { notes: seed.note }),
+      sortOrder: seed.sortOrder,
+      updatedAt: seed.timestamps[1],
+      urlId: url.id,
+    }
+  }
+
+  for (const [index, seed] of seeds.entries()) {
+    const url = urls[index]
+    const primary = collections[index % collections.length]
+    memberships.push(
+      buildMembership(seed.primaryMembership, primary, url, index),
+    )
+    if (seed.extraMembership !== undefined && collections.length > 1) {
+      const secondary =
+        collections[
+          (index +
+            1 +
+            (seed.extraMembership.offset % (collections.length - 1))) %
+            collections.length
+        ]
+      if (secondary.id !== primary.id) {
+        memberships.push(
+          buildMembership(seed.extraMembership.seed, secondary, url, index + 1),
+        )
+      }
+    }
+  }
+  return memberships
+}
+
+const assembleSnapshot = (
+  groupSeeds: readonly GroupSeed[],
+  collectionSeeds: readonly CollectionSeed[],
+  urlSeeds: readonly UrlSeed[],
+): PersistenceV2Snapshot => {
+  const groups = assembleGroups(groupSeeds)
+  const { categories, collections } = assembleCollections(
+    collectionSeeds,
+    groups,
+  )
+  const urls = assembleUrls(urlSeeds)
+  const memberships = assembleMemberships(urlSeeds, urls, collections, [
+    ...categories,
+  ])
+  return { categories, collections, groups, memberships, urls }
+}
+
+const groupSeedArbitrary = fc.record({
+  name: displayTextArbitrary,
+  sortOrder: sortOrderArbitrary,
+  timestamps: orderedTimestampPairArbitrary,
+})
+
+/**
+ * Generates snapshots satisfying every Persistence Model v2 invariant:
+ * unique URL id / normalized URL, unique `[collectionId, urlId]`
+ * memberships, same-collection category references, existing group
+ * references, safe-integer ranks, and ordered timestamps. Every Url is
+ * referenced by at least one membership so no orphan warning appears.
+ */
+export const validPersistenceV2SnapshotArbitrary = fc
+  .tuple(
+    fc.array(groupSeedArbitrary, { maxLength: 2 }),
+    fc.array(collectionSeedArbitrary, { minLength: 1, maxLength: 3 }),
+    fc.array(urlSeedArbitrary, { minLength: 1, maxLength: 6 }),
+  )
+  .map(([groups, collections, urls]) =>
+    assembleSnapshot(groups, collections, urls),
+  )
+
+export type SnapshotCorruption = {
+  readonly apply: (snapshot: PersistenceV2Snapshot) => PersistenceV2Snapshot
+  readonly codes: readonly PersistenceV2InvariantCode[]
+  readonly isApplicable: (snapshot: PersistenceV2Snapshot) => boolean
+  readonly name: string
+}
+
+const UNSAFE_RANK = Number.MAX_SAFE_INTEGER + 1
+
+const withFirstUrl = (
+  snapshot: PersistenceV2Snapshot,
+  update: (url: PersistenceV2Url) => PersistenceV2Url,
+): PersistenceV2Snapshot => ({
+  ...snapshot,
+  urls: snapshot.urls.map((url, index) => (index === 0 ? update(url) : url)),
+})
+
+const withFirstMembership = (
+  snapshot: PersistenceV2Snapshot,
+  update: (
+    membership: PersistenceV2CollectionMembership,
+  ) => PersistenceV2CollectionMembership,
+): PersistenceV2Snapshot => ({
+  ...snapshot,
+  memberships: snapshot.memberships.map((membership, index) =>
+    index === 0 ? update(membership) : membership,
+  ),
+})
+
+const withFirstCollection = (
+  snapshot: PersistenceV2Snapshot,
+  update: (collection: PersistenceV2Collection) => PersistenceV2Collection,
+): PersistenceV2Snapshot => ({
+  ...snapshot,
+  collections: snapshot.collections.map((collection, index) =>
+    index === 0 ? update(collection) : collection,
+  ),
+})
+
+const DUPLICATE_MEMBERSHIP_CORRUPTION: SnapshotCorruption = {
+  apply: (snapshot) => ({
+    ...snapshot,
+    memberships: [...snapshot.memberships, snapshot.memberships[0]],
+  }),
+  codes: ['DUPLICATE_MEMBERSHIP'],
+  isApplicable: (snapshot) => snapshot.memberships.length > 0,
+  name: 'duplicate-membership',
+}
+
+/** Malformed / corrupted snapshot mutations and the issue codes they induce. */
+export const SNAPSHOT_CORRUPTIONS: readonly SnapshotCorruption[] = [
+  {
+    apply: (snapshot) => {
+      const [first] = snapshot.urls
+      return {
+        ...snapshot,
+        urls: [
+          ...snapshot.urls,
+          {
+            ...first,
+            normalizedUrl: `https://duplicate-id-${snapshot.urls.length}.invalid/`,
+            url: `https://duplicate-id-${snapshot.urls.length}.invalid/`,
+          },
+        ],
+      }
+    },
+    codes: ['DUPLICATE_URL_ID'],
+    isApplicable: (snapshot) => snapshot.urls.length > 0,
+    name: 'duplicate-url-id',
+  },
+  {
+    apply: (snapshot) => {
+      const [first] = snapshot.urls
+      return {
+        ...snapshot,
+        urls: [...snapshot.urls, { ...first, id: 'url-duplicate-normalized' }],
+      }
+    },
+    codes: ['DUPLICATE_NORMALIZED_URL'],
+    isApplicable: (snapshot) => snapshot.urls.length > 0,
+    name: 'duplicate-normalized-url',
+  },
+  {
+    apply: (snapshot) => ({
+      ...snapshot,
+      memberships: [
+        ...snapshot.memberships,
+        {
+          addedAt: 0,
+          collectionId: snapshot.collections[0].id,
+          sortOrder: 0,
+          updatedAt: 0,
+          urlId: 'url-missing',
+        },
+      ],
+    }),
+    codes: ['URL_MISSING'],
+    isApplicable: (snapshot) => snapshot.collections.length > 0,
+    name: 'dangling-membership-url',
+  },
+  {
+    apply: (snapshot) => ({
+      ...snapshot,
+      memberships: [
+        ...snapshot.memberships,
+        {
+          addedAt: 0,
+          collectionId: 'collection-missing',
+          sortOrder: 0,
+          updatedAt: 0,
+          urlId: snapshot.urls[0].id,
+        },
+      ],
+    }),
+    codes: ['COLLECTION_MISSING'],
+    isApplicable: (snapshot) => snapshot.urls.length > 0,
+    name: 'dangling-membership-collection',
+  },
+  {
+    apply: (snapshot) =>
+      withFirstMembership(snapshot, (membership) => ({
+        ...membership,
+        categoryId: 'category-missing',
+      })),
+    codes: ['CATEGORY_MISSING'],
+    isApplicable: (snapshot) => snapshot.memberships.length > 0,
+    name: 'dangling-membership-category',
+  },
+  {
+    apply: (snapshot) => {
+      const category = snapshot.categories[0]
+      const foreignCollection = snapshot.collections.find(
+        (collection) => collection.id !== category.collectionId,
+      )
+      const url: PersistenceV2Url = {
+        firstSavedAt: 0,
+        id: 'url-cross-category',
+        lastSavedAt: 0,
+        normalizedUrl: 'https://cross-category.invalid/',
+        title: 'cross category',
+        updatedAt: 0,
+        url: 'https://cross-category.invalid/',
+      }
+      return {
+        ...snapshot,
+        memberships: [
+          ...snapshot.memberships,
+          {
+            addedAt: 0,
+            categoryId: category.id,
+            collectionId: foreignCollection?.id ?? 'collection-missing',
+            sortOrder: 0,
+            updatedAt: 0,
+            urlId: url.id,
+          },
+        ],
+        urls: [...snapshot.urls, url],
+      }
+    },
+    codes: ['CATEGORY_COLLECTION_MISMATCH'],
+    isApplicable: (snapshot) =>
+      snapshot.categories.length > 0 &&
+      snapshot.collections.some(
+        (collection) => collection.id !== snapshot.categories[0].collectionId,
+      ),
+    name: 'cross-collection-category',
+  },
+  {
+    apply: (snapshot) =>
+      withFirstCollection(snapshot, (collection) => ({
+        ...collection,
+        groupId: 'group-missing',
+      })),
+    codes: ['GROUP_MISSING'],
+    isApplicable: (snapshot) => snapshot.collections.length > 0,
+    name: 'missing-group-target',
+  },
+  DUPLICATE_MEMBERSHIP_CORRUPTION,
+  {
+    apply: (snapshot) =>
+      withFirstMembership(snapshot, (membership) => ({
+        ...membership,
+        sortOrder: UNSAFE_RANK,
+      })),
+    codes: ['INVALID_MEMBERSHIP_ORDER'],
+    isApplicable: (snapshot) => snapshot.memberships.length > 0,
+    name: 'invalid-membership-order',
+  },
+  {
+    apply: (snapshot) =>
+      withFirstUrl(snapshot, (url) => ({
+        ...url,
+        firstSavedAt: url.lastSavedAt + 1,
+      })),
+    codes: ['INVALID_TIMESTAMP_RELATION'],
+    isApplicable: (snapshot) => snapshot.urls.length > 0,
+    name: 'invalid-timestamp-relation',
+  },
+]
+
+export type CorruptedSnapshot = {
+  readonly corruptionNames: readonly string[]
+  readonly expectedCodes: readonly PersistenceV2InvariantCode[]
+  readonly snapshot: PersistenceV2Snapshot
+}
+
+const applyCorruptions = (
+  snapshot: PersistenceV2Snapshot,
+  corruptions: readonly SnapshotCorruption[],
+): CorruptedSnapshot => {
+  const expected = new Set<PersistenceV2InvariantCode>()
+  let current = snapshot
+  for (const corruption of corruptions) {
+    current = corruption.apply(current)
+    for (const code of corruption.codes) {
+      expected.add(code)
+    }
+  }
+  return {
+    corruptionNames: corruptions.map(({ name }) => name),
+    expectedCodes: [...expected],
+    snapshot: current,
+  }
+}
+
+/**
+ * Valid snapshot mutated by 1-3 distinct corruptions. The integrity
+ * checker must detect at least `expectedCodes`; cascading secondary
+ * issues are allowed and asserted as a superset.
+ */
+export const corruptedPersistenceV2SnapshotArbitrary =
+  validPersistenceV2SnapshotArbitrary.chain((snapshot) => {
+    const applicable = SNAPSHOT_CORRUPTIONS.filter((corruption) =>
+      corruption.isApplicable(snapshot),
+    )
+    return fc
+      .uniqueArray(fc.constantFrom(...applicable), {
+        minLength: 1,
+        maxLength: Math.min(3, applicable.length),
+        selector: (corruption) => corruption.name,
+      })
+      .map((corruptions) => applyCorruptions(snapshot, corruptions))
+  })
+
+/** Valid snapshot corrupted only by duplicate memberships (repair-safe). */
+export const duplicateMembershipCorruptedSnapshotArbitrary =
+  validPersistenceV2SnapshotArbitrary.chain((snapshot) =>
+    fc.integer({ min: 1, max: 2 }).map((count) =>
+      applyCorruptions(
+        snapshot,
+        Array.from({ length: count }, () => DUPLICATE_MEMBERSHIP_CORRUPTION),
+      ),
+    ),
+  )

--- a/src/test/arbitraries/persistence/persistenceSnapshotArbitrary.ts
+++ b/src/test/arbitraries/persistence/persistenceSnapshotArbitrary.ts
@@ -64,14 +64,16 @@ const urlSeedArbitrary = fc.record({
   url: urlStringArbitrary,
 })
 
-type CollectionSeed =
-  typeof collectionSeedArbitrary extends fc.Arbitrary<infer T> ? T : never
+type SeedOf<A> = A extends fc.Arbitrary<infer T> ? T : never
+
+type CollectionSeed = SeedOf<typeof collectionSeedArbitrary>
 type GroupSeed = {
   readonly name: string
   readonly sortOrder: number
   readonly timestamps: readonly [number, number]
 }
-type UrlSeed = typeof urlSeedArbitrary extends fc.Arbitrary<infer T> ? T : never
+type UrlSeed = SeedOf<typeof urlSeedArbitrary>
+type MembershipSeed = SeedOf<typeof membershipSeedArbitrary>
 
 const assembleGroups = (
   seeds: readonly GroupSeed[],
@@ -157,9 +159,7 @@ const assembleMemberships = (
 ): PersistenceV2CollectionMembership[] => {
   const memberships: PersistenceV2CollectionMembership[] = []
   const buildMembership = (
-    seed: typeof membershipSeedArbitrary extends fc.Arbitrary<infer T>
-      ? T
-      : never,
+    seed: MembershipSeed,
     collection: PersistenceV2Collection,
     url: PersistenceV2Url,
     urlIndex: number,

--- a/src/test/arbitraries/persistence/primitives.ts
+++ b/src/test/arbitraries/persistence/primitives.ts
@@ -1,0 +1,49 @@
+import * as fc from 'fast-check'
+
+/** Non-negative epoch-millisecond timestamps up to 2100-01-01. */
+export const timestampArbitrary = fc.integer({
+  min: 0,
+  max: 4_102_444_800_000,
+})
+
+/** `[earlier, later]` pair satisfying `earlier <= later`. */
+export const orderedTimestampPairArbitrary = fc
+  .tuple(timestampArbitrary, timestampArbitrary)
+  .map(([left, right]): readonly [number, number] =>
+    left <= right ? [left, right] : [right, left],
+  )
+
+/** Safe-integer gap rank accepted by the v2 ordering policy. */
+export const sortOrderArbitrary = fc.integer({
+  min: 0,
+  max: Number.MAX_SAFE_INTEGER,
+})
+
+/** Hostname-shaped domain used by domain collections and legacy groups. */
+export const domainNameArbitrary = fc.stringMatching(
+  /^[a-z][a-z0-9-]{0,10}\.(test|example|dev)$/,
+)
+
+const urlPathArbitrary = fc.option(
+  fc
+    .array(fc.stringMatching(/^[a-z0-9-]{1,8}$/), {
+      minLength: 1,
+      maxLength: 3,
+    })
+    .map((segments) => `/${segments.join('/')}`),
+  { nil: undefined },
+)
+
+/**
+ * Valid absolute https URL string. Identity follows the exact-string
+ * `exact-url-v1` policy, so the string itself is the normalized form.
+ */
+export const urlStringArbitrary = fc
+  .tuple(domainNameArbitrary, urlPathArbitrary)
+  .map(([domain, path]) => `https://${domain}${path ?? ''}`)
+
+/**
+ * Free-form display text. Keeps whitespace-only, empty-adjacent, and
+ * unusual Unicode inputs in scope for titles, notes, and category names.
+ */
+export const displayTextArbitrary = fc.string({ maxLength: 24 })

--- a/vitest.ci.config.ts
+++ b/vitest.ci.config.ts
@@ -172,6 +172,7 @@ export default defineConfig({
             'src/features/**/lib/**/*.test.ts',
             'src/features/i18n/lib/**/*.test.ts',
             'src/features/analytics/**/*.test.ts',
+            'src/test/**/*.test.ts',
             'tools/**/*.test.ts',
           ],
         },


### PR DESCRIPTION
## 原因 / 背景

Issue #718。storage / import-export は URL 参照・旧形式 migration・custom project order・
category relation の組み合わせが多く、example-based test だけでは edge case を網羅しづらい。
#724 配下の cross-cutting task として、migration / import-export / integrity checker の
invariant を property として検証する基盤を追加する。

## 採用した解決

fast-check を devDependency に追加し、共有 arbitrary を
`src/test/arbitraries/persistence/` に集約（test file ごとの重複定義を防止）。
対象はすべて純粋関数（`mapLegacyStorageToPersistenceV2`、`checkPersistenceIntegrity`、
`createStorageRepairPlan`、`BackupMapper`、`convertLegacyBackup`、URL/domain
normalization）なので、clock / id generator の stub なしに決定性を直接検証できる。

## 主要変更

- `src/test/arbitraries/persistence/`
  - `primitives.ts`: timestamp / sortOrder / domain / URL / display text
  - `persistenceSnapshotArbitrary.ts`: v2 valid snapshot generator + 10 種の
    corruption generator（誘発 issue code 付き）
  - `legacyStorageSnapshotArbitrary.ts`: 歴史的 legacy shape（urlIds / nested /
    parallel mixed、urlSubCategories、urlMetadata、ParentCategory、mappings）の
    well-formed generator + malformed raw generator
  - `backupArbitrary.ts`: canonical user settings + pre-IDB backup envelope
  - `fastCheckParameters.ts`: `FAST_CHECK_SEED` / `FAST_CHECK_RUNS` による
    seed 再現・run 数制御
- Property tests（6 file / 19 tests）
  - normalization idempotence
  - #712 integrity checker の決定性 + corruption 検出
  - safe repair の fixpoint（repair(repair(x)) === repair(x)）
  - #728 legacy migration の決定性・semantic preservation・timestamp invariant・
    #732 shared-URL membership semantics
  - #713/#730 Backup V2 round trip
  - pre-IDB legacy backup 変換（#734 cleanup 対象として明示）
- `docs/testing/property-based-tests.md`: 対象 invariant の明文化、seed 再現手順、
  regression fixture 昇格基準、execution strategy、#734 識別
- `.oxlintrc.json`: `vitest/expect-expect` の `assertFunctionNames` に
  `expectTypeOf` / `fc.assert` を追加（property test を assertion として認識）

実装中に generator 側の学習として、legacy mixed shape は `urlIds` と nested `urls` の
並列表現（id・url・title・savedAt 完全一致）のみ conflict-free であり、CustomProject は
`urlIds` 存在時に同長の `urls` を必須とする mapper 仕様を確認。production code の変更は
ない（test-only）。

## 受け入れ条件への対応

- [x] 対象 invariant が明文化（`docs/testing/property-based-tests.md` の対応表）
- [x] v2 valid / invalid generator（`persistenceSnapshotArbitrary.ts`）
- [x] #712 integrity checker に property test
- [x] #728 legacy migration に determinism / semantic preservation property
- [x] migration timestamp invariant（`firstSavedAt <= lastSavedAt` 等、malformed 入力でも検証）
- [x] malformed / partially corrupted data generator
- [x] failure seed 再現（`FAST_CHECK_SEED`、docs に手順）
- [x] regression fixture 昇格基準（docs に明記）
- [x] Backup V2 round trip property
- [x] pre-IDB legacy backup property test を #734 cleanup 対象として識別
  （file 先頭コメント + docs）
- [x] runtime: 19 tests / 約 0.5 秒（`FAST_CHECK_RUNS=200` でも）で quality gate を悪化させない

## 検証結果

- 新規 property tests: 19 tests pass（既定 50 runs、確認用に 200 runs でも pass）
- `FAST_CHECK_SEED=18927364` での seed replay 動作確認
- `bun run quality:check`: pass（format / lint / compile / 409 test files /
  knip / duplication / secretlint / arch:check）
- `bun run test:coverage`: pass（global 96.14% stmts / 91% branches /
  96.96% funcs / 96.12% lines、全 threshold 充足）

## Regression risk

低。test-only の追加で production code 変更なし。`.oxlintrc.json` の
`assertFunctionNames` 拡張は既存テスト（expect / expectTypeOf）の判定を維持したまま
`fc.assert` を追加するのみ。coverage は import-export critical glob を含め全 threshold を
満たす。

Closes #718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 保存データの変換、整合性検証、修復計画、URL正規化、バックアップ入出力を対象としたプロパティベーステストを追加しました。
  * 正常・異常データを用いて、決定性、データ保持、不整合の検出・修復を幅広く検証します。
  * CIで共通テストも実行されるようになりました。
* **ドキュメント**
  * テスト方針、再現手順、実行戦略、回帰テストへの昇格基準を追加しました。
* **開発者向け改善**
  * テスト実行回数やシードを設定でき、失敗ケースを再現しやすくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->