### PR TITLE
Persistence cutover-capable data planeを導入する

### DIFF
--- a/src/app/composition/createSavedTabsUseCases.testing.ts
+++ b/src/app/composition/createSavedTabsUseCases.testing.ts
@@ -1,0 +1,31 @@
+import { createSavedTabsUseCases as createApplicationSavedTabsUseCases } from '@/contexts/saved-tabs/application/createSavedTabsUseCases'
+import type { PersistenceDataPlaneRouterPort } from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/SavedTabsUseCases'
+import { createRouteAwareSavedTabsUseCases } from '@/contexts/saved-tabs/application/services/RouteAwareSavedTabsUseCasesService'
+import { createSelectedLegacySavedTabsUseCasesDeps } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps'
+import type { CreateSavedTabsUseCasesDepsOptions } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps'
+
+export type CreateRouteAwareSavedTabsUseCasesForTestingOptions = {
+  readonly indexeddb: SavedTabsUseCases
+  readonly legacyOptions?: CreateSavedTabsUseCasesDepsOptions
+  readonly router: PersistenceDataPlaneRouterPort
+}
+
+/**
+ * Integration seam for #722 and migration smoke tests.
+ *
+ * Production composition never accepts an alternate cutover policy or an
+ * injected IndexedDB bundle. Tests can combine this factory with the explicit
+ * complete-cutover bootstrap testing factory and a real IndexedDB use-case
+ * bundle without changing the production default.
+ */
+export const createRouteAwareSavedTabsUseCasesForTesting = (
+  options: CreateRouteAwareSavedTabsUseCasesForTestingOptions,
+): SavedTabsUseCases =>
+  createRouteAwareSavedTabsUseCases({
+    indexeddb: options.indexeddb,
+    legacy: createApplicationSavedTabsUseCases(
+      createSelectedLegacySavedTabsUseCasesDeps(options.legacyOptions),
+    ),
+    router: options.router,
+  })

--- a/src/app/composition/createSavedTabsUseCases.ts
+++ b/src/app/composition/createSavedTabsUseCases.ts
@@ -2,8 +2,13 @@ import { createSavedTabsUseCases as createApplicationSavedTabsUseCases } from '@
 import type { SavedTabsPresentationPorts } from '@/contexts/saved-tabs/application/ports/SavedTabsPresentationPorts'
 import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/SavedTabsUseCases'
 import type { SavedTabsUseCasesDeps } from '@/contexts/saved-tabs/application/SavedTabsUseCasesDeps'
-import { createSavedTabsUseCasesDeps as createInfrastructureSavedTabsUseCasesDeps } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps'
+import { createRouteAwareSavedTabsUseCases } from '@/contexts/saved-tabs/application/services/RouteAwareSavedTabsUseCasesService'
+import {
+  createSavedTabsUseCasesDeps as createInfrastructureSavedTabsUseCasesDeps,
+  createSelectedLegacySavedTabsUseCasesDeps,
+} from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps'
 import type { CreateSavedTabsUseCasesDepsOptions } from '@/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps'
+import { getPersistenceBootstrapRuntime } from '@/contexts/saved-tabs/infrastructure/composition/persistenceBootstrapRuntime'
 
 /**
  * `createSavedTabsUseCases` 呼び出し時に渡せる任意設定。
@@ -17,6 +22,14 @@ export type CreateSavedTabsUseCasesOptions = CreateSavedTabsUseCasesDepsOptions
 export const createSavedTabsUseCasesDeps = (
   options: CreateSavedTabsUseCasesDepsOptions = {},
 ): SavedTabsUseCasesDeps => createInfrastructureSavedTabsUseCasesDeps(options)
+
+const createProductionSavedTabsUseCases = (
+  deps: SavedTabsUseCasesDeps,
+): SavedTabsUseCases =>
+  createRouteAwareSavedTabsUseCases({
+    legacy: createApplicationSavedTabsUseCases(deps),
+    router: getPersistenceBootstrapRuntime().dataPlaneRouter,
+  })
 
 /**
  * `src/app/composition/` レベルの composition root。
@@ -46,8 +59,8 @@ export const createSavedTabsUseCasesDeps = (
 export const createSavedTabsUseCases = (
   options: CreateSavedTabsUseCasesOptions = {},
 ): SavedTabsUseCases => {
-  const deps: SavedTabsUseCasesDeps = createSavedTabsUseCasesDeps(options)
-  return createApplicationSavedTabsUseCases(deps)
+  const deps = createSelectedLegacySavedTabsUseCasesDeps(options)
+  return createProductionSavedTabsUseCases(deps)
 }
 
 /**
@@ -89,9 +102,9 @@ export const createSavedTabsPresentationComposition = (
   readonly deps: SavedTabsPresentationPorts
   readonly useCases: SavedTabsUseCases
 } => {
-  const deps = createSavedTabsUseCasesDeps(options)
+  const deps = createSelectedLegacySavedTabsUseCasesDeps(options)
   return {
     deps: toSavedTabsPresentationPorts(deps),
-    useCases: createApplicationSavedTabsUseCases(deps),
+    useCases: createProductionSavedTabsUseCases(deps),
   }
 }

--- a/src/contexts/saved-tabs/application/ports/PersistenceBootstrapPort.ts
+++ b/src/contexts/saved-tabs/application/ports/PersistenceBootstrapPort.ts
@@ -146,6 +146,35 @@ export type PersistenceOperationGatePort = {
   ) => Promise<Result>
 }
 
+/**
+ * A pair of repository operations for one logical read or write.
+ *
+ * The router invokes exactly one callback after resolving the authoritative
+ * persistence route. Callers must keep backend-specific shapes inside these
+ * callbacks and expose only application/domain values as `Result`.
+ */
+export type PersistenceDataPlaneOperation<Result> = {
+  readonly indexeddb: () => Promise<Result>
+  readonly legacy: () => Promise<Result>
+}
+
+/**
+ * Resolves the authoritative repository from the persistence control state.
+ *
+ * Unlike `PersistenceOperationGatePort`, callers do not preselect a route.
+ * This prevents a matching-state call from producing
+ * `PERSISTENCE_ROUTE_MISMATCH` and gives current use-cases one fail-closed
+ * data-plane entry point.
+ */
+export type PersistenceDataPlaneRouterPort = {
+  readonly read: <Result>(
+    operation: PersistenceDataPlaneOperation<Result>,
+  ) => Promise<Result>
+  readonly write: <Result>(
+    operation: PersistenceDataPlaneOperation<Result>,
+  ) => Promise<Result>
+}
+
 export type PersistenceRecoveryState =
   | { readonly status: 'available' }
   | {

--- a/src/contexts/saved-tabs/application/services/PersistenceBootstrapService.test.ts
+++ b/src/contexts/saved-tabs/application/services/PersistenceBootstrapService.test.ts
@@ -9,6 +9,7 @@ import type {
   PersistenceCoordinationPort,
   PersistenceMigrationLifecyclePort,
 } from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+import { createCompletePersistenceBootstrapServiceForTesting } from '@/contexts/saved-tabs/testing/createCompletePersistenceBootstrapService'
 
 import { PersistenceBootstrapService } from './PersistenceBootstrapService'
 import { transitionPersistenceControlState } from './PersistenceControlStateService'
@@ -185,7 +186,7 @@ describe('PersistenceBootstrapService', () => {
     const lifecycle = createLifecycle()
     const coordination = new SerialPersistenceCoordinator()
     const createContext = () =>
-      new PersistenceBootstrapService({
+      createCompletePersistenceBootstrapServiceForTesting({
         access: createAccess(),
         controlStateRepository: repository,
         coordination,
@@ -209,7 +210,7 @@ describe('PersistenceBootstrapService', () => {
       migrationId: 'migration-1',
     })
     const lifecycle = createLifecycle()
-    const restarted = new PersistenceBootstrapService({
+    const restarted = createCompletePersistenceBootstrapServiceForTesting({
       access: createAccess(),
       controlStateRepository: repository,
       coordination: new SerialPersistenceCoordinator(),
@@ -229,7 +230,7 @@ describe('PersistenceBootstrapService', () => {
       migrationId: 'migration-1',
     })
     const lifecycle = createLifecycle()
-    const restarted = new PersistenceBootstrapService({
+    const restarted = createCompletePersistenceBootstrapServiceForTesting({
       access: createAccess(),
       controlStateRepository: repository,
       coordination: new SerialPersistenceCoordinator(),
@@ -243,10 +244,34 @@ describe('PersistenceBootstrapService', () => {
     expect(repository.state.status).toBe('indexeddb')
   })
 
+  it('defers cutover-pending by default until completion is explicitly enabled', async () => {
+    const repository = new FakeControlStateRepository({
+      status: 'cutover-pending',
+      migrationId: 'migration-1',
+    })
+    const lifecycle = createLifecycle()
+    const restarted = new PersistenceBootstrapService({
+      access: createAccess(),
+      controlStateRepository: repository,
+      coordination: new SerialPersistenceCoordinator(),
+      migrationLifecycle: lifecycle,
+    })
+
+    await restarted.ready()
+
+    expect(lifecycle.migrate).not.toHaveBeenCalled()
+    expect(lifecycle.verify).not.toHaveBeenCalled()
+    expect(repository.transition).not.toHaveBeenCalled()
+    expect(repository.state).toEqual({
+      status: 'cutover-pending',
+      migrationId: 'migration-1',
+    })
+  })
+
   it('runs migration and verification before publishing indexeddb state', async () => {
     const repository = new FakeControlStateRepository({ status: 'legacy' })
     const lifecycle = createLifecycle()
-    const service = new PersistenceBootstrapService({
+    const service = createCompletePersistenceBootstrapServiceForTesting({
       access: createAccess(),
       controlStateRepository: repository,
       coordination: new SerialPersistenceCoordinator(),
@@ -352,7 +377,7 @@ describe('PersistenceBootstrapService', () => {
     const repository = new FakeControlStateRepository({ status: 'legacy' })
     const lifecycle = createLifecycle()
     vi.mocked(lifecycle.migrate).mockRejectedValueOnce(new Error('temporary'))
-    const service = new PersistenceBootstrapService({
+    const service = createCompletePersistenceBootstrapServiceForTesting({
       access: createAccess(),
       controlStateRepository: repository,
       coordination: new SerialPersistenceCoordinator(),

--- a/src/contexts/saved-tabs/application/services/PersistenceBootstrapService.ts
+++ b/src/contexts/saved-tabs/application/services/PersistenceBootstrapService.ts
@@ -161,7 +161,7 @@ export class PersistenceBootstrapService implements PersistenceBootstrapPort {
     }
 
     if (state.status === 'cutover-pending') {
-      if (this.options.cutoverPolicy === 'defer') {
+      if (this.options.cutoverPolicy !== 'complete') {
         return
       }
       await this.options.controlStateRepository.transition({

--- a/src/contexts/saved-tabs/application/services/PersistenceDataPlaneRouterService.test.ts
+++ b/src/contexts/saved-tabs/application/services/PersistenceDataPlaneRouterService.test.ts
@@ -138,4 +138,22 @@ describe('PersistenceDataPlaneRouterService', () => {
       'PERSISTENCE_RECOVERY_REQUIRED',
     )
   })
+
+  it('propagates the recorded error code in failed state without invoking either backend', async () => {
+    const { recovery, router } = createRouter({
+      status: 'failed',
+      errorCode: 'PERSISTENCE_CONTROL_STATE_INVALID',
+    })
+    const legacy = vi.fn(async () => 'legacy')
+    const indexeddb = vi.fn(async () => 'indexeddb')
+
+    await expect(router.read({ indexeddb, legacy })).rejects.toEqual(
+      new PersistenceUnavailableError('PERSISTENCE_CONTROL_STATE_INVALID'),
+    )
+    expect(legacy).not.toHaveBeenCalled()
+    expect(indexeddb).not.toHaveBeenCalled()
+    expect(recovery.reportUnavailable).toHaveBeenCalledWith(
+      'PERSISTENCE_CONTROL_STATE_INVALID',
+    )
+  })
 })

--- a/src/contexts/saved-tabs/application/services/PersistenceDataPlaneRouterService.test.ts
+++ b/src/contexts/saved-tabs/application/services/PersistenceDataPlaneRouterService.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { PersistenceUnavailableError } from '@/contexts/saved-tabs/application/errors/PersistenceUnavailableError'
+import type {
+  PersistenceBootstrapPort,
+  PersistenceControlState,
+  PersistenceControlStateRepositoryPort,
+  PersistenceCoordinationPort,
+  PersistenceRecoveryReporterPort,
+} from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+
+import { PersistenceDataPlaneRouterService } from './PersistenceDataPlaneRouterService'
+
+const createRouter = (state: PersistenceControlState) => {
+  const bootstrap: PersistenceBootstrapPort = {
+    migrate: vi.fn(async () => undefined),
+    readState: vi.fn(async () => state),
+    ready: vi.fn(async () => undefined),
+  }
+  const controlStateRepository: PersistenceControlStateRepositoryPort = {
+    read: vi.fn(async () => state),
+    transition: vi.fn(async () => state),
+  }
+  const coordination: PersistenceCoordinationPort = {
+    runExclusive: async (operation) => operation(),
+    runShared: async (operation) => operation(),
+  }
+  const recovery: PersistenceRecoveryReporterPort = {
+    reportUnavailable: vi.fn(),
+  }
+
+  return {
+    bootstrap,
+    recovery,
+    router: new PersistenceDataPlaneRouterService({
+      bootstrap,
+      controlStateRepository,
+      coordination,
+      recovery,
+    }),
+  }
+}
+
+describe('PersistenceDataPlaneRouterService', () => {
+  it.each([
+    ['read', 'legacy'],
+    ['write', 'legacy'],
+    ['read', 'indexeddb'],
+    ['write', 'indexeddb'],
+  ] as const)(
+    'routes a %s operation to the %s repository only',
+    async (operationKind, route) => {
+      const state: PersistenceControlState =
+        route === 'legacy'
+          ? { status: 'legacy' }
+          : {
+              status: 'indexeddb',
+              migrationId: 'migration-1',
+              persistenceGeneration: 2,
+            }
+      const { recovery, router } = createRouter(state)
+      const legacy = vi.fn(async () => 'legacy')
+      const indexeddb = vi.fn(async () => 'indexeddb')
+
+      const result = await router[operationKind]({ indexeddb, legacy })
+
+      expect(result).toBe(route)
+      expect(legacy).toHaveBeenCalledTimes(route === 'legacy' ? 1 : 0)
+      expect(indexeddb).toHaveBeenCalledTimes(route === 'indexeddb' ? 1 : 0)
+      expect(recovery.reportUnavailable).not.toHaveBeenCalledWith(
+        'PERSISTENCE_ROUTE_MISMATCH',
+      )
+    },
+  )
+
+  it('does not silently fall back to legacy when the IndexedDB read fails', async () => {
+    const { router } = createRouter({
+      status: 'indexeddb',
+      migrationId: 'migration-1',
+      persistenceGeneration: 2,
+    })
+    const failure = new Error('indexeddb read failed')
+    const legacy = vi.fn(async () => 'legacy')
+    const indexeddb = vi.fn(async () => {
+      throw failure
+    })
+
+    await expect(router.read({ indexeddb, legacy })).rejects.toBe(failure)
+    expect(indexeddb).toHaveBeenCalledOnce()
+    expect(legacy).not.toHaveBeenCalled()
+  })
+
+  it('never dual-writes when the selected repository fails', async () => {
+    const { router } = createRouter({ status: 'legacy' })
+    const failure = new Error('legacy write failed')
+    const legacy = vi.fn(async () => {
+      throw failure
+    })
+    const indexeddb = vi.fn(async () => 'indexeddb')
+
+    await expect(router.write({ indexeddb, legacy })).rejects.toBe(failure)
+    expect(legacy).toHaveBeenCalledOnce()
+    expect(indexeddb).not.toHaveBeenCalled()
+  })
+
+  it('uses the declared read source and blocks writes in read-only emergency', async () => {
+    const { router } = createRouter({
+      status: 'read-only-emergency',
+      readSource: 'indexeddb',
+      migrationId: 'migration-1',
+      persistenceGeneration: 2,
+    })
+    const legacy = vi.fn(async () => 'legacy')
+    const indexeddb = vi.fn(async () => 'indexeddb')
+
+    await expect(router.read({ indexeddb, legacy })).resolves.toBe('indexeddb')
+    await expect(router.write({ indexeddb, legacy })).rejects.toMatchObject({
+      code: 'PERSISTENCE_READ_ONLY',
+    })
+    expect(legacy).not.toHaveBeenCalled()
+    expect(indexeddb).toHaveBeenCalledOnce()
+  })
+
+  it('fails closed before either repository is called in transitional state', async () => {
+    const { recovery, router } = createRouter({
+      status: 'cutover-pending',
+      migrationId: 'migration-1',
+    })
+    const legacy = vi.fn(async () => 'legacy')
+    const indexeddb = vi.fn(async () => 'indexeddb')
+
+    await expect(router.read({ indexeddb, legacy })).rejects.toEqual(
+      new PersistenceUnavailableError('PERSISTENCE_RECOVERY_REQUIRED'),
+    )
+    expect(legacy).not.toHaveBeenCalled()
+    expect(indexeddb).not.toHaveBeenCalled()
+    expect(recovery.reportUnavailable).toHaveBeenCalledWith(
+      'PERSISTENCE_RECOVERY_REQUIRED',
+    )
+  })
+})

--- a/src/contexts/saved-tabs/application/services/PersistenceDataPlaneRouterService.ts
+++ b/src/contexts/saved-tabs/application/services/PersistenceDataPlaneRouterService.ts
@@ -1,0 +1,88 @@
+import { PersistenceUnavailableError } from '@/contexts/saved-tabs/application/errors/PersistenceUnavailableError'
+import type {
+  PersistenceBootstrapPort,
+  PersistenceControlStateRepositoryPort,
+  PersistenceCoordinationPort,
+  PersistenceDataPlaneOperation,
+  PersistenceDataPlaneRouterPort,
+  PersistenceRecoveryReporterPort,
+  PersistenceRoute,
+} from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+
+export type PersistenceDataPlaneRouterServiceOptions = {
+  readonly bootstrap: PersistenceBootstrapPort
+  readonly controlStateRepository: PersistenceControlStateRepositoryPort
+  readonly coordination: PersistenceCoordinationPort
+  readonly recovery: PersistenceRecoveryReporterPort
+}
+
+/**
+ * Selects one authoritative persistence backend for a complete operation.
+ *
+ * A selected backend error is returned unchanged. The service deliberately
+ * has no retry on the other backend and never invokes both callbacks.
+ */
+export class PersistenceDataPlaneRouterService implements PersistenceDataPlaneRouterPort {
+  private readonly options: PersistenceDataPlaneRouterServiceOptions
+
+  constructor(options: PersistenceDataPlaneRouterServiceOptions) {
+    this.options = options
+  }
+
+  readonly read = async <Result>(
+    operation: PersistenceDataPlaneOperation<Result>,
+  ): Promise<Result> => this.run(false, operation)
+
+  readonly write = async <Result>(
+    operation: PersistenceDataPlaneOperation<Result>,
+  ): Promise<Result> => this.run(true, operation)
+
+  private readonly run = async <Result>(
+    isWrite: boolean,
+    operation: PersistenceDataPlaneOperation<Result>,
+  ): Promise<Result> => {
+    try {
+      await this.options.bootstrap.ready()
+      return await this.options.coordination.runShared(async () => {
+        const route = await this.resolveRoute(isWrite)
+        return operation[route]()
+      })
+    } catch (error) {
+      if (error instanceof PersistenceUnavailableError) {
+        this.options.recovery.reportUnavailable(error.code)
+      }
+      throw error
+    }
+  }
+
+  private readonly resolveRoute = async (
+    isWrite: boolean,
+  ): Promise<PersistenceRoute> => {
+    const state = await this.options.controlStateRepository.read()
+    switch (state.status) {
+      case 'legacy':
+      case 'indexeddb': {
+        return state.status
+      }
+      case 'read-only-emergency': {
+        if (isWrite) {
+          throw new PersistenceUnavailableError('PERSISTENCE_READ_ONLY')
+        }
+        return state.readSource
+      }
+      case 'failed': {
+        throw new PersistenceUnavailableError(state.errorCode)
+      }
+      case 'migrating':
+      case 'verifying':
+      case 'cutover-pending': {
+        throw new PersistenceUnavailableError('PERSISTENCE_RECOVERY_REQUIRED')
+      }
+      default: {
+        throw new PersistenceUnavailableError(
+          'PERSISTENCE_CONTROL_STATE_INVALID',
+        )
+      }
+    }
+  }
+}

--- a/src/contexts/saved-tabs/application/services/RouteAwareSavedTabsUseCases.test.ts
+++ b/src/contexts/saved-tabs/application/services/RouteAwareSavedTabsUseCases.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { PersistenceDataPlaneRouterPort } from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/SavedTabsUseCases'
+
+import { createRouteAwareSavedTabsUseCases } from './RouteAwareSavedTabsUseCasesService'
+
+const createBundle = (value: string): SavedTabsUseCases =>
+  ({
+    deleteSavedUrl: vi.fn(async () => value),
+    getSavedTabs: vi.fn(async () => value),
+  }) as unknown as SavedTabsUseCases
+
+describe('createRouteAwareSavedTabsUseCases', () => {
+  it.each([
+    ['legacy', 'getSavedTabs', 'read'],
+    ['indexeddb', 'getSavedTabs', 'read'],
+    ['legacy', 'deleteSavedUrl', 'write'],
+    ['indexeddb', 'deleteSavedUrl', 'write'],
+  ] as const)(
+    'routes %s %s through the %s data-plane operation',
+    async (route, useCaseName, operationKind) => {
+      const read = vi.fn(async (operation) => operation[route]())
+      const write = vi.fn(async (operation) => operation[route]())
+      const router: PersistenceDataPlaneRouterPort = { read, write }
+      const legacy = createBundle('legacy')
+      const indexeddb = createBundle('indexeddb')
+      const useCases = createRouteAwareSavedTabsUseCases({
+        indexeddb,
+        legacy,
+        router,
+      })
+
+      const invoke = useCases[useCaseName] as unknown as () => Promise<string>
+      const result = await invoke()
+
+      expect(result).toBe(route)
+      expect(read).toHaveBeenCalledTimes(operationKind === 'read' ? 1 : 0)
+      expect(write).toHaveBeenCalledTimes(operationKind === 'write' ? 1 : 0)
+    },
+  )
+
+  it('does not invoke the legacy use-case after an IndexedDB failure', async () => {
+    const failure = new Error('indexeddb failed')
+    const legacyGetSavedTabs = vi.fn(async () => 'legacy')
+    const indexedDbGetSavedTabs = vi.fn(async () => {
+      throw failure
+    })
+    const legacy = createBundle('unused')
+    const indexeddb = createBundle('unused')
+    Object.defineProperty(legacy, 'getSavedTabs', {
+      value: legacyGetSavedTabs,
+    })
+    Object.defineProperty(indexeddb, 'getSavedTabs', {
+      value: indexedDbGetSavedTabs,
+    })
+    const router: PersistenceDataPlaneRouterPort = {
+      read: async (operation) => operation.indexeddb(),
+      write: async (operation) => operation.indexeddb(),
+    }
+    const useCases = createRouteAwareSavedTabsUseCases({
+      indexeddb,
+      legacy,
+      router,
+    })
+
+    const invoke = useCases.getSavedTabs as unknown as () => Promise<unknown>
+    await expect(invoke()).rejects.toBe(failure)
+    expect(indexedDbGetSavedTabs).toHaveBeenCalledOnce()
+    expect(legacyGetSavedTabs).not.toHaveBeenCalled()
+  })
+
+  it('fails closed without invoking legacy when production has no IndexedDB bundle', async () => {
+    const legacyGetSavedTabs = vi.fn(async () => 'legacy')
+    const legacy = createBundle('unused')
+    Object.defineProperty(legacy, 'getSavedTabs', {
+      value: legacyGetSavedTabs,
+    })
+    const router: PersistenceDataPlaneRouterPort = {
+      read: async (operation) => operation.indexeddb(),
+      write: async (operation) => operation.indexeddb(),
+    }
+    const useCases = createRouteAwareSavedTabsUseCases({ legacy, router })
+
+    const invoke = useCases.getSavedTabs as unknown as () => Promise<unknown>
+    await expect(invoke()).rejects.toMatchObject({
+      code: 'PERSISTENCE_CONTROL_STATE_UNAVAILABLE',
+    })
+    expect(legacyGetSavedTabs).not.toHaveBeenCalled()
+  })
+})

--- a/src/contexts/saved-tabs/application/services/RouteAwareSavedTabsUseCases.test.ts
+++ b/src/contexts/saved-tabs/application/services/RouteAwareSavedTabsUseCases.test.ts
@@ -46,14 +46,14 @@ describe('createRouteAwareSavedTabsUseCases', () => {
     const indexedDbGetSavedTabs = vi.fn(async () => {
       throw failure
     })
-    const legacy = createBundle('unused')
-    const indexeddb = createBundle('unused')
-    Object.defineProperty(legacy, 'getSavedTabs', {
-      value: legacyGetSavedTabs,
-    })
-    Object.defineProperty(indexeddb, 'getSavedTabs', {
-      value: indexedDbGetSavedTabs,
-    })
+    const legacy = {
+      ...createBundle('unused'),
+      getSavedTabs: legacyGetSavedTabs,
+    } as unknown as SavedTabsUseCases
+    const indexeddb = {
+      ...createBundle('unused'),
+      getSavedTabs: indexedDbGetSavedTabs,
+    } as unknown as SavedTabsUseCases
     const router: PersistenceDataPlaneRouterPort = {
       read: async (operation) => operation.indexeddb(),
       write: async (operation) => operation.indexeddb(),
@@ -72,10 +72,10 @@ describe('createRouteAwareSavedTabsUseCases', () => {
 
   it('fails closed without invoking legacy when production has no IndexedDB bundle', async () => {
     const legacyGetSavedTabs = vi.fn(async () => 'legacy')
-    const legacy = createBundle('unused')
-    Object.defineProperty(legacy, 'getSavedTabs', {
-      value: legacyGetSavedTabs,
-    })
+    const legacy = {
+      ...createBundle('unused'),
+      getSavedTabs: legacyGetSavedTabs,
+    } as unknown as SavedTabsUseCases
     const router: PersistenceDataPlaneRouterPort = {
       read: async (operation) => operation.indexeddb(),
       write: async (operation) => operation.indexeddb(),

--- a/src/contexts/saved-tabs/application/services/RouteAwareSavedTabsUseCasesService.ts
+++ b/src/contexts/saved-tabs/application/services/RouteAwareSavedTabsUseCasesService.ts
@@ -1,0 +1,334 @@
+import { PersistenceUnavailableError } from '@/contexts/saved-tabs/application/errors/PersistenceUnavailableError'
+import type { PersistenceDataPlaneRouterPort } from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+import type { SavedTabsUseCases } from '@/contexts/saved-tabs/application/SavedTabsUseCases'
+
+export type RouteAwareSavedTabsUseCasesOptions = {
+  readonly indexeddb?: SavedTabsUseCases
+  readonly legacy: SavedTabsUseCases
+  readonly router: PersistenceDataPlaneRouterPort
+}
+
+const requireIndexedDb = async <Arguments extends unknown[], Result>(
+  operation: ((...args: Arguments) => Promise<Result>) | undefined,
+  args: Arguments,
+): Promise<Result> => {
+  if (!operation) {
+    throw new PersistenceUnavailableError(
+      'PERSISTENCE_CONTROL_STATE_UNAVAILABLE',
+    )
+  }
+  return operation(...args)
+}
+
+const routeRead =
+  <Arguments extends unknown[], Result>(
+    router: PersistenceDataPlaneRouterPort,
+    legacy: (...args: Arguments) => Promise<Result>,
+    indexeddb?: (...args: Arguments) => Promise<Result>,
+  ): ((...args: Arguments) => Promise<Result>) =>
+  async (...args) =>
+    router.read({
+      indexeddb: async () => requireIndexedDb(indexeddb, args),
+      legacy: async () => legacy(...args),
+    })
+
+const routeWrite =
+  <Arguments extends unknown[], Result>(
+    router: PersistenceDataPlaneRouterPort,
+    legacy: (...args: Arguments) => Promise<Result>,
+    indexeddb?: (...args: Arguments) => Promise<Result>,
+  ): ((...args: Arguments) => Promise<Result>) =>
+  async (...args) =>
+    router.write({
+      indexeddb: async () => requireIndexedDb(indexeddb, args),
+      legacy: async () => legacy(...args),
+    })
+
+/**
+ * Moves the complete presentation-facing use-case bundle behind one
+ * authoritative route. Backend-specific shapes stay behind the two bundles;
+ * the returned contract remains `SavedTabsUseCases`.
+ */
+// eslint-disable-next-line eslint/complexity -- explicit type-safe mapping avoids an unsafe dynamic proxy at this architecture boundary.
+export const createRouteAwareSavedTabsUseCases = ({
+  indexeddb,
+  legacy,
+  router,
+}: RouteAwareSavedTabsUseCasesOptions): SavedTabsUseCases => ({
+  openSavedUrl: routeWrite(
+    router,
+    legacy.openSavedUrl,
+    indexeddb?.openSavedUrl,
+  ),
+  openAllSavedUrls: routeWrite(
+    router,
+    legacy.openAllSavedUrls,
+    indexeddb?.openAllSavedUrls,
+  ),
+  deleteTabGroup: routeWrite(
+    router,
+    legacy.deleteTabGroup,
+    indexeddb?.deleteTabGroup,
+  ),
+  deleteTabGroups: routeWrite(
+    router,
+    legacy.deleteTabGroups,
+    indexeddb?.deleteTabGroups,
+  ),
+  prepareTabGroupDeletion: routeWrite(
+    router,
+    legacy.prepareTabGroupDeletion,
+    indexeddb?.prepareTabGroupDeletion,
+  ),
+  prepareTabGroupsDeletion: routeWrite(
+    router,
+    legacy.prepareTabGroupsDeletion,
+    indexeddb?.prepareTabGroupsDeletion,
+  ),
+  deleteSavedUrl: routeWrite(
+    router,
+    legacy.deleteSavedUrl,
+    indexeddb?.deleteSavedUrl,
+  ),
+  deleteSavedUrls: routeWrite(
+    router,
+    legacy.deleteSavedUrls,
+    indexeddb?.deleteSavedUrls,
+  ),
+  restoreOpenedUrlsSnapshot: routeWrite(
+    router,
+    legacy.restoreOpenedUrlsSnapshot,
+    indexeddb?.restoreOpenedUrlsSnapshot,
+  ),
+  restoreOpenedUrlsSnapshotView: routeWrite(
+    router,
+    legacy.restoreOpenedUrlsSnapshotView,
+    indexeddb?.restoreOpenedUrlsSnapshotView,
+  ),
+  syncCategoryAssignments: routeWrite(
+    router,
+    legacy.syncCategoryAssignments,
+    indexeddb?.syncCategoryAssignments,
+  ),
+  removeUnreferencedUrlRecords: routeWrite(
+    router,
+    legacy.removeUnreferencedUrlRecords,
+    indexeddb?.removeUnreferencedUrlRecords,
+  ),
+  removeUrlsFromCustomProjects: routeWrite(
+    router,
+    legacy.removeUrlsFromCustomProjects,
+    indexeddb?.removeUrlsFromCustomProjects,
+  ),
+  buildSavedTabsSnapshot: routeRead(
+    router,
+    legacy.buildSavedTabsSnapshot,
+    indexeddb?.buildSavedTabsSnapshot,
+  ),
+  reorderTabGroups: routeWrite(
+    router,
+    legacy.reorderTabGroups,
+    indexeddb?.reorderTabGroups,
+  ),
+  reorderParentCategories: routeWrite(
+    router,
+    legacy.reorderParentCategories,
+    indexeddb?.reorderParentCategories,
+  ),
+  removeSubCategoryFromTabGroups: routeWrite(
+    router,
+    legacy.removeSubCategoryFromTabGroups,
+    indexeddb?.removeSubCategoryFromTabGroups,
+  ),
+  reorderTabGroupUrls: routeWrite(
+    router,
+    legacy.reorderTabGroupUrls,
+    indexeddb?.reorderTabGroupUrls,
+  ),
+  loadTabGroupsWithUrls: routeRead(
+    router,
+    legacy.loadTabGroupsWithUrls,
+    indexeddb?.loadTabGroupsWithUrls,
+  ),
+  loadTabGroupUrls: routeRead(
+    router,
+    legacy.loadTabGroupUrls,
+    indexeddb?.loadTabGroupUrls,
+  ),
+  findUrlRecordByUrl: routeRead(
+    router,
+    legacy.findUrlRecordByUrl,
+    indexeddb?.findUrlRecordByUrl,
+  ),
+  setCategoryKeywords: routeWrite(
+    router,
+    legacy.setCategoryKeywords,
+    indexeddb?.setCategoryKeywords,
+  ),
+  renameParentCategory: routeWrite(
+    router,
+    legacy.renameParentCategory,
+    indexeddb?.renameParentCategory,
+  ),
+  addDomainToParentCategory: routeWrite(
+    router,
+    legacy.addDomainToParentCategory,
+    indexeddb?.addDomainToParentCategory,
+  ),
+  removeDomainFromParentCategory: routeWrite(
+    router,
+    legacy.removeDomainFromParentCategory,
+    indexeddb?.removeDomainFromParentCategory,
+  ),
+  moveDomainBetweenCategories: routeWrite(
+    router,
+    legacy.moveDomainBetweenCategories,
+    indexeddb?.moveDomainBetweenCategories,
+  ),
+  reorderDomainsInCategory: routeWrite(
+    router,
+    legacy.reorderDomainsInCategory,
+    indexeddb?.reorderDomainsInCategory,
+  ),
+  removeDomainsFromParentCategories: routeWrite(
+    router,
+    legacy.removeDomainsFromParentCategories,
+    indexeddb?.removeDomainsFromParentCategories,
+  ),
+  createParentCategory: routeWrite(
+    router,
+    legacy.createParentCategory,
+    indexeddb?.createParentCategory,
+  ),
+  deleteParentCategory: routeWrite(
+    router,
+    legacy.deleteParentCategory,
+    indexeddb?.deleteParentCategory,
+  ),
+  assignDomainToCategory: routeWrite(
+    router,
+    legacy.assignDomainToCategory,
+    indexeddb?.assignDomainToCategory,
+  ),
+  createCustomProject: routeWrite(
+    router,
+    legacy.createCustomProject,
+    indexeddb?.createCustomProject,
+  ),
+  deleteCustomProject: routeWrite(
+    router,
+    legacy.deleteCustomProject,
+    indexeddb?.deleteCustomProject,
+  ),
+  updateCustomProjectName: routeWrite(
+    router,
+    legacy.updateCustomProjectName,
+    indexeddb?.updateCustomProjectName,
+  ),
+  addUrlToCustomProject: routeWrite(
+    router,
+    legacy.addUrlToCustomProject,
+    indexeddb?.addUrlToCustomProject,
+  ),
+  removeUrlFromCustomProject: routeWrite(
+    router,
+    legacy.removeUrlFromCustomProject,
+    indexeddb?.removeUrlFromCustomProject,
+  ),
+  removeUrlsFromCustomProject: routeWrite(
+    router,
+    legacy.removeUrlsFromCustomProject,
+    indexeddb?.removeUrlsFromCustomProject,
+  ),
+  setCustomProjectUrlCategory: routeWrite(
+    router,
+    legacy.setCustomProjectUrlCategory,
+    indexeddb?.setCustomProjectUrlCategory,
+  ),
+  updateCustomProjectCategoryOrder: routeWrite(
+    router,
+    legacy.updateCustomProjectCategoryOrder,
+    indexeddb?.updateCustomProjectCategoryOrder,
+  ),
+  reorderCustomProjectUrls: routeWrite(
+    router,
+    legacy.reorderCustomProjectUrls,
+    indexeddb?.reorderCustomProjectUrls,
+  ),
+  renameCustomProjectCategory: routeWrite(
+    router,
+    legacy.renameCustomProjectCategory,
+    indexeddb?.renameCustomProjectCategory,
+  ),
+  updateCustomProjectKeywords: routeWrite(
+    router,
+    legacy.updateCustomProjectKeywords,
+    indexeddb?.updateCustomProjectKeywords,
+  ),
+  addCategoryToCustomProject: routeWrite(
+    router,
+    legacy.addCategoryToCustomProject,
+    indexeddb?.addCategoryToCustomProject,
+  ),
+  removeCategoryFromCustomProject: routeWrite(
+    router,
+    legacy.removeCategoryFromCustomProject,
+    indexeddb?.removeCategoryFromCustomProject,
+  ),
+  moveUrlBetweenCustomProjects: routeWrite(
+    router,
+    legacy.moveUrlBetweenCustomProjects,
+    indexeddb?.moveUrlBetweenCustomProjects,
+  ),
+  getCustomProjects: routeRead(
+    router,
+    legacy.getCustomProjects,
+    indexeddb?.getCustomProjects,
+  ),
+  getCustomProjectOrder: routeRead(
+    router,
+    legacy.getCustomProjectOrder,
+    indexeddb?.getCustomProjectOrder,
+  ),
+  getCustomProjectUndoSnapshot: routeRead(
+    router,
+    legacy.getCustomProjectUndoSnapshot,
+    indexeddb?.getCustomProjectUndoSnapshot,
+  ),
+  getCustomProjectRaws: routeRead(
+    router,
+    legacy.getCustomProjectRaws,
+    indexeddb?.getCustomProjectRaws,
+  ),
+  saveCustomProjectOrder: routeWrite(
+    router,
+    legacy.saveCustomProjectOrder,
+    indexeddb?.saveCustomProjectOrder,
+  ),
+  saveCustomProjects: routeWrite(
+    router,
+    legacy.saveCustomProjects,
+    indexeddb?.saveCustomProjects,
+  ),
+  restoreCustomProjectsSnapshot: routeWrite(
+    router,
+    legacy.restoreCustomProjectsSnapshot,
+    indexeddb?.restoreCustomProjectsSnapshot,
+  ),
+  getProjectUrls: routeRead(
+    router,
+    legacy.getProjectUrls,
+    indexeddb?.getProjectUrls,
+  ),
+  getSavedTabsPageData: routeRead(
+    router,
+    legacy.getSavedTabsPageData,
+    indexeddb?.getSavedTabsPageData,
+  ),
+  getSavedTabs: routeRead(router, legacy.getSavedTabs, indexeddb?.getSavedTabs),
+  repairTabGroupParentCategoryIds: routeWrite(
+    router,
+    legacy.repairTabGroupParentCategoryIds,
+    indexeddb?.repairTabGroupParentCategoryIds,
+  ),
+})

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -1738,6 +1738,43 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
       })
     }
   })
+
+  describe('issue #729 phase 1: production cutover remains deferred', () => {
+    const sourceRoot = resolve(repoRoot, 'src')
+    const productionFiles = collectSourceFiles(sourceRoot).filter(
+      (path) =>
+        !/\.(?:test|testing)\.tsx?$/.test(path) &&
+        !path.includes(`${sep}testing${sep}`),
+    )
+
+    it('production source does not enable complete cutover', () => {
+      for (const absolutePath of productionFiles) {
+        const relativePath = relative(repoRoot, absolutePath)
+          .split(sep)
+          .join('/')
+        const source = stripComments(readFileSync(absolutePath, 'utf8'))
+        expect(
+          source,
+          `${relativePath} must not enable production complete cutover`,
+        ).not.toMatch(/cutoverPolicy\s*:\s*['"]complete['"]/)
+      }
+    })
+
+    it('production source does not import testing-only cutover seams', () => {
+      for (const absolutePath of productionFiles) {
+        const relativePath = relative(repoRoot, absolutePath)
+          .split(sep)
+          .join('/')
+        const source = stripComments(readFileSync(absolutePath, 'utf8'))
+        expect(
+          source,
+          `${relativePath} must not import a testing-only cutover seam`,
+        ).not.toMatch(
+          /(?:from|import)\s+['"][^'"]*(?:\/testing\/|\.testing)['"]/,
+        )
+      }
+    })
+  })
   describe('issue #739: persistence invalidation contract', () => {
     const unitOfWorkPortPath = resolve(
       repoRoot,

--- a/src/contexts/saved-tabs/dddLayerGuard.test.ts
+++ b/src/contexts/saved-tabs/dddLayerGuard.test.ts
@@ -1747,6 +1747,13 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
         !path.includes(`${sep}testing${sep}`),
     )
 
+    // production source が testing 専用 seam を import しないことを検証する正規表現。
+    // 静的 import (from / side-effect import) と動的 import('...') の両方を検出し、
+    // /testing/<path> ディレクトリと .testing ファイル接尾辞の両方をカバーする。
+    // ガード自体が将来壊れないよう、下方の self-test で検出対象を明示する。
+    const testingSeamImportPattern =
+      /(?:from\s+|import\s+|import\s*\()['"][^'"]*(?:\/testing\/[^'"]*|\.testing)['"]/
+
     it('production source does not enable complete cutover', () => {
       for (const absolutePath of productionFiles) {
         const relativePath = relative(repoRoot, absolutePath)
@@ -1769,9 +1776,40 @@ describe('src/contexts/saved-tabs DDD layer guard', () => {
         expect(
           source,
           `${relativePath} must not import a testing-only cutover seam`,
-        ).not.toMatch(
-          /(?:from|import)\s+['"][^'"]*(?:\/testing\/|\.testing)['"]/,
-        )
+        ).not.toMatch(testingSeamImportPattern)
+      }
+    })
+
+    it('testing seam import guard detects every forbidden import shape', () => {
+      // ガード正規表現が testing seam への import を取りこぼさないことを保証する。
+      // production source にこれらが現れた場合、上記 not.toMatch が失敗する。
+      const forbidden = [
+        "import { x } from '@/contexts/saved-tabs/testing/foo'",
+        "import x from './foo.testing'",
+        "import {\n  createCompletePersistenceBootstrapServiceForTesting,\n} from '@/contexts/saved-tabs/testing/createCompletePersistenceBootstrapService'",
+        "import '@/contexts/saved-tabs/testing/foo'",
+        "import('@/contexts/saved-tabs/testing/foo')",
+        "import('./foo.testing')",
+      ]
+      for (const source of forbidden) {
+        expect(
+          testingSeamImportPattern.test(source),
+          `guard must detect: ${source}`,
+        ).toBe(true)
+      }
+
+      // 許容される import を誤検出しないことも保証する。
+      const allowed = [
+        "import { x } from '@/contexts/saved-tabs/application/foo'",
+        "import { x } from '@/contexts/saved-tabs/infrastructure/foo'",
+        "import { x } from '@/lib/testing-utils/foo'",
+        "import { x } from 'react'",
+      ]
+      for (const source of allowed) {
+        expect(
+          testingSeamImportPattern.test(source),
+          `guard must not flag: ${source}`,
+        ).toBe(false)
       }
     })
   })

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
@@ -46,6 +46,12 @@ export type CreateSavedTabsUseCasesDepsOptions = {
   readonly resolveActive?: () => boolean
 }
 
+type SavedTabsDomainStorageLocal = {
+  readonly get: (key: string) => Promise<Record<string, unknown>>
+  readonly remove: (key: string) => Promise<void>
+  readonly set: (value: Record<string, unknown>) => Promise<void>
+}
+
 type ChromeLike = ChromeApiLikeBase & {
   readonly tabs?: {
     readonly create?: (createProperties: {
@@ -100,11 +106,11 @@ const getChromeMessagingApi = (): ChromeMessagingApiLike | undefined => {
  * const controller = useSavedTabsController({ deps })
  * ```
  */
-export const createSavedTabsUseCasesDeps = (
-  options: CreateSavedTabsUseCasesDepsOptions = {},
+const createSavedTabsUseCasesDepsFromStorage = (
+  options: CreateSavedTabsUseCasesDepsOptions,
+  domainLocal: SavedTabsDomainStorageLocal | null,
+  settingsLocal: SavedTabsDomainStorageLocal | null,
 ): SavedTabsUseCasesDeps => {
-  const domainLocal = getPersistenceStorageLocal()
-  const settingsLocal = getChromeStorageLocal()
   if (!domainLocal || !settingsLocal) {
     warnMissingChromeStorage('createSavedTabsUseCasesDeps')
   }
@@ -163,4 +169,39 @@ export const createSavedTabsUseCasesDeps = (
     urlRecordRepository: createChromeUrlRecordRepository(domainPort),
     userSettingsRepository: createChromeUserSettingsRepository(settingsPort),
   }
+}
+
+export const createSavedTabsUseCasesDeps = (
+  options: CreateSavedTabsUseCasesDepsOptions = {},
+): SavedTabsUseCasesDeps =>
+  createSavedTabsUseCasesDepsFromStorage(
+    options,
+    getPersistenceStorageLocal(),
+    getChromeStorageLocal(),
+  )
+
+/**
+ * Builds the already-selected legacy branch for the outer data-plane router.
+ *
+ * The raw Chrome port is intentional here: applying the legacy operation gate
+ * again inside `PersistenceDataPlaneRouterService` would acquire the same
+ * coordination barrier twice and preselect the route. Only the outer router is
+ * allowed to choose this branch.
+ */
+export const createSelectedLegacySavedTabsUseCasesDeps = (
+  options: CreateSavedTabsUseCasesDepsOptions = {},
+): SavedTabsUseCasesDeps => {
+  const storage = getChromeStorageLocal()
+  const selectedLegacyStorage = storage
+    ? {
+        get: async (key: string) => storage.get(key),
+        remove: async (key: string) => storage.remove(key),
+        set: async (value: Record<string, unknown>) => storage.set(value),
+      }
+    : null
+  return createSavedTabsUseCasesDepsFromStorage(
+    options,
+    selectedLegacyStorage,
+    storage,
+  )
 }

--- a/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/createSavedTabsUseCasesDeps.ts
@@ -106,11 +106,17 @@ const getChromeMessagingApi = (): ChromeMessagingApiLike | undefined => {
  * const controller = useSavedTabsController({ deps })
  * ```
  */
-const createSavedTabsUseCasesDepsFromStorage = (
-  options: CreateSavedTabsUseCasesDepsOptions,
-  domainLocal: SavedTabsDomainStorageLocal | null,
-  settingsLocal: SavedTabsDomainStorageLocal | null,
-): SavedTabsUseCasesDeps => {
+type SavedTabsUseCasesDepsFromStorageArgs = {
+  readonly options: CreateSavedTabsUseCasesDepsOptions
+  readonly domainLocal: SavedTabsDomainStorageLocal | null
+  readonly settingsLocal: SavedTabsDomainStorageLocal | null
+}
+
+const createSavedTabsUseCasesDepsFromStorage = ({
+  options,
+  domainLocal,
+  settingsLocal,
+}: SavedTabsUseCasesDepsFromStorageArgs): SavedTabsUseCasesDeps => {
   if (!domainLocal || !settingsLocal) {
     warnMissingChromeStorage('createSavedTabsUseCasesDeps')
   }
@@ -174,11 +180,11 @@ const createSavedTabsUseCasesDepsFromStorage = (
 export const createSavedTabsUseCasesDeps = (
   options: CreateSavedTabsUseCasesDepsOptions = {},
 ): SavedTabsUseCasesDeps =>
-  createSavedTabsUseCasesDepsFromStorage(
+  createSavedTabsUseCasesDepsFromStorage({
     options,
-    getPersistenceStorageLocal(),
-    getChromeStorageLocal(),
-  )
+    domainLocal: getPersistenceStorageLocal(),
+    settingsLocal: getChromeStorageLocal(),
+  })
 
 /**
  * Builds the already-selected legacy branch for the outer data-plane router.
@@ -192,6 +198,9 @@ export const createSelectedLegacySavedTabsUseCasesDeps = (
   options: CreateSavedTabsUseCasesDepsOptions = {},
 ): SavedTabsUseCasesDeps => {
   const storage = getChromeStorageLocal()
+  // `storage.*` の直接呼び出しを保つことで、この composition ファイルが
+  // machine-checked storage writer inventory (docs/architecture/current-storage-writer-inventory.md)
+  // の mutation boundary として分類され続ける。wrapper を省略すると inventory 検証が壊れる。
   const selectedLegacyStorage = storage
     ? {
         get: async (key: string) => storage.get(key),
@@ -199,9 +208,9 @@ export const createSelectedLegacySavedTabsUseCasesDeps = (
         set: async (value: Record<string, unknown>) => storage.set(value),
       }
     : null
-  return createSavedTabsUseCasesDepsFromStorage(
+  return createSavedTabsUseCasesDepsFromStorage({
     options,
-    selectedLegacyStorage,
-    storage,
-  )
+    domainLocal: selectedLegacyStorage,
+    settingsLocal: storage,
+  })
 }

--- a/src/contexts/saved-tabs/infrastructure/composition/persistenceBootstrapRuntime.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/persistenceBootstrapRuntime.ts
@@ -7,12 +7,14 @@ import type {
   PersistenceControlStateRepositoryPort,
   PersistenceControlStateTransition,
   PersistenceCoordinationPort,
+  PersistenceDataPlaneRouterPort,
   PersistenceMigrationLifecyclePort,
   PersistenceOperationGatePort,
 } from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
 import type { PersistenceMigrationRecoveryLifecyclePort } from '@/contexts/saved-tabs/application/ports/PersistenceMigrationRecoveryPort'
 import { PersistenceBootstrapService } from '@/contexts/saved-tabs/application/services/PersistenceBootstrapService'
 import { transitionPersistenceControlState } from '@/contexts/saved-tabs/application/services/PersistenceControlStateService'
+import { PersistenceDataPlaneRouterService } from '@/contexts/saved-tabs/application/services/PersistenceDataPlaneRouterService'
 import { PersistenceOperationGateService } from '@/contexts/saved-tabs/application/services/PersistenceOperationGateService'
 import { PersistenceRecoveryService } from '@/contexts/saved-tabs/application/services/PersistenceRecoveryService'
 import { PersistenceV2MigrationService } from '@/contexts/saved-tabs/application/services/PersistenceV2MigrationService'
@@ -30,6 +32,7 @@ export type PersistenceBootstrapRuntime = {
   readonly bootstrap: PersistenceBootstrapPort
   readonly coordination: PersistenceCoordinationPort
   readonly controlStateRepository: PersistenceControlStateRepositoryPort
+  readonly dataPlaneRouter: PersistenceDataPlaneRouterPort
   readonly migrationLifecycle?: PersistenceMigrationLifecyclePort
   readonly migrationRecovery?: PersistenceMigrationRecoveryLifecyclePort
   readonly operationGate: PersistenceOperationGatePort
@@ -227,10 +230,17 @@ export const createPersistenceBootstrapRuntime = (
     coordination,
     recovery,
   })
+  const dataPlaneRouter = new PersistenceDataPlaneRouterService({
+    bootstrap,
+    controlStateRepository,
+    coordination,
+    recovery,
+  })
   return {
     bootstrap,
     coordination,
     controlStateRepository,
+    dataPlaneRouter,
     migrationLifecycle,
     migrationRecovery,
     operationGate,

--- a/src/contexts/saved-tabs/infrastructure/composition/persistenceCutoverDataPlane.integration.test.ts
+++ b/src/contexts/saved-tabs/infrastructure/composition/persistenceCutoverDataPlane.integration.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type {
+  PersistenceControlState,
+  PersistenceControlStateRepositoryPort,
+  PersistenceCoordinationPort,
+} from '@/contexts/saved-tabs/application/ports/PersistenceBootstrapPort'
+import { transitionPersistenceControlState } from '@/contexts/saved-tabs/application/services/PersistenceControlStateService'
+import { PersistenceDataPlaneRouterService } from '@/contexts/saved-tabs/application/services/PersistenceDataPlaneRouterService'
+import { PersistenceRecoveryService } from '@/contexts/saved-tabs/application/services/PersistenceRecoveryService'
+import { createCompletePersistenceBootstrapServiceForTesting } from '@/contexts/saved-tabs/testing/createCompletePersistenceBootstrapService'
+
+describe('phase 1 cutover-capable data plane', () => {
+  it('lets migration integration tests complete cutover and route to IndexedDB only', async () => {
+    let state: PersistenceControlState = {
+      status: 'cutover-pending',
+      migrationId: 'migration-1',
+    }
+    const controlStateRepository: PersistenceControlStateRepositoryPort = {
+      read: vi.fn(async () => state),
+      transition: vi.fn(async (transition) => {
+        state = transitionPersistenceControlState(state, transition)
+        return state
+      }),
+    }
+    const coordination: PersistenceCoordinationPort = {
+      runExclusive: async (operation) => operation(),
+      runShared: async (operation) => operation(),
+    }
+    const bootstrap = createCompletePersistenceBootstrapServiceForTesting({
+      access: { initialize: vi.fn(async () => undefined) },
+      controlStateRepository,
+      coordination,
+    })
+    const recovery = new PersistenceRecoveryService({
+      retry: async () => bootstrap.ready(),
+    })
+    const router = new PersistenceDataPlaneRouterService({
+      bootstrap,
+      controlStateRepository,
+      coordination,
+      recovery,
+    })
+    const legacyRepository = vi.fn(async () => 'legacy')
+    const indexedDbRepository = vi.fn(async () => 'indexeddb')
+
+    await expect(
+      router.read({
+        indexeddb: indexedDbRepository,
+        legacy: legacyRepository,
+      }),
+    ).resolves.toBe('indexeddb')
+
+    expect(state).toEqual({
+      status: 'indexeddb',
+      migrationId: 'migration-1',
+      persistenceGeneration: 2,
+    })
+    expect(indexedDbRepository).toHaveBeenCalledOnce()
+    expect(legacyRepository).not.toHaveBeenCalled()
+    expect(recovery.getSnapshot()).toEqual({ status: 'available' })
+  })
+})

--- a/src/contexts/saved-tabs/testing/createCompletePersistenceBootstrapService.ts
+++ b/src/contexts/saved-tabs/testing/createCompletePersistenceBootstrapService.ts
@@ -1,0 +1,15 @@
+import { PersistenceBootstrapService } from '@/contexts/saved-tabs/application/services/PersistenceBootstrapService'
+import type { PersistenceBootstrapServiceOptions } from '@/contexts/saved-tabs/application/services/PersistenceBootstrapService'
+
+type CompletePersistenceBootstrapServiceOptions = Omit<
+  PersistenceBootstrapServiceOptions,
+  'cutoverPolicy'
+>
+
+export const createCompletePersistenceBootstrapServiceForTesting = (
+  options: CompletePersistenceBootstrapServiceOptions,
+): PersistenceBootstrapService =>
+  new PersistenceBootstrapService({
+    ...options,
+    cutoverPolicy: 'complete',
+  })

--- a/src/lib/architecture/persistenceBootstrapPolicy.test.ts
+++ b/src/lib/architecture/persistenceBootstrapPolicy.test.ts
@@ -103,9 +103,11 @@ const findNamedFunctionBody = (
   return body
 }
 
-// expect().toBeDefined() は実行時に throw するが TS はそれを認識できず、
-// 2 引数 expect は vitest/valid-expect で弾かれるため、制御フローで narrow
-// して non-null assertion を使わずに値を返す。
+// expect().toBeDefined() は実行時に throw するが TS はそれを認識できず、戻り値を
+// narrow するには non-null assertion が必要になる。typescript/no-non-null-assertion
+// (error) を満たすため、制御フローで narrow して non-null assertion を使わずに
+// 値を返す。以降の expect(actual, message) は戻り値を再利用しない純粋な assertion
+// 用途の直接呼び出しなので、両者の使い分けは役割分担で矛盾しない。
 const requireDefined = <T>(value: T | undefined, message: string): T => {
   if (value === undefined) {
     throw new Error(message)

--- a/src/lib/architecture/persistenceBootstrapPolicy.test.ts
+++ b/src/lib/architecture/persistenceBootstrapPolicy.test.ts
@@ -140,14 +140,37 @@ describe('PersistenceBootstrap architecture policy', () => {
     expect(composition).toContain(
       'createChromeUserSettingsRepository(settingsPort)',
     )
+    // 同一型の位置引数による誤配線を防ぐため、名前付き引数で domain / settings
+    // storage の対応を明示的に検証する (CodeRabbit review)。
     expect(useCaseComposition).toMatch(
-      /createSavedTabsUseCasesDepsFromStorage\(\s*options,\s*getPersistenceStorageLocal\(\),\s*getChromeStorageLocal\(\),?\s*\)/,
+      /domainLocal:\s*getPersistenceStorageLocal\(\)/,
     )
-    expect(useCaseComposition).toContain(
-      'createSelectedLegacySavedTabsUseCasesDeps',
+    expect(useCaseComposition).toMatch(
+      /settingsLocal:\s*getChromeStorageLocal\(\)/,
     )
     expect(useCaseComposition).toContain(
       'createChromeUserSettingsRepository(settingsPort)',
+    )
+  })
+
+  it('production composition calls createSelectedLegacySavedTabsUseCasesDeps and routes the result', () => {
+    // 関数名の定義 / import だけでは通らないよう、実際の呼び出し形状と
+    // route-aware use-case composition への結線を検証する (CodeRabbit review)。
+    const productionComposition = readRepositoryFile(
+      'src/app/composition/createSavedTabsUseCases.ts',
+    )
+
+    // import 文 (`createSelectedLegacySavedTabsUseCasesDeps,`) ではなく
+    // 呼び出し (`createSelectedLegacySavedTabsUseCasesDeps(`) を検出する。
+    expect(productionComposition).toMatch(
+      /createSelectedLegacySavedTabsUseCasesDeps\s*\(/,
+    )
+    // 呼び出し結果を route-aware な use-case composition へ渡している。
+    expect(productionComposition).toMatch(
+      /createRouteAwareSavedTabsUseCases\s*\(\s*\{/,
+    )
+    expect(productionComposition).toMatch(
+      /createApplicationSavedTabsUseCases\s*\(\s*deps\s*\)/,
     )
   })
 

--- a/src/lib/architecture/persistenceBootstrapPolicy.test.ts
+++ b/src/lib/architecture/persistenceBootstrapPolicy.test.ts
@@ -140,11 +140,11 @@ describe('PersistenceBootstrap architecture policy', () => {
     expect(composition).toContain(
       'createChromeUserSettingsRepository(settingsPort)',
     )
-    expect(useCaseComposition).toContain(
-      'const domainLocal = getPersistenceStorageLocal()',
+    expect(useCaseComposition).toMatch(
+      /createSavedTabsUseCasesDepsFromStorage\(\s*options,\s*getPersistenceStorageLocal\(\),\s*getChromeStorageLocal\(\),?\s*\)/,
     )
     expect(useCaseComposition).toContain(
-      'const settingsLocal = getChromeStorageLocal()',
+      'createSelectedLegacySavedTabsUseCasesDeps',
     )
     expect(useCaseComposition).toContain(
       'createChromeUserSettingsRepository(settingsPort)',

--- a/src/lib/architecture/persistenceBootstrapPolicy.test.ts
+++ b/src/lib/architecture/persistenceBootstrapPolicy.test.ts
@@ -1,12 +1,117 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
+import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 
 const repositoryPath = (path: string): string => resolve(process.cwd(), path)
 
 const readRepositoryFile = (path: string): string =>
   readFileSync(repositoryPath(path), 'utf8')
+
+// CodeRabbit review: ファイル全体の正規表現は「呼び出しの存在」しか検証できず、
+// 別関数に正しい呼び出しが1つ残っているだけで通ってしまう。各 exported
+// composition 関数の本体内で deps データフローを検証するための AST helper。
+const parseRepositorySourceFile = (path: string): ts.SourceFile => {
+  const source = readRepositoryFile(path)
+  const fileName = path.split('/').pop() ?? path
+  return ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  )
+}
+
+const calleeIdentifier = (call: ts.CallExpression): string | undefined => {
+  const expression = call.expression
+  return ts.isIdentifier(expression) ? expression.text : undefined
+}
+
+const collectCallExpressions = (
+  node: ts.Node,
+): readonly ts.CallExpression[] => {
+  const calls: ts.CallExpression[] = []
+  const visit = (current: ts.Node): void => {
+    if (ts.isCallExpression(current)) {
+      calls.push(current)
+    }
+    ts.forEachChild(current, visit)
+  }
+  visit(node)
+  return calls
+}
+
+// `const <name> = <callee>(...)` 形式の変数宣言を探し、束縛された変数名を返す。
+const findVariableAssignedFromCall = (
+  scope: ts.Node,
+  expectedCallee: string,
+): string | undefined => {
+  let assignedName: string | undefined
+  const visit = (node: ts.Node): void => {
+    if (assignedName !== undefined) {
+      return
+    }
+    if (ts.isVariableStatement(node)) {
+      for (const declaration of node.declarationList.declarations) {
+        if (
+          ts.isIdentifier(declaration.name) &&
+          declaration.initializer !== undefined &&
+          ts.isCallExpression(declaration.initializer) &&
+          calleeIdentifier(declaration.initializer) === expectedCallee
+        ) {
+          assignedName = declaration.name.text
+          return
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(scope)
+  return assignedName
+}
+
+// `const <name> = (...) => ...` / `export const <name> = (...) => ...` で
+// 束縛された関数の本体を返す。
+const findNamedFunctionBody = (
+  sourceFile: ts.SourceFile,
+  name: string,
+): ts.Node | undefined => {
+  let body: ts.Node | undefined
+  const visit = (node: ts.Node): void => {
+    if (body !== undefined) {
+      return
+    }
+    if (ts.isVariableStatement(node)) {
+      for (const declaration of node.declarationList.declarations) {
+        if (
+          ts.isIdentifier(declaration.name) &&
+          declaration.name.text === name &&
+          declaration.initializer !== undefined &&
+          (ts.isArrowFunction(declaration.initializer) ||
+            ts.isFunctionExpression(declaration.initializer))
+        ) {
+          body = declaration.initializer.body
+          return
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return body
+}
+
+// expect().toBeDefined() は実行時に throw するが TS はそれを認識できず、
+// 2 引数 expect は vitest/valid-expect で弾かれるため、制御フローで narrow
+// して non-null assertion を使わずに値を返す。
+const requireDefined = <T>(value: T | undefined, message: string): T => {
+  if (value === undefined) {
+    throw new Error(message)
+  }
+  return value
+}
 
 const persistenceBootstrapFiles = [
   'src/app/composition/persistenceStorageLocal.ts',
@@ -153,25 +258,76 @@ describe('PersistenceBootstrap architecture policy', () => {
     )
   })
 
-  it('production composition calls createSelectedLegacySavedTabsUseCasesDeps and routes the result', () => {
-    // 関数名の定義 / import だけでは通らないよう、実際の呼び出し形状と
-    // route-aware use-case composition への結線を検証する (CodeRabbit review)。
-    const productionComposition = readRepositoryFile(
+  it('production composition routes the selected legacy deps through the route-aware use-case wiring', () => {
+    // CodeRabbit review: ファイル全体への正規表現は3つの呼び出しの存在しか確認
+    // せず、別関数に正しい呼び出しが1つ残っていれば結線が壊れても通る。
+    // 各 exported composition 関数の本体内で、同じ deps 変数のデータフローを
+    // AST で検証する。
+    const sourceFile = parseRepositorySourceFile(
       'src/app/composition/createSavedTabsUseCases.ts',
     )
 
-    // import 文 (`createSelectedLegacySavedTabsUseCasesDeps,`) ではなく
-    // 呼び出し (`createSelectedLegacySavedTabsUseCasesDeps(`) を検出する。
-    expect(productionComposition).toMatch(
-      /createSelectedLegacySavedTabsUseCasesDeps\s*\(/,
+    // createProductionSavedTabsUseCases は deps を createApplicationSavedTabsUseCases へ渡し、
+    // その結果を createRouteAwareSavedTabsUseCases の legacy slot へ結線する。
+    const productionBody = requireDefined(
+      findNamedFunctionBody(sourceFile, 'createProductionSavedTabsUseCases'),
+      'createProductionSavedTabsUseCases must be defined',
     )
-    // 呼び出し結果を route-aware な use-case composition へ渡している。
-    expect(productionComposition).toMatch(
-      /createRouteAwareSavedTabsUseCases\s*\(\s*\{/,
+    const productionCalls = collectCallExpressions(productionBody)
+    const routeAwareCall = productionCalls.find(
+      (call) => calleeIdentifier(call) === 'createRouteAwareSavedTabsUseCases',
     )
-    expect(productionComposition).toMatch(
-      /createApplicationSavedTabsUseCases\s*\(\s*deps\s*\)/,
+    expect(
+      routeAwareCall,
+      'createProductionSavedTabsUseCases must call createRouteAwareSavedTabsUseCases',
+    ).toBeDefined()
+    const applicationUseCaseCall = requireDefined(
+      productionCalls.find(
+        (call) =>
+          calleeIdentifier(call) === 'createApplicationSavedTabsUseCases',
+      ),
+      'createProductionSavedTabsUseCases must call createApplicationSavedTabsUseCases',
     )
+    const applicationUseCaseArgument = applicationUseCaseCall.arguments[0]
+    expect(
+      ts.isIdentifier(applicationUseCaseArgument) &&
+        applicationUseCaseArgument.text === 'deps',
+      'createApplicationSavedTabsUseCases must receive the deps parameter directly',
+    ).toBe(true)
+
+    // 各 exported entry point は createSelectedLegacySavedTabsUseCasesDeps の戻り値を
+    // 同じ変数へ束縛し、その変数を createProductionSavedTabsUseCases へ渡す。
+    const entryPoints = [
+      'createSavedTabsUseCases',
+      'createSavedTabsPresentationComposition',
+    ]
+    for (const entryPoint of entryPoints) {
+      const body = requireDefined(
+        findNamedFunctionBody(sourceFile, entryPoint),
+        `${entryPoint} must be defined`,
+      )
+      const depsVariableName = requireDefined(
+        findVariableAssignedFromCall(
+          body,
+          'createSelectedLegacySavedTabsUseCasesDeps',
+        ),
+        `${entryPoint} must assign createSelectedLegacySavedTabsUseCasesDeps result to a variable`,
+      )
+      const calls = collectCallExpressions(body)
+      const productionCall = requireDefined(
+        calls.find(
+          (call) =>
+            calleeIdentifier(call) === 'createProductionSavedTabsUseCases',
+        ),
+        `${entryPoint} must call createProductionSavedTabsUseCases`,
+      )
+      const productionArgument = productionCall.arguments[0]
+      expect(
+        ts.isIdentifier(productionArgument) &&
+          productionArgument.text === depsVariableName,
+        `${entryPoint} must pass the selected legacy deps variable to createProductionSavedTabsUseCases`,
+      ).toBe(true)
+    }
   })
 
   it('enforces preflight freshness, silent startup, and app-level recovery', () => {


### PR DESCRIPTION
#729 phase 1 / production cutover deferred

## 背景

Issue #729 全体の production cutover ではなく、Firefox migration smoke (#722) が production cutover を検証できるようにする第1段階です。production の source of truth は引き続き Chrome Storage とし、このPRでは complete-cutover を有効化しません。

## 原因

- current Saved Tabs read/write path は legacy persistence を前提とし、control state に応じて backend 全体を切り替える composition boundary がありませんでした。
- bootstrap policy を省略した場合にも complete 相当へ進み得るため、production defer を構造的に保証できていませんでした。

## 採用した解決

- control state を coordination lock 内で読み、legacy / indexeddb のどちらか一方だけを実行する PersistenceDataPlaneRouterService を追加しました。
- presentation が利用する current SavedTabsUseCases 全体を RouteAwareSavedTabsUseCasesService で route-aware にし、backend 固有 shape を presentation/application/domain から隔離しました。
- legacy backend は既存 Chrome Storage repository/use-case bundle、IndexedDB backend は dependency injection された bundleを利用します。
- 選択された backend の失敗はそのまま再送出します。反対側への fallback、dual write、retry-as-other-backend は実装していません。
- production composition は cutoverPolicy: defer を明示し、IndexedDB bundle を受け取らない構造にしました。
- complete policy と IndexedDB use-case bundle の注入は testing files / testing directory 配下の seam のみに限定しました。

## production cutover が無効な根拠

- production runtime は cutoverPolicy: defer を明示しています。
- PersistenceBootstrapService は cutoverPolicy === complete の場合だけ cutover を進め、省略時も defer します。
- production createSavedTabsUseCases は IndexedDB bundle の注入口を公開していません。
- DDD architecture guard が production source における complete policy と testing seam import を拒否します。
- したがって production behavior と source of truth は従来どおり Chrome Storageです。

## route / fail-closed 証跡

- legacy: read/write とも legacy callback のみ1回、IndexedDB callback は0回。
- indexeddb: injection test で read/write とも IndexedDB callback のみ1回、legacy callback は0回。
- route選択後の IndexedDB error は同一error instanceを再送出し、legacy callbackは0回です。
- write failureでも選択backendだけが呼ばれ、dual writeはありません。
- successful route matrixで recovery に PERSISTENCE_ROUTE_MISMATCH が渡らないことを検証しています。
- productionで到達不能な IndexedDB stateとbundle不在が併存した場合は typed errorでfail closedし、legacyへfallbackしません。

## #722 向け test seam

- createCompletePersistenceBootstrapService が migration smoke/integration test からのみ complete policy を注入します。
- createSavedTabsUseCases.testing.ts が test側のIndexedDB use-case bundleを注入します。
- integration testで cutover-pending -> indexeddb 遷移後、IndexedDB repository callbackのみが選択されることを確認しています。

## 検証

- focused fresh-context verification: 8 files / 905 tests passed
- bun run compile: passed
- bun run agent:check: passed (416 files / 4615 passed / 1 skipped)
- bun run test:coverage: passed
  - statements 95.93%
  - branches 90.76%
  - functions 96.74%
  - lines 95.90%
- bun run release:check: passed
  - Knip / duplication / secretlint / dependency-cruiser
  - Chrome / Firefox production builds
  - production logging / version / persistence metadata / network policy verifiers
- fresh-context Harness Evaluator: approved

## Regression risk

- production routingはlegacy stateのままであり、既存Chrome Storage pathを選択します。
- UI変更、permission変更、network policy変更はありません。
- complete-cutover と Firefox smoke の本実装は #722 のbranchで行います。

Refs #729

Related #722

このPR単体では #729 をcloseしません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改善**
  - 保存タブの読み書き先を状態に応じて適切に切り替え、データ移行中も安全に利用できるようになりました。
  - 移行完了前に保存先が意図せず切り替わる問題を防止しました。
  - 保存先のエラー時に不要な再試行や二重書き込みを抑制し、エラーを適切に通知します。
  - 緊急時の読み取り専用状態や、保存機能が利用できない状態に対応しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->