### PR TITLE
fix: 旧形式バックアップのインポート互換性を復元

### DIFF
--- a/docs/architecture/legacy-persistence-v2-migration.md
+++ b/docs/architecture/legacy-persistence-v2-migration.md
@@ -68,6 +68,24 @@ preflight and the actual migration.
   preflight approval policy blocks every issue except a missing top-level key,
   so a conflicting title cannot reach target writes.
 
+The temporary schema-less backup importer has a compatibility adapter before
+this raw-storage mapper. It recognizes representations emitted by the former
+public exporters:
+
+- the validated runtime-only `userSettings.activeAiSystemPrompt` projection is
+  removed while `activeAiSystemPromptId` and `aiSystemPrompts` remain;
+- nested saved-tab URLs are paired with same-position `urlIds`, and custom
+  project URL IDs are restored only when URL and title identify exactly one
+  canonical top-level record; and
+- a valid partial domain category order is completed with the remaining
+  declared categories in declaration order.
+
+The 2.x exporter always included its nested URLs in the canonical top-level URL
+list, so ambiguous or unmatched 2.x references remain typed blocking issues.
+The 1.x importer contract still permits mixed canonical and nested-only URL
+representations. Unknown settings and duplicate or unknown category-order
+entries remain blocking for every legacy version.
+
 The mapper runs `PersistenceIntegrityChecker` before any IndexedDB operation.
 Only an approved, error-free target may be written.
 

--- a/e2e/options.extension.spec.ts
+++ b/e2e/options.extension.spec.ts
@@ -37,27 +37,82 @@ const createSeedWithUrls = () =>
     userSettings: { ...defaultUserSettings, clickBehavior: 'saveCurrentTab' },
   })
 
-const createLegacyBackup = () => ({
-  parentCategories: [],
-  savedTabs: [
-    {
-      domain: 'legacy.example',
-      id: 'group-legacy',
-      urlIds: ['url-legacy'],
+const createLegacyBackup = () => {
+  const activeAiSystemPrompt = {
+    createdAt: now - 1,
+    id: 'legacy-active-prompt',
+    name: 'Legacy active prompt',
+    template: 'Legacy prompt template',
+    updatedAt: now,
+  }
+  const legacyUrl = {
+    id: 'url-legacy',
+    savedAt: now,
+    title: 'Legacy Home',
+    url: 'https://legacy.example/',
+  }
+
+  return {
+    customProjectOrder: ['project-legacy'],
+    customProjects: [
+      {
+        categories: ['Reference'],
+        categoryOrder: ['Reference'],
+        createdAt: now - 1,
+        id: 'project-legacy',
+        name: 'Legacy Project',
+        projectKeywords: {
+          domainKeywords: [],
+          titleKeywords: [],
+          urlKeywords: [],
+        },
+        updatedAt: now,
+        urls: [
+          {
+            category: 'Reference',
+            notes: 'Legacy memo',
+            savedAt: legacyUrl.savedAt,
+            title: legacyUrl.title,
+            url: legacyUrl.url,
+          },
+        ],
+      },
+    ],
+    parentCategories: [],
+    savedTabs: [
+      {
+        categoryKeywords: [
+          { categoryName: 'news', keywords: [] },
+          { categoryName: 'docs', keywords: [] },
+        ],
+        domain: 'legacy.example',
+        id: 'group-legacy',
+        savedAt: now,
+        subCategories: ['news', 'docs'],
+        subCategoryOrder: ['news'],
+        subCategoryOrderWithUncategorized: ['__uncategorized', 'news'],
+        urlIds: [legacyUrl.id],
+        urls: [
+          {
+            savedAt: legacyUrl.savedAt,
+            subCategory: 'news',
+            title: legacyUrl.title,
+            url: legacyUrl.url,
+          },
+        ],
+        urlSubCategories: { [legacyUrl.id]: 'news' },
+      },
+    ],
+    timestamp: new Date(now).toISOString(),
+    urls: [legacyUrl],
+    userSettings: {
+      activeAiSystemPrompt,
+      activeAiSystemPromptId: activeAiSystemPrompt.id,
+      aiSystemPrompts: [activeAiSystemPrompt],
     },
-  ],
-  timestamp: new Date(now).toISOString(),
-  urls: [
-    {
-      id: 'url-legacy',
-      savedAt: now,
-      title: 'Legacy Home',
-      url: 'https://legacy.example/',
-    },
-  ],
-  userSettings: {},
-  version: '1.0.0',
-})
+    version: '2.0.9',
+  }
+}
 
 const emptyPersistenceV2Seed = {
   categories: [],

--- a/src/contexts/saved-tabs/application/mappers/LegacyStorageToPersistenceV2Mapper.test.ts
+++ b/src/contexts/saved-tabs/application/mappers/LegacyStorageToPersistenceV2Mapper.test.ts
@@ -534,6 +534,30 @@ describe('analyzeLegacyMigrationPreflight', () => {
     )
   })
 
+  it('blocks duplicate uncategorized markers in legacy domain category order', () => {
+    const source = withSource(createEmptySnapshot(), 'savedTabs', [
+      {
+        domain: 'example.com',
+        id: 'group-1',
+        savedAt: 1,
+        subCategories: ['docs', 'news'],
+        subCategoryOrderWithUncategorized: [
+          '__uncategorized',
+          '__uncategorized',
+          'news',
+          'docs',
+        ],
+        urlIds: [],
+      },
+    ])
+
+    const result = analyzeLegacyMigrationPreflight(source)
+
+    expect(result.issueCodes).toContain(
+      'LEGACY_DOMAIN_CATEGORY_MAPPING_CONFLICT',
+    )
+  })
+
   it.each([
     {
       categoryKeywords: [

--- a/src/contexts/saved-tabs/application/mappers/LegacyStorageToPersistenceV2Mapper.ts
+++ b/src/contexts/saved-tabs/application/mappers/LegacyStorageToPersistenceV2Mapper.ts
@@ -646,14 +646,18 @@ const readSavedTabCategoryOrder = (
   if (order === null || orderWithUncategorized === null) {
     return null
   }
+  const uncategorizedMarkerCount =
+    orderWithUncategorized?.filter((category) => category === '__uncategorized')
+      .length ?? 0
   const filteredOrder = orderWithUncategorized?.filter(
     (category) => category !== '__uncategorized',
   )
   if (
-    order &&
-    filteredOrder &&
-    (order.length !== filteredOrder.length ||
-      order.some((category, index) => category !== filteredOrder[index]))
+    uncategorizedMarkerCount > 1 ||
+    (order &&
+      filteredOrder &&
+      (order.length !== filteredOrder.length ||
+        order.some((category, index) => category !== filteredOrder[index])))
   ) {
     addIssue(state, 'LEGACY_DOMAIN_CATEGORY_MAPPING_CONFLICT', 'error')
   }

--- a/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.test.ts
+++ b/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.test.ts
@@ -1,8 +1,102 @@
 import { describe, expect, it } from 'vitest'
 
+import { checkPersistenceIntegrity } from '@/contexts/saved-tabs/public-api'
 import { BackupSchemaError } from '@/lib/persistence/backupSchema'
 
-import { convertLegacyBackup } from './LegacyBackupAdapter'
+import {
+  convertLegacyBackup,
+  LegacyBackupImportError,
+} from './LegacyBackupAdapter'
+
+const createLegacyExporterBackup = () => {
+  const activeAiSystemPrompt = {
+    createdAt: 1,
+    id: 'legacy-active-prompt',
+    name: 'Legacy active prompt',
+    template: 'Legacy prompt template',
+    updatedAt: 2,
+  }
+  const urls = [
+    {
+      id: 'url-a',
+      savedAt: 11,
+      title: 'URL A',
+      url: 'https://legacy-export.example/a',
+    },
+    {
+      id: 'url-b',
+      savedAt: 12,
+      title: 'URL B',
+      url: 'https://legacy-export.example/b',
+    },
+  ]
+  return {
+    customProjectOrder: ['project-1'],
+    customProjects: [
+      {
+        categories: ['Research'],
+        categoryOrder: ['Research'],
+        createdAt: 1,
+        id: 'project-1',
+        name: 'Project',
+        projectKeywords: {
+          domainKeywords: [],
+          titleKeywords: [],
+          urlKeywords: [],
+        },
+        updatedAt: 2,
+        urls: urls.map((url, index) => ({
+          ...(index === 0 ? { category: 'Research', notes: 'memo' } : {}),
+          savedAt: url.savedAt,
+          title: url.title,
+          url: url.url,
+        })),
+      },
+    ],
+    parentCategories: [],
+    savedTabs: [
+      {
+        categoryKeywords: [
+          { categoryName: 'news', keywords: ['latest'] },
+          { categoryName: 'docs', keywords: [] },
+        ],
+        domain: 'legacy-export.example',
+        id: 'domain-group',
+        savedAt: 10,
+        subCategories: ['news', 'docs'],
+        subCategoryOrder: ['news'],
+        subCategoryOrderWithUncategorized: ['__uncategorized', 'news'],
+        urlIds: urls.map(({ id }) => id),
+        urls: urls.map((url, index) => ({
+          savedAt: url.savedAt,
+          subCategory: index === 0 ? 'news' : 'docs',
+          title: url.title,
+          url: url.url,
+        })),
+        urlSubCategories: { 'url-a': 'news', 'url-b': 'docs' },
+      },
+    ],
+    timestamp: '2026-08-15T00:00:00.000Z',
+    urls,
+    userSettings: {
+      activeAiSystemPrompt,
+      activeAiSystemPromptId: activeAiSystemPrompt.id,
+      aiSystemPrompts: [activeAiSystemPrompt],
+    },
+    version: '2.0.9',
+  }
+}
+
+const captureError = (action: () => unknown): Error => {
+  try {
+    action()
+  } catch (error) {
+    if (error instanceof Error) {
+      return error
+    }
+  }
+  throw new Error('Expected action to throw')
+}
 
 describe('convertLegacyBackup', () => {
   it('rejects non-legacy input before applying the legacy cutoff', () => {
@@ -19,6 +113,138 @@ describe('convertLegacyBackup', () => {
     expect(error).toMatchObject({
       code: 'INVALID_SCHEMA',
       name: 'BackupSchemaError',
+    })
+  })
+
+  it('converts the canonical schema-less exporter shape without duplicating URLs', () => {
+    const conversion = convertLegacyBackup(
+      createLegacyExporterBackup(),
+      '2026-08-15',
+    )
+
+    expect(conversion.data.savedTabs.urls.map(({ id }) => id)).toEqual([
+      'url-a',
+      'url-b',
+    ])
+    expect(conversion.data.savedTabs.memberships).toHaveLength(4)
+    expect(
+      conversion.data.savedTabs.categories
+        .filter(({ collectionId }) => collectionId === 'domain-group')
+        .map(({ name }) => name),
+    ).toEqual(['news', 'docs'])
+    expect(checkPersistenceIntegrity(conversion.data.savedTabs).issues).toEqual(
+      [],
+    )
+    expect(conversion.data.savedTabs.memberships).toContainEqual(
+      expect.objectContaining({
+        categoryId: 'project-1:category:0',
+        collectionId: 'project-1',
+        notes: 'memo',
+        urlId: 'url-a',
+      }),
+    )
+    expect(conversion.data.userSettings).not.toHaveProperty(
+      'activeAiSystemPrompt',
+    )
+  })
+
+  it('keeps mismatched parallel URLs fail-closed', () => {
+    const backup = createLegacyExporterBackup()
+    backup.savedTabs[0].urls[0].url = 'https://mismatch.example/a'
+
+    const error = captureError(() => convertLegacyBackup(backup, '2026-08-15'))
+
+    expect(error).toBeInstanceOf(LegacyBackupImportError)
+    expect(error).toMatchObject({
+      code: 'LEGACY_MIGRATION_BLOCKED',
+      issueCodes: expect.arrayContaining(['LEGACY_URL_REFERENCE_CONFLICT']),
+    })
+  })
+
+  it('keeps an unmatched saved-tab URL without an id fail-closed', () => {
+    const backup = createLegacyExporterBackup()
+    backup.savedTabs[0].urlIds = []
+    Reflect.deleteProperty(backup.savedTabs[0], 'urlSubCategories')
+    backup.savedTabs[0].urls[0].url = 'https://unmatched.example/a'
+
+    const error = captureError(() => convertLegacyBackup(backup, '2026-08-15'))
+
+    expect(error).toBeInstanceOf(LegacyBackupImportError)
+    expect(error).toMatchObject({
+      code: 'LEGACY_MIGRATION_BLOCKED',
+      issueCodes: expect.arrayContaining(['LEGACY_URL_REFERENCE_CONFLICT']),
+    })
+  })
+
+  it('keeps ambiguous canonical URL matches fail-closed', () => {
+    const backup = createLegacyExporterBackup()
+    backup.urls.push({ ...backup.urls[0], id: 'url-a-duplicate' })
+    backup.savedTabs[0].urlIds = []
+
+    const error = captureError(() => convertLegacyBackup(backup, '2026-08-15'))
+
+    expect(error).toBeInstanceOf(LegacyBackupImportError)
+    expect(error).toMatchObject({
+      code: 'LEGACY_MIGRATION_BLOCKED',
+      issueCodes: expect.arrayContaining(['LEGACY_URL_REFERENCE_CONFLICT']),
+    })
+  })
+
+  it('keeps an unmatched custom-project URL without an id fail-closed', () => {
+    const backup = createLegacyExporterBackup()
+    backup.customProjects[0].urls[0].url = 'https://unmatched.example/a'
+
+    const error = captureError(() => convertLegacyBackup(backup, '2026-08-15'))
+
+    expect(error).toBeInstanceOf(LegacyBackupImportError)
+    expect(error).toMatchObject({
+      code: 'LEGACY_MIGRATION_BLOCKED',
+      issueCodes: expect.arrayContaining(['LEGACY_URL_REFERENCE_CONFLICT']),
+    })
+  })
+
+  it('requires top-level canonical URLs for nested saved-tab URLs in 2.x backups', () => {
+    const backup = createLegacyExporterBackup()
+    backup.customProjectOrder = []
+    backup.customProjects = []
+    backup.savedTabs[0].urlIds = []
+    backup.urls = []
+
+    const error = captureError(() => convertLegacyBackup(backup, '2026-08-15'))
+
+    expect(error).toBeInstanceOf(LegacyBackupImportError)
+    expect(error).toMatchObject({
+      code: 'LEGACY_MIGRATION_BLOCKED',
+      issueCodes: expect.arrayContaining(['LEGACY_URL_REFERENCE_CONFLICT']),
+    })
+  })
+
+  it('requires top-level canonical URLs for nested custom URLs in 2.x backups', () => {
+    const backup = createLegacyExporterBackup()
+    backup.savedTabs = []
+    backup.urls = []
+
+    const error = captureError(() => convertLegacyBackup(backup, '2026-08-15'))
+
+    expect(error).toBeInstanceOf(LegacyBackupImportError)
+    expect(error).toMatchObject({
+      code: 'LEGACY_MIGRATION_BLOCKED',
+      issueCodes: expect.arrayContaining(['LEGACY_URL_REFERENCE_CONFLICT']),
+    })
+  })
+
+  it('keeps an unknown category in a partial order fail-closed', () => {
+    const backup = createLegacyExporterBackup()
+    backup.savedTabs[0].subCategoryOrder = ['news', 'unknown']
+
+    const error = captureError(() => convertLegacyBackup(backup, '2026-08-15'))
+
+    expect(error).toBeInstanceOf(LegacyBackupImportError)
+    expect(error).toMatchObject({
+      code: 'LEGACY_MIGRATION_BLOCKED',
+      issueCodes: expect.arrayContaining([
+        'LEGACY_DOMAIN_CATEGORY_MAPPING_CONFLICT',
+      ]),
     })
   })
 })

--- a/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.ts
+++ b/src/features/options/lib/import-export/legacy/LegacyBackupAdapter.ts
@@ -83,6 +83,43 @@ const toRawLegacyStorageSnapshot = (
 type LegacyNestedUrl = NonNullable<
   LegacyBackupV0['savedTabs'][number]['urls']
 >[number]
+type LegacyCanonicalUrl = NonNullable<LegacyBackupV0['urls']>[number]
+type LegacyCustomProject = NonNullable<LegacyBackupV0['customProjects']>[number]
+type LegacyCustomProjectUrl = NonNullable<LegacyCustomProject['urls']>[number]
+type LegacyUrlMetadata = NonNullable<LegacyCustomProject['urlMetadata']>
+
+const createExporterUrlKey = (url: {
+  readonly title: string
+  readonly url: string
+}): string => JSON.stringify([url.url, url.title])
+
+const createCanonicalUrlIndex = (
+  urls: readonly LegacyCanonicalUrl[],
+): ReadonlyMap<string, readonly LegacyCanonicalUrl[]> => {
+  const index = new Map<string, LegacyCanonicalUrl[]>()
+  for (const url of urls) {
+    const key = createExporterUrlKey(url)
+    const matches = index.get(key) ?? []
+    matches.push(url)
+    index.set(key, matches)
+  }
+  return index
+}
+
+const resolveCanonicalUrlIds = (
+  urls: readonly { readonly title: string; readonly url: string }[],
+  canonicalUrlIndex: ReadonlyMap<string, readonly LegacyCanonicalUrl[]>,
+): readonly string[] | undefined => {
+  const ids: string[] = []
+  for (const url of urls) {
+    const matches = canonicalUrlIndex.get(createExporterUrlKey(url)) ?? []
+    if (matches.length !== 1) {
+      return undefined
+    }
+    ids.push(matches[0].id)
+  }
+  return ids
+}
 
 const normalizeLegacyNestedUrl = (
   url: LegacyNestedUrl,
@@ -98,33 +135,198 @@ const normalizeLegacyNestedUrl = (
   }
 }
 
+const completeLegacyCategoryOrder = (
+  order: readonly string[] | undefined,
+  categories: readonly string[] | undefined,
+  options: { readonly hasUncategorizedMarker: boolean },
+): string[] | undefined => {
+  if (!order || !categories) {
+    return order === undefined ? undefined : [...order]
+  }
+  const categorySet = new Set(categories)
+  if (categorySet.size !== categories.length) {
+    return [...order]
+  }
+  const orderedCategories = options.hasUncategorizedMarker
+    ? order.filter((category) => category !== '__uncategorized')
+    : order
+  const orderedSet = new Set(orderedCategories)
+  if (
+    orderedSet.size !== orderedCategories.length ||
+    orderedCategories.some((category) => !categorySet.has(category))
+  ) {
+    return [...order]
+  }
+  return [
+    ...order,
+    ...categories.filter((category) => !orderedSet.has(category)),
+  ]
+}
+
+const resolveSavedTabUrlIds = (
+  normalizedUrls: readonly LegacyNestedUrl[] | undefined,
+  existingUrlIds: readonly string[] | undefined,
+  canonicalUrlIndex: ReadonlyMap<string, readonly LegacyCanonicalUrl[]>,
+): readonly string[] | undefined => {
+  if (normalizedUrls === undefined) {
+    return undefined
+  }
+  if (existingUrlIds && existingUrlIds.length > 0) {
+    if (existingUrlIds.length !== normalizedUrls.length) {
+      return undefined
+    }
+    return existingUrlIds
+  }
+  return resolveCanonicalUrlIds(normalizedUrls, canonicalUrlIndex)
+}
+
+const normalizeLegacySavedTab = (
+  savedTab: LegacyBackupV0['savedTabs'][number],
+  canonicalUrlIndex: ReadonlyMap<string, readonly LegacyCanonicalUrl[]>,
+  requiresCanonicalUrlReferences: boolean,
+): LegacyBackupV0['savedTabs'][number] => {
+  const normalizedUrls = savedTab.urls?.map(normalizeLegacyNestedUrl)
+  const resolvedUrlIds = resolveSavedTabUrlIds(
+    normalizedUrls,
+    savedTab.urlIds,
+    canonicalUrlIndex,
+  )
+  if (
+    normalizedUrls !== undefined &&
+    (savedTab.urlIds?.length ?? 0) === 0 &&
+    requiresCanonicalUrlReferences &&
+    resolvedUrlIds === undefined
+  ) {
+    throw new LegacyBackupImportError('LEGACY_MIGRATION_BLOCKED', [
+      'LEGACY_URL_REFERENCE_CONFLICT',
+    ])
+  }
+  return {
+    ...savedTab,
+    ...(resolvedUrlIds === undefined ? {} : { urlIds: [...resolvedUrlIds] }),
+    ...(normalizedUrls === undefined
+      ? {}
+      : {
+          urls: normalizedUrls.map((url, index) =>
+            url.id === undefined && resolvedUrlIds?.[index]
+              ? { ...url, id: resolvedUrlIds[index] }
+              : url,
+          ),
+        }),
+    ...(savedTab.subCategoryOrder === undefined
+      ? {}
+      : {
+          subCategoryOrder: completeLegacyCategoryOrder(
+            savedTab.subCategoryOrder,
+            savedTab.subCategories,
+            { hasUncategorizedMarker: false },
+          ),
+        }),
+    ...(savedTab.subCategoryOrderWithUncategorized === undefined
+      ? {}
+      : {
+          subCategoryOrderWithUncategorized: completeLegacyCategoryOrder(
+            savedTab.subCategoryOrderWithUncategorized,
+            savedTab.subCategories,
+            { hasUncategorizedMarker: true },
+          ),
+        }),
+  }
+}
+
+const buildLegacyProjectUrlMetadata = (
+  project: LegacyCustomProject,
+  urls: readonly LegacyCustomProjectUrl[],
+  urlIds: readonly string[],
+): LegacyUrlMetadata | undefined => {
+  const metadata: LegacyUrlMetadata = { ...project.urlMetadata }
+  urls.forEach((url, index) => {
+    const urlId = urlIds[index]
+    if (
+      Object.hasOwn(metadata, urlId) ||
+      (url.category === undefined && url.notes === undefined)
+    ) {
+      return
+    }
+    metadata[urlId] = {
+      ...(url.category === undefined ? {} : { category: url.category }),
+      ...(url.notes === undefined ? {} : { notes: url.notes }),
+    }
+  })
+  return Object.keys(metadata).length > 0 ? metadata : undefined
+}
+
+const normalizeLegacyCustomProject = (
+  project: LegacyCustomProject,
+  canonicalUrlIndex: ReadonlyMap<string, readonly LegacyCanonicalUrl[]>,
+  requiresCanonicalUrlReferences: boolean,
+): LegacyCustomProject => {
+  const normalizedProject = {
+    ...project,
+    ...(project.projectKeywords === undefined
+      ? {}
+      : {
+          projectKeywords: {
+            domainKeywords: project.projectKeywords.domainKeywords ?? [],
+            titleKeywords: project.projectKeywords.titleKeywords ?? [],
+            urlKeywords: project.projectKeywords.urlKeywords ?? [],
+          },
+        }),
+  }
+  if (
+    project.urls === undefined ||
+    (project.urlIds !== undefined && project.urlIds.length > 0)
+  ) {
+    return normalizedProject
+  }
+  const urlIds = resolveCanonicalUrlIds(project.urls, canonicalUrlIndex)
+  if (!urlIds) {
+    if (requiresCanonicalUrlReferences) {
+      throw new LegacyBackupImportError('LEGACY_MIGRATION_BLOCKED', [
+        'LEGACY_URL_REFERENCE_CONFLICT',
+      ])
+    }
+    return normalizedProject
+  }
+  const urlMetadata = buildLegacyProjectUrlMetadata(
+    project,
+    project.urls,
+    urlIds,
+  )
+  return {
+    ...normalizedProject,
+    urlIds: [...urlIds],
+    ...(urlMetadata === undefined ? {} : { urlMetadata }),
+  }
+}
+
 const normalizeLegacyBackupForMapper = (
   backup: LegacyBackupV0,
-): LegacyBackupV0 => ({
-  ...backup,
-  ...(backup.customProjects === undefined
-    ? {}
-    : {
-        customProjects: backup.customProjects.map((project) => ({
-          ...project,
-          ...(project.projectKeywords === undefined
-            ? {}
-            : {
-                projectKeywords: {
-                  domainKeywords: project.projectKeywords.domainKeywords ?? [],
-                  titleKeywords: project.projectKeywords.titleKeywords ?? [],
-                  urlKeywords: project.projectKeywords.urlKeywords ?? [],
-                },
-              }),
-        })),
-      }),
-  savedTabs: backup.savedTabs.map((savedTab) => ({
-    ...savedTab,
-    ...(savedTab.urls === undefined
+): LegacyBackupV0 => {
+  const canonicalUrlIndex = createCanonicalUrlIndex(backup.urls ?? [])
+  const requiresCanonicalUrlReferences = backup.version.startsWith('2.')
+  return {
+    ...backup,
+    ...(backup.customProjects === undefined
       ? {}
-      : { urls: savedTab.urls.map(normalizeLegacyNestedUrl) }),
-  })),
-})
+      : {
+          customProjects: backup.customProjects.map((project) =>
+            normalizeLegacyCustomProject(
+              project,
+              canonicalUrlIndex,
+              requiresCanonicalUrlReferences,
+            ),
+          ),
+        }),
+    savedTabs: backup.savedTabs.map((savedTab) =>
+      normalizeLegacySavedTab(
+        savedTab,
+        canonicalUrlIndex,
+        requiresCanonicalUrlReferences,
+      ),
+    ),
+  }
+}
 
 export const convertLegacyBackup = (
   input: unknown,

--- a/src/features/options/lib/import-export/legacy/LegacyBackupV0Schema.test.ts
+++ b/src/features/options/lib/import-export/legacy/LegacyBackupV0Schema.test.ts
@@ -33,6 +33,30 @@ describe('LegacyBackupV0Schema', () => {
     )
   })
 
+  it('accepts and strips the runtime-only active prompt emitted by the legacy exporter', () => {
+    const backup = createLegacyBackup()
+    const activeAiSystemPrompt = {
+      createdAt: 1,
+      id: 'legacy-active-prompt',
+      name: 'Legacy active prompt',
+      template: 'Legacy prompt template',
+      updatedAt: 2,
+    }
+    backup.userSettings = {
+      activeAiSystemPrompt,
+      activeAiSystemPromptId: activeAiSystemPrompt.id,
+      aiSystemPrompts: [activeAiSystemPrompt],
+    }
+
+    const result = LegacyBackupV0Schema.parse(backup)
+
+    expect(result.userSettings).toMatchObject({
+      activeAiSystemPromptId: activeAiSystemPrompt.id,
+      aiSystemPrompts: [activeAiSystemPrompt],
+    })
+    expect(result.userSettings).not.toHaveProperty('activeAiSystemPrompt')
+  })
+
   it('accepts legacy nested timestamp and runtime tabId fields', () => {
     const backup = createLegacyBackup()
     backup.savedTabs = [

--- a/src/features/options/lib/import-export/legacy/LegacyBackupV0Schema.ts
+++ b/src/features/options/lib/import-export/legacy/LegacyBackupV0Schema.ts
@@ -16,46 +16,52 @@ const legacyAiSystemPromptPresetSchema = z.strictObject({
   updatedAt: z.number(),
 })
 
-const legacyUserSettingsSchema = z.strictObject({
-  activeAiSystemPromptId: z.string().optional(),
-  aiSystemPrompts: z.array(legacyAiSystemPromptPresetSchema).optional(),
-  autoDeletePeriod: z
-    .enum([
-      'never',
-      '30sec',
-      '1min',
-      '1hour',
-      '1day',
-      '7days',
-      '14days',
-      '30days',
-      '180days',
-      '365days',
-    ])
-    .optional(),
-  clickBehavior: z
-    .enum([
-      'saveCurrentTab',
-      'saveWindowTabs',
-      'saveSameDomainTabs',
-      'saveAllWindowsTabs',
-    ])
-    .optional(),
-  colors: z.record(z.string(), z.string()).optional(),
-  confirmDeleteAll: z.boolean().optional(),
-  confirmDeleteEach: z.boolean().optional(),
-  enableCategories: z.boolean().optional(),
-  excludePatterns: z.array(z.string()).optional(),
-  excludePinnedTabs: z.boolean().optional(),
-  fontSizePercent: z.number().optional(),
-  language: z.enum(['system', 'ja', 'en']).optional(),
-  ollamaModel: z.string().optional(),
-  openAllInNewWindow: z.boolean().optional(),
-  openUrlInBackground: z.boolean().optional(),
-  removeTabAfterExternalDrop: z.boolean().optional(),
-  removeTabAfterOpen: z.boolean().optional(),
-  showSavedTime: z.boolean().optional(),
-})
+const legacyUserSettingsSchema = z
+  .strictObject({
+    activeAiSystemPrompt: legacyAiSystemPromptPresetSchema.optional(),
+    activeAiSystemPromptId: z.string().optional(),
+    aiSystemPrompts: z.array(legacyAiSystemPromptPresetSchema).optional(),
+    autoDeletePeriod: z
+      .enum([
+        'never',
+        '30sec',
+        '1min',
+        '1hour',
+        '1day',
+        '7days',
+        '14days',
+        '30days',
+        '180days',
+        '365days',
+      ])
+      .optional(),
+    clickBehavior: z
+      .enum([
+        'saveCurrentTab',
+        'saveWindowTabs',
+        'saveSameDomainTabs',
+        'saveAllWindowsTabs',
+      ])
+      .optional(),
+    colors: z.record(z.string(), z.string()).optional(),
+    confirmDeleteAll: z.boolean().optional(),
+    confirmDeleteEach: z.boolean().optional(),
+    enableCategories: z.boolean().optional(),
+    excludePatterns: z.array(z.string()).optional(),
+    excludePinnedTabs: z.boolean().optional(),
+    fontSizePercent: z.number().optional(),
+    language: z.enum(['system', 'ja', 'en']).optional(),
+    ollamaModel: z.string().optional(),
+    openAllInNewWindow: z.boolean().optional(),
+    openUrlInBackground: z.boolean().optional(),
+    removeTabAfterExternalDrop: z.boolean().optional(),
+    removeTabAfterOpen: z.boolean().optional(),
+    showSavedTime: z.boolean().optional(),
+  })
+  .transform(
+    ({ activeAiSystemPrompt: _activeAiSystemPrompt, ...persistableSettings }) =>
+      persistableSettings,
+  )
 
 const legacyNestedUrlSchema = z.strictObject({
   favIconUrl: legacyFavIconUrlSchema.optional(),

--- a/src/features/options/lib/import-export/productionImportGate.test.ts
+++ b/src/features/options/lib/import-export/productionImportGate.test.ts
@@ -136,6 +136,45 @@ describe('assertProductionImportAllowed', () => {
     })
   })
 
+  it('accepts the legacy exporter runtime prompt without forwarding it to settings', () => {
+    const legacy: unknown = JSON.parse(
+      readFixture('legacy-tab-group-url-ids.json'),
+    )
+    if (typeof legacy !== 'object' || legacy === null) {
+      throw new TypeError('Expected legacy backup fixture')
+    }
+    const userSettings = Reflect.get(legacy, 'userSettings')
+    if (typeof userSettings !== 'object' || userSettings === null) {
+      throw new TypeError('Expected legacy user settings fixture')
+    }
+    const activeAiSystemPrompt = {
+      createdAt: 1,
+      id: 'legacy-active-prompt',
+      name: 'Legacy active prompt',
+      template: 'Legacy prompt template',
+      updatedAt: 2,
+    }
+    Object.assign(userSettings, {
+      activeAiSystemPrompt,
+      activeAiSystemPromptId: activeAiSystemPrompt.id,
+      aiSystemPrompts: [activeAiSystemPrompt],
+    })
+
+    const allowed = assertProductionImportAllowed(JSON.stringify(legacy), {
+      importDate: '2026-08-31',
+      importMode: 'merge',
+    })
+    if (allowed?.kind !== 'legacy-merge') {
+      throw new TypeError('Expected legacy merge import')
+    }
+
+    expect(allowed.userSettingsPatch).toMatchObject({
+      activeAiSystemPromptId: activeAiSystemPrompt.id,
+      aiSystemPrompts: [activeAiSystemPrompt],
+    })
+    expect(allowed.userSettingsPatch).not.toHaveProperty('activeAiSystemPrompt')
+  })
+
   it('accepts schema-less backups containing versioned analytics queries', () => {
     const legacy: unknown = JSON.parse(
       readFixture('legacy-tab-group-url-ids.json'),


### PR DESCRIPTION
## 原因

PR #821 で旧形式インポートを strict schema と Persistence v2 mapper に接続した際、旧 public exporter が実際に出力していた次の表現が互換契約へ反映されていませんでした。

- `userSettings.activeAiSystemPrompt` という実行時 projection
- top-level canonical URL と、Saved Tab / Custom Project 内の nested URL の重複表現
- 一部だけ保存された domain category order

そのため実在する 2.0.9 の旧バックアップが schema validation または migration preflight で拒否されていました。

## 解決方法

- runtime-only prompt は構造を検証してから破棄し、永続対象の prompt ID / preset list だけを残す
- 2.x exporter の nested URL は same-position `urlIds` または URL + title の一意な canonical match で復元する
- 1.x で許可済みの canonical / nested-only 混在形式は維持する
- valid な partial category order だけを宣言順で補完する
- URL の不一致・曖昧性・canonical 全欠落、unknown / duplicate category order は typed error で fail-closed にする
- `__uncategorized` sentinel の重複も migration mapper で拒否する

## 主要変更

- 旧 Backup V0 schema と compatibility adapter を実 exporter 形式へ適合
- Custom Project の category / notes を含む membership metadata を保持
- 実ファイルと同じ構造を匿名化した unit / integration / Playwright regression fixture を追加
- 旧形式 migration の version boundary と fail-closed 方針を architecture doc に追記

## Regression risk と確認

- 新規 export の Backup V2 経路には変更なし
- 1.x nested-only compatibility は既存 fixture と property test で維持
- 2.x の unmatched / ambiguous / missing canonical reference は明示的に拒否
- user data、URL、prompt 内容のログ追加なし。提供ファイルはリポジトリへコピーせず、aggregate-only で検証
- 提供された旧 JSON は production gate の merge / overwrite 両経路で通過し、1351 URLs / 2684 memberships を重複なしで変換

## 検証

- focused node regression: 7 files / 86 tests passed
- `bun run e2e`: 20 passed
- `bun run quality:check`: 429 files / 4676 passed / 1 skipped
- `bun run test:coverage`: statements 93.95%, branches 88.26%, functions 92.25%, lines 93.98%
- `bun run release:check`: passed（Chrome / Firefox production build と release verifier を含む）
- fresh code review: Critical 0 / Important 0 / Minor 0

## Acceptance criteria 対応

- 新しい export は Backup V2 のまま維持
- import は Backup V2 と旧 schema-less backup の双方に対応
- 実在する 2.0.9 exporter 形式を data loss なく受理
- 不正・曖昧な legacy reference は書き込み前に fail-closed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 旧形式のバックアップから、設定、保存タブ、カスタムプロジェクトURL、カテゴリ順序をより正確に復元できるようになりました。
  * URLメタデータやプロジェクトキーワードなど、不足情報を補完して移行できるようになりました。
  * AIシステムプロンプトを含む旧形式バックアップに対応しました。

* **バグ修正**
  * URL参照やカテゴリ順序を一意に解決できない場合、移行を適切に停止するよう改善しました。
  * 重複した未分類カテゴリ指定を検出できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->